### PR TITLE
Fix port in network_discovery docs

### DIFF
--- a/docs/backends/network_discovery.md
+++ b/docs/backends/network_discovery.md
@@ -16,7 +16,7 @@ orb:
         agent_name: agent01
     network_discovery:
       host: 192.168.5.11 # default 0.0.0.0
-      port: 8863 # default 8072
+      port: 8863 # default 8073
       log_level: ERROR # default INFO
       log_format: JSON # default TEXT
 


### PR DESCRIPTION
`network_discovery` is bound to port 8073, 8072 is reserved for the `device_discovery` api.