### PR TITLE
Clarify discovery method

### DIFF
--- a/docs/backends/network_discovery.md
+++ b/docs/backends/network_discovery.md
@@ -1,5 +1,5 @@
 # Network Discovery
-The network discovery backend leverages [NMAP](https://nmap.org/) to scan networks and discover IP information.
+The network discovery backend leverages [NMAP](https://nmap.org/) to scan networks with icmp echo requests and discover IP information.
 
 
 ## Configuration


### PR DESCRIPTION
Currently, network_discovery uses icmp, as can be seen [here](https://github.com/netboxlabs/orb-discovery/blob/develop/network-discovery/policy/runner.go#L71)