### PR TITLE
chore: gha arm64 fix

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -37,6 +37,11 @@ jobs:
             username: ${{ secrets.DOCKERHUB_USERNAME }}
             password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+        - name: Verify QEMU installation
+          run: |
+              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+              docker run --rm --platform linux/arm64 debian:latest uname -m
+
         - name: Set build info
           run: |
             echo ${GITHUB_SHA::7} > ./agent/version/BUILD_COMMIT.txt

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -24,10 +24,10 @@ jobs:
           uses: actions/checkout@v4
 
         - name: Set up QEMU
-          uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf #v3.2.0
+          uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 #v3.4.0
 
         - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 #v3.8.0
+          uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca #v3.9.0
 
         - name: Login to Docker Hub
           uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
@@ -42,7 +42,7 @@ jobs:
             echo $LATEST_RELEASE > ./agent/version/BUILD_VERSION.txt
 
         - name: Build image and push
-          uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 #v6.10.0
+          uses: docker/build-push-action@0adf9959216b96bec444f325f1e493d4aa344497 #v6.14.0
           with:
             context: .
             file: agent/docker/Dockerfile

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -1,8 +1,6 @@
 name: Orb Agent - develop
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [ develop ]
   push:
     branches: [ develop ]
     paths:

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -1,6 +1,8 @@
 name: Orb Agent - develop
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [ develop ]
   push:
     branches: [ develop ]
     paths:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -143,6 +143,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Verify QEMU installation
+        run: |
+              docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+              docker run --rm --platform linux/arm64 debian:latest uname -m
+
       - name: Set build info
         run: |
           echo $BUILD_COMMIT > ./agent/version/BUILD_COMMIT.txt

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -132,10 +132,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf #v3.2.0
+        uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 #v3.4.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 #v3.8.0
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca #v3.9.0
 
       - name: Login to Docker Hub
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
@@ -149,7 +149,7 @@ jobs:
           echo $BUILD_VERSION > ./agent/version/BUILD_VERSION.txt
 
       - name: Build image and push
-        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 #v6.10.0
+        uses: docker/build-push-action@0adf9959216b96bec444f325f1e493d4aa344497 #v6.14.0
         with:
           context: .
           file: agent/docker/Dockerfile


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows for both the development and release processes. The primary changes involve updating the versions of several Docker-related actions and adding a verification step for QEMU installation.

Updates to GitHub Actions workflows:

* [`.github/workflows/develop.yaml`](diffhunk://#diff-75eb13a90ba4bddf3480256b071d4609bebe36aac7675d2c293bbaf9b58868f6L27-R50): Updated the versions of `docker/setup-qemu-action`, `docker/setup-buildx-action`, and `docker/build-push-action` to newer versions. Added a step to verify the QEMU installation.
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL135-R157): Updated the versions of `docker/setup-qemu-action`, `docker/setup-buildx-action`, and `docker/build-push-action` to newer versions. Added a step to verify the QEMU installation.