### PR TITLE
fix: selector applies to all block matches

### DIFF
--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -192,7 +192,10 @@ func (gc *gitConfigManager) processSelector(file *object.File, cfg config.Config
 		return nil, err
 	}
 
-	// Check for matching selector
+	// Use a set (map) to store unique policy paths
+	policyPathsSet := make(map[string]struct{})
+
+	// Iterate through all selectors and collect all matching ones
 	for selectorName, entry := range selectors {
 		matches := true
 		for key, value := range entry.Selector {
@@ -204,18 +207,22 @@ func (gc *gitConfigManager) processSelector(file *object.File, cfg config.Config
 
 		if matches {
 			gc.logger.Info("Selector matched", zap.String("selector", selectorName))
-			policyPaths := make([]string, 0)
 			for _, policy := range entry.Policies {
 				if policy.Enabled != nil && !*policy.Enabled {
 					continue
 				}
-				policyPaths = append(policyPaths, policy.Path)
+				policyPathsSet[policy.Path] = struct{}{} // Add path to set (ensures uniqueness)
 			}
-			return policyPaths, nil
 		}
 	}
 
-	return nil, nil
+	// Convert map keys to a slice
+	var policyPaths []string
+	for path := range policyPathsSet {
+		policyPaths = append(policyPaths, path)
+	}
+
+	return policyPaths, nil
 }
 
 func (gc *gitConfigManager) schedule(cfg config.Config, backends map[string]backend.Backend) {

--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -198,13 +198,10 @@ func (gc *gitConfigManager) processSelector(file *object.File, cfg config.Config
 	// Iterate through all selectors and collect all matching ones
 	for selectorName, entry := range selectors {
 		matches := true
-		// If selector is empty, it matches everything
-		if len(entry.Selector) > 0 {
-			for key, value := range entry.Selector {
-				if cfgValue, exists := cfg.OrbAgent.Labels[key]; !exists || cfgValue != value {
-					matches = false
-					break
-				}
+		for key, value := range entry.Selector {
+			if cfgValue, exists := cfg.OrbAgent.Labels[key]; !exists || cfgValue != value {
+				matches = false
+				break
 			}
 		}
 		if matches {

--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -206,9 +206,13 @@ func (gc *gitConfigManager) processSelector(file *object.File, cfg config.Config
 		}
 		if matches {
 			gc.logger.Info("Selector matched", zap.String("selector", selectorName))
-			for _, policy := range entry.Policies {
+			for pName, policy := range entry.Policies {
 				if policy.Enabled != nil && !*policy.Enabled {
 					continue
+				}
+				if _, exists := policyPathsSet[policy.Path]; exists {
+					gc.logger.Warn("Policy path already exists", zap.String("selector", selectorName),
+						zap.String("policy", pName), zap.String("path", policy.Path))
 				}
 				policyPathsSet[policy.Path] = struct{}{}
 			}

--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -198,20 +198,22 @@ func (gc *gitConfigManager) processSelector(file *object.File, cfg config.Config
 	// Iterate through all selectors and collect all matching ones
 	for selectorName, entry := range selectors {
 		matches := true
-		for key, value := range entry.Selector {
-			if cfgValue, exists := cfg.OrbAgent.Labels[key]; !exists || cfgValue != value {
-				matches = false
-				break
+		// If selector is empty, it matches everything
+		if len(entry.Selector) > 0 {
+			for key, value := range entry.Selector {
+				if cfgValue, exists := cfg.OrbAgent.Labels[key]; !exists || cfgValue != value {
+					matches = false
+					break
+				}
 			}
 		}
-
 		if matches {
 			gc.logger.Info("Selector matched", zap.String("selector", selectorName))
 			for _, policy := range entry.Policies {
 				if policy.Enabled != nil && !*policy.Enabled {
 					continue
 				}
-				policyPathsSet[policy.Path] = struct{}{} // Add path to set (ensures uniqueness)
+				policyPathsSet[policy.Path] = struct{}{}
 			}
 		}
 	}

--- a/docs/configs/git.md
+++ b/docs/configs/git.md
@@ -42,12 +42,13 @@ The Orb Agent requires the Git repository containing its policies to have the fo
 .
 ├── .git
 ├── selector.yaml
-├── dir2
-│   ├── newpolicy.yaml
-│   └── dir3
-│       └── newpolicy2.yaml
-└── folder1
-    └── policy1.yaml
+├── policy1.yaml
+├── folder2
+│   ├── policy2.yaml
+│   └── folder3
+│       └── policy3.yaml
+└── folder4
+    └── policy4.yaml
 ```
 
 ### selector.yaml 
@@ -64,8 +65,8 @@ agent_selector_1:
   policies:
     policy1:
       path: policy1.yaml
-	policy2:
-	  enabled: false
+    policy2:
+      enabled: false
       path: folder2/policy2.yaml
 agent_selector_2:
   selector:
@@ -73,8 +74,8 @@ agent_selector_2:
     pop: nyc02
   policies:
     policy1:
-	  enabled: true
-	  path: policy1.yaml
-	policy3:
-      path: folder3/policy3.yaml 
+      enabled: true
+      path: policy1.yaml
+    policy3:
+      path: folder2/folder3/policy3.yaml
 ```

--- a/docs/configs/git.md
+++ b/docs/configs/git.md
@@ -53,7 +53,7 @@ The Orb Agent requires the Git repository containing its policies to have the fo
 
 ### selector.yaml 
 The `selector.yaml` file must include the `selector` and `policies` sections:
- - `selector`: Defines key-value pairs (agent labels) used to identify agents
+ - `selector`: Defines key-value pairs that identify agents based on their labels. If the selector is empty, it matches all agents.
  - `policies`: Specifies policy file paths and their enabled or disabled state. If the `enabled` field is not provided, the policy is enabled by default
 
 
@@ -78,4 +78,8 @@ agent_selector_2:
       path: policy1.yaml
     policy3:
       path: folder2/folder3/policy3.yaml
+agent_selector_matches_all:
+  selector:
+  policies:
+    path: folder4/policy4.yaml
 ```


### PR DESCRIPTION
This pull request includes changes to the `processSelector` function in the `gitConfigManager` and updates to the documentation for the Orb Agent's configuration. The key changes are focused on improving the handling of policy paths and clarifying the documentation.

Improvements to `processSelector` function:

* [`agent/configmgr/git.go`](diffhunk://#diff-2e7ff6a74db68db7bf67abb785553044c99821d929cf7e1d742485bc43decfe8L195-R227): Replaced the list of policy paths with a set to ensure uniqueness, and added logic to convert the set back to a list before returning it. This change ensures that duplicate policy paths are not included in the results. Also ensure that every match applies and not only the first one.

Documentation updates:

* [`docs/configs/git.md`](diffhunk://#diff-394366c4c1632186d717eb52066554546fc54195458442ef622f9bbd0bc7a992L45-R56): Updated the example directory structure to reflect a more organized layout and added a new example for a selector that matches all agents. [[1]](diffhunk://#diff-394366c4c1632186d717eb52066554546fc54195458442ef622f9bbd0bc7a992L45-R56) [[2]](diffhunk://#diff-394366c4c1632186d717eb52066554546fc54195458442ef622f9bbd0bc7a992L79-R84)
* Clarified the description of the `selector` section to indicate that an empty selector matches all agents.