### PR TITLE
feat: implement pktvisor config parser

### DIFF
--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -3,13 +3,16 @@ package pktvisor
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
+	"os"
 	"os/exec"
 	"strconv"
 	"time"
 
 	"github.com/go-cmd/cmd"
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/config"
@@ -27,7 +30,6 @@ const (
 	versionTimeout      = 2
 	scrapeTimeout       = 5
 	tapsTimeout         = 5
-	defaultConfigPath   = "/opt/orb/agent.yaml"
 	defaultAPIHost      = "localhost"
 	defaultAPIPort      = "10853"
 )
@@ -235,20 +237,71 @@ func (p *pktvisorBackend) Configure(logger *zap.Logger, repo policies.PolicyRepo
 	p.logger = logger
 	p.policyRepo = repo
 
-	var prs bool
-	if p.binary, prs = config["binary"].(string); !prs {
-		p.binary = defaultBinary
-	}
-	if p.configFile, prs = config["config_file"].(string); !prs {
-		p.configFile = defaultConfigPath
-	}
-	if p.adminAPIHost, prs = config["api_host"].(string); !prs {
-		p.adminAPIHost = defaultAPIHost
-	}
-	if p.adminAPIPort, prs = config["api_port"].(string); !prs {
-		p.adminAPIPort = defaultAPIPort
-	}
+	p.binary = defaultBinary
+	p.adminAPIHost = defaultAPIHost
+	p.adminAPIPort = defaultAPIPort
 	p.agentLabels = common.Otel.AgentLabels
+
+	// Create temp config file
+	tmpDir := os.TempDir()
+	tmpFile, err := os.CreateTemp(tmpDir, "pktvisor-*.yaml")
+	if err != nil {
+		return fmt.Errorf("failed to create pktvisor temp config file: %w", err)
+	}
+
+	// Prepare the visor configuration structure
+	visorConfig := make(map[string]interface{})
+	configSection := make(map[string]interface{})
+
+	// Process all config entries
+	for key, value := range config {
+		switch key {
+		case "host":
+			if v, ok := value.(string); ok {
+				p.adminAPIHost = v
+			}
+			configSection[key] = value
+		case "port":
+			if v, ok := value.(string); ok {
+				p.adminAPIPort = v
+			}
+			configSection[key] = value
+		case "taps":
+			visorConfig["taps"] = value
+		default:
+			configSection[key] = value
+		}
+	}
+
+	// Only add config section if it's not empty
+	if len(configSection) > 0 {
+		visorConfig["config"] = configSection
+	}
+
+	// Create the full config structure
+	fullConfig := map[string]any{
+		"visor": visorConfig,
+	}
+
+	// Convert config to YAML
+	yamlData, err := yaml.Marshal(fullConfig)
+	if err != nil {
+		if rerr := os.Remove(tmpFile.Name()); rerr != nil {
+			p.logger.Error("failed to remove temp config file", zap.String("file", tmpFile.Name()), zap.Error(rerr))
+		}
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	// Write config to temp file
+	if err := os.WriteFile(tmpFile.Name(), yamlData, 0o644); err != nil {
+		if rerr := os.Remove(tmpFile.Name()); rerr != nil {
+			p.logger.Error("failed to remove temp config file", zap.String("file", tmpFile.Name()), zap.Error(rerr))
+		}
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	// Update config file path to use the temp file
+	p.configFile = tmpFile.Name()
 
 	if common.Otel.Host != "" && common.Otel.Port != 0 {
 		p.otelReceiverHost = common.Otel.Host

--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -287,7 +287,7 @@ func (p *pktvisorBackend) Configure(logger *zap.Logger, repo policies.PolicyRepo
 	}
 
 	// Write config to temp file
-	if err := os.WriteFile(tmpFile.Name(), yamlData, 0644); err != nil {
+	if err := os.WriteFile(tmpFile.Name(), yamlData, 0o644); err != nil {
 		if rerr := os.Remove(tmpFile.Name()); rerr != nil {
 			p.logger.Error("failed to remove temp config file", zap.String("file", tmpFile.Name()), zap.Error(rerr))
 		}

--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -267,17 +267,14 @@ func (p *pktvisorBackend) Configure(logger *zap.Logger, repo policies.PolicyRepo
 		}
 	}
 
-	// Only add config section if it's not empty
 	if len(configSection) > 0 {
 		visorConfig["config"] = configSection
 	}
 
-	// Create the full config structure
 	fullConfig := map[string]any{
 		"visor": visorConfig,
 	}
 
-	// Convert config to YAML
 	yamlData, err := yaml.Marshal(fullConfig)
 	if err != nil {
 		if rerr := os.Remove(tmpFile.Name()); rerr != nil {
@@ -285,8 +282,6 @@ func (p *pktvisorBackend) Configure(logger *zap.Logger, repo policies.PolicyRepo
 		}
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
-
-	// Write config to temp file
 	if err := os.WriteFile(tmpFile.Name(), yamlData, 0o644); err != nil {
 		if rerr := os.Remove(tmpFile.Name()); rerr != nil {
 			p.logger.Error("failed to remove temp config file", zap.String("file", tmpFile.Name()), zap.Error(rerr))
@@ -294,7 +289,6 @@ func (p *pktvisorBackend) Configure(logger *zap.Logger, repo policies.PolicyRepo
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
 
-	// Update config file path to use the temp file
 	p.configFile = tmpFile.Name()
 
 	if common.Otel.Host != "" && common.Otel.Port != 0 {

--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -112,13 +112,7 @@ func (p *pktvisorBackend) Start(ctx context.Context, cancelFunc context.CancelFu
 		return err
 	}
 
-	pvOptions := []string{
-		"--admin-api",
-		"-l",
-		p.adminAPIHost,
-		"-p",
-		p.adminAPIPort,
-	}
+	pvOptions := []string{"--admin-api"}
 	if len(p.configFile) > 0 {
 		pvOptions = append(pvOptions, "--config", p.configFile)
 	}
@@ -293,7 +287,7 @@ func (p *pktvisorBackend) Configure(logger *zap.Logger, repo policies.PolicyRepo
 	}
 
 	// Write config to temp file
-	if err := os.WriteFile(tmpFile.Name(), yamlData, 0o644); err != nil {
+	if err := os.WriteFile(tmpFile.Name(), yamlData, 0644); err != nil {
 		if rerr := os.Remove(tmpFile.Name()); rerr != nil {
 			p.logger.Error("failed to remove temp config file", zap.String("file", tmpFile.Name()), zap.Error(rerr))
 		}

--- a/agent/backend/pktvisor/vars.go
+++ b/agent/backend/pktvisor/vars.go
@@ -7,7 +7,6 @@ import (
 // RegisterBackendSpecificVariables registers the backend specific variables for the pktvisor backend
 func RegisterBackendSpecificVariables(v *viper.Viper) {
 	v.SetDefault("orb.backends.pktvisor.binary", "/usr/local/bin/pktvisord")
-	v.SetDefault("orb.backends.pktvisor.config_file", "/opt/orb/agent.yaml")
-	v.SetDefault("orb.backends.pktvisor.api_host", "localhost")
-	v.SetDefault("orb.backends.pktvisor.api_port", "10853")
+	v.SetDefault("orb.backends.pktvisor.host", "localhost")
+	v.SetDefault("orb.backends.pktvisor.port", "10853")
 }


### PR DESCRIPTION
This pull request includes several changes to the `pktvisor` backend in the `agent` package. The key changes involve updating configuration handling, modifying default settings, and improving error handling. Below are the most important changes:

### Configuration Handling:

* Introduced the creation of a temporary YAML configuration file within the `Configure` method, including the conversion of the configuration map to YAML and writing it to the temp file. (`agent/backend/pktvisor/pktvisor.go`)

### Default Settings:

* Removed the `defaultConfigPath` constant and updated default settings for `host` and `port` in `RegisterBackendSpecificVariables`. (`agent/backend/pktvisor/pktvisor.go`, `agent/backend/pktvisor/vars.go`) [[1]](diffhunk://#diff-a3efed70ceda5dfeee2a24c126eae9180ce3866c316f85a0b436c0fadae66c19L30) [[2]](diffhunk://#diff-570c7341463e750d085e9c0dfbc23ae7bbeff0ff1a712834d49ab073e8cfd2d0L10-R11)

### Imports and Dependencies:

* Added new imports for `fmt`, `os`, and `yaml.v3` to support the new configuration handling logic. (`agent/backend/pktvisor/pktvisor.go`)