### PR TITLE
fix: docker image nmap issue

### DIFF
--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -29,9 +29,8 @@ FROM python:3.12-slim-bullseye
 
 RUN \
     apt update && \
-    apt install --yes --no-install-recommends nmap libcap2-bin openssh-client && \
-    rm -rf /var/lib/apt && \
-    setcap cap_net_raw,cap_net_admin=eip $(which nmap)
+    apt install --yes --no-install-recommends nmap openssh-client && \
+    rm -rf /var/lib/apt
 
 RUN mkdir -p /opt/orb
 


### PR DESCRIPTION
This pull request includes a small change to the `agent/docker/Dockerfile` file. The change removes the installation of the `libcap2-bin` package and the setting of capabilities for `nmap`.

Changes in `agent/docker/Dockerfile`:

* Removed the installation of `libcap2-bin` and the setting of capabilities for `nmap`.
* This avoids not permitted operation with nmap