### PR TITLE
chore: Add secrets manager documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,28 @@ Currently, only the `local` and `git` sources are supported for config manager.
 - [Local](./docs/configs/local.md)
 - [Git](./docs/configs/git.md)
 
+### Secrets Manager
+The `secrets_manager` section specifies how Orb agent should retrieve and inject secrets into policies. The secrets manager can reference external secret stores like HashiCorp Vault to retrieve sensitive information such as credentials without hardcoding them in configuration files.
+
+```yaml
+orb:
+  secrets_manager:
+    active: vault
+    sources:
+      vault:
+        address: "https://vault.example.com:8200"
+        namespace: "my-namespace"
+        timeout: 60
+        auth: "token"
+        auth_args:
+          token: "${VAULT_TOKEN}"
+        schedule: "*/5 * * * *"
+  ...
+```
+
+Currently, only HashiCorp Vault is supported as a secrets manager.
+- [Vault](./docs/secretsmgr/vault.md)
+
 ### Backends
 The `backends` section specifies what Orb agent backends should be enabled. Each Orb agent backend offers specific discovery or observability capabilities and may require specific configuration information.  
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ orb:
   ...
 ```
 
-Currently, only HashiCorp Vault is supported as a secrets manager.
-- [Vault](./docs/secretsmgr/vault.md)
+Supported secrets managers:
+- [HashiCorp Vault](./docs/secretsmgr/vault.md)
 
 ### Backends
 The `backends` section specifies what Orb agent backends should be enabled. Each Orb agent backend offers specific discovery or observability capabilities and may require specific configuration information.  

--- a/docs/secretsmgr/vault.md
+++ b/docs/secretsmgr/vault.md
@@ -1,0 +1,127 @@
+# Vault Secrets Manager
+
+The Orb Agent can integrate with HashiCorp Vault to securely manage sensitive information such as passwords and API keys. This feature allows you to reference secrets stored in Vault directly in your policy configurations without hardcoding sensitive values.
+
+## Configuration
+
+The Vault secrets manager is configured in the `secrets_manager` section of your Orb Agent configuration file:
+
+```yaml
+orb:
+  secrets_manager:
+    active: vault
+    sources:
+      vault:
+        address: "https://vault.example.com:8200"
+        namespace: "my-namespace"  # Optional
+        timeout: 60  # Optional, in seconds
+        auth: "token"  # Required, see authentication methods below
+        auth_args:     # Required, depends on the auth method
+          token: "${VAULT_TOKEN}"
+        schedule: "*/5 * * * *"  # Optional, cron format for polling interval
+```
+
+### Configuration Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `address` | string | Yes | The URL of your Vault server |
+| `namespace` | string | No | Vault Enterprise namespace |
+| `timeout` | int | No | Request timeout in seconds (default: 60) |
+| `auth` | string | Yes | Authentication method (see below) |
+| `auth_args` | map | Yes | Authentication method arguments |
+| `schedule` | string | No | Cron expression for secret polling interval |
+
+## Authentication Methods
+
+The Vault secrets manager supports several authentication methods:
+
+### Token Authentication
+
+```yaml
+auth: "token"
+auth_args:
+  token: "s.abcdefghijklmnopqrstuvwxyz"
+```
+
+### AppRole Authentication
+
+```yaml
+auth: "approle"
+auth_args:
+  role_id: "12345678-abcd-efgh-ijkl-123456789012"
+  secret_id: "98765432-zyxw-vusr-qpon-987654321098"
+  wrapping_token: false  # Optional
+  mount_path: "approle"  # Optional
+```
+
+### UserPass Authentication
+
+```yaml
+auth: "userpass"
+auth_args:
+  username: "myuser"
+  password: "mypassword"
+  mount_path: "userpass"  # Optional
+```
+
+### Kubernetes Authentication
+
+```yaml
+auth: "kubernetes"
+auth_args:
+  role: "orb-agent"
+  service_account_file: "/var/run/secrets/kubernetes.io/serviceaccount/token"  # Optional
+  mount_path: "kubernetes"  # Optional
+```
+
+### LDAP Authentication
+
+```yaml
+auth: "ldap"
+auth_args:
+  username: "myuser"
+  password: "mypassword"
+  mount_path: "ldap"  # Optional
+```
+
+## Usage
+
+To use a secret from Vault in your policy configuration, use the following format:
+
+```
+${vault://engine/path/to/secret/key}
+```
+
+For example, if you have a KV v2 secret engine mounted at `kv` with a secret at `path/credentials` that has a key `password` with value `secretvalue`, you would reference it as:
+
+```
+${vault://kv/path/credentials/password}
+```
+
+### Example
+
+Here's an example of using Vault secrets in a device discovery policy:
+
+```yaml
+orb:
+  policies:
+    device_discovery:
+      discovery_1:
+        schedule: "0 * * * *"  # Run hourly
+        defaults:
+          site: NY
+        scope:
+          - driver: ios
+            hostname: 10.1.2.24
+            username: admin
+            password: "${vault://secret/cisco/v8000/password}"
+```
+
+The Orb Agent will resolve the Vault reference and use the actual secret value from Vault when the policy is applied.
+
+## Secret Polling
+
+If you configure the `schedule` parameter, the Orb Agent will periodically check for changes to referenced secrets. If a secret value changes, the related policies are automatically updated with the new values.
+
+This is useful for credential rotation scenarios, where you want to update credentials in Vault without restarting the Orb Agent or manually updating policies.


### PR DESCRIPTION
This pull request introduces a new feature for integrating the Orb Agent with HashiCorp Vault for managing secrets. The changes include updates to the documentation and configuration files to support this new functionality.

### New Feature: HashiCorp Vault Integration

* **README.md**: Added a new section for the `secrets_manager` to explain how to configure and use HashiCorp Vault for retrieving and injecting secrets into policies.
* **docs/secretsmgr/vault.md**: Created a new documentation file detailing the configuration options and usage of the Vault secrets manager, including various authentication methods and examples of how to reference secrets in policy configurations.