### PR TITLE
chore: add unit tests for policies, policymgr and secretsmgr packages

### DIFF
--- a/agent/policies/repo_test.go
+++ b/agent/policies/repo_test.go
@@ -1,0 +1,396 @@
+package policies_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/policies"
+)
+
+func TestNewMemRepo(t *testing.T) {
+	repo, err := policies.NewMemRepo()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, repo)
+}
+
+func TestExists(t *testing.T) {
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	// Non-existent policy
+	exists := repo.Exists("non-existent-id")
+	assert.False(t, exists)
+
+	// Create a policy
+	pd := policies.PolicyData{
+		ID:       "test-id",
+		Name:     "test-policy",
+		Backend:  "test-backend",
+		Version:  1,
+		Datasets: map[string]bool{"dataset1": true},
+		GroupIDs: map[string]bool{"group1": true},
+		Data:     map[string]any{"key": "value"},
+		State:    policies.Unknown,
+	}
+
+	err = repo.Update(pd)
+	require.NoError(t, err)
+
+	// Now it should exist
+	exists = repo.Exists("test-id")
+	assert.True(t, exists)
+}
+
+func TestGet(t *testing.T) {
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	// Try to get a non-existent policy
+	_, err = repo.Get("non-existent-id")
+	assert.Error(t, err)
+
+	// Create a policy
+	pd := policies.PolicyData{
+		ID:       "test-id",
+		Name:     "test-policy",
+		Backend:  "test-backend",
+		Version:  1,
+		Datasets: map[string]bool{"dataset1": true},
+		GroupIDs: map[string]bool{"group1": true},
+		Data:     map[string]any{"key": "value"},
+		State:    policies.Unknown,
+	}
+
+	err = repo.Update(pd)
+	require.NoError(t, err)
+
+	// Get the policy
+	retrievedPD, err := repo.Get("test-id")
+	require.NoError(t, err)
+
+	assert.Equal(t, pd.ID, retrievedPD.ID)
+	assert.Equal(t, pd.Name, retrievedPD.Name)
+	assert.Equal(t, pd.Backend, retrievedPD.Backend)
+	assert.Equal(t, pd.Version, retrievedPD.Version)
+	assert.Equal(t, pd.Datasets, retrievedPD.Datasets)
+	assert.Equal(t, pd.GroupIDs, retrievedPD.GroupIDs)
+	assert.Equal(t, pd.State, retrievedPD.State)
+}
+
+func TestGetByName(t *testing.T) {
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	// Try to get a non-existent policy by name
+	_, err = repo.GetByName("non-existent-name")
+	assert.Error(t, err)
+
+	// Create a policy
+	pd := policies.PolicyData{
+		ID:       "test-id",
+		Name:     "test-policy",
+		Backend:  "test-backend",
+		Version:  1,
+		Datasets: map[string]bool{"dataset1": true},
+		GroupIDs: map[string]bool{"group1": true},
+		Data:     map[string]any{"key": "value"},
+		State:    policies.Unknown,
+	}
+
+	err = repo.Update(pd)
+	require.NoError(t, err)
+
+	// Get the policy by name
+	retrievedPD, err := repo.GetByName("test-policy")
+	require.NoError(t, err)
+
+	assert.Equal(t, pd.ID, retrievedPD.ID)
+	assert.Equal(t, pd.Name, retrievedPD.Name)
+}
+
+func TestUpdate(t *testing.T) {
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	// Create a policy
+	pd := policies.PolicyData{
+		ID:       "test-id",
+		Name:     "test-policy",
+		Backend:  "test-backend",
+		Version:  1,
+		Datasets: map[string]bool{"dataset1": true},
+		GroupIDs: map[string]bool{"group1": true},
+		Data:     map[string]any{"key": "value"},
+		State:    policies.Unknown,
+	}
+
+	err = repo.Update(pd)
+	require.NoError(t, err)
+
+	// Update the policy
+	pd.Version = 2
+	pd.State = policies.Running
+
+	err = repo.Update(pd)
+	require.NoError(t, err)
+
+	// Get the updated policy
+	retrievedPD, err := repo.Get("test-id")
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(2), retrievedPD.Version)
+	assert.Equal(t, policies.Running, retrievedPD.State)
+}
+
+func TestRemove(t *testing.T) {
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	// Try to remove a non-existent policy
+	err = repo.Remove("non-existent-id")
+	assert.Error(t, err)
+
+	// Create a policy
+	pd := policies.PolicyData{
+		ID:       "test-id",
+		Name:     "test-policy",
+		Backend:  "test-backend",
+		Version:  1,
+		Datasets: map[string]bool{"dataset1": true},
+		GroupIDs: map[string]bool{"group1": true},
+		Data:     map[string]any{"key": "value"},
+		State:    policies.Unknown,
+	}
+
+	err = repo.Update(pd)
+	require.NoError(t, err)
+
+	// Remove the policy
+	err = repo.Remove("test-id")
+	assert.NoError(t, err)
+
+	// Verify it's removed
+	exists := repo.Exists("test-id")
+	assert.False(t, exists)
+
+	// Verify name mapping is also removed
+	_, err = repo.GetByName("test-policy")
+	assert.Error(t, err)
+}
+
+func TestGetAll(t *testing.T) {
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	// Get all policies when none exist
+	allPolicies, err := repo.GetAll()
+	require.NoError(t, err)
+	assert.Empty(t, allPolicies)
+
+	// Create policies
+	pd1 := policies.PolicyData{
+		ID:       "test-id-1",
+		Name:     "test-policy-1",
+		Backend:  "test-backend",
+		Version:  1,
+		Datasets: map[string]bool{"dataset1": true},
+		GroupIDs: map[string]bool{"group1": true},
+		Data:     map[string]any{"key": "value"},
+		State:    policies.Unknown,
+	}
+
+	pd2 := policies.PolicyData{
+		ID:       "test-id-2",
+		Name:     "test-policy-2",
+		Backend:  "test-backend",
+		Version:  1,
+		Datasets: map[string]bool{"dataset2": true},
+		GroupIDs: map[string]bool{"group2": true},
+		Data:     map[string]any{"key": "value"},
+		State:    policies.Running,
+	}
+
+	err = repo.Update(pd1)
+	require.NoError(t, err)
+
+	err = repo.Update(pd2)
+	require.NoError(t, err)
+
+	// Get all policies
+	allPolicies, err = repo.GetAll()
+	require.NoError(t, err)
+
+	assert.Len(t, allPolicies, 2)
+
+	// Create a map of policies by ID for easier checking
+	policiesMap := make(map[string]policies.PolicyData)
+	for _, p := range allPolicies {
+		policiesMap[p.ID] = p
+	}
+
+	// Verify both policies are returned
+	assert.Contains(t, policiesMap, "test-id-1")
+	assert.Contains(t, policiesMap, "test-id-2")
+}
+
+func TestEnsureDataset(t *testing.T) {
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	// Try to ensure dataset for a non-existent policy
+	err = repo.EnsureDataset("non-existent-id", "dataset2")
+	assert.Error(t, err)
+
+	// Create a policy
+	pd := policies.PolicyData{
+		ID:       "test-id",
+		Name:     "test-policy",
+		Backend:  "test-backend",
+		Version:  1,
+		Datasets: map[string]bool{"dataset1": true},
+		GroupIDs: map[string]bool{"group1": true},
+		Data:     map[string]any{"key": "value"},
+		State:    policies.Unknown,
+	}
+
+	err = repo.Update(pd)
+	require.NoError(t, err)
+
+	// Ensure a new dataset
+	err = repo.EnsureDataset("test-id", "dataset2")
+	assert.NoError(t, err)
+
+	// Verify the dataset is added
+	retrievedPD, err := repo.Get("test-id")
+	require.NoError(t, err)
+
+	assert.True(t, retrievedPD.Datasets["dataset1"])
+	assert.True(t, retrievedPD.Datasets["dataset2"])
+}
+
+func TestRemoveDataset(t *testing.T) {
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	// Try to remove dataset from a non-existent policy
+	_, err = repo.RemoveDataset("non-existent-id", "dataset1")
+	assert.Error(t, err)
+
+	// Create a policy with multiple datasets
+	pd := policies.PolicyData{
+		ID:       "test-id",
+		Name:     "test-policy",
+		Backend:  "test-backend",
+		Version:  1,
+		Datasets: map[string]bool{"dataset1": true, "dataset2": true, "dataset3": true},
+		GroupIDs: map[string]bool{"group1": true},
+		Data:     map[string]any{"key": "value"},
+		State:    policies.Unknown,
+	}
+
+	err = repo.Update(pd)
+	require.NoError(t, err)
+
+	// Remove a dataset that doesn't affect policy removal
+	removePolicy, err := repo.RemoveDataset("test-id", "dataset1")
+	require.NoError(t, err)
+	assert.False(t, removePolicy)
+
+	// Verify the dataset is removed but policy still exists
+	retrievedPD, err := repo.Get("test-id")
+	require.NoError(t, err)
+	assert.False(t, retrievedPD.Datasets["dataset1"])
+	assert.True(t, retrievedPD.Datasets["dataset2"])
+	assert.True(t, retrievedPD.Datasets["dataset3"])
+
+	// Remove another dataset
+	removePolicy, err = repo.RemoveDataset("test-id", "dataset2")
+	require.NoError(t, err)
+	assert.False(t, removePolicy)
+
+	// Remove the last dataset which should trigger policy removal
+	removePolicy, err = repo.RemoveDataset("test-id", "dataset3")
+	require.NoError(t, err)
+	assert.True(t, removePolicy)
+
+	// Verify the datasets are all removed
+	retrievedPD, err = repo.Get("test-id")
+	require.NoError(t, err)
+	assert.Empty(t, retrievedPD.Datasets)
+}
+
+func TestEnsureGroupID(t *testing.T) {
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	// Try to ensure group ID for a non-existent policy
+	err = repo.EnsureGroupID("non-existent-id", "group2")
+	assert.Error(t, err)
+
+	// Create a policy
+	pd := policies.PolicyData{
+		ID:       "test-id",
+		Name:     "test-policy",
+		Backend:  "test-backend",
+		Version:  1,
+		Datasets: map[string]bool{"dataset1": true},
+		GroupIDs: map[string]bool{"group1": true},
+		Data:     map[string]any{"key": "value"},
+		State:    policies.Unknown,
+	}
+
+	err = repo.Update(pd)
+	require.NoError(t, err)
+
+	// Ensure a new group ID
+	err = repo.EnsureGroupID("test-id", "group2")
+	assert.NoError(t, err)
+
+	// Verify the group ID is added
+	retrievedPD, err := repo.Get("test-id")
+	require.NoError(t, err)
+
+	assert.True(t, retrievedPD.GroupIDs["group1"])
+	assert.True(t, retrievedPD.GroupIDs["group2"])
+}
+
+func TestUpdateRenamingPolicy(t *testing.T) {
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	// Create a policy
+	pd := policies.PolicyData{
+		ID:       "test-id",
+		Name:     "old-name",
+		Backend:  "test-backend",
+		Version:  1,
+		Datasets: map[string]bool{"dataset1": true},
+		GroupIDs: map[string]bool{"group1": true},
+		Data:     map[string]any{"key": "value"},
+		State:    policies.Unknown,
+	}
+
+	err = repo.Update(pd)
+	require.NoError(t, err)
+
+	// Verify we can get by old name
+	_, err = repo.GetByName("old-name")
+	require.NoError(t, err)
+
+	// Update the policy with a new name
+	pd.Name = "new-name"
+	err = repo.Update(pd)
+	require.NoError(t, err)
+
+	// Verify we can get by new name
+	retrievedPD, err := repo.GetByName("new-name")
+	require.NoError(t, err)
+	assert.Equal(t, "test-id", retrievedPD.ID)
+
+	// Verify we cannot get by old name
+	_, err = repo.GetByName("old-name")
+	assert.Error(t, err)
+}

--- a/agent/policies/types_test.go
+++ b/agent/policies/types_test.go
@@ -1,0 +1,95 @@
+package policies_test
+
+import (
+	"database/sql/driver"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/netboxlabs/orb-agent/agent/policies"
+)
+
+func TestPolicyStateString(t *testing.T) {
+	testCases := []struct {
+		state    policies.PolicyState
+		expected string
+	}{
+		{policies.Unknown, "unknown"},
+		{policies.Running, "running"},
+		{policies.FailedToApply, "failed_to_apply"},
+		{policies.Offline, "offline"},
+		{policies.NoTapMatch, "no_tap_match"},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expected, tc.state.String())
+	}
+}
+
+func TestPolicyStateScan(t *testing.T) {
+	testCases := []struct {
+		input    []byte
+		expected policies.PolicyState
+	}{
+		{[]byte("unknown"), policies.Unknown},
+		{[]byte("running"), policies.Running},
+		{[]byte("failed_to_apply"), policies.FailedToApply},
+		{[]byte("offline"), policies.Offline},
+		{[]byte("no_tap_match"), policies.NoTapMatch},
+	}
+
+	for _, tc := range testCases {
+		var state policies.PolicyState
+		err := state.Scan(tc.input)
+
+		assert.NoError(t, err)
+		assert.Equal(t, tc.expected, state)
+	}
+}
+
+func TestPolicyStateValue(t *testing.T) {
+	testCases := []struct {
+		state    policies.PolicyState
+		expected driver.Value
+	}{
+		{policies.Unknown, "unknown"},
+		{policies.Running, "running"},
+		{policies.FailedToApply, "failed_to_apply"},
+		{policies.Offline, "offline"},
+		{policies.NoTapMatch, "no_tap_match"},
+	}
+
+	for _, tc := range testCases {
+		value, err := tc.state.Value()
+
+		assert.NoError(t, err)
+		assert.Equal(t, tc.expected, value)
+	}
+}
+
+func TestGetDatasetIDs(t *testing.T) {
+	testCases := []struct {
+		datasets  map[string]bool
+		expectedN int
+	}{
+		{map[string]bool{}, 0},
+		{map[string]bool{"dataset1": true}, 1},
+		{map[string]bool{"dataset1": true, "dataset2": true}, 2},
+		{map[string]bool{"dataset1": true, "dataset2": true, "dataset3": true}, 3},
+	}
+
+	for _, tc := range testCases {
+		pd := policies.PolicyData{
+			Datasets: tc.datasets,
+		}
+
+		ids := pd.GetDatasetIDs()
+
+		assert.Len(t, ids, tc.expectedN)
+
+		// Verify all expected IDs are in the result
+		for id := range tc.datasets {
+			assert.Contains(t, ids, id)
+		}
+	}
+}

--- a/agent/policymgr/manager_test.go
+++ b/agent/policymgr/manager_test.go
@@ -1,0 +1,674 @@
+package policymgr_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/config"
+	"github.com/netboxlabs/orb-agent/agent/policies"
+	"github.com/netboxlabs/orb-agent/agent/policymgr"
+)
+
+// Mock for the backend.Backend interface
+type mockBackend struct {
+	mock.Mock
+	name string
+}
+
+func (m *mockBackend) GetName() string {
+	return m.name
+}
+
+func (m *mockBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo, cfg map[string]any, commons config.BackendCommons) error {
+	args := m.Called(logger, repo, cfg, commons)
+	return args.Error(0)
+}
+
+func (m *mockBackend) Version() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
+func (m *mockBackend) Start(ctx context.Context, cancelFunc context.CancelFunc) error {
+	args := m.Called(ctx, cancelFunc)
+	return args.Error(0)
+}
+
+func (m *mockBackend) Stop(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockBackend) FullReset(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockBackend) GetStartTime() time.Time {
+	args := m.Called()
+	return args.Get(0).(time.Time)
+}
+
+func (m *mockBackend) GetCapabilities() (map[string]any, error) {
+	args := m.Called()
+	return args.Get(0).(map[string]any), args.Error(1)
+}
+
+func (m *mockBackend) GetRunningStatus() (backend.RunningStatus, string, error) {
+	args := m.Called()
+	return args.Get(0).(backend.RunningStatus), args.String(1), args.Error(2)
+}
+
+func (m *mockBackend) GetInitialState() backend.RunningStatus {
+	args := m.Called()
+	return args.Get(0).(backend.RunningStatus)
+}
+
+func (m *mockBackend) ApplyPolicy(policy policies.PolicyData, updatePolicy bool) error {
+	args := m.Called(policy, updatePolicy)
+	return args.Error(0)
+}
+
+func (m *mockBackend) RemovePolicy(policy policies.PolicyData) error {
+	args := m.Called(policy)
+	return args.Error(0)
+}
+
+// Mock for the secretsmgr.Manager interface
+type mockSecretsManager struct {
+	mock.Mock
+	callbacks []func(map[string]bool)
+}
+
+func (m *mockSecretsManager) SolveSecrets(payload config.PolicyPayload) (config.PolicyPayload, error) {
+	args := m.Called(payload)
+	return args.Get(0).(config.PolicyPayload), args.Error(1)
+}
+
+func (m *mockSecretsManager) RegisterUpdateCallback(callback func(map[string]bool)) {
+	m.callbacks = append(m.callbacks, callback)
+}
+
+func (m *mockSecretsManager) Start(context.Context) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *mockSecretsManager) TriggerCallbacks(policiesIDs map[string]bool) {
+	for _, callback := range m.callbacks {
+		callback(policiesIDs)
+	}
+}
+
+func TestNew(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	cfg := config.Config{}
+
+	mgr, err := policymgr.New(logger, secretsMgr, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, mgr)
+
+	// Verify the repo was properly initialized
+	repo := mgr.GetRepo()
+	require.NotNil(t, repo)
+}
+
+func TestManagePolicy_ManageAction_NewPolicy(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	cfg := config.Config{}
+
+	// Configure mock backend
+	mockBe := &mockBackend{name: "testbackend"}
+	backend.Register("testbackend", mockBe)
+
+	mgr, err := policymgr.New(logger, secretsMgr, cfg)
+	require.NoError(t, err)
+
+	// Set up expectations
+	policyData := map[string]any{"key": "value"}
+	payload := config.PolicyPayload{
+		Action:       "manage",
+		ID:           "policy1",
+		Name:         "Test Policy",
+		Backend:      "testbackend",
+		Version:      1,
+		Data:         policyData,
+		DatasetID:    "dataset1",
+		AgentGroupID: "group1",
+	}
+
+	solvedPayload := payload
+	secretsMgr.On("SolveSecrets", payload).Return(solvedPayload, nil)
+
+	expectedPolicy := policies.PolicyData{
+		ID:       "policy1",
+		Name:     "Test Policy",
+		Backend:  "testbackend",
+		Version:  1,
+		Data:     policyData,
+		State:    policies.Running,
+		Datasets: map[string]bool{"dataset1": true},
+		GroupIDs: map[string]bool{"group1": true},
+	}
+
+	mockBe.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool {
+		return pd.ID == expectedPolicy.ID && pd.Name == expectedPolicy.Name
+	}), false).Return(nil)
+
+	// Execute
+	mgr.ManagePolicy(payload)
+
+	// Validate
+	mockBe.AssertExpectations(t)
+	secretsMgr.AssertExpectations(t)
+
+	// Verify policy is in repo with correct state
+	state, err := mgr.GetPolicyState()
+	require.NoError(t, err)
+	require.Len(t, state, 1)
+	assert.Equal(t, expectedPolicy.ID, state[0].ID)
+	assert.Equal(t, expectedPolicy.Name, state[0].Name)
+	assert.Equal(t, policies.Running, state[0].State)
+	assert.Equal(t, expectedPolicy.Datasets, state[0].Datasets)
+	assert.Equal(t, expectedPolicy.GroupIDs, state[0].GroupIDs)
+}
+
+func TestManagePolicy_ManageAction_UpdatePolicy(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	cfg := config.Config{}
+
+	// Configure mock backend
+	mockBe := &mockBackend{name: "testbackend"}
+	backend.Register("testbackend", mockBe)
+
+	mgr, err := policymgr.New(logger, secretsMgr, cfg)
+	require.NoError(t, err)
+
+	// First add a policy
+	initialPayload := config.PolicyPayload{
+		Action:    "manage",
+		ID:        "policy1",
+		Name:      "Test Policy",
+		Backend:   "testbackend",
+		Version:   1,
+		Data:      map[string]any{"key": "value"},
+		DatasetID: "dataset1",
+	}
+
+	secretsMgr.On("SolveSecrets", initialPayload).Return(initialPayload, nil)
+	mockBe.On("ApplyPolicy", mock.Anything, false).Return(nil)
+
+	// Initial setup
+	mgr.ManagePolicy(initialPayload)
+
+	// Now update the policy with a higher version
+	updatePayload := config.PolicyPayload{
+		Action:    "manage",
+		ID:        "policy1",
+		Name:      "Updated Policy", // Changed name
+		Backend:   "testbackend",
+		Version:   2, // Increased version
+		Data:      map[string]any{"key": "updated"},
+		DatasetID: "dataset2", // Additional dataset
+	}
+
+	secretsMgr.On("SolveSecrets", updatePayload).Return(updatePayload, nil)
+	mockBe.On("ApplyPolicy", mock.Anything, true).Return(nil)
+
+	// Execute the update
+	mgr.ManagePolicy(updatePayload)
+
+	// Validate state after update
+	state, err := mgr.GetPolicyState()
+	require.NoError(t, err)
+	require.Len(t, state, 1)
+
+	// Check updated properties
+	assert.Equal(t, "policy1", state[0].ID)
+	assert.Equal(t, "Updated Policy", state[0].Name)
+	assert.Equal(t, int32(2), state[0].Version)
+	assert.Equal(t, policies.Running, state[0].State)
+
+	// Check that both datasets are there
+	assert.True(t, state[0].Datasets["dataset1"])
+	assert.True(t, state[0].Datasets["dataset2"])
+
+	// Check for PreviousPolicyData with original name
+	require.NotNil(t, state[0].PreviousPolicyData)
+	assert.Equal(t, "Test Policy", state[0].PreviousPolicyData.Name)
+}
+
+func TestManagePolicy_ManageAction_BackendUnavailable(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	cfg := config.Config{}
+
+	// Don't register any backends
+
+	mgr, err := policymgr.New(logger, secretsMgr, cfg)
+	require.NoError(t, err)
+
+	payload := config.PolicyPayload{
+		Action:    "manage",
+		ID:        "policy1",
+		Name:      "Test Policy",
+		Backend:   "unavailablebackend", // This backend doesn't exist
+		Version:   1,
+		Data:      map[string]any{"key": "value"},
+		DatasetID: "dataset1",
+	}
+
+	// Execute
+	mgr.ManagePolicy(payload)
+
+	// Validate state - policy should be saved but marked as failed
+	state, err := mgr.GetPolicyState()
+	require.NoError(t, err)
+	require.Len(t, state, 1)
+	assert.Equal(t, "policy1", state[0].ID)
+	assert.Equal(t, policies.FailedToApply, state[0].State)
+	assert.Equal(t, "backend not available", state[0].BackendErr)
+}
+
+func TestManagePolicy_RemoveAction(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	cfg := config.Config{}
+
+	mockBe := &mockBackend{name: "testbackend"}
+	backend.Register("testbackend", mockBe)
+
+	mgr, err := policymgr.New(logger, secretsMgr, cfg)
+	require.NoError(t, err)
+
+	// First add a policy
+	initialPayload := config.PolicyPayload{
+		Action:    "manage",
+		ID:        "policy1",
+		Name:      "Test Policy",
+		Backend:   "testbackend",
+		Version:   1,
+		Data:      map[string]any{"key": "value"},
+		DatasetID: "dataset1",
+	}
+
+	secretsMgr.On("SolveSecrets", initialPayload).Return(initialPayload, nil)
+	mockBe.On("ApplyPolicy", mock.Anything, false).Return(nil)
+
+	// Initial setup
+	mgr.ManagePolicy(initialPayload)
+
+	// Now remove the policy
+	removePayload := config.PolicyPayload{
+		Action:  "remove",
+		ID:      "policy1",
+		Name:    "Test Policy",
+		Backend: "testbackend",
+	}
+
+	mockBe.On("RemovePolicy", mock.MatchedBy(func(pd policies.PolicyData) bool {
+		return pd.ID == "policy1" && pd.Name == "Test Policy"
+	})).Return(nil)
+
+	// Execute remove
+	mgr.ManagePolicy(removePayload)
+
+	// Validate - policy should be removed
+	state, err := mgr.GetPolicyState()
+	require.NoError(t, err)
+	assert.Empty(t, state)
+}
+
+func TestRemovePolicy(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	cfg := config.Config{}
+
+	mockBe := &mockBackend{name: "testbackend"}
+	backend.Register("testbackend", mockBe)
+
+	mgr, err := policymgr.New(logger, secretsMgr, cfg)
+	require.NoError(t, err)
+
+	// Add a policy to the repo first (we need to use ManagePolicy)
+	addPayload := config.PolicyPayload{
+		Action:    "manage",
+		ID:        "policy1",
+		Name:      "Test Policy",
+		Backend:   "testbackend",
+		Version:   1,
+		Data:      map[string]any{},
+		DatasetID: "dataset1",
+	}
+	secretsMgr.On("SolveSecrets", addPayload).Return(addPayload, nil)
+	mockBe.On("ApplyPolicy", mock.Anything, false).Return(nil)
+	mgr.ManagePolicy(addPayload)
+
+	// Set up expectations for removal
+	mockBe.On("RemovePolicy", mock.MatchedBy(func(pd policies.PolicyData) bool {
+		return pd.ID == "policy1" && pd.Name == "Test Policy"
+	})).Return(nil)
+
+	// Execute removal
+	err = mgr.RemovePolicy("policy1", "Test Policy", "testbackend")
+	require.NoError(t, err)
+
+	// Verify policy is gone
+	state, err := mgr.GetPolicyState()
+	require.NoError(t, err)
+	assert.Empty(t, state)
+}
+
+func TestRemoveBackendPolicies(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	cfg := config.Config{}
+
+	mockBe := &mockBackend{name: "testbackend"}
+	backend.Register("testbackend", mockBe)
+
+	mgr, err := policymgr.New(logger, secretsMgr, cfg)
+	require.NoError(t, err)
+
+	// Add multiple policies
+	for i := 1; i <= 3; i++ {
+		payload := config.PolicyPayload{
+			Action:    "manage",
+			ID:        fmt.Sprintf("policy%d", i),
+			Name:      fmt.Sprintf("Test Policy %d", i),
+			Backend:   "testbackend",
+			Version:   int32(i),
+			Data:      map[string]any{},
+			DatasetID: fmt.Sprintf("dataset%d", i),
+		}
+		secretsMgr.On("SolveSecrets", payload).Return(payload, nil)
+		mockBe.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool {
+			return pd.ID == payload.ID
+		}), false).Return(nil)
+
+		mgr.ManagePolicy(payload)
+	}
+
+	// Verify we have 3 policies
+	state, err := mgr.GetPolicyState()
+	require.NoError(t, err)
+	assert.Len(t, state, 3)
+
+	// Set up expectations for removal - all policies should be removed
+	mockBe.On("RemovePolicy", mock.Anything).Return(nil).Times(3)
+
+	// Test non-permanent removal (only marks policies as unknown)
+	err = mgr.RemoveBackendPolicies(mockBe, false)
+	require.NoError(t, err)
+
+	// Verify policies are still there but with state Unknown
+	state, err = mgr.GetPolicyState()
+	require.NoError(t, err)
+	assert.Len(t, state, 3)
+	for _, policy := range state {
+		assert.Equal(t, policies.Unknown, policy.State)
+	}
+
+	// Test permanent removal
+	mockBe.On("RemovePolicy", mock.Anything).Return(nil).Times(3)
+	err = mgr.RemoveBackendPolicies(mockBe, true)
+	require.NoError(t, err)
+
+	// Verify policies are gone
+	state, err = mgr.GetPolicyState()
+	require.NoError(t, err)
+	assert.Empty(t, state)
+}
+
+func TestApplyBackendPolicies(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	cfg := config.Config{}
+
+	mockBe := &mockBackend{name: "testbackend"}
+	backend.Register("testbackend", mockBe)
+
+	mgr, err := policymgr.New(logger, secretsMgr, cfg)
+	require.NoError(t, err)
+
+	// First add policies but mark them as unknown (simulating a backend restart)
+	repo := mgr.GetRepo()
+	for i := 1; i <= 3; i++ {
+		policy := policies.PolicyData{
+			ID:       fmt.Sprintf("policy%d", i),
+			Name:     fmt.Sprintf("Test Policy %d", i),
+			Backend:  "testbackend",
+			Version:  int32(i),
+			Data:     map[string]any{},
+			State:    policies.Unknown,
+			Datasets: map[string]bool{fmt.Sprintf("dataset%d", i): true},
+		}
+		err := repo.Update(policy)
+		require.NoError(t, err)
+	}
+
+	// Set up expectations for applying policies
+	mockBe.On("ApplyPolicy", mock.Anything, false).Return(nil).Times(3)
+
+	// Execute
+	err = mgr.ApplyBackendPolicies(mockBe)
+	require.NoError(t, err)
+
+	// Verify policies are now running
+	state, err := mgr.GetPolicyState()
+	require.NoError(t, err)
+	assert.Len(t, state, 3)
+	for _, policy := range state {
+		assert.Equal(t, policies.Running, policy.State)
+		assert.Empty(t, policy.BackendErr)
+	}
+
+	// Test error case - one policy fails to apply
+	repo = mgr.GetRepo() // Get fresh repo
+	for i := 1; i <= 3; i++ {
+		policy := policies.PolicyData{
+			ID:       fmt.Sprintf("policy%d", i),
+			Name:     fmt.Sprintf("Test Policy %d", i),
+			Backend:  "testbackend",
+			Version:  int32(i),
+			Data:     map[string]any{},
+			State:    policies.Unknown,
+			Datasets: map[string]bool{fmt.Sprintf("dataset%d", i): true},
+		}
+		err := repo.Update(policy)
+		require.NoError(t, err)
+	}
+
+	// Make policy2 fail
+	mockBe.ExpectedCalls = nil
+	mockBe.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool {
+		return pd.ID == "policy1" || pd.ID == "policy3"
+	}), false).Return(nil).Times(2)
+	mockBe.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool {
+		return pd.ID == "policy2"
+	}), false).Return(errors.New("failed to apply")).Once()
+
+	// Execute
+	err = mgr.ApplyBackendPolicies(mockBe)
+	require.NoError(t, err) // Function should not return error even if some policies fail
+
+	// Verify status
+	state, err = mgr.GetPolicyState()
+	require.NoError(t, err)
+	assert.Len(t, state, 3)
+
+	for _, policy := range state {
+		if policy.ID == "policy2" {
+			assert.Equal(t, policies.FailedToApply, policy.State)
+			assert.Equal(t, "failed to apply", policy.BackendErr)
+		} else {
+			assert.Equal(t, policies.Running, policy.State)
+			assert.Empty(t, policy.BackendErr)
+		}
+	}
+}
+
+func TestPoliciesChanged(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	cfg := config.Config{}
+
+	mockBe := &mockBackend{name: "testbackend"}
+	backend.Register("testbackend", mockBe)
+
+	mgr, err := policymgr.New(logger, secretsMgr, cfg)
+	require.NoError(t, err)
+
+	// First add some policies
+	for i := 1; i <= 3; i++ {
+		payload := config.PolicyPayload{
+			Action:    "manage",
+			ID:        fmt.Sprintf("policy%d", i),
+			Name:      fmt.Sprintf("Test Policy %d", i),
+			Backend:   "testbackend",
+			Version:   int32(i),
+			Data:      map[string]any{"original": "data"},
+			DatasetID: fmt.Sprintf("dataset%d", i),
+		}
+		secretsMgr.On("SolveSecrets", mock.MatchedBy(func(pd config.PolicyPayload) bool {
+			return pd.ID == payload.ID
+		})).Return(payload, nil)
+		mockBe.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool {
+			return pd.ID == payload.ID
+		}), mock.Anything).Return(nil)
+
+		mgr.ManagePolicy(payload)
+	}
+
+	// Set up for policy update callback
+	// Scenario: policy1 unchanged, policy2 updated, policy3 removed
+	policiesStatus := map[string]bool{
+		"policy1": true,  // Valid - no change
+		"policy2": true,  // Valid - will be updated
+		"policy3": false, // Invalid - will be removed
+	}
+	// policy3 not included, meaning it should be removed
+
+	// Setup expectations for policy2 update
+	solvedPayload := config.PolicyPayload{
+		ID:   "policy2",
+		Name: "Test Policy 2",
+		Data: map[string]any{"updated": "data"},
+	}
+	secretsMgr.On("SolveSecrets", mock.MatchedBy(func(payload config.PolicyPayload) bool {
+		return payload.ID == "policy2"
+	})).Return(solvedPayload, nil)
+
+	mockBe.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool {
+		return pd.ID == "policy2" && pd.Data.(map[string]any)["updated"] == "data"
+	}), true).Return(nil)
+
+	// Setup expectations for policy3 removal
+	mockBe.On("RemovePolicy", mock.MatchedBy(func(pd policies.PolicyData) bool {
+		return pd.ID == "policy3"
+	})).Return(nil)
+
+	// Trigger the secret update callback
+	secretsMgr.TriggerCallbacks(policiesStatus)
+
+	// Verify final state
+	state, err := mgr.GetPolicyState()
+	require.NoError(t, err)
+
+	// We should have 2 policies left
+	stateMap := make(map[string]policies.PolicyData)
+	for _, p := range state {
+		stateMap[p.ID] = p
+	}
+
+	assert.Len(t, stateMap, 2)
+	assert.Contains(t, stateMap, "policy1")
+	assert.Contains(t, stateMap, "policy2")
+	assert.NotContains(t, stateMap, "policy3")
+
+	// Verify policy2 was not updated in DB
+	updatedPolicy := stateMap["policy2"]
+	updatedData := updatedPolicy.Data.(map[string]any)
+	assert.NotEqual(t, "data", updatedData["updated"])
+}
+
+func TestRemovePolicyDataset(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	cfg := config.Config{}
+
+	mockBe := &mockBackend{name: "testbackend"}
+	backend.Register("testbackend", mockBe)
+
+	mgr, err := policymgr.New(logger, secretsMgr, cfg)
+	require.NoError(t, err)
+
+	// First add a policy with multiple datasets
+	payload := config.PolicyPayload{
+		Action:    "manage",
+		ID:        "policy1",
+		Name:      "Test Policy",
+		Backend:   "testbackend",
+		Version:   1,
+		Data:      map[string]any{},
+		DatasetID: "dataset1",
+	}
+	secretsMgr.On("SolveSecrets", payload).Return(payload, nil)
+	mockBe.On("ApplyPolicy", mock.Anything, false).Return(nil)
+	mgr.ManagePolicy(payload)
+
+	// Add another dataset to the policy
+	payload2 := config.PolicyPayload{
+		Action:    "manage",
+		ID:        "policy1", // Same policy ID
+		Name:      "Test Policy",
+		Backend:   "testbackend",
+		Version:   1,
+		Data:      map[string]any{},
+		DatasetID: "dataset2", // Different dataset
+	}
+	secretsMgr.On("SolveSecrets", payload2).Return(payload2, nil)
+	mockBe.On("ApplyPolicy", mock.Anything, true).Return(nil)
+	mgr.ManagePolicy(payload2)
+
+	// Verify policy has both datasets
+	state, err := mgr.GetPolicyState()
+	require.NoError(t, err)
+	require.Len(t, state, 1)
+	assert.Len(t, state[0].Datasets, 2)
+	assert.True(t, state[0].Datasets["dataset1"])
+	assert.True(t, state[0].Datasets["dataset2"])
+
+	// Test removing one dataset
+	mgr.RemovePolicyDataset("policy1", "dataset1", mockBe)
+
+	// Verify policy still exists but with only one dataset
+	state, err = mgr.GetPolicyState()
+	require.NoError(t, err)
+	require.Len(t, state, 1)
+	assert.Len(t, state[0].Datasets, 1)
+	assert.False(t, state[0].Datasets["dataset1"])
+	assert.True(t, state[0].Datasets["dataset2"])
+
+	// Test removing the last dataset - should remove the policy
+	mockBe.On("RemovePolicy", mock.Anything).Return(nil)
+	mgr.RemovePolicyDataset("policy1", "dataset2", mockBe)
+
+	// Verify policy is gone
+	state, err = mgr.GetPolicyState()
+	require.NoError(t, err)
+	assert.Empty(t, state)
+}

--- a/agent/secretsmgr/vault_auth_test.go
+++ b/agent/secretsmgr/vault_auth_test.go
@@ -1,0 +1,71 @@
+package secretsmgr
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewAuthentication(t *testing.T) {
+	tests := []struct {
+		name      string
+		method    string
+		args      map[string]any
+		expectErr bool
+	}{
+		{
+			name:      "token auth with valid args",
+			method:    "token",
+			args:      map[string]any{"token": "test-token"},
+			expectErr: false,
+		},
+		{
+			name:      "token auth without token",
+			method:    "token",
+			args:      map[string]any{},
+			expectErr: true,
+		},
+		{
+			name:      "unsupported auth method",
+			method:    "unsupported",
+			args:      map[string]any{},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			auth, err := newAuthentication(tt.method, tt.args)
+
+			if tt.expectErr {
+				assert.Error(t, err)
+				assert.Nil(t, auth)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, auth)
+			}
+		})
+	}
+}
+
+func TestTokenAuth_Authenticate(t *testing.T) {
+	// Create test vault server
+	ln, client := createTestVault(t)
+	defer func() {
+		if err := ln.Close(); err != nil {
+			assert.NoError(t, err, "Failed to close test vault listener")
+		}
+	}()
+
+	ctx := context.Background()
+
+	// Test with invalid token
+	auth := &AuthToken{Token: "invalid-token"}
+	client.SetToken("invalid-token")
+
+	// This should fail
+	secret, err := auth.vaultAuthenticate(ctx, client)
+	assert.Error(t, err)
+	assert.Nil(t, secret)
+}

--- a/agent/secretsmgr/vault_test.go
+++ b/agent/secretsmgr/vault_test.go
@@ -2,9 +2,11 @@ package secretsmgr
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -129,7 +131,7 @@ func createTestVault(t *testing.T) (net.Listener, *vault.Client) {
 	}
 
 	// Wait for KV v2 to become available
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	// Setup various test secrets
 	secrets := map[string]map[string]interface{}{
@@ -146,4 +148,621 @@ func createTestVault(t *testing.T) (net.Listener, *vault.Client) {
 	}
 
 	return ln, client
+}
+
+func TestVaultManager_processString(t *testing.T) {
+	// Create test vault server
+	ln, client := createTestVault(t)
+	defer func() {
+		if err := ln.Close(); err != nil {
+			assert.NoError(t, err, "Failed to close test vault listener")
+		}
+	}()
+	// Create the vault manager with the test client
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	vm := &vaultManager{
+		logger:   logger,
+		config:   config.VaultManager{},
+		ctx:      ctx,
+		client:   client,
+		usedVars: make(map[string]cachedSecret),
+	}
+
+	tests := []struct {
+		name          string
+		input         string
+		policyID      string
+		expectedValue string
+		expectError   bool
+	}{
+		{
+			name:          "no vault reference",
+			input:         "plain text",
+			policyID:      "policy1",
+			expectedValue: "plain text",
+			expectError:   false,
+		},
+		{
+			name:          "valid vault reference",
+			input:         "${vault://testsecret/app/credentials/password}",
+			policyID:      "policy1",
+			expectedValue: "secretvalue",
+			expectError:   false,
+		},
+		{
+			name:          "invalid vault path",
+			input:         "${vault://testsecret/nonexistent/key}",
+			policyID:      "policy1",
+			expectedValue: "",
+			expectError:   true,
+		},
+		{
+			name:          "malformed reference",
+			input:         "${vault:/malformed}",
+			policyID:      "policy1",
+			expectedValue: "${vault:/malformed}",
+			expectError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := vm.processString(tt.input, tt.policyID)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedValue, result)
+
+				// For valid vault references, verify they're cached properly
+				if strings.Contains(tt.input, "${vault://") && !tt.expectError {
+					path := strings.TrimPrefix(strings.TrimSuffix(tt.input, "}"), "${vault://")
+					cached, exists := vm.usedVars[path]
+					assert.True(t, exists, "Secret should be cached")
+					assert.Equal(t, tt.expectedValue, cached.Value)
+					assert.True(t, cached.policyIDs[tt.policyID])
+				}
+			}
+		})
+	}
+}
+
+func TestVaultManager_processMap(t *testing.T) {
+	// Create test vault server
+	ln, client := createTestVault(t)
+	defer func() {
+		if err := ln.Close(); err != nil {
+			assert.NoError(t, err, "Failed to close test vault listener")
+		}
+	}()
+
+	// Create the vault manager with the test client
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	vm := &vaultManager{
+		logger:   logger,
+		config:   config.VaultManager{},
+		ctx:      ctx,
+		client:   client,
+		usedVars: make(map[string]cachedSecret),
+	}
+
+	tests := []struct {
+		name        string
+		input       map[string]any
+		policyID    string
+		expected    map[string]any
+		expectError bool
+	}{
+		{
+			name: "map with no vault references",
+			input: map[string]any{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			policyID: "policy1",
+			expected: map[string]any{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			expectError: false,
+		},
+		{
+			name: "map with vault references",
+			input: map[string]any{
+				"key1": "value1",
+				"key2": "${vault://testsecret/app/credentials/password}",
+			},
+			policyID: "policy1",
+			expected: map[string]any{
+				"key1": "value1",
+				"key2": "secretvalue",
+			},
+			expectError: false,
+		},
+		{
+			name: "map with invalid vault reference",
+			input: map[string]any{
+				"key1": "value1",
+				"key2": "${vault://testsecret/nonexistent/key}",
+			},
+			policyID:    "policy1",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name: "nested map",
+			input: map[string]any{
+				"key1": "value1",
+				"nested": map[string]any{
+					"subkey": "${vault://testsecret/app/credentials/password}",
+				},
+			},
+			policyID: "policy1",
+			expected: map[string]any{
+				"key1": "value1",
+				"nested": map[string]any{
+					"subkey": "secretvalue",
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := vm.processMap(tt.input, tt.policyID)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestVaultManager_processSlice(t *testing.T) {
+	// Create test vault server
+	ln, client := createTestVault(t)
+	defer func() {
+		if err := ln.Close(); err != nil {
+			assert.NoError(t, err, "Failed to close test vault listener")
+		}
+	}()
+
+	// Create the vault manager with the test client
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	vm := &vaultManager{
+		logger:   logger,
+		config:   config.VaultManager{},
+		ctx:      ctx,
+		client:   client,
+		usedVars: make(map[string]cachedSecret),
+	}
+
+	tests := []struct {
+		name        string
+		input       []any
+		policyID    string
+		expected    []any
+		expectError bool
+	}{
+		{
+			name:     "slice with no vault references",
+			input:    []any{"value1", "value2", 123},
+			policyID: "policy1",
+			expected: []any{"value1", "value2", 123},
+		},
+		{
+			name:     "slice with vault references",
+			input:    []any{"value1", "${vault://testsecret/app/credentials/password}", 123},
+			policyID: "policy1",
+			expected: []any{"value1", "secretvalue", 123},
+		},
+		{
+			name:        "slice with invalid vault reference",
+			input:       []any{"value1", "${vault://testsecret/nonexistent/key}"},
+			policyID:    "policy1",
+			expectError: true,
+		},
+		{
+			name: "slice with nested map",
+			input: []any{
+				"value1",
+				map[string]any{
+					"subkey": "${vault://testsecret/app/credentials/password}",
+				},
+			},
+			policyID: "policy1",
+			expected: []any{
+				"value1",
+				map[string]any{
+					"subkey": "secretvalue",
+				},
+			},
+		},
+		{
+			name: "slice with nested slice",
+			input: []any{
+				"value1",
+				[]any{"nested1", "${vault://testsecret/app/credentials/password}"},
+			},
+			policyID: "policy1",
+			expected: []any{
+				"value1",
+				[]any{"nested1", "secretvalue"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := vm.processSlice(tt.input, tt.policyID)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestVaultManager_SolveSecrets(t *testing.T) {
+	// Create test vault server
+	ln, client := createTestVault(t)
+	defer func() {
+		if err := ln.Close(); err != nil {
+			assert.NoError(t, err, "Failed to close test vault listener")
+		}
+	}()
+
+	// Create the vault manager with the test client
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	vm := &vaultManager{
+		logger:   logger,
+		config:   config.VaultManager{},
+		ctx:      ctx,
+		client:   client,
+		usedVars: make(map[string]cachedSecret),
+	}
+
+	tests := []struct {
+		name        string
+		payload     config.PolicyPayload
+		expected    config.PolicyPayload
+		expectError bool
+	}{
+		{
+			name: "payload with no secrets",
+			payload: config.PolicyPayload{
+				ID:   "policy1",
+				Name: "test-policy",
+				Data: map[string]any{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			expected: config.PolicyPayload{
+				ID:   "policy1",
+				Name: "test-policy",
+				Data: map[string]any{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "payload with vault references",
+			payload: config.PolicyPayload{
+				ID:   "policy2",
+				Name: "test-policy-secrets",
+				Data: map[string]any{
+					"key1": "value1",
+					"key2": "${vault://testsecret/app/credentials/password}",
+					"nested": map[string]any{
+						"subkey": "${vault://testsecret/app/credentials/password}",
+					},
+				},
+			},
+			expected: config.PolicyPayload{
+				ID:   "policy2",
+				Name: "test-policy-secrets",
+				Data: map[string]any{
+					"key1": "value1",
+					"key2": "secretvalue",
+					"nested": map[string]any{
+						"subkey": "secretvalue",
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "payload with invalid vault reference",
+			payload: config.PolicyPayload{
+				ID:   "policy3",
+				Name: "test-policy-invalid",
+				Data: map[string]any{
+					"key1": "value1",
+					"key2": "${vault://testsecret/nonexistent/key}",
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := vm.SolveSecrets(tt.payload)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestVaultManager_RegisterUpdateCallback(t *testing.T) {
+	// Create the vault manager
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	vm := &vaultManager{
+		logger: logger,
+		config: config.VaultManager{},
+	}
+
+	// Test registering a callback
+	called := false
+	callback := func(_ map[string]bool) {
+		called = true
+	}
+
+	vm.RegisterUpdateCallback(callback)
+	assert.NotNil(t, vm.callback)
+
+	// Manually call the callback to verify it works
+	vm.callback(map[string]bool{"policy1": true})
+	assert.True(t, called)
+}
+
+func TestVaultManager_pollSecrets(t *testing.T) {
+	// Create test vault server
+	ln, client := createTestVault(t)
+	defer func() {
+		if err := ln.Close(); err != nil {
+			assert.NoError(t, err, "Failed to close test vault listener")
+		}
+	}()
+
+	// Create the vault manager with the test client
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var callbackCalled bool
+	var callbackPolicyIDs map[string]bool
+
+	callback := func(policyIDs map[string]bool) {
+		callbackCalled = true
+		callbackPolicyIDs = policyIDs
+	}
+
+	vm := &vaultManager{
+		logger:   logger,
+		config:   config.VaultManager{},
+		ctx:      ctx,
+		client:   client,
+		usedVars: make(map[string]cachedSecret),
+		callback: callback,
+	}
+
+	// Setup initial secret state
+	vm.usedVars["testsecret/app/credentials/password"] = cachedSecret{
+		Value:     "secretvalue",
+		policyIDs: map[string]bool{"policy1": true, "policy2": true},
+	}
+
+	// First poll with no changes
+	callbackCalled = false
+	callbackPolicyIDs = nil
+	vm.pollSecrets()
+	assert.False(t, callbackCalled)
+
+	// Update the secret in vault
+	_, err := client.KVv2("testsecret").Put(ctx, "app/credentials", map[string]interface{}{
+		"password": "newsecretvalue",
+		"numeric":  12345,
+		"empty":    "",
+	})
+	require.NoError(t, err)
+
+	// Poll again - should detect the change
+	callbackCalled = false
+	callbackPolicyIDs = nil
+	vm.pollSecrets()
+
+	assert.True(t, callbackCalled)
+	assert.NotNil(t, callbackPolicyIDs)
+	assert.Contains(t, callbackPolicyIDs, "policy1")
+	assert.Contains(t, callbackPolicyIDs, "policy2")
+	assert.True(t, callbackPolicyIDs["policy1"])
+	assert.True(t, callbackPolicyIDs["policy2"])
+
+	// Verify the cached value was updated
+	assert.Equal(t, "newsecretvalue", vm.usedVars["testsecret/app/credentials/password"].Value)
+}
+
+func TestVaultManager_Start(t *testing.T) {
+	// Create test vault server
+	ln, client := createTestVault(t)
+	defer func() {
+		if err := ln.Close(); err != nil {
+			assert.NoError(t, err, "Failed to close test vault listener")
+		}
+	}()
+
+	addr := ln.Addr().String()
+	token := client.Token()
+
+	tests := []struct {
+		name        string
+		config      config.VaultManager
+		expectError bool
+	}{
+		{
+			name: "valid config with token auth",
+			config: config.VaultManager{
+				Address: "http://" + addr,
+				Auth:    "token",
+				AuthArgs: map[string]any{
+					"token": token,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "missing auth method",
+			config: config.VaultManager{
+				Address: "http://" + addr,
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid auth method",
+			config: config.VaultManager{
+				Address: "http://" + addr,
+				Auth:    "invalid-method",
+				AuthArgs: map[string]any{
+					"token": token,
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "with timeout",
+			config: config.VaultManager{
+				Address: "http://" + addr,
+				Auth:    "token",
+				AuthArgs: map[string]any{
+					"token": token,
+				},
+				Timeout: func() *int { i := 10; return &i }(),
+			},
+			expectError: false,
+		},
+		{
+			name: "with namespace",
+			config: config.VaultManager{
+				Address:   "http://" + addr,
+				Auth:      "token",
+				Namespace: "test-namespace",
+				AuthArgs: map[string]any{
+					"token": token,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "with schedule",
+			config: config.VaultManager{
+				Address: "http://" + addr,
+				Auth:    "token",
+				AuthArgs: map[string]any{
+					"token": token,
+				},
+				Schedule: func() *string { s := "*/5 * * * *"; return &s }(),
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			vm := &vaultManager{
+				logger: logger,
+				config: tt.config,
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			err := vm.Start(ctx)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, vm.client)
+				assert.NotNil(t, vm.token)
+				assert.NotNil(t, vm.usedVars)
+
+				if tt.config.Schedule != nil {
+					assert.NotNil(t, vm.scheduler)
+					err = vm.scheduler.Shutdown()
+					assert.NoError(t, err)
+				}
+			}
+
+			cancel()
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	tests := []struct {
+		name         string
+		config       config.ManagerSecrets
+		expectedType string
+	}{
+		{
+			name: "vault manager",
+			config: config.ManagerSecrets{
+				Active: "vault",
+				Sources: config.SecretsSources{
+					Vault: config.VaultManager{
+						Address: "http://localhost:8200",
+					},
+				},
+			},
+			expectedType: "*secretsmgr.vaultManager",
+		},
+		{
+			name: "dummy manager when active is empty",
+			config: config.ManagerSecrets{
+				Active: "",
+			},
+			expectedType: "*secretsmgr.dummyManager",
+		},
+		{
+			name: "dummy manager when active is invalid",
+			config: config.ManagerSecrets{
+				Active: "invalid",
+			},
+			expectedType: "*secretsmgr.dummyManager",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := New(logger, tt.config)
+			assert.NotNil(t, manager)
+			assert.Equal(t, tt.expectedType, fmt.Sprintf("%T", manager))
+		})
+	}
 }


### PR DESCRIPTION
This pull request adds extensive unit tests for the `policies` and `secretsmgr` packages to ensure the robustness and reliability of the code. The most important changes include the addition of tests for the `MemRepo` methods, `PolicyState` methods, and the `newAuthentication` function.

### Unit Tests for `policies` Package:

* [`agent/policies/repo_test.go`](diffhunk://#diff-e2b7b79aac6e155c41c10f2a982d55468953a59eb34feb431312c379fdd7fda6R1-R396): Added comprehensive tests for `MemRepo` methods including `NewMemRepo`, `Exists`, `Get`, `GetByName`, `Update`, `Remove`, `GetAll`, `EnsureDataset`, `RemoveDataset`, `EnsureGroupID`, and `UpdateRenamingPolicy`.
* [`agent/policies/types_test.go`](diffhunk://#diff-ec939bcfc04a908448577735055fe669907d1f62cef39b189456d320c2171eb3R1-R95): Added tests for `PolicyState` methods including `String`, `Scan`, `Value`, and `GetDatasetIDs`.

### Unit Tests for `secretsmgr` Package:

* [`agent/secretsmgr/vault_auth_test.go`](diffhunk://#diff-ac2936c265d75861fa97f2b8e5ed62c21c14b0d2b707a8026b1d554350b8171fR1-R71): Added tests for `newAuthentication` function and `TokenAuth_Authenticate` method to validate different authentication scenarios and ensure proper handling of authentication errors.