### PR TITLE
chore: add configmgr basic tests

### DIFF
--- a/agent/configmgr/git_test.go
+++ b/agent/configmgr/git_test.go
@@ -1,0 +1,120 @@
+package configmgr_test
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	gitv5 "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/config"
+	"github.com/netboxlabs/orb-agent/agent/configmgr"
+)
+
+// TestGitStart tests the Start method of gitConfigManager.
+func TestGitStart(t *testing.T) {
+	// Create a temporary directory for the fake remote repository.
+	remoteDir, err := os.MkdirTemp("", "fake-remote")
+	require.NoError(t, err)
+
+	defer func() {
+		if err := os.RemoveAll(remoteDir); err != nil {
+			require.NoError(t, err, "failed to remove temp dir")
+		}
+	}()
+
+	// Initialize a new git repository in remoteDir.
+	remoteRepo, err := gitv5.PlainInit(remoteDir, false)
+	require.NoError(t, err)
+
+	// Create a minimal selector.yaml file.
+	selectorContent := `
+test_selector:
+  selector:
+    env: test
+  policies:
+    test_policy:
+      enabled: true
+      path: "policy.yaml"
+`
+	selectorPath := filepath.Join(remoteDir, "selector.yaml")
+	err = os.WriteFile(selectorPath, []byte(selectorContent), 0o644)
+	require.NoError(t, err)
+
+	// Create a minimal policy file.
+	policyContent := `
+backend1:
+  test_policy:
+    key: "value"
+`
+	policyPath := filepath.Join(remoteDir, "policy.yaml")
+	err = os.WriteFile(policyPath, []byte(policyContent), 0o644)
+	require.NoError(t, err)
+
+	// Add and commit files.
+	w, err := remoteRepo.Worktree()
+	require.NoError(t, err)
+	_, err = w.Add("selector.yaml")
+	require.NoError(t, err)
+	_, err = w.Add("policy.yaml")
+	require.NoError(t, err)
+	commitMsg := "initial commit"
+	_, err = w.Commit(commitMsg, &gitv5.CommitOptions{
+		Author: &object.Signature{
+			Name:  "tester",
+			Email: "tester@example.com",
+			When:  time.Now(),
+		},
+	})
+	require.NoError(t, err)
+
+	// Build a file:// URL for the repository.
+	repoURL := "file://" + remoteDir
+
+	// Create a fake policy manager.
+	pMgr := new(mockPolicyManager)
+
+	// Build a minimal config for testing.
+	cfg := config.Config{
+		OrbAgent: config.OrbAgent{
+			Labels: map[string]string{"env": "test"},
+		},
+	}
+	schedule := "* * * * *"
+	gitManagerConfig := config.ManagerConfig{
+		Active: "git",
+		Sources: config.Sources{
+			Git: config.GitManager{
+				URL:      repoURL,
+				Branch:   "",        // let it detect default branch
+				Auth:     "none",    // no auth for file:// protocol
+				Schedule: &schedule, // every minute
+			},
+		},
+	}
+
+	// Create a logger.
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	// Instantiate the gitConfigManager.
+	gc := configmgr.New(logger, pMgr, gitManagerConfig)
+
+	// Call Start
+	backends := map[string]backend.Backend{
+		"backend1": &mockBackend{name: "backend1"},
+	}
+
+	pMgr.On("ManagePolicy", mock.MatchedBy(func(payload config.PolicyPayload) bool {
+		return payload.Backend == "backend1" &&
+			payload.Action == "manage"
+	})).Return()
+
+	err = gc.Start(cfg, backends)
+	require.NoError(t, err)
+}

--- a/agent/configmgr/local_test.go
+++ b/agent/configmgr/local_test.go
@@ -1,0 +1,108 @@
+package configmgr_test
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/config"
+	"github.com/netboxlabs/orb-agent/agent/configmgr"
+)
+
+// Test the localConfigManager implementation
+func TestLocalConfigManager(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	pMgr := new(mockPolicyManager)
+
+	t.Run("Start with policies", func(t *testing.T) {
+		cfg := config.ManagerConfig{
+			Active: "local",
+		}
+
+		// Create test configuration with policies
+		testConfig := config.Config{
+			OrbAgent: config.OrbAgent{
+				Policies: map[string]map[string]any{
+					"testbackend": {
+						"testpolicy": map[string]string{
+							"key": "value",
+						},
+					},
+				},
+			},
+		}
+
+		// Create a mock backend
+		mockBE := &mockBackend{name: "testbackend"}
+		backends := map[string]backend.Backend{
+			"testbackend": mockBE,
+		}
+
+		// Setup expectations
+		pMgr.On("ManagePolicy", mock.MatchedBy(func(payload config.PolicyPayload) bool {
+			return payload.Name == "testpolicy" &&
+				payload.Backend == "testbackend" &&
+				payload.Action == "manage"
+		})).Return()
+
+		// Create and start the manager
+		mgr := configmgr.New(logger, pMgr, cfg)
+		err := mgr.Start(testConfig, backends)
+
+		// Verify
+		assert.NoError(t, err)
+		pMgr.AssertExpectations(t)
+	})
+
+	t.Run("Start with no policies", func(t *testing.T) {
+		cfg := config.ManagerConfig{
+			Active: "local",
+		}
+
+		// Create test configuration with no policies
+		testConfig := config.Config{}
+
+		backends := map[string]backend.Backend{}
+
+		// Create the manager
+		mgr := configmgr.New(logger, pMgr, cfg)
+		err := mgr.Start(testConfig, backends)
+
+		// Should return an error
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no policies specified")
+	})
+
+	t.Run("Start with missing backend", func(t *testing.T) {
+		cfg := config.ManagerConfig{
+			Active: "local",
+		}
+
+		// Create test configuration with policies for non-existent backend
+		testConfig := config.Config{
+			OrbAgent: config.OrbAgent{
+				Policies: map[string]map[string]any{
+					"nonexistentbackend": {
+						"testpolicy": map[string]string{
+							"key": "value",
+						},
+					},
+				},
+			},
+		}
+
+		backends := map[string]backend.Backend{}
+
+		// Create the manager
+		mgr := configmgr.New(logger, pMgr, cfg)
+		err := mgr.Start(testConfig, backends)
+
+		// Should return an error
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "backend not found")
+	})
+}

--- a/agent/configmgr/manager_test.go
+++ b/agent/configmgr/manager_test.go
@@ -1,0 +1,173 @@
+package configmgr_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/config"
+	"github.com/netboxlabs/orb-agent/agent/configmgr"
+	"github.com/netboxlabs/orb-agent/agent/policies"
+)
+
+// Mock implementations for testing
+
+type mockPolicyManager struct {
+	mock.Mock
+}
+
+func (m *mockPolicyManager) ManagePolicy(payload config.PolicyPayload) {
+	m.Called(payload)
+}
+
+func (m *mockPolicyManager) RemovePolicyDataset(policyID string, datasetID string, be backend.Backend) {
+	m.Called(policyID, datasetID, be)
+}
+
+func (m *mockPolicyManager) GetPolicyState() ([]policies.PolicyData, error) {
+	args := m.Called()
+	return args.Get(0).([]policies.PolicyData), args.Error(1)
+}
+
+func (m *mockPolicyManager) GetRepo() policies.PolicyRepo {
+	args := m.Called()
+	return args.Get(0).(policies.PolicyRepo)
+}
+
+func (m *mockPolicyManager) ApplyBackendPolicies(be backend.Backend) error {
+	args := m.Called(be)
+	return args.Error(0)
+}
+
+func (m *mockPolicyManager) RemoveBackendPolicies(be backend.Backend, permanently bool) error {
+	args := m.Called(be, permanently)
+	return args.Error(0)
+}
+
+func (m *mockPolicyManager) RemovePolicy(policyID string, policyName string, beName string) error {
+	args := m.Called(policyID, policyName, beName)
+	return args.Error(0)
+}
+
+type mockBackend struct {
+	mock.Mock
+	name string
+}
+
+func (m *mockBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo, cfg map[string]any, commons config.BackendCommons) error {
+	args := m.Called(logger, repo, cfg, commons)
+	return args.Error(0)
+}
+
+func (m *mockBackend) Start(ctx context.Context, cancelFunc context.CancelFunc) error {
+	args := m.Called(ctx, cancelFunc)
+	return args.Error(0)
+}
+
+func (m *mockBackend) Stop(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockBackend) GetStartTime() time.Time {
+	args := m.Called()
+	return args.Get(0).(time.Time)
+}
+
+func (m *mockBackend) GetRunningStatus() (backend.RunningStatus, string, error) {
+	args := m.Called()
+	return args.Get(0).(backend.RunningStatus), args.String(1), args.Error(2)
+}
+
+func (m *mockBackend) GetInitialState() backend.RunningStatus {
+	args := m.Called()
+	return args.Get(0).(backend.RunningStatus)
+}
+
+func (m *mockBackend) Version() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
+func (m *mockBackend) GetName() string {
+	return m.name
+}
+
+func (m *mockBackend) GetCapabilities() (map[string]any, error) {
+	args := m.Called()
+	return args.Get(0).(map[string]any), args.Error(1)
+}
+
+func (m *mockBackend) FullReset(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockBackend) ApplyPolicy(policy policies.PolicyData, updatePolicy bool) error {
+	args := m.Called(policy, updatePolicy)
+	return args.Error(0)
+}
+
+func (m *mockBackend) RemovePolicy(policy policies.PolicyData) error {
+	args := m.Called(policy)
+	return args.Error(0)
+}
+
+// Test the manager.New function
+func TestManagerNew(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	pMgr := new(mockPolicyManager)
+
+	t.Run("LocalManager", func(t *testing.T) {
+		cfg := config.ManagerConfig{
+			Active: "local",
+			Sources: config.Sources{
+				Local: config.LocalManager{},
+			},
+		}
+
+		mgr := configmgr.New(logger, pMgr, cfg)
+		assert.NotNil(t, mgr)
+		// Check we got the expected implementation
+		ctx := context.Background()
+		resultCtx := mgr.GetContext(ctx)
+		assert.Equal(t, ctx, resultCtx)
+	})
+
+	t.Run("GitManager", func(t *testing.T) {
+		cfg := config.ManagerConfig{
+			Active: "git",
+			Sources: config.Sources{
+				Git: config.GitManager{
+					URL: "https://github.com/example/repo.git",
+				},
+			},
+		}
+
+		mgr := configmgr.New(logger, pMgr, cfg)
+		assert.NotNil(t, mgr)
+		// Check we got the expected implementation
+		ctx := context.Background()
+		resultCtx := mgr.GetContext(ctx)
+		assert.Equal(t, ctx, resultCtx)
+	})
+
+	t.Run("DefaultToLocalManager", func(t *testing.T) {
+		cfg := config.ManagerConfig{
+			Active: "unknown",
+		}
+
+		mgr := configmgr.New(logger, pMgr, cfg)
+		assert.NotNil(t, mgr)
+		// Check we got the local implementation
+		ctx := context.Background()
+		resultCtx := mgr.GetContext(ctx)
+		assert.Equal(t, ctx, resultCtx)
+	})
+}


### PR DESCRIPTION
This pull request introduces new test cases for the `configmgr` package, focusing on the `gitConfigManager`, `localConfigManager`, and the `manager.New` function. The changes primarily involve adding comprehensive unit tests to ensure the proper functioning of these components.

### New Tests for `configmgr` Package:

* **Tests for `gitConfigManager`:**
  - Added a test case `TestGitStart` to validate the `Start` method of `gitConfigManager`. This test includes setting up a temporary Git repository, committing files, and verifying the start process without errors.

* **Tests for `localConfigManager`:**
  - Introduced a test case `TestLocalConfigManager` to ensure the `localConfigManager` behaves correctly under different scenarios, including starting with policies, no policies, and missing backend.

* **Tests for `manager.New` Function:**
  - Added a test case `TestManagerNew` to verify that the `New` function returns the correct manager implementation based on the configuration. This includes tests for `LocalManager`, `GitManager`, and defaulting to `LocalManager` when an unknown type is provided.