### PR TITLE
chore: add interface to abstract cmd which allows unit testing backends

### DIFF
--- a/agent/backend/cmd.go
+++ b/agent/backend/cmd.go
@@ -1,0 +1,90 @@
+package backend
+
+import (
+	"github.com/go-cmd/cmd"
+)
+
+// CmdInterface abstracts the functionality from go-cmd/cmd package
+type CmdInterface interface {
+	Start() <-chan CmdStatus
+	Stop() error
+	Status() CmdStatus
+
+	// For accessing output channels
+	GetStdout() <-chan string
+	GetStderr() <-chan string
+}
+
+// CmdStatus holds the status of a command
+type CmdStatus struct {
+	PID      int   // Process ID of command
+	Complete bool  // Whether the command has completed
+	Exit     int   // Exit code of the command
+	Error    error // Go error
+	StopTs   int64 // Timestamp when the command was stopped
+}
+
+// CmdOptions holds the options for command execution
+type CmdOptions struct {
+	Buffered  bool // Whether to buffer the output
+	Streaming bool // Whether to stream the output
+}
+
+// NewCmdOptions creates a new command with specific options
+var NewCmdOptions = func(options CmdOptions, name string, args ...string) CmdInterface {
+	cmdOptions := cmd.Options{
+		Buffered:  options.Buffered,
+		Streaming: options.Streaming,
+	}
+	return &CmdWrapper{Cmd: cmd.NewCmdOptions(cmdOptions, name, args...)}
+}
+
+// CmdWrapper wraps the cmd.Cmd struct to implement CmdInterface
+type CmdWrapper struct {
+	*cmd.Cmd
+}
+
+// ConvertStatus converts cmd.Status to our Status
+func ConvertStatus(status cmd.Status) CmdStatus {
+	return CmdStatus{
+		PID:      status.PID,
+		Complete: status.Complete,
+		Exit:     status.Exit,
+		Error:    status.Error,
+		StopTs:   status.StopTs,
+	}
+}
+
+// Start starts the command and returns a channel for its status
+func (c *CmdWrapper) Start() <-chan CmdStatus {
+	statusChan := make(chan CmdStatus, 1)
+	origChan := c.Cmd.Start()
+
+	go func() {
+		status := <-origChan
+		statusChan <- ConvertStatus(status)
+		close(statusChan)
+	}()
+
+	return statusChan
+}
+
+// Stop stops the running command
+func (c *CmdWrapper) Stop() error {
+	return c.Cmd.Stop()
+}
+
+// Status returns the current command status
+func (c *CmdWrapper) Status() CmdStatus {
+	return ConvertStatus(c.Cmd.Status())
+}
+
+// GetStdout returns the stdout channel
+func (c *CmdWrapper) GetStdout() <-chan string {
+	return c.Cmd.Stdout
+}
+
+// GetStderr returns the stderr channel
+func (c *CmdWrapper) GetStderr() <-chan string {
+	return c.Cmd.Stderr
+}

--- a/agent/backend/cmd.go
+++ b/agent/backend/cmd.go
@@ -4,8 +4,8 @@ import (
 	"github.com/go-cmd/cmd"
 )
 
-// CmdInterface abstracts the functionality from go-cmd/cmd package
-type CmdInterface interface {
+// Commander abstracts the functionality from go-cmd/cmd package
+type Commander interface {
 	Start() <-chan CmdStatus
 	Stop() error
 	Status() CmdStatus
@@ -31,7 +31,7 @@ type CmdOptions struct {
 }
 
 // NewCmdOptions creates a new command with specific options
-var NewCmdOptions = func(options CmdOptions, name string, args ...string) CmdInterface {
+var NewCmdOptions = func(options CmdOptions, name string, args ...string) Commander {
 	cmdOptions := cmd.Options{
 		Buffered:  options.Buffered,
 		Streaming: options.Streaming,

--- a/agent/backend/devicediscovery/device_discovery.go
+++ b/agent/backend/devicediscovery/device_discovery.go
@@ -44,7 +44,7 @@ type deviceDiscoveryBackend struct {
 	diodeAppNamePrefix string
 
 	startTime  time.Time
-	proc       backend.CmdInterface
+	proc       backend.Commander
 	statusChan <-chan backend.CmdStatus
 	cancelFunc context.CancelFunc
 	ctx        context.Context

--- a/agent/backend/devicediscovery/device_discovery.go
+++ b/agent/backend/devicediscovery/device_discovery.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-cmd/cmd"
 	"gopkg.in/yaml.v3"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
@@ -45,8 +44,8 @@ type deviceDiscoveryBackend struct {
 	diodeAppNamePrefix string
 
 	startTime  time.Time
-	proc       *cmd.Cmd
-	statusChan <-chan cmd.Status
+	proc       backend.CmdInterface
+	statusChan <-chan backend.CmdStatus
 	cancelFunc context.CancelFunc
 	ctx        context.Context
 }
@@ -114,7 +113,7 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 
 	pvOptions[7] = d.diodeAPIKey
 
-	d.proc = cmd.NewCmdOptions(cmd.Options{
+	d.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,
 		Streaming: true,
 	}, d.exec, pvOptions...)
@@ -128,17 +127,19 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 				close(doneChan)
 			}
 		}()
-		for d.proc.Stdout != nil || d.proc.Stderr != nil {
+		stdout := d.proc.GetStdout()
+		stderr := d.proc.GetStderr()
+		for stdout != nil || stderr != nil {
 			select {
-			case line, open := <-d.proc.Stdout:
+			case line, open := <-stdout:
 				if !open {
-					d.proc.Stdout = nil
+					stdout = nil
 					continue
 				}
 				d.logger.Info("device-discovery stdout", slog.String("log", line))
-			case line, open := <-d.proc.Stderr:
+			case line, open := <-stderr:
 				if !open {
-					d.proc.Stderr = nil
+					stderr = nil
 					continue
 				}
 				d.logger.Info("device-discovery stderr", slog.String("log", line))
@@ -166,9 +167,10 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 
 	d.logger.Info("device-discovery process started", slog.Int("pid", status.PID))
 
+	var version string
 	var readinessErr error
-	for backoff := 0; backoff < readinessBackoff; backoff++ {
-		version, readinessErr := d.Version()
+	for backoff := range readinessBackoff {
+		version, readinessErr = d.Version()
 		if readinessErr == nil {
 			d.logger.Info("device-discovery readiness ok, got version ",
 				slog.String("device_discovery_version", version))

--- a/agent/backend/mocks/mocks.go
+++ b/agent/backend/mocks/mocks.go
@@ -1,0 +1,168 @@
+package mocks
+
+import (
+	"errors"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/netboxlabs/orb-agent/agent/backend"
+)
+
+// MockCmd is a testify-based mock implementation of backend.CmdInterface
+type MockCmd struct {
+	mock.Mock
+}
+
+// Start mocks the Start method
+func (m *MockCmd) Start() <-chan backend.CmdStatus {
+	args := m.Called()
+	return args.Get(0).(<-chan backend.CmdStatus)
+}
+
+// Stop mocks the Stop method
+func (m *MockCmd) Stop() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+// Status mocks the Status method
+func (m *MockCmd) Status() backend.CmdStatus {
+	args := m.Called()
+	return args.Get(0).(backend.CmdStatus)
+}
+
+// GetStdout mocks the GetStdout method
+func (m *MockCmd) GetStdout() <-chan string {
+	args := m.Called()
+	return args.Get(0).(<-chan string)
+}
+
+// GetStderr mocks the GetStderr method
+func (m *MockCmd) GetStderr() <-chan string {
+	args := m.Called()
+	return args.Get(0).(<-chan string)
+}
+
+// SetupSuccessfulProcess configures the mock for a successful running process
+func SetupSuccessfulProcess(mockCmd *MockCmd, pid int) (<-chan string, <-chan string) {
+	// Create status channel - create it as bidirectional first
+	statusCh := make(chan backend.CmdStatus, 1)
+	// Create a receive-only channel to return from the mock
+	var readOnlyStatusCh <-chan backend.CmdStatus = statusCh
+
+	status := backend.CmdStatus{
+		PID:      pid,
+		Complete: false,
+		Exit:     -1, // Not completed yet
+		Error:    nil,
+	}
+
+	// Create stdout/stderr channels
+	stdoutCh := make(chan string, 10)
+	stderrCh := make(chan string, 10)
+
+	// Create read-only versions of stdout/stderr channels
+	var readOnlyStdoutCh <-chan string = stdoutCh
+	var readOnlyStderrCh <-chan string = stderrCh
+
+	// Configure mock behavior - pass the read-only channels
+	mockCmd.On("Start").Return(readOnlyStatusCh)
+	mockCmd.On("Status").Return(status)
+	mockCmd.On("GetStdout").Return(readOnlyStdoutCh)
+	mockCmd.On("GetStderr").Return(readOnlyStderrCh)
+	mockCmd.On("Stop").Return(nil)
+
+	// Send the status in another goroutine to simulate async behavior
+	go func() {
+		// Delay before sending to simulate process startup
+		time.Sleep(10 * time.Millisecond)
+		statusCh <- status
+	}()
+
+	return readOnlyStdoutCh, readOnlyStderrCh
+}
+
+// SetupCompletedProcess configures the mock for a process that has completed
+func SetupCompletedProcess(mockCmd *MockCmd, exitCode int, err error) {
+	// Create status channel
+	statusCh := make(chan backend.CmdStatus, 1)
+	// Create a read-only view of the channel
+	var readOnlyStatusCh <-chan backend.CmdStatus = statusCh
+
+	status := backend.CmdStatus{
+		PID:      12345, // Example PID
+		Complete: true,
+		Exit:     exitCode,
+		Error:    err,
+		StopTs:   time.Now().UnixNano(),
+	}
+
+	// Empty channels for stdout/stderr since process is complete
+	stdoutCh := make(chan string)
+	stderrCh := make(chan string)
+
+	// Create read-only versions
+	var readOnlyStdoutCh <-chan string = stdoutCh
+	var readOnlyStderrCh <-chan string = stderrCh
+
+	// Configure mock behavior
+	mockCmd.On("Start").Return(readOnlyStatusCh)
+	mockCmd.On("Status").Return(status)
+	mockCmd.On("Stop").Return(nil)
+
+	mockCmd.On("GetStdout").Return(readOnlyStdoutCh)
+	mockCmd.On("GetStderr").Return(readOnlyStderrCh)
+
+	// Close the channels
+	close(stdoutCh)
+	close(stderrCh)
+
+	// Send status immediately
+	go func() {
+		statusCh <- status
+	}()
+}
+
+// SetupFailingProcess configures the mock for a process that fails to start
+func SetupFailingProcess(mockCmd *MockCmd, errorMsg string) {
+	// Create error
+	cmdError := errors.New(errorMsg)
+
+	// Create status channel
+	statusCh := make(chan backend.CmdStatus, 1)
+	// Create a read-only view of the channel
+	var readOnlyStatusCh <-chan backend.CmdStatus = statusCh
+
+	status := backend.CmdStatus{
+		PID:      0,
+		Complete: true,
+		Exit:     1,
+		Error:    cmdError,
+		StopTs:   time.Now().UnixNano(),
+	}
+
+	// Empty channels for stdout/stderr
+	stdoutCh := make(chan string)
+	stderrCh := make(chan string)
+
+	// Create read-only versions
+	var readOnlyStdoutCh <-chan string = stdoutCh
+	var readOnlyStderrCh <-chan string = stderrCh
+
+	// Configure mock behavior
+	mockCmd.On("Start").Return(readOnlyStatusCh)
+	mockCmd.On("Status").Return(status)
+	mockCmd.On("Stop").Return(nil)
+	mockCmd.On("GetStdout").Return(readOnlyStdoutCh)
+	mockCmd.On("GetStderr").Return(readOnlyStderrCh)
+
+	// Close the channels
+	close(stdoutCh)
+	close(stderrCh)
+
+	// Send status immediately
+	go func() {
+		statusCh <- status
+	}()
+}

--- a/agent/backend/networkdiscovery/network_discovery.go
+++ b/agent/backend/networkdiscovery/network_discovery.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-cmd/cmd"
 	"gopkg.in/yaml.v3"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
@@ -45,8 +44,8 @@ type networkDiscoveryBackend struct {
 	diodeAppNamePrefix string
 
 	startTime  time.Time
-	proc       *cmd.Cmd
-	statusChan <-chan cmd.Status
+	proc       backend.CmdInterface
+	statusChan <-chan backend.CmdStatus
 	cancelFunc context.CancelFunc
 	ctx        context.Context
 }
@@ -114,7 +113,7 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 
 	pvOptions[7] = d.diodeAPIKey
 
-	d.proc = cmd.NewCmdOptions(cmd.Options{
+	d.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,
 		Streaming: true,
 	}, d.exec, pvOptions...)
@@ -128,17 +127,19 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 				close(doneChan)
 			}
 		}()
-		for d.proc.Stdout != nil || d.proc.Stderr != nil {
+		stdout := d.proc.GetStdout()
+		stderr := d.proc.GetStderr()
+		for stdout != nil || stderr != nil {
 			select {
-			case line, open := <-d.proc.Stdout:
+			case line, open := <-stdout:
 				if !open {
-					d.proc.Stdout = nil
+					stdout = nil
 					continue
 				}
 				d.logger.Info("network-discovery stdout", slog.String("log", line))
-			case line, open := <-d.proc.Stderr:
+			case line, open := <-stderr:
 				if !open {
-					d.proc.Stderr = nil
+					stderr = nil
 					continue
 				}
 				d.logger.Info("network-discovery stderr", slog.String("log", line))
@@ -166,9 +167,10 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 
 	d.logger.Info("network-discovery process started", slog.Int("pid", status.PID))
 
+	var version string
 	var readinessErr error
-	for backoff := 0; backoff < readinessBackoff; backoff++ {
-		version, readinessErr := d.Version()
+	for backoff := range readinessBackoff {
+		version, readinessErr = d.Version()
 		if readinessErr == nil {
 			d.logger.Info("network-discovery readiness ok, got version ",
 				slog.String("network_discovery_version", version))

--- a/agent/backend/networkdiscovery/network_discovery.go
+++ b/agent/backend/networkdiscovery/network_discovery.go
@@ -44,7 +44,7 @@ type networkDiscoveryBackend struct {
 	diodeAppNamePrefix string
 
 	startTime  time.Time
-	proc       backend.CmdInterface
+	proc       backend.Commander
 	statusChan <-chan backend.CmdStatus
 	cancelFunc context.CancelFunc
 	ctx        context.Context

--- a/agent/backend/otel/otel.go
+++ b/agent/backend/otel/otel.go
@@ -40,7 +40,7 @@ type openTelemetryBackend struct {
 	apiProtocol string
 
 	startTime   time.Time
-	proc        backend.CmdInterface
+	proc        backend.Commander
 	agentLabels map[string]string
 	statusChan  <-chan backend.CmdStatus
 	cancelFunc  context.CancelFunc

--- a/agent/backend/otel/otel.go
+++ b/agent/backend/otel/otel.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-cmd/cmd"
 	"gopkg.in/yaml.v3"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
@@ -41,9 +40,9 @@ type openTelemetryBackend struct {
 	apiProtocol string
 
 	startTime   time.Time
-	proc        *cmd.Cmd
+	proc        backend.CmdInterface
 	agentLabels map[string]string
-	statusChan  <-chan cmd.Status
+	statusChan  <-chan backend.CmdStatus
 	cancelFunc  context.CancelFunc
 	ctx         context.Context
 }
@@ -111,7 +110,7 @@ func (o *openTelemetryBackend) Start(ctx context.Context, cancelFunc context.Can
 
 	o.logger.Info("opentelemetry infinity startup", slog.Any("arguments", pvOptions))
 
-	o.proc = cmd.NewCmdOptions(cmd.Options{
+	o.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,
 		Streaming: true,
 	}, o.exec, pvOptions...)
@@ -125,17 +124,19 @@ func (o *openTelemetryBackend) Start(ctx context.Context, cancelFunc context.Can
 				close(doneChan)
 			}
 		}()
-		for o.proc.Stdout != nil || o.proc.Stderr != nil {
+		stdout := o.proc.GetStdout()
+		stderr := o.proc.GetStderr()
+		for stdout != nil || stderr != nil {
 			select {
-			case line, open := <-o.proc.Stdout:
+			case line, open := <-stdout:
 				if !open {
-					o.proc.Stdout = nil
+					stdout = nil
 					continue
 				}
 				o.logger.Info("opentelemetry infinity stdout", slog.String("log", line))
-			case line, open := <-o.proc.Stderr:
+			case line, open := <-stderr:
 				if !open {
-					o.proc.Stderr = nil
+					stderr = nil
 					continue
 				}
 				o.logger.Info("opentelemetry infinity stderr", slog.String("log", line))
@@ -163,9 +164,10 @@ func (o *openTelemetryBackend) Start(ctx context.Context, cancelFunc context.Can
 
 	o.logger.Info("opentelemetry infinity process started", slog.Int("pid", status.PID))
 
+	var version string
 	var readinessErr error
-	for backoff := 0; backoff < readinessBackoff; backoff++ {
-		version, readinessErr := o.Version()
+	for backoff := range readinessBackoff {
+		version, readinessErr = o.Version()
 		if readinessErr == nil {
 			o.logger.Info("opentelemetry infinity readiness ok, got version ",
 				slog.String("device_discovery_version", version))

--- a/agent/backend/otel/otel_test.go
+++ b/agent/backend/otel/otel_test.go
@@ -1,0 +1,110 @@
+// otel_test.go
+package otel_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/backend/mocks"
+	"github.com/netboxlabs/orb-agent/agent/backend/otel"
+	"github.com/netboxlabs/orb-agent/agent/config"
+	"github.com/netboxlabs/orb-agent/agent/policies"
+)
+
+type StatusResponse struct {
+	StartTime string  `json:"start_time"`
+	Version   string  `json:"version"`
+	UpTime    float64 `json:"up_time"`
+}
+
+func TestOpenTelemetryBackendStart(t *testing.T) {
+	// Create server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path == "/api/v1/status" {
+			response := StatusResponse{
+				Version:   "1.3.4",
+				StartTime: "2023-10-01T12:00:00Z",
+				UpTime:    123.456,
+			}
+			w.WriteHeader(http.StatusOK)
+			err := json.NewEncoder(w).Encode(response)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	// Parse server URL
+	serverURL, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+
+	// Create logger
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	// Create a mock repository
+	repo, err := policies.NewMemRepo()
+	assert.NoError(t, err)
+
+	// Create a mock command
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 12345)
+
+	// Save original function and restore after test
+	originalNewCmdOptions := backend.NewCmdOptions
+	defer func() {
+		backend.NewCmdOptions = originalNewCmdOptions
+	}()
+
+	// Override NewCmdOptions to return our mock
+	backend.NewCmdOptions = func(options backend.CmdOptions, name string, args ...string) backend.CmdInterface {
+		// Assert that the correct parameters were passed
+		assert.Equal(t, "otlpinf", name, "Expected command name to be otlpinf")
+		assert.Contains(t, args, "run", "Expected args to contain 'run'")
+		assert.Contains(t, args, "--server_host", "Expected args to contain server host")
+		assert.False(t, options.Buffered, "Expected buffered to be false")
+		assert.True(t, options.Streaming, "Expected streaming to be true")
+		return mockCmd
+	}
+
+	assert.True(t, otel.Register(), "Failed to register OpenTelemetry backend")
+
+	assert.True(t, backend.HaveBackend("otel"), "Failed to get OpenTelemetry backend")
+
+	be := backend.GetBackend("otel")
+
+	// Configure backend
+	err = be.Configure(logger, repo, map[string]any{
+		"host": serverURL.Hostname(),
+		"port": serverURL.Port(),
+	}, config.BackendCommons{})
+	assert.NoError(t, err)
+
+	// Start the backend
+	ctx, cancel := context.WithCancel(context.Background())
+	err = be.Start(ctx, cancel)
+
+	// Assert successful start
+	assert.NoError(t, err)
+
+	// Assert that the command was started
+	err = be.Stop(ctx)
+	assert.NoError(t, err)
+
+	// Verify expectations
+	mockCmd.AssertExpectations(t)
+}

--- a/agent/backend/otel/otel_test.go
+++ b/agent/backend/otel/otel_test.go
@@ -71,7 +71,7 @@ func TestOpenTelemetryBackendStart(t *testing.T) {
 	}()
 
 	// Override NewCmdOptions to return our mock
-	backend.NewCmdOptions = func(options backend.CmdOptions, name string, args ...string) backend.CmdInterface {
+	backend.NewCmdOptions = func(options backend.CmdOptions, name string, args ...string) backend.Commander {
 		// Assert that the correct parameters were passed
 		assert.Equal(t, "otlpinf", name, "Expected command name to be otlpinf")
 		assert.Contains(t, args, "run", "Expected args to contain 'run'")

--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/go-cmd/cmd"
 	"gopkg.in/yaml.v3"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
@@ -48,8 +47,8 @@ type pktvisorBackend struct {
 	binary          string
 	configFile      string
 	pktvisorVersion string
-	proc            *cmd.Cmd
-	statusChan      <-chan cmd.Status
+	proc            backend.CmdInterface
+	statusChan      <-chan backend.CmdStatus
 	startTime       time.Time
 	cancelFunc      context.CancelFunc
 	ctx             context.Context
@@ -137,7 +136,7 @@ func (p *pktvisorBackend) Start(ctx context.Context, cancelFunc context.CancelFu
 
 	p.logger.Info("pktvisor startup", slog.Any("arguments", pvOptions))
 
-	p.proc = cmd.NewCmdOptions(cmd.Options{
+	p.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,
 		Streaming: true,
 	}, p.binary, pvOptions...)
@@ -151,17 +150,19 @@ func (p *pktvisorBackend) Start(ctx context.Context, cancelFunc context.CancelFu
 				close(doneChan)
 			}
 		}()
-		for p.proc.Stdout != nil || p.proc.Stderr != nil {
+		stdout := p.proc.GetStdout()
+		stderr := p.proc.GetStderr()
+		for stdout != nil || stderr != nil {
 			select {
-			case line, open := <-p.proc.Stdout:
+			case line, open := <-stdout:
 				if !open {
-					p.proc.Stdout = nil
+					stdout = nil
 					continue
 				}
 				p.logger.Info("pktvisor stdout", slog.String("log", line))
-			case line, open := <-p.proc.Stderr:
+			case line, open := <-stderr:
 				if !open {
-					p.proc.Stderr = nil
+					stderr = nil
 					continue
 				}
 				p.logger.Info("pktvisor stderr", slog.String("log", line))
@@ -190,7 +191,7 @@ func (p *pktvisorBackend) Start(ctx context.Context, cancelFunc context.CancelFu
 	p.logger.Info("pktvisor process started", slog.Int("pid", status.PID))
 
 	var readinessError error
-	for backoff := 0; backoff < readinessBackoff; backoff++ {
+	for backoff := range readinessBackoff {
 		var appMetrics AppInfo
 		url := fmt.Sprintf("%s://%s:%s/api/v1/metrics/app", p.adminAPIProtocol, p.adminAPIHost, p.adminAPIHost)
 		readinessError = backend.CommonRequest("pktvisor", p.proc, p.logger, url, &appMetrics, http.MethodGet,

--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -47,7 +47,7 @@ type pktvisorBackend struct {
 	binary          string
 	configFile      string
 	pktvisorVersion string
-	proc            backend.CmdInterface
+	proc            backend.Commander
 	statusChan      <-chan backend.CmdStatus
 	startTime       time.Time
 	cancelFunc      context.CancelFunc

--- a/agent/backend/utils.go
+++ b/agent/backend/utils.go
@@ -12,7 +12,7 @@ import (
 )
 
 // GetRunningStatus checks the status of the backend process
-func GetRunningStatus(proc CmdInterface) (RunningStatus, string, error) {
+func GetRunningStatus(proc Commander) (RunningStatus, string, error) {
 	if proc == nil {
 		return Unknown, "backend not started yet", nil
 	}
@@ -35,7 +35,7 @@ func GetRunningStatus(proc CmdInterface) (RunningStatus, string, error) {
 }
 
 // CommonRequest is a generic function to make HTTP requests to the backend
-func CommonRequest(backendName string, proc CmdInterface, logger *slog.Logger, url string, payload any,
+func CommonRequest(backendName string, proc Commander, logger *slog.Logger, url string, payload any,
 	method string, body io.Reader, contentType string, timeout int32, errorMsg string,
 ) error {
 	client := http.Client{

--- a/agent/backend/utils.go
+++ b/agent/backend/utils.go
@@ -8,12 +8,11 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-cmd/cmd"
 	"gopkg.in/yaml.v3"
 )
 
 // GetRunningStatus checks the status of the backend process
-func GetRunningStatus(proc *cmd.Cmd) (RunningStatus, string, error) {
+func GetRunningStatus(proc CmdInterface) (RunningStatus, string, error) {
 	if proc == nil {
 		return Unknown, "backend not started yet", nil
 	}
@@ -36,7 +35,7 @@ func GetRunningStatus(proc *cmd.Cmd) (RunningStatus, string, error) {
 }
 
 // CommonRequest is a generic function to make HTTP requests to the backend
-func CommonRequest(backendName string, proc *cmd.Cmd, logger *slog.Logger, url string, payload any,
+func CommonRequest(backendName string, proc CmdInterface, logger *slog.Logger, url string, payload any,
 	method string, body io.Reader, contentType string, timeout int32, errorMsg string,
 ) error {
 	client := http.Client{

--- a/agent/backend/worker/worker.go
+++ b/agent/backend/worker/worker.go
@@ -44,7 +44,7 @@ type workerBackend struct {
 	diodeAppNamePrefix string
 
 	startTime  time.Time
-	proc       backend.CmdInterface
+	proc       backend.Commander
 	statusChan <-chan backend.CmdStatus
 	cancelFunc context.CancelFunc
 	ctx        context.Context

--- a/agent/backend/worker/worker.go
+++ b/agent/backend/worker/worker.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-cmd/cmd"
 	"gopkg.in/yaml.v3"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
@@ -45,8 +44,8 @@ type workerBackend struct {
 	diodeAppNamePrefix string
 
 	startTime  time.Time
-	proc       *cmd.Cmd
-	statusChan <-chan cmd.Status
+	proc       backend.CmdInterface
+	statusChan <-chan backend.CmdStatus
 	cancelFunc context.CancelFunc
 	ctx        context.Context
 }
@@ -114,7 +113,7 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 
 	pvOptions[7] = d.diodeAPIKey
 
-	d.proc = cmd.NewCmdOptions(cmd.Options{
+	d.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,
 		Streaming: true,
 	}, d.exec, pvOptions...)
@@ -128,17 +127,19 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 				close(doneChan)
 			}
 		}()
-		for d.proc.Stdout != nil || d.proc.Stderr != nil {
+		stdout := d.proc.GetStdout()
+		stderr := d.proc.GetStderr()
+		for stdout != nil || stderr != nil {
 			select {
-			case line, open := <-d.proc.Stdout:
+			case line, open := <-stderr:
 				if !open {
-					d.proc.Stdout = nil
+					stdout = nil
 					continue
 				}
 				d.logger.Info("worker stdout", slog.String("log", line))
-			case line, open := <-d.proc.Stderr:
+			case line, open := <-stderr:
 				if !open {
-					d.proc.Stderr = nil
+					stderr = nil
 					continue
 				}
 				d.logger.Info("worker stderr", slog.String("log", line))
@@ -166,9 +167,10 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 
 	d.logger.Info("worker process started", slog.Int("pid", status.PID))
 
+	var version string
 	var readinessErr error
-	for backoff := 0; backoff < readinessBackoff; backoff++ {
-		version, readinessErr := d.Version()
+	for backoff := range readinessBackoff {
+		version, readinessErr = d.Version()
 		if readinessErr == nil {
 			d.logger.Info("worker readiness ok, got version ",
 				slog.String("worker_version", version))


### PR DESCRIPTION
This pull request introduces a new abstraction layer for command execution and refactors existing code to use this new abstraction. The changes also include the addition of a mock implementation for testing purposes. The most important changes include the introduction of the `CmdInterface`, refactoring of multiple backend components to use this interface, and the addition of tests for the OpenTelemetry backend.

### Introduction of `CmdInterface`:
* [`agent/backend/cmd.go`](diffhunk://#diff-d8a50a24575f6d5997d5275fa3627dda29bc60923e22fce8c56ce445dc4c2f24R1-R90): Added `CmdInterface` to abstract the functionality of the `go-cmd` package and implemented `CmdWrapper` to wrap the `cmd.Cmd` struct.

### Refactoring to use `CmdInterface`:
* [`agent/backend/devicediscovery/device_discovery.go`](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L12): Replaced direct usage of `cmd.Cmd` with `backend.CmdInterface` and updated related code. [[1]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L12) [[2]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L48-R48) [[3]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L117-R116) [[4]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L131-R142) [[5]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02R170-R173)
* [`agent/backend/networkdiscovery/network_discovery.go`](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L12): Similar refactoring to replace `cmd.Cmd` with `backend.CmdInterface`. [[1]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L12) [[2]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L48-R48) [[3]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L117-R116) [[4]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L131-R142) [[5]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854R170-R173)
* [`agent/backend/otel/otel.go`](diffhunk://#diff-ff0fa5bf58640406ae91364cf9a2b28e3aec4b7b348ff80b5a0d986909438a71L12): Updated to use `backend.CmdInterface` instead of `cmd.Cmd`. [[1]](diffhunk://#diff-ff0fa5bf58640406ae91364cf9a2b28e3aec4b7b348ff80b5a0d986909438a71L12) [[2]](diffhunk://#diff-ff0fa5bf58640406ae91364cf9a2b28e3aec4b7b348ff80b5a0d986909438a71L44-R45) [[3]](diffhunk://#diff-ff0fa5bf58640406ae91364cf9a2b28e3aec4b7b348ff80b5a0d986909438a71L114-R113) [[4]](diffhunk://#diff-ff0fa5bf58640406ae91364cf9a2b28e3aec4b7b348ff80b5a0d986909438a71L128-R139) [[5]](diffhunk://#diff-ff0fa5bf58640406ae91364cf9a2b28e3aec4b7b348ff80b5a0d986909438a71R167-R170)
* [`agent/backend/pktvisor/pktvisor.go`](diffhunk://#diff-a3efed70ceda5dfeee2a24c126eae9180ce3866c316f85a0b436c0fadae66c19L15): Refactored to use `backend.CmdInterface`. [[1]](diffhunk://#diff-a3efed70ceda5dfeee2a24c126eae9180ce3866c316f85a0b436c0fadae66c19L15) [[2]](diffhunk://#diff-a3efed70ceda5dfeee2a24c126eae9180ce3866c316f85a0b436c0fadae66c19L51-R51) [[3]](diffhunk://#diff-a3efed70ceda5dfeee2a24c126eae9180ce3866c316f85a0b436c0fadae66c19L140-R139) [[4]](diffhunk://#diff-a3efed70ceda5dfeee2a24c126eae9180ce3866c316f85a0b436c0fadae66c19L154-R165)

### Addition of mock implementation for testing:
* [`agent/backend/mocks/mocks.go`](diffhunk://#diff-437d469fd21ed0ab1095905062a94f017f1be418ec35bac0baf1c14d119c90eaR1-R168): Added `MockCmd`, a mock implementation of `CmdInterface`, and helper functions to set up different process states for testing.

### Tests for OpenTelemetry backend:
* [`agent/backend/otel/otel_test.go`](diffhunk://#diff-e0f650848a313698b988dd460da24a6624694ff0c378fe9cfa0b7ec427272316R1-R110): Added tests for the OpenTelemetry backend using the new mock implementation.