### PR TITLE
chore: add code coverage to orb backends

### DIFF
--- a/agent/backend/devicediscovery/device_discovery_test.go
+++ b/agent/backend/devicediscovery/device_discovery_test.go
@@ -137,6 +137,11 @@ func TestDeviceDiscoveryBackendStart(t *testing.T) {
 	// Assert successful start
 	assert.NoError(t, err)
 
+	// Get Running status
+	status, _, err := be.GetRunningStatus()
+	assert.NoError(t, err)
+	assert.Equal(t, backend.Running, status, "Expected backend to be running")
+
 	// Get capabilities
 	capabilities, err := be.GetCapabilities()
 	assert.NoError(t, err)
@@ -155,10 +160,43 @@ func TestDeviceDiscoveryBackendStart(t *testing.T) {
 	err = be.ApplyPolicy(data, true)
 	assert.NoError(t, err)
 
-	// Assert that the command was started
-	err = be.Stop(ctx)
+	// Assert restart
+	err = be.FullReset(ctx)
 	assert.NoError(t, err)
 
 	// Verify expectations
 	mockCmd.AssertExpectations(t)
+}
+
+func TestDeviceDiscoveryBackendCompleted(t *testing.T) {
+	// Create a mock command that simulates a failure
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupCompletedProcess(mockCmd, 0, nil)
+	// Save original function and restore after test
+	originalNewCmdOptions := backend.NewCmdOptions
+	defer func() {
+		backend.NewCmdOptions = originalNewCmdOptions
+	}()
+
+	// Override NewCmdOptions to return our mock
+	backend.NewCmdOptions = func(_ backend.CmdOptions, _ string, _ ...string) backend.Commander {
+		return mockCmd
+	}
+
+	assert.True(t, devicediscovery.Register(), "Failed to register DeviceDiscovery backend")
+
+	assert.True(t, backend.HaveBackend("device_discovery"), "Failed to get DeviceDiscovery backend")
+
+	be := backend.GetBackend("device_discovery")
+
+	// Configure backend with invalid parameters
+	err := be.Configure(slog.Default(), nil, map[string]any{
+		"host": "invalid-host",
+	}, config.BackendCommons{})
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err = be.Start(ctx, cancel)
+
+	assert.Error(t, err)
 }

--- a/agent/backend/devicediscovery/device_discovery_test.go
+++ b/agent/backend/devicediscovery/device_discovery_test.go
@@ -1,5 +1,4 @@
-// otel_test.go
-package otel_test
+package devicediscovery_test
 
 import (
 	"context"
@@ -15,8 +14,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/backend/devicediscovery"
 	"github.com/netboxlabs/orb-agent/agent/backend/mocks"
-	"github.com/netboxlabs/orb-agent/agent/backend/otel"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/policies"
 )
@@ -27,7 +26,7 @@ type StatusResponse struct {
 	UpTime    float64 `json:"up_time"`
 }
 
-func TestOpenTelemetryBackendStart(t *testing.T) {
+func TestDeviceDiscoveryBackendStart(t *testing.T) {
 	// Create server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -108,19 +107,21 @@ func TestOpenTelemetryBackendStart(t *testing.T) {
 	// Override NewCmdOptions to return our mock
 	backend.NewCmdOptions = func(options backend.CmdOptions, name string, args ...string) backend.Commander {
 		// Assert that the correct parameters were passed
-		assert.Equal(t, "otlpinf", name, "Expected command name to be otlpinf")
-		assert.Contains(t, args, "run", "Expected args to contain 'run'")
-		assert.Contains(t, args, "--server_host", "Expected args to contain server host")
+		assert.Equal(t, "device-discovery", name, "Expected command name to be device-discovery")
+		assert.Contains(t, args, "--port", "Expected args to contain port")
+		assert.Contains(t, args, "--host", "Expected args to contain host")
 		assert.False(t, options.Buffered, "Expected buffered to be false")
 		assert.True(t, options.Streaming, "Expected streaming to be true")
 		return mockCmd
 	}
 
-	assert.True(t, otel.Register(), "Failed to register OpenTelemetry backend")
+	assert.True(t, devicediscovery.Register(), "Failed to register DeviceDiscovery backend")
 
-	assert.True(t, backend.HaveBackend("otel"), "Failed to get OpenTelemetry backend")
+	assert.True(t, backend.HaveBackend("device_discovery"), "Failed to get DeviceDiscovery backend")
 
-	be := backend.GetBackend("otel")
+	be := backend.GetBackend("device_discovery")
+
+	assert.Equal(t, backend.Unknown, be.GetInitialState())
 
 	// Configure backend
 	err = be.Configure(logger, repo, map[string]any{

--- a/agent/backend/mocks/mocks.go
+++ b/agent/backend/mocks/mocks.go
@@ -78,6 +78,9 @@ func SetupSuccessfulProcess(mockCmd *MockCmd, pid int) (<-chan string, <-chan st
 		// Delay before sending to simulate process startup
 		time.Sleep(10 * time.Millisecond)
 		statusCh <- status
+		// Simulate some output
+		stdoutCh <- "success"
+		stderrCh <- "error"
 	}()
 
 	return readOnlyStdoutCh, readOnlyStderrCh

--- a/agent/backend/networkdiscovery/network_discovery_test.go
+++ b/agent/backend/networkdiscovery/network_discovery_test.go
@@ -137,6 +137,11 @@ func TestNetworkDiscoveryBackendStart(t *testing.T) {
 	// Assert successful start
 	assert.NoError(t, err)
 
+	// Get Running status
+	status, _, err := be.GetRunningStatus()
+	assert.NoError(t, err)
+	assert.Equal(t, backend.Running, status, "Expected backend to be running")
+
 	// Get capabilities
 	capabilities, err := be.GetCapabilities()
 	assert.NoError(t, err)
@@ -155,10 +160,43 @@ func TestNetworkDiscoveryBackendStart(t *testing.T) {
 	err = be.ApplyPolicy(data, true)
 	assert.NoError(t, err)
 
-	// Assert that the command was started
-	err = be.Stop(ctx)
+	// Assert restart
+	err = be.FullReset(ctx)
 	assert.NoError(t, err)
 
 	// Verify expectations
 	mockCmd.AssertExpectations(t)
+}
+
+func TestNetworkDiscoveryBackendCompleted(t *testing.T) {
+	// Create a mock command that simulates a failure
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupCompletedProcess(mockCmd, 0, nil)
+	// Save original function and restore after test
+	originalNewCmdOptions := backend.NewCmdOptions
+	defer func() {
+		backend.NewCmdOptions = originalNewCmdOptions
+	}()
+
+	// Override NewCmdOptions to return our mock
+	backend.NewCmdOptions = func(_ backend.CmdOptions, _ string, _ ...string) backend.Commander {
+		return mockCmd
+	}
+
+	assert.True(t, networkdiscovery.Register(), "Failed to register NetworkDiscovery backend")
+
+	assert.True(t, backend.HaveBackend("network_discovery"), "Failed to get NetworkDiscovery backend")
+
+	be := backend.GetBackend("network_discovery")
+
+	// Configure backend with invalid parameters
+	err := be.Configure(slog.Default(), nil, map[string]any{
+		"host": "invalid-host",
+	}, config.BackendCommons{})
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err = be.Start(ctx, cancel)
+
+	assert.Error(t, err)
 }

--- a/agent/backend/networkdiscovery/network_discovery_test.go
+++ b/agent/backend/networkdiscovery/network_discovery_test.go
@@ -1,5 +1,4 @@
-// otel_test.go
-package otel_test
+package networkdiscovery_test
 
 import (
 	"context"
@@ -16,7 +15,7 @@ import (
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/backend/mocks"
-	"github.com/netboxlabs/orb-agent/agent/backend/otel"
+	"github.com/netboxlabs/orb-agent/agent/backend/networkdiscovery"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/policies"
 )
@@ -27,7 +26,7 @@ type StatusResponse struct {
 	UpTime    float64 `json:"up_time"`
 }
 
-func TestOpenTelemetryBackendStart(t *testing.T) {
+func TestNetworkDiscoveryBackendStart(t *testing.T) {
 	// Create server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -108,19 +107,21 @@ func TestOpenTelemetryBackendStart(t *testing.T) {
 	// Override NewCmdOptions to return our mock
 	backend.NewCmdOptions = func(options backend.CmdOptions, name string, args ...string) backend.Commander {
 		// Assert that the correct parameters were passed
-		assert.Equal(t, "otlpinf", name, "Expected command name to be otlpinf")
-		assert.Contains(t, args, "run", "Expected args to contain 'run'")
-		assert.Contains(t, args, "--server_host", "Expected args to contain server host")
+		assert.Equal(t, "network-discovery", name, "Expected command name to be network-discovery")
+		assert.Contains(t, args, "--port", "Expected args to contain port")
+		assert.Contains(t, args, "--host", "Expected args to contain host")
 		assert.False(t, options.Buffered, "Expected buffered to be false")
 		assert.True(t, options.Streaming, "Expected streaming to be true")
 		return mockCmd
 	}
 
-	assert.True(t, otel.Register(), "Failed to register OpenTelemetry backend")
+	assert.True(t, networkdiscovery.Register(), "Failed to register NetworkDiscovery backend")
 
-	assert.True(t, backend.HaveBackend("otel"), "Failed to get OpenTelemetry backend")
+	assert.True(t, backend.HaveBackend("network_discovery"), "Failed to get NetworkDiscovery backend")
 
-	be := backend.GetBackend("otel")
+	be := backend.GetBackend("network_discovery")
+
+	assert.Equal(t, backend.Unknown, be.GetInitialState())
 
 	// Configure backend
 	err = be.Configure(logger, repo, map[string]any{

--- a/agent/backend/otel/otel_test.go
+++ b/agent/backend/otel/otel_test.go
@@ -136,6 +136,11 @@ func TestOpenTelemetryBackendStart(t *testing.T) {
 	// Assert successful start
 	assert.NoError(t, err)
 
+	// Get Running status
+	status, _, err := be.GetRunningStatus()
+	assert.NoError(t, err)
+	assert.Equal(t, backend.Running, status, "Expected backend to be running")
+
 	// Get capabilities
 	capabilities, err := be.GetCapabilities()
 	assert.NoError(t, err)
@@ -154,10 +159,43 @@ func TestOpenTelemetryBackendStart(t *testing.T) {
 	err = be.ApplyPolicy(data, true)
 	assert.NoError(t, err)
 
-	// Assert that the command was started
-	err = be.Stop(ctx)
+	// Assert restart
+	err = be.FullReset(ctx)
 	assert.NoError(t, err)
 
 	// Verify expectations
 	mockCmd.AssertExpectations(t)
+}
+
+func TestOpenTelemetryBackendCompleted(t *testing.T) {
+	// Create a mock command that simulates a failure
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupCompletedProcess(mockCmd, 0, nil)
+	// Save original function and restore after test
+	originalNewCmdOptions := backend.NewCmdOptions
+	defer func() {
+		backend.NewCmdOptions = originalNewCmdOptions
+	}()
+
+	// Override NewCmdOptions to return our mock
+	backend.NewCmdOptions = func(_ backend.CmdOptions, _ string, _ ...string) backend.Commander {
+		return mockCmd
+	}
+
+	assert.True(t, otel.Register(), "Failed to register Opentelemetry backend")
+
+	assert.True(t, backend.HaveBackend("otel"), "Failed to get Opentelemetry backend")
+
+	be := backend.GetBackend("otel")
+
+	// Configure backend with invalid parameters
+	err := be.Configure(slog.Default(), nil, map[string]any{
+		"host": "invalid-host",
+	}, config.BackendCommons{})
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err = be.Start(ctx, cancel)
+
+	assert.Error(t, err)
 }

--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -193,7 +193,7 @@ func (p *pktvisorBackend) Start(ctx context.Context, cancelFunc context.CancelFu
 	var readinessError error
 	for backoff := range readinessBackoff {
 		var appMetrics AppInfo
-		url := fmt.Sprintf("%s://%s:%s/api/v1/metrics/app", p.adminAPIProtocol, p.adminAPIHost, p.adminAPIHost)
+		url := fmt.Sprintf("%s://%s:%s/api/v1/metrics/app", p.adminAPIProtocol, p.adminAPIHost, p.adminAPIPort)
 		readinessError = backend.CommonRequest("pktvisor", p.proc, p.logger, url, &appMetrics, http.MethodGet,
 			http.NoBody, "application/json", readinessTimeout, "error")
 		if readinessError == nil {
@@ -314,7 +314,7 @@ func (p *pktvisorBackend) Configure(logger *slog.Logger, repo policies.PolicyRep
 
 func (p *pktvisorBackend) GetCapabilities() (map[string]any, error) {
 	var taps any
-	url := fmt.Sprintf("%s://%s:%s/api/v1/taps", p.adminAPIProtocol, p.adminAPIHost, p.adminAPIHost)
+	url := fmt.Sprintf("%s://%s:%s/api/v1/taps", p.adminAPIProtocol, p.adminAPIHost, p.adminAPIPort)
 	err := backend.CommonRequest("pktvisor", p.proc, p.logger, url, &taps, http.MethodGet,
 		http.NoBody, "application/json", tapsTimeout, "error")
 	if err != nil {
@@ -381,7 +381,7 @@ func (p *pktvisorBackend) ApplyPolicy(data policies.PolicyData, updatePolicy boo
 	}
 
 	var resp map[string]any
-	url := fmt.Sprintf("%s://%s:%s/api/v1/policies", p.adminAPIProtocol, p.adminAPIHost, p.adminAPIHost)
+	url := fmt.Sprintf("%s://%s:%s/api/v1/policies", p.adminAPIProtocol, p.adminAPIHost, p.adminAPIPort)
 	err = backend.CommonRequest("pktvisor", p.proc, p.logger, url, &resp, http.MethodPost,
 		bytes.NewBuffer(policyYaml), "application/x-yaml", applyPolicyTimeout, "error")
 	if err != nil {
@@ -402,7 +402,7 @@ func (p *pktvisorBackend) RemovePolicy(data policies.PolicyData) error {
 	} else {
 		name = data.Name
 	}
-	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", p.adminAPIProtocol, p.adminAPIHost, p.adminAPIHost, name)
+	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", p.adminAPIProtocol, p.adminAPIHost, p.adminAPIPort, name)
 	err := backend.CommonRequest("pktvisor", p.proc, p.logger, url, &resp, http.MethodDelete,
 		http.NoBody, "application/json", removePolicyTimeout, "error")
 	if err != nil {
@@ -413,7 +413,7 @@ func (p *pktvisorBackend) RemovePolicy(data policies.PolicyData) error {
 
 func (p *pktvisorBackend) getAppInfo() (AppInfo, error) {
 	var appInfo AppInfo
-	url := fmt.Sprintf("%s://%s:%s/api/v1/metrics/app", p.adminAPIProtocol, p.adminAPIHost, p.adminAPIHost)
+	url := fmt.Sprintf("%s://%s:%s/api/v1/metrics/app", p.adminAPIProtocol, p.adminAPIHost, p.adminAPIPort)
 	err := backend.CommonRequest("pktvisor", p.proc, p.logger, url, &appInfo, http.MethodGet,
 		http.NoBody, "application/json", versionTimeout, "error")
 	return appInfo, err

--- a/agent/backend/pktvisor/pktvisor_test.go
+++ b/agent/backend/pktvisor/pktvisor_test.go
@@ -1,5 +1,4 @@
-// otel_test.go
-package otel_test
+package pktvisor_test
 
 import (
 	"context"
@@ -9,14 +8,16 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/backend/mocks"
-	"github.com/netboxlabs/orb-agent/agent/backend/otel"
+	"github.com/netboxlabs/orb-agent/agent/backend/pktvisor"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/policies"
 )
@@ -27,26 +28,24 @@ type StatusResponse struct {
 	UpTime    float64 `json:"up_time"`
 }
 
-func TestOpenTelemetryBackendStart(t *testing.T) {
+func TestPktvisorBackendStart(t *testing.T) {
 	// Create server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
-		if r.URL.Path == "/api/v1/status" {
-			response := StatusResponse{
-				Version:   "1.3.4",
-				StartTime: "2023-10-01T12:00:00Z",
-				UpTime:    123.456,
-			}
+		if r.URL.Path == "/api/v1/metrics/app" {
+			var response pktvisor.AppInfo
+			response.App.Version = "1.2.3"
+			response.App.UpTimeMin = 42.5
 			w.WriteHeader(http.StatusOK)
 			err := json.NewEncoder(w).Encode(response)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
-		} else if r.URL.Path == "/api/v1/capabilities" {
+		} else if r.URL.Path == "/api/v1/taps" {
 			capabilities := map[string]any{
-				"capability": true,
+				"iface": "eth0",
 			}
 			w.WriteHeader(http.StatusOK)
 			err := json.NewEncoder(w).Encode(capabilities)
@@ -84,6 +83,22 @@ func TestOpenTelemetryBackendStart(t *testing.T) {
 	}))
 	defer server.Close()
 
+	// Create a temporary directory and file for the test
+	tempDir := t.TempDir()
+	binaryPath := path.Join(tempDir, "pktvisord")
+	dummyBinary, err := os.Create(binaryPath)
+	require.NoError(t, err)
+	err = dummyBinary.Close()
+	require.NoError(t, err)
+
+	// Make the binary executable
+	err = os.Chmod(binaryPath, 0o755)
+	require.NoError(t, err)
+
+	// Add our temp directory to the PATH
+	err = os.Setenv("PATH", tempDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	require.NoError(t, err)
+
 	// Parse server URL
 	serverURL, err := url.Parse(server.URL)
 	assert.NoError(t, err)
@@ -108,19 +123,20 @@ func TestOpenTelemetryBackendStart(t *testing.T) {
 	// Override NewCmdOptions to return our mock
 	backend.NewCmdOptions = func(options backend.CmdOptions, name string, args ...string) backend.Commander {
 		// Assert that the correct parameters were passed
-		assert.Equal(t, "otlpinf", name, "Expected command name to be otlpinf")
-		assert.Contains(t, args, "run", "Expected args to contain 'run'")
-		assert.Contains(t, args, "--server_host", "Expected args to contain server host")
+		assert.Equal(t, "pktvisord", name, "Expected command name to be pktvisord")
+		assert.Contains(t, args, "--admin-api", "Expected args to contain admin-api")
 		assert.False(t, options.Buffered, "Expected buffered to be false")
 		assert.True(t, options.Streaming, "Expected streaming to be true")
 		return mockCmd
 	}
 
-	assert.True(t, otel.Register(), "Failed to register OpenTelemetry backend")
+	assert.True(t, pktvisor.Register(), "Failed to register Pktvisor backend")
 
-	assert.True(t, backend.HaveBackend("otel"), "Failed to get OpenTelemetry backend")
+	assert.True(t, backend.HaveBackend("pktvisor"), "Failed to get Pktvisor backend")
 
-	be := backend.GetBackend("otel")
+	be := backend.GetBackend("pktvisor")
+
+	assert.Equal(t, backend.Unknown, be.GetInitialState())
 
 	// Configure backend
 	err = be.Configure(logger, repo, map[string]any{
@@ -139,7 +155,7 @@ func TestOpenTelemetryBackendStart(t *testing.T) {
 	// Get capabilities
 	capabilities, err := be.GetCapabilities()
 	assert.NoError(t, err)
-	assert.Equal(t, capabilities["capability"], true, "Expected capability to be true")
+	assert.Equal(t, map[string]any{"iface": "eth0"}, capabilities["taps"], "Expected taps")
 
 	data := policies.PolicyData{
 		ID:   "dummy-policy-id",

--- a/agent/backend/pktvisor/pktvisor_test.go
+++ b/agent/backend/pktvisor/pktvisor_test.go
@@ -152,6 +152,11 @@ func TestPktvisorBackendStart(t *testing.T) {
 	// Assert successful start
 	assert.NoError(t, err)
 
+	// Get Running status
+	status, _, err := be.GetRunningStatus()
+	assert.NoError(t, err)
+	assert.Equal(t, backend.Running, status, "Expected backend to be running")
+
 	// Get capabilities
 	capabilities, err := be.GetCapabilities()
 	assert.NoError(t, err)
@@ -170,10 +175,43 @@ func TestPktvisorBackendStart(t *testing.T) {
 	err = be.ApplyPolicy(data, true)
 	assert.NoError(t, err)
 
-	// Assert that the command was started
-	err = be.Stop(ctx)
+	// Assert restart
+	err = be.FullReset(ctx)
 	assert.NoError(t, err)
 
 	// Verify expectations
 	mockCmd.AssertExpectations(t)
+}
+
+func TestPktvisorBackendCompleted(t *testing.T) {
+	// Create a mock command that simulates a failure
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupCompletedProcess(mockCmd, 0, nil)
+	// Save original function and restore after test
+	originalNewCmdOptions := backend.NewCmdOptions
+	defer func() {
+		backend.NewCmdOptions = originalNewCmdOptions
+	}()
+
+	// Override NewCmdOptions to return our mock
+	backend.NewCmdOptions = func(_ backend.CmdOptions, _ string, _ ...string) backend.Commander {
+		return mockCmd
+	}
+
+	assert.True(t, pktvisor.Register(), "Failed to register Pktvisor backend")
+
+	assert.True(t, backend.HaveBackend("pktvisor"), "Failed to get Pktvisor backend")
+
+	be := backend.GetBackend("pktvisor")
+
+	// Configure backend with invalid parameters
+	err := be.Configure(slog.Default(), nil, map[string]any{
+		"host": "invalid-host",
+	}, config.BackendCommons{})
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err = be.Start(ctx, cancel)
+
+	assert.Error(t, err)
 }

--- a/agent/backend/worker/worker_test.go
+++ b/agent/backend/worker/worker_test.go
@@ -1,5 +1,4 @@
-// otel_test.go
-package otel_test
+package worker_test
 
 import (
 	"context"
@@ -16,7 +15,7 @@ import (
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/backend/mocks"
-	"github.com/netboxlabs/orb-agent/agent/backend/otel"
+	"github.com/netboxlabs/orb-agent/agent/backend/worker"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/policies"
 )
@@ -27,7 +26,7 @@ type StatusResponse struct {
 	UpTime    float64 `json:"up_time"`
 }
 
-func TestOpenTelemetryBackendStart(t *testing.T) {
+func TestWorkerBackendStart(t *testing.T) {
 	// Create server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -108,19 +107,19 @@ func TestOpenTelemetryBackendStart(t *testing.T) {
 	// Override NewCmdOptions to return our mock
 	backend.NewCmdOptions = func(options backend.CmdOptions, name string, args ...string) backend.Commander {
 		// Assert that the correct parameters were passed
-		assert.Equal(t, "otlpinf", name, "Expected command name to be otlpinf")
-		assert.Contains(t, args, "run", "Expected args to contain 'run'")
-		assert.Contains(t, args, "--server_host", "Expected args to contain server host")
+		assert.Equal(t, "orb-worker", name, "Expected command name to be orb-worker")
+		assert.Contains(t, args, "--port", "Expected args to contain port")
+		assert.Contains(t, args, "--host", "Expected args to contain host")
 		assert.False(t, options.Buffered, "Expected buffered to be false")
 		assert.True(t, options.Streaming, "Expected streaming to be true")
 		return mockCmd
 	}
 
-	assert.True(t, otel.Register(), "Failed to register OpenTelemetry backend")
+	assert.True(t, worker.Register(), "Failed to register Worker backend")
 
-	assert.True(t, backend.HaveBackend("otel"), "Failed to get OpenTelemetry backend")
+	assert.True(t, backend.HaveBackend("worker"), "Failed to get Worker backend")
 
-	be := backend.GetBackend("otel")
+	be := backend.GetBackend("worker")
 
 	// Configure backend
 	err = be.Configure(logger, repo, map[string]any{
@@ -128,6 +127,8 @@ func TestOpenTelemetryBackendStart(t *testing.T) {
 		"port": serverURL.Port(),
 	}, config.BackendCommons{})
 	assert.NoError(t, err)
+
+	assert.Equal(t, backend.Unknown, be.GetInitialState())
 
 	// Start the backend
 	ctx, cancel := context.WithCancel(context.Background())

--- a/agent/backend/worker/worker_test.go
+++ b/agent/backend/worker/worker_test.go
@@ -137,6 +137,11 @@ func TestWorkerBackendStart(t *testing.T) {
 	// Assert successful start
 	assert.NoError(t, err)
 
+	// Get Running status
+	status, _, err := be.GetRunningStatus()
+	assert.NoError(t, err)
+	assert.Equal(t, backend.Running, status, "Expected backend to be running")
+
 	// Get capabilities
 	capabilities, err := be.GetCapabilities()
 	assert.NoError(t, err)
@@ -155,10 +160,43 @@ func TestWorkerBackendStart(t *testing.T) {
 	err = be.ApplyPolicy(data, true)
 	assert.NoError(t, err)
 
-	// Assert that the command was started
-	err = be.Stop(ctx)
+	// Assert restart
+	err = be.FullReset(ctx)
 	assert.NoError(t, err)
 
 	// Verify expectations
 	mockCmd.AssertExpectations(t)
+}
+
+func TestWorkerBackendCompleted(t *testing.T) {
+	// Create a mock command that simulates a failure
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupCompletedProcess(mockCmd, 0, nil)
+	// Save original function and restore after test
+	originalNewCmdOptions := backend.NewCmdOptions
+	defer func() {
+		backend.NewCmdOptions = originalNewCmdOptions
+	}()
+
+	// Override NewCmdOptions to return our mock
+	backend.NewCmdOptions = func(_ backend.CmdOptions, _ string, _ ...string) backend.Commander {
+		return mockCmd
+	}
+
+	assert.True(t, worker.Register(), "Failed to register Worker backend")
+
+	assert.True(t, backend.HaveBackend("worker"), "Failed to get Worker backend")
+
+	be := backend.GetBackend("worker")
+
+	// Configure backend with invalid parameters
+	err := be.Configure(slog.Default(), nil, map[string]any{
+		"host": "invalid-host",
+	}, config.BackendCommons{})
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err = be.Start(ctx, cancel)
+
+	assert.Error(t, err)
 }


### PR DESCRIPTION
This pull request introduces several new test cases for various backend components and includes some minor fixes and improvements. The most significant changes include the addition of new test files for device discovery, network discovery, and pktvisor backends, as well as updates to existing tests to simulate process output and correct URL formatting.

New test cases:

* [`agent/backend/devicediscovery/device_discovery_test.go`](diffhunk://#diff-d8cd58f53782228d6e966e2617d17185d5c43c3e13354103f356c6ceeb179132R1-R164): Added comprehensive tests for the DeviceDiscovery backend, including server setup, backend configuration, and policy application.
* [`agent/backend/networkdiscovery/network_discovery_test.go`](diffhunk://#diff-6b6bc95e89f599a44ce52ca0b65600c07498fdec88d42c6e72a6b56a49e9967aR1-R164): Added comprehensive tests for the NetworkDiscovery backend, including server setup, backend configuration, and policy application.
* [`agent/backend/pktvisor/pktvisor_test.go`](diffhunk://#diff-1858ed655f47d6c3d130842311a47e1b16a12c408666d8d4b85a6fde7345d3faR1-R179): Added comprehensive tests for the Pktvisor backend, including server setup, backend configuration, and policy application.

Updates to existing tests:

* [`agent/backend/mocks/mocks.go`](diffhunk://#diff-437d469fd21ed0ab1095905062a94f017f1be418ec35bac0baf1c14d119c90eaR81-R83): Updated `SetupSuccessfulProcess` to simulate process output by sending "success" to stdout and "error" to stderr.
* [`agent/backend/otel/otel_test.go`](diffhunk://#diff-e0f650848a313698b988dd460da24a6624694ff0c378fe9cfa0b7ec427272316R47-R80): Added capabilities and policy handling to the OpenTelemetry backend test. [[1]](diffhunk://#diff-e0f650848a313698b988dd460da24a6624694ff0c378fe9cfa0b7ec427272316R47-R80) [[2]](diffhunk://#diff-e0f650848a313698b988dd460da24a6624694ff0c378fe9cfa0b7ec427272316R139-R156)

Minor fixes:

* [`agent/backend/pktvisor/pktvisor.go`](diffhunk://#diff-a3efed70ceda5dfeee2a24c126eae9180ce3866c316f85a0b436c0fadae66c19L196-R196): Corrected URL formatting for various API endpoints by using the correct port variable. [[1]](diffhunk://#diff-a3efed70ceda5dfeee2a24c126eae9180ce3866c316f85a0b436c0fadae66c19L196-R196) [[2]](diffhunk://#diff-a3efed70ceda5dfeee2a24c126eae9180ce3866c316f85a0b436c0fadae66c19L317-R317) [[3]](diffhunk://#diff-a3efed70ceda5dfeee2a24c126eae9180ce3866c316f85a0b436c0fadae66c19L384-R384) [[4]](diffhunk://#diff-a3efed70ceda5dfeee2a24c126eae9180ce3866c316f85a0b436c0fadae66c19L405-R405) [[5]](diffhunk://#diff-a3efed70ceda5dfeee2a24c126eae9180ce3866c316f85a0b436c0fadae66c19L416-R416)