### PR TITLE
perf: support diode oauth2

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ A special `common` subsection under `backends` defines configuration settings th
       common:
         diode:
           target: grpc://192.168.0.22:8080/diode
-          api_key: ${DIODE_API_KEY}
+          client_id: ${DIODE_CLIENT_ID}
+          client_secret: ${DIODE_CLIENT_SECRET}
           agent_name: agent01
 ```
 

--- a/agent/backend/devicediscovery/device_discovery.go
+++ b/agent/backend/devicediscovery/device_discovery.go
@@ -114,7 +114,7 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 
 	d.logger.Info("device-discovery startup", slog.Any("arguments", pvOptions))
 
-	pvOptions[8] = d.diodeClientSecret
+	pvOptions[9] = d.diodeClientSecret
 
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,

--- a/agent/backend/devicediscovery/device_discovery.go
+++ b/agent/backend/devicediscovery/device_discovery.go
@@ -40,7 +40,8 @@ type deviceDiscoveryBackend struct {
 	apiProtocol string
 
 	diodeTarget        string
-	diodeAPIKey        string
+	diodeClientID      string
+	diodeClientSecret  string
 	diodeAppNamePrefix string
 
 	startTime  time.Time
@@ -79,7 +80,8 @@ func (d *deviceDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Po
 	}
 
 	d.diodeTarget = common.Diode.Target
-	d.diodeAPIKey = common.Diode.APIKey
+	d.diodeClientID = common.Diode.ClientID
+	d.diodeClientSecret = common.Diode.ClientSecret
 	d.diodeAppNamePrefix = common.Diode.AgentName
 
 	return nil
@@ -105,13 +107,14 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 		"--host", d.apiHost,
 		"--port", d.apiPort,
 		"--diode-target", d.diodeTarget,
-		"--diode-api-key", "********",
+		"--diode-client-id", d.diodeClientID,
+		"--diode-client-secret", "********",
 		"--diode-app-name-prefix", d.diodeAppNamePrefix,
 	}
 
 	d.logger.Info("device-discovery startup", slog.Any("arguments", pvOptions))
 
-	pvOptions[7] = d.diodeAPIKey
+	pvOptions[8] = d.diodeClientSecret
 
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,

--- a/agent/backend/networkdiscovery/network_discovery.go
+++ b/agent/backend/networkdiscovery/network_discovery.go
@@ -114,7 +114,7 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 
 	d.logger.Info("network-discovery startup", slog.Any("arguments", pvOptions))
 
-	pvOptions[8] = d.diodeClientSecret
+	pvOptions[9] = d.diodeClientSecret
 
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,

--- a/agent/backend/networkdiscovery/network_discovery.go
+++ b/agent/backend/networkdiscovery/network_discovery.go
@@ -40,7 +40,8 @@ type networkDiscoveryBackend struct {
 	apiProtocol string
 
 	diodeTarget        string
-	diodeAPIKey        string
+	diodeClientID      string
+	diodeClientSecret  string
 	diodeAppNamePrefix string
 
 	startTime  time.Time
@@ -79,7 +80,8 @@ func (d *networkDiscoveryBackend) Configure(logger *slog.Logger, repo policies.P
 	}
 
 	d.diodeTarget = common.Diode.Target
-	d.diodeAPIKey = common.Diode.APIKey
+	d.diodeClientID = common.Diode.ClientID
+	d.diodeClientSecret = common.Diode.ClientSecret
 	d.diodeAppNamePrefix = common.Diode.AgentName
 
 	return nil
@@ -105,13 +107,14 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 		"--host", d.apiHost,
 		"--port", d.apiPort,
 		"--diode-target", d.diodeTarget,
-		"--diode-api-key", "********",
+		"--diode-client-id", d.diodeClientID,
+		"--diode-client-secret", "********",
 		"--diode-app-name-prefix", d.diodeAppNamePrefix,
 	}
 
 	d.logger.Info("network-discovery startup", slog.Any("arguments", pvOptions))
 
-	pvOptions[7] = d.diodeAPIKey
+	pvOptions[8] = d.diodeClientSecret
 
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,

--- a/agent/backend/worker/worker.go
+++ b/agent/backend/worker/worker.go
@@ -40,7 +40,8 @@ type workerBackend struct {
 	apiProtocol string
 
 	diodeTarget        string
-	diodeAPIKey        string
+	diodeClientID      string
+	diodeClientSecret  string
 	diodeAppNamePrefix string
 
 	startTime  time.Time
@@ -79,7 +80,8 @@ func (d *workerBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	}
 
 	d.diodeTarget = common.Diode.Target
-	d.diodeAPIKey = common.Diode.APIKey
+	d.diodeClientID = common.Diode.ClientID
+	d.diodeClientSecret = common.Diode.ClientSecret
 	d.diodeAppNamePrefix = common.Diode.AgentName
 
 	return nil
@@ -105,13 +107,14 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 		"--host", d.apiHost,
 		"--port", d.apiPort,
 		"--diode-target", d.diodeTarget,
-		"--diode-api-key", "********",
+		"--diode-client-id", d.diodeClientID,
+		"--diode-client-secret", "********",
 		"--diode-app-name-prefix", d.diodeAppNamePrefix,
 	}
 
 	d.logger.Info("worker startup", slog.Any("arguments", pvOptions))
 
-	pvOptions[7] = d.diodeAPIKey
+	pvOptions[8] = d.diodeClientSecret
 
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,

--- a/agent/backend/worker/worker.go
+++ b/agent/backend/worker/worker.go
@@ -114,7 +114,7 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 
 	d.logger.Info("worker startup", slog.Any("arguments", pvOptions))
 
-	pvOptions[8] = d.diodeClientSecret
+	pvOptions[9] = d.diodeClientSecret
 
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -73,9 +73,10 @@ type BackendCommons struct {
 		AgentLabels map[string]string `yaml:"agent_labels"`
 	} `yaml:"otel"`
 	Diode struct {
-		Target    string `yaml:"target"`
-		APIKey    string `yaml:"api_key"`
-		AgentName string `yaml:"agent_name"`
+		Target       string `yaml:"target"`
+		ClientID     string `yaml:"client_id"`
+		ClientSecret string `yaml:"client_secret"`
+		AgentName    string `yaml:"agent_name"`
 	}
 }
 

--- a/docs/backends/device_discovery.md
+++ b/docs/backends/device_discovery.md
@@ -26,7 +26,8 @@ orb:
     common:
       diode:
         target: grpc://192.168.0.100:8080/diode
-        api_key: ${DIODE_API_KEY}
+        client_id: ${DIODE_CLIENT_ID}
+        client_secret: ${DIODE_CLIENT_SECRET}
         agent_name: agent01
     device_discovery:
       host: 192.168.5.11 # default 0.0.0.0

--- a/docs/backends/network_discovery.md
+++ b/docs/backends/network_discovery.md
@@ -14,7 +14,8 @@ orb:
     common:
       diode:
         target: grpc://192.168.0.100:8080/diode
-        api_key: ${DIODE_API_KEY}
+        client_id: ${DIODE_CLIENT_ID}
+        client_secret: ${DIODE_CLIENT_SECRET}
         agent_name: agent01
     network_discovery:
       host: 192.168.5.11 # default 0.0.0.0

--- a/docs/backends/worker.md
+++ b/docs/backends/worker.md
@@ -13,7 +13,8 @@ orb:
     common:
       diode:
         target: grpc://192.168.0.100:8080/diode
-        api_key: ${DIODE_API_KEY}
+        client_id: ${DIODE_CLIENT_ID}
+        client_secret: ${DIODE_CLIENT_SECRET}
         agent_name: agent01
     worker:
       host: 192.168.5.11 # default 0.0.0.0

--- a/docs/config_samples.md
+++ b/docs/config_samples.md
@@ -13,7 +13,8 @@ orb:
     common:
       diode:
         target: grpc://192.168.0.100:8080/diode
-        api_key: ${DIODE_API_KEY}
+        client_id: ${DIODE_CLIENT_ID}
+        client_secret: ${DIODE_CLIENT_SECRET}
         agent_name: agent01
   policies:
     device_discovery:
@@ -79,7 +80,8 @@ orb:
     common:
       diode:
         target: grpc://192.168.31.114:8080/diode
-        api_key: ${DIODE_API_KEY}
+        client_id: ${DIODE_CLIENT_ID}
+        client_secret: ${DIODE_CLIENT_SECRET}
         agent_name: agent02
   policies:
     network_discovery:
@@ -108,7 +110,8 @@ orb:
     common:
       diode:
         target: grpc://192.168.31.114:8080/diode
-        api_key: ${DIODE_API_KEY}
+        client_id: ${DIODE_CLIENT_ID}
+        client_secret: ${DIODE_CLIENT_SECRET}
         agent_name: agent02
   policies:
     worker:


### PR DESCRIPTION
This pull request refactors the authentication mechanism across multiple backend components by replacing the use of `diodeAPIKey` with `diodeClientID` and `diodeClientSecret`. The changes ensure a more secure and flexible approach to authentication by introducing a client ID and secret pair. Updates span the `deviceDiscoveryBackend`, `networkDiscoveryBackend`, and `workerBackend` components, as well as the shared configuration structure.

### Authentication Refactor:

* **Backend Struct Updates**:
  - Replaced `diodeAPIKey` with `diodeClientID` and `diodeClientSecret` in the `deviceDiscoveryBackend`, `networkDiscoveryBackend`, and `workerBackend` structs. (`agent/backend/devicediscovery/device_discovery.go` [[1]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L43-R44) `agent/backend/networkdiscovery/network_discovery.go` [[2]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L43-R44) `agent/backend/worker/worker.go` [[3]](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcL43-R44)

* **Configuration Updates**:
  - Updated the `Configure` method in all backends to assign `diodeClientID` and `diodeClientSecret` from the shared `common.Diode` configuration. (`agent/backend/devicediscovery/device_discovery.go` [[1]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L82-R84) `agent/backend/networkdiscovery/network_discovery.go` [[2]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L82-R84) `agent/backend/worker/worker.go` [[3]](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcL82-R84)

* **Startup Command Updates**:
  - Modified the `Start` method in all backends to pass `diodeClientID` and `diodeClientSecret` as arguments instead of `diodeAPIKey`. (`agent/backend/devicediscovery/device_discovery.go` [[1]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L108-R117) `agent/backend/networkdiscovery/network_discovery.go` [[2]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L108-R117) `agent/backend/worker/worker.go` [[3]](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcL108-R117)

* **Configuration Structure Changes**:
  - Replaced `APIKey` with `ClientID` and `ClientSecret` in the `BackendCommons.Diode` configuration structure. (`agent/config/types.go` [agent/config/types.goL77-R78](diffhunk://#diff-fa50c62688210fe1e87f900fd800e4984fcda45ea46a9ea08ff29558e33f17dbL77-R78))