### PR TITLE
chore: update docs

### DIFF
--- a/docs/backends/device_discovery.md
+++ b/docs/backends/device_discovery.md
@@ -13,6 +13,7 @@ The device discovery backend uses [Diode Python SDK](https://github.com/netboxla
 * [Role](https://github.com/netboxlabs/diode-sdk-python/blob/develop/docs/entities.md#role)
 * [IP Address](https://github.com/netboxlabs/diode-sdk-python/blob/develop/docs/entities.md#ip-address)
 * [Prefix](https://github.com/netboxlabs/diode-sdk-python/blob/develop/docs/entities.md#prefix)
+* [VLAN](https://github.com/netboxlabs/diode-sdk-python/blob/develop/README.md#supported-entities-object-types)
 
 Interfaces are attached to the device and ip addresses will be attached to the interfaces. Prefixes are added to the same interface site that it belongs to.
 
@@ -51,8 +52,9 @@ Current supported defaults:
 
 |  Key  | Type |  Description  |
 |:-----:|:----:|:-------------:|
-| site  | str | NetBox Site Name |
-| role       | str  | Device role (e.g., switch) |
+| site  | str | NetBox Site Name (defaults to 'undefined' if not specified) |
+| role  | str  | Device role (e.g., switch) (defaults to 'undefined' if not specified) |
+| if_type | str | Interface Type (defaults to 'other' if not specified) |
 | description | str  | General description   |
 | comments   | str  | General comments       |
 | tags       | list | List of tags           |
@@ -69,13 +71,26 @@ Current supported defaults:
 | ├─ description | str  | Interface description        |
 | ├─ tags       | list | Interface tags               |
 | ipaddress    | map  | IP address-specific defaults  |
+| ├─ role   | str  | IP address role                  |
+| ├─ tenant   | str  | IP address tenant              |
+| ├─ vrf   | str  | IP address vrf                    |
 | ├─ description | str  | IP address description      |
 | ├─ comments   | str  | IP address comments          |
 | ├─ tags       | list | IP address tags              |
 | prefix       | map  | Prefix-specific defaults      |
-| ├─ description | str  | Prefix description          |
-| ├─ comments   | str  | Prefix comments              |
-| ├─ tags       | list | Prefix tags                  |
+| ├─ role   | str  | Prefix role                    |
+| ├─ tenant   | str  | Prefix tenant                |
+| ├─ vrf   | str  | Prefix vrf                      |
+| ├─ description | str  | Prefix description        |
+| ├─ comments   | str  | Prefix comments            |
+| ├─ tags       | list | Prefix tags                |
+| vlan       | map  | VLAN-specific defaults        |
+| ├─ group   | str  | VLAN group                    |
+| ├─ tenant   | str  | VLAN tenant                  |
+| ├─ role   | str  | VLAN role                      |
+| ├─ description | str  | VLAN description          |
+| ├─ comments   | str  | VLAN comments              |
+| ├─ tags       | list | VLAN tags                  |
 
 ### Scope
 The scope defines a list of devices that can be accessed and pulled data. 
@@ -121,6 +136,8 @@ orb:
               description:
               comments:
               tags: [tag7]
+            vlan:
+              role: role
         scope:
           - driver: ios
             hostname: 192.168.0.5

--- a/docs/configs/git.md
+++ b/docs/configs/git.md
@@ -1,6 +1,8 @@
 # Git
 The Git configuration manager outlines a policy management system where an agent fetches policies from a Git repository.
 
+**Important**: The `config_manager` and `backends` sections must still be passed directly to the agent via the config file at startup time. These components are not yet dynamically reconfigurable, so ensure the relevant settings are correctly defined before launching the agent.
+
 ### Config
 The following sample of a git configuration
 ```yaml
@@ -19,6 +21,9 @@ orb:
         username: "username"
         password: ${PASSWORD|TOKEN}
         private_key: path/to/certificate.pem
+  backends:
+    network_discovery:
+    device_discovery:
 ```
 
 | Parameter | Type | Required | Description |
@@ -82,4 +87,22 @@ agent_selector_matches_all:
   selector:
   policies:
     path: folder4/policy4.yaml
+```
+
+
+### policy.yaml
+Each policy file should explicitly declare the backend it applies to within the policy data itself. For example, a `policy.yaml` that targets the `device_discovery` backend might look like this:
+
+```yaml
+device_discovery:
+  discovery_1:
+    config:
+      schedule: "* * * * *"
+      defaults:
+        site: New York NY
+    scope:
+      - driver: ios
+        hostname: 192.168.0.5
+        username: admin
+        password: ${PASS}
 ```

--- a/docs/configs/git.md
+++ b/docs/configs/git.md
@@ -90,7 +90,6 @@ agent_selector_matches_all:
     path: folder4/policy4.yaml
 ```
 
-
 ### policy.yaml
 Each policy file should explicitly declare the backend it applies to within the policy data itself. For example, a `policy.yaml` that targets the `device_discovery` backend might look like this:
 

--- a/docs/configs/git.md
+++ b/docs/configs/git.md
@@ -24,6 +24,7 @@ orb:
   backends:
     network_discovery:
     device_discovery:
+    ...
 ```
 
 | Parameter | Type | Required | Description |


### PR DESCRIPTION
This pull request updates the documentation for the `device_discovery` backend and the Git configuration manager. The changes enhance clarity, add new supported defaults, and provide additional examples for configuration. Below is a summary of the most important changes:

### Updates to `device_discovery` documentation:

* Added `VLAN` as a supported entity in the `device_discovery` backend, with a link to its documentation. (`docs/backends/device_discovery.md`)
* Expanded the list of supported defaults to include `if_type` (interface type), `role`, `tenant`, and `vrf` for `IP address` and `Prefix` entities, as well as a comprehensive set of defaults for `VLAN` entities. (`docs/backends/device_discovery.md`) [[1]](diffhunk://#diff-fd6435e682861ef0784f56de4f84ffa7c0f26c0eecdad68c0d77b5ed92713a06L54-R57) [[2]](diffhunk://#diff-fd6435e682861ef0784f56de4f84ffa7c0f26c0eecdad68c0d77b5ed92713a06R74-R93)
* Updated example configuration to include `vlan` settings under the `defaults` section. (`docs/backends/device_discovery.md`)

### Updates to Git configuration documentation:

* Added an important note clarifying that the `config_manager` and `backends` sections must be passed directly to the agent at startup since they are not dynamically reconfigurable. (`docs/configs/git.md`)
* Introduced `backends` configuration examples for `network_discovery` and `device_discovery`. (`docs/configs/git.md`)
* Provided a detailed example of a `policy.yaml` file, demonstrating how to declare the backend it applies to and configure schedules, defaults, and scope for `device_discovery`. (`docs/configs/git.md`)