### PR TITLE
feat: add openteletry metrics support for each backend

### DIFF
--- a/agent/backend/devicediscovery/device_discovery.go
+++ b/agent/backend/devicediscovery/device_discovery.go
@@ -43,6 +43,7 @@ type deviceDiscoveryBackend struct {
 	diodeClientID      string
 	diodeClientSecret  string
 	diodeAppNamePrefix string
+	diodeOtelEndpoint  string
 
 	startTime  time.Time
 	proc       backend.Commander
@@ -84,6 +85,12 @@ func (d *deviceDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Po
 	d.diodeClientSecret = common.Diode.ClientSecret
 	d.diodeAppNamePrefix = common.Diode.AgentName
 
+	if common.Otel.Grpc != "" {
+		d.diodeOtelEndpoint = common.Otel.Grpc
+		d.logger.Info("device-discovery using OTLP metrics endpoint",
+			slog.String("endpoint", d.diodeOtelEndpoint))
+	}
+
 	return nil
 }
 
@@ -110,6 +117,10 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 		"--diode-client-id", d.diodeClientID,
 		"--diode-client-secret", "********",
 		"--diode-app-name-prefix", d.diodeAppNamePrefix,
+	}
+
+	if d.diodeOtelEndpoint != "" {
+		pvOptions = append(pvOptions, "--otel-endpoint", d.diodeOtelEndpoint)
 	}
 
 	d.logger.Info("device-discovery startup", slog.Any("arguments", pvOptions))

--- a/agent/backend/networkdiscovery/network_discovery.go
+++ b/agent/backend/networkdiscovery/network_discovery.go
@@ -43,6 +43,7 @@ type networkDiscoveryBackend struct {
 	diodeClientID      string
 	diodeClientSecret  string
 	diodeAppNamePrefix string
+	diodeOtelEndpoint  string
 
 	startTime  time.Time
 	proc       backend.Commander
@@ -84,6 +85,12 @@ func (d *networkDiscoveryBackend) Configure(logger *slog.Logger, repo policies.P
 	d.diodeClientSecret = common.Diode.ClientSecret
 	d.diodeAppNamePrefix = common.Diode.AgentName
 
+	if common.Otel.Grpc != "" {
+		d.diodeOtelEndpoint = common.Otel.Grpc
+		d.logger.Info("network-discovery using OTLP metrics endpoint",
+			slog.String("endpoint", d.diodeOtelEndpoint))
+	}
+
 	return nil
 }
 
@@ -110,6 +117,10 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 		"--diode-client-id", d.diodeClientID,
 		"--diode-client-secret", "********",
 		"--diode-app-name-prefix", d.diodeAppNamePrefix,
+	}
+
+	if d.diodeOtelEndpoint != "" {
+		pvOptions = append(pvOptions, "--otel-endpoint", d.diodeOtelEndpoint)
 	}
 
 	d.logger.Info("network-discovery startup", slog.Any("arguments", pvOptions))

--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"strconv"
@@ -302,9 +303,17 @@ func (p *pktvisorBackend) Configure(logger *slog.Logger, repo policies.PolicyRep
 
 	p.configFile = tmpFile.Name()
 
-	if common.Otel.Host != "" && common.Otel.Port != 0 {
-		p.otelReceiverHost = common.Otel.Host
-		p.otelReceiverPort = common.Otel.Port
+	if common.Otel.HTTP != "" {
+		uri, err := url.Parse(common.Otel.HTTP)
+		if err != nil {
+			return fmt.Errorf("failed to parse otel receiver http url: %w", err)
+		}
+		p.otelReceiverHost = uri.Hostname()
+		port, err := strconv.Atoi(uri.Port())
+		if err != nil {
+			return fmt.Errorf("failed to parse otel receiver port: %w", err)
+		}
+		p.otelReceiverPort = port
 		p.logger.Info("configured otel receiver host", slog.String("host", p.otelReceiverHost),
 			slog.Int("port", p.otelReceiverPort))
 	}

--- a/agent/backend/worker/worker.go
+++ b/agent/backend/worker/worker.go
@@ -43,6 +43,7 @@ type workerBackend struct {
 	diodeClientID      string
 	diodeClientSecret  string
 	diodeAppNamePrefix string
+	diodeOtelEndpoint  string
 
 	startTime  time.Time
 	proc       backend.Commander
@@ -84,6 +85,12 @@ func (d *workerBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	d.diodeClientSecret = common.Diode.ClientSecret
 	d.diodeAppNamePrefix = common.Diode.AgentName
 
+	if common.Otel.Grpc != "" {
+		d.diodeOtelEndpoint = common.Otel.Grpc
+		d.logger.Info("orb-worker using OTLP metrics endpoint",
+			slog.String("endpoint", d.diodeOtelEndpoint))
+	}
+
 	return nil
 }
 
@@ -110,6 +117,10 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 		"--diode-client-id", d.diodeClientID,
 		"--diode-client-secret", "********",
 		"--diode-app-name-prefix", d.diodeAppNamePrefix,
+	}
+
+	if d.diodeOtelEndpoint != "" {
+		pvOptions = append(pvOptions, "--otel-endpoint", d.diodeOtelEndpoint)
 	}
 
 	d.logger.Info("worker startup", slog.Any("arguments", pvOptions))

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -68,8 +68,8 @@ type ManagerSecrets struct {
 // BackendCommons represents common configuration for backends
 type BackendCommons struct {
 	Otel struct {
-		Host        string            `yaml:"host"`
-		Port        int               `yaml:"port"`
+		Grpc        string            `yaml:"grpc"`
+		HTTP        string            `yaml:"http"`
 		AgentLabels map[string]string `yaml:"agent_labels"`
 	} `yaml:"otel"`
 	Diode struct {


### PR DESCRIPTION
This pull request introduces support for OpenTelemetry (OTLP) metrics endpoints across multiple backend components (`deviceDiscoveryBackend`, `networkDiscoveryBackend`, `workerBackend`, and `pktvisorBackend`). It replaces the previous host/port configuration for OTLP with HTTP and gRPC endpoint URLs, ensuring more flexibility and consistency in configuration. Key changes include adding new fields for OTLP endpoints, updating configuration logic, and modifying startup commands to include OTLP-related options.

### OpenTelemetry (OTLP) Integration:

* Added a new `diodeOtelEndpoint` field to the `deviceDiscoveryBackend`, `networkDiscoveryBackend`, and `workerBackend` structs to store the gRPC OTLP endpoint. Updated their `Configure` methods to set this field based on the `common.Otel.Grpc` configuration and log the endpoint being used. Modified the `Start` methods to append the `--otel-endpoint` option to the startup arguments if the endpoint is configured. (`device_discovery.go`: [[1]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02R46) [[2]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02R88-R93) [[3]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02R122-R125); `network_discovery.go`: [[4]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854R46) [[5]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854R88-R93) [[6]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854R122-R125); `worker.go`: [[7]](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcR46) [[8]](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcR88-R93) [[9]](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcR122-R125)

* Updated the `pktvisorBackend` to parse and validate the OTLP HTTP endpoint URL (`common.Otel.HTTP`) instead of using separate host and port fields. Extracted and logged the host and port from the URL during configuration. (`pktvisor.go`: [[1]](diffhunk://#diff-a3efed70ceda5dfeee2a24c126eae9180ce3866c316f85a0b436c0fadae66c19R10) [[2]](diffhunk://#diff-a3efed70ceda5dfeee2a24c126eae9180ce3866c316f85a0b436c0fadae66c19L305-R316)

### Configuration Schema Updates:

* Replaced the `host` and `port` fields in the `BackendCommons.Otel` configuration with `grpc` and `http` fields to support full endpoint URLs for OTLP metrics. (`types.go`: [agent/config/types.goL71-R72](diffhunk://#diff-fa50c62688210fe1e87f900fd800e4984fcda45ea46a9ea08ff29558e33f17dbL71-R72))