### PR TITLE
fix: device-discovery remove scope site from prefix

### DIFF
--- a/docs/backends/device_discovery.md
+++ b/docs/backends/device_discovery.md
@@ -55,6 +55,8 @@ Current supported defaults:
 | site  | str | NetBox Site Name (defaults to 'undefined' if not specified) |
 | role  | str  | Device role (e.g., switch) (defaults to 'undefined' if not specified) |
 | if_type | str | Interface Type (defaults to 'other' if not specified) |
+| location | str | Device location |
+| tenant | str | Device tenant |
 | description | str  | General description   |
 | comments   | str  | General comments       |
 | tags       | list | List of tags           |
@@ -118,6 +120,8 @@ orb:
           defaults:
             site: New York NY
             role: switch
+            location: Row A
+            tenant: NetBox Labs
             description: for all
             comments: comment all
             tags: [tag1, tag2]


### PR DESCRIPTION
This pull request uses the new release of device discovery: https://github.com/netboxlabs/orb-discovery/releases/tag/device-discovery%2Fv1.1.0

It also updates the `docs/backends/device_discovery.md` file to include new supported defaults for device discovery. The most important changes involve adding support for `location` and `tenant` fields in the documentation.

Updates to supported defaults:

* Added `location` and `tenant` fields to the "Current supported defaults" table, specifying that these fields are now part of the device discovery process. (`[docs/backends/device_discovery.mdR58-R59](diffhunk://#diff-fd6435e682861ef0784f56de4f84ffa7c0f26c0eecdad68c0d77b5ed92713a06R58-R59)`)

Updates to example defaults:

* Updated the `orb:` example to include default values for the newly added `location` (`Row A`) and `tenant` (`NetBox Labs`) fields. (`[docs/backends/device_discovery.mdR123-R124](diffhunk://#diff-fd6435e682861ef0784f56de4f84ffa7c0f26c0eecdad68c0d77b5ed92713a06R123-R124)`)