### PR TITLE
feat: add skip tls to git config manager

### DIFF
--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -30,6 +30,7 @@ type GitManager struct {
 	Username   string  `yaml:"username"`
 	Password   string  `yaml:"password"`
 	PrivateKey string  `yaml:"private_key"`
+	SkipTLS    bool    `yaml:"skip_tls"`
 }
 
 // Sources represents the configuration for manager sources, including cloud, local and git.

--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -213,9 +213,10 @@ func (gc *gitConfigManager) processSelector(file *object.File, cfg config.Config
 func (gc *gitConfigManager) schedule(cfg config.Config, backends map[string]backend.Backend) {
 	// Fetch latest updates from remote
 	err := gc.repo.Fetch(&gitv5.FetchOptions{
-		RemoteName: "origin",
-		Auth:       gc.authMethod,
-		RefSpecs:   []gitconfig.RefSpec{"refs/heads/*:refs/heads/*"},
+		RemoteName:      "origin",
+		Auth:            gc.authMethod,
+		InsecureSkipTLS: gc.config.SkipTLS,
+		RefSpecs:        []gitconfig.RefSpec{"refs/heads/*:refs/heads/*"},
 	})
 	if err != nil && err != gitv5.NoErrAlreadyUpToDate {
 		gc.logger.Error("Failed to fetch latest changes", slog.Any("error", err))
@@ -382,8 +383,9 @@ func (gc *gitConfigManager) Start(cfg config.Config, backends map[string]backend
 
 	// Fetch all branches and references
 	if err = repo.Fetch(&gitv5.FetchOptions{
-		RemoteName: "origin",
-		Auth:       gc.authMethod,
+		RemoteName:      "origin",
+		Auth:            gc.authMethod,
+		InsecureSkipTLS: gc.config.SkipTLS,
 	}); err != nil && err != gitv5.NoErrAlreadyUpToDate {
 		return err
 	}

--- a/docs/configs/git.md
+++ b/docs/configs/git.md
@@ -21,6 +21,7 @@ orb:
         username: "username"
         password: ${PASSWORD|TOKEN}
         private_key: path/to/certificate.pem
+        skip_tls: True #defaults false
   backends:
     network_discovery:
     device_discovery:


### PR DESCRIPTION
This pull request introduces a new feature to allow skipping TLS verification for Git operations. The most important changes include adding a new `SkipTLS` field to the `GitManager` struct, updating Git fetch operations to respect this new configuration, and documenting the feature in the configuration guide.

### Feature: Skip TLS Verification for Git Operations

* **Configuration Update**:
  - Added a new `SkipTLS` boolean field to the `GitManager` struct in `agent/config/types.go`. This field allows users to specify whether TLS verification should be skipped.

* **Git Fetch Operations**:
  - Updated the `schedule` method in `agent/configmgr/git.go` to pass the `SkipTLS` value to the `InsecureSkipTLS` option in the Git fetch operation.
  - Updated the `Start` method in `agent/configmgr/git.go` to similarly respect the `SkipTLS` configuration during Git fetch operations.

* **Documentation**:
  - Updated `docs/configs/git.md` to include the new `skip_tls` configuration option, with a note that it defaults to `false`.