### PR TITLE
fix: apply skipTLS to every git remote call

### DIFF
--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -396,7 +396,7 @@ func (gc *gitConfigManager) Start(cfg config.Config, backends map[string]backend
 		return err
 	}
 
-	refs, err := remote.List(&gitv5.ListOptions{Auth: gc.authMethod})
+	refs, err := remote.List(&gitv5.ListOptions{Auth: gc.authMethod, InsecureSkipTLS: gc.config.SkipTLS})
 	if err != nil {
 		return err
 	}
@@ -421,10 +421,11 @@ func (gc *gitConfigManager) Start(cfg config.Config, backends map[string]backend
 
 	// Now clone the repository with the determined branch
 	gc.repo, err = gitv5.Clone(memory.NewStorage(), nil, &gitv5.CloneOptions{
-		Auth:          gc.authMethod,
-		URL:           gc.config.URL,
-		ReferenceName: plumbing.NewBranchReferenceName(branchName),
-		SingleBranch:  true,
+		Auth:            gc.authMethod,
+		URL:             gc.config.URL,
+		ReferenceName:   plumbing.NewBranchReferenceName(branchName),
+		SingleBranch:    true,
+		InsecureSkipTLS: gc.config.SkipTLS,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `gitConfigManager` in `agent/configmgr/git.go` by adding support for skipping TLS verification when specified in the configuration. 

Key changes:

* Updated the `remote.List` method to include the `InsecureSkipTLS` option, which is set based on the `gc.config.SkipTLS` configuration.
* Added the `InsecureSkipTLS` option to the `git.Clone` method to ensure consistency with the skip TLS configuration.