### PR TITLE
chore: update network discovery docs

### DIFF
--- a/docs/backends/network_discovery.md
+++ b/docs/backends/network_discovery.md
@@ -45,6 +45,7 @@ Current supported defaults:
 | comments | str | NetBox Comments information to be added to discovered IP |
 | description | str | NetBox Description data to be added to discovered IP |
 | tags | list | NetBox Tags to be added to discovered IP |
+| network_mask | int | Default network mask to be applied to IPv4 (default: 32) |
 
 ### Scope
 The scope defines a list of targets to be scanned.
@@ -60,6 +61,9 @@ The scope defines a list of targets to be scanned.
 | top_ports | int | no | Scan <number> most common ports (--top-ports). |
 | max_retries | int | no | Caps number of port scan probe retransmissions (--max-retries). |
 | scan_types | list | no | Scan technique to be used by NMAP. Supports [udp,connect,syn,ack,window,null,fin,xmas,maimon,sctp_init,sctp_cookie_echo,ip_protocol]. If more than one TCP scan type (`connect,syn,ack,window,null,fin,xmas,maimon`) is defined, only the fist one will be applied. |
+| dns_servers | list | no | Specify alternate DNS servers for DNS resolution |
+| os_detection | bool | no | Enables NMAP OS detection. |
+| use_target_masks | bool | no | When enabled (default: True), applies the most specific subnet mask from the defined targets to discovered IPs. Only affects targets defined as subnets (e.g., 192.168.1.0/24), not ranges or individual IPs. |
 
 ### Sample
 A sample policy including all parameters supported by the network discovery backend.
@@ -73,7 +77,6 @@ orb:
           schedule: "* * * * *"
           timeout: 5
           defaults:
-            comments: none
             description: IP discovered by network discovery
             tags: [net-discovery, orb-agent]
         scope:

--- a/docs/backends/network_discovery.md
+++ b/docs/backends/network_discovery.md
@@ -61,8 +61,8 @@ The scope defines a list of targets to be scanned.
 | top_ports | int | no | Scan <number> most common ports (--top-ports). |
 | max_retries | int | no | Caps number of port scan probe retransmissions (--max-retries). |
 | scan_types | list | no | Scan technique to be used by NMAP. Supports [udp,connect,syn,ack,window,null,fin,xmas,maimon,sctp_init,sctp_cookie_echo,ip_protocol]. If more than one TCP scan type (`connect,syn,ack,window,null,fin,xmas,maimon`) is defined, only the fist one will be applied. |
-| dns_servers | list | no | Specify alternate DNS servers for DNS resolution |
-| os_detection | bool | no | Enables NMAP OS detection. |
+| dns_servers | list | no | Specify alternate DNS servers for DNS resolution (--dns-servers). |
+| os_detection | bool | no | Enables NMAP OS detection (-O). |
 | use_target_masks | bool | no | When enabled (default: True), applies the most specific subnet mask from the defined targets to discovered IPs. Only affects targets defined as subnets (e.g., 192.168.1.0/24), not ranges or individual IPs. |
 
 ### Sample

--- a/docs/config_samples.md
+++ b/docs/config_samples.md
@@ -97,7 +97,7 @@ orb:
 
 Run command:
 ```sh
- docker run -v /local/orb:/opt/orb/ \
+ docker run --net=host -v /local/orb:/opt/orb/ \
  -e DIODE_CLIENT_ID={YOUR_DIODE_CLIENT_ID} \
  -e DIODE_CLIENT_SECRET={YOUR_DIODE_CLIENT_SECRET} \
  netboxlabs/orb-agent:latest run -c /opt/orb/agent.yaml


### PR DESCRIPTION
This pull request updates documentation for the network discovery backend and modifies a sample command in the configuration documentation. The most significant changes include adding new configuration options for network discovery, updating default values, and modifying the Docker run command to include the `--net=host` option.

### Documentation updates for network discovery:

* [`docs/backends/network_discovery.md`](diffhunk://#diff-bd3c9c52dbd9e1b16a5afbcf8adba2224a5180c7144d2d71f5f90d3505677111R48): Added `network_mask` as a default configuration option, specifying the default network mask for IPv4 (default: 32).
* [`docs/backends/network_discovery.md`](diffhunk://#diff-bd3c9c52dbd9e1b16a5afbcf8adba2224a5180c7144d2d71f5f90d3505677111R64-R66): Added new scope parameters: `dns_servers` for alternate DNS resolution, `os_detection` to enable NMAP OS detection, and `use_target_masks` to apply specific subnet masks to discovered IPs (default: True).
* [`docs/backends/network_discovery.md`](diffhunk://#diff-bd3c9c52dbd9e1b16a5afbcf8adba2224a5180c7144d2d71f5f90d3505677111L76): Removed the `comments` field from the `defaults` section in the sample configuration.

### Configuration sample update:

* [`docs/config_samples.md`](diffhunk://#diff-c89006d67ac3f5e07361eb1d39ebf0cc2af11b0dab0a2ec0e09a4eb33a55bcd6L100-R100): Updated the sample Docker run command to include the `--net=host` option, allowing the container to use the host network.