### PR TITLE
chore: add device-discovery docs for YAML anchors/aliases

### DIFF
--- a/docs/backends/device_discovery.md
+++ b/docs/backends/device_discovery.md
@@ -154,3 +154,32 @@ orb:
             username: remote
             password: 12345
 ```
+
+### Advanced Sample
+
+You can reuse credentials across multiple devices in the `scope` section by using YAML anchors (`&`) and aliases (`<<`). This reduces redundancy and simplifies configuration management.
+
+```yaml
+orb:
+  ...
+  policies:
+    device_discovery:
+      discovery_1:
+        credentials: &ios_credentials
+          username: admin
+          password: ${PASS}
+          driver: ios
+        config:
+          defaults:
+            site: my site
+            tenant: my tenant
+        scope:
+          - hostname: 192.168.10.3
+            <<: *ios_credentials
+          - hostname: 192.168.10.5
+            <<: *ios_credentials
+```
+
+In this example:
+- The `credentials` section defines reusable credentials using the anchor `&ios_credentials`.
+- The `<<: *ios_credentials` alias is used to include the credentials in multiple devices within the `scope` section.


### PR DESCRIPTION
This pull request adds an advanced example to the `device_discovery.md` documentation, demonstrating how to use YAML anchors and aliases to reuse credentials across multiple devices, thereby reducing redundancy and simplifying configuration management.

Documentation improvement:

* [`docs/backends/device_discovery.md`](diffhunk://#diff-fd6435e682861ef0784f56de4f84ffa7c0f26c0eecdad68c0d77b5ed92713a06R157-R185): Added an "Advanced Sample" section with an example of using YAML anchors (`&`) and aliases (`<<`) for reusing credentials in the `scope` section of the `orb` configuration. This makes the configuration more concise and easier to maintain.