### PR TITLE
feat: adds snmp to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,11 @@ orb:
     network_discovery:
     ...
 ```
-Only the `network_discovery`, `device_discovery` and `worker` backends are currently supported. They do not require any special configuration.
+Only the `network_discovery`, `device_discovery`, `worker` and `snmp_discovery` backends are currently supported. They do not require any special configuration.
 - [Device Discovery](./docs/backends/device_discovery.md) 
 - [Network Discovery](./docs/backends/network_discovery.md)
 - [Worker](./docs/backends/worker.md)
+- [SNMP Discovery](./docs/backends/snmp_discovery.md)
 
 #### Common
 A special `common` subsection under `backends` defines configuration settings that are shared with all backends. Currently, it supports passing [diode](https://github.com/netboxlabs/diode) server settings to all backends.

--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -27,7 +27,7 @@ const (
 	removePolicyTimeout = 20
 	defaultExec         = "snmp-discovery"
 	defaultAPIHost      = "localhost"
-	defaultAPIPort      = "8073"
+	defaultAPIPort      = "8070"
 )
 
 type snmpDiscoveryBackend struct {


### PR DESCRIPTION
This pull request updates the documentation in `README.md` to include information about the newly supported `snmp_discovery` backend.

Key change:

* Added `snmp_discovery` to the list of supported backends and included a link to its documentation in the `README.md`.