### PR TITLE
feat: bundle the lookup extensions in orb-agent image

### DIFF
--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -49,7 +49,10 @@ COPY --from=pktvisor /iana /iana
 COPY --from=otlpinf /exe /usr/local/bin/otlpinf
 
 COPY --from=network-discovery /usr/local/bin/network-discovery /usr/local/bin/network-discovery
+
+RUN mkdir -p /etc/snmp-discovery/lookup-extensions
 COPY --from=snmp-discovery /usr/local/bin/snmp-discovery /usr/local/bin/snmp-discovery
+COPY --from=snmp-discovery /etc/snmp-discovery/lookup-extensions /etc/snmp-discovery/lookup-extensions
 
 RUN pip3 install netboxlabs-device-discovery netboxlabs-orb-worker
 


### PR DESCRIPTION
This pull request updates the `agent/docker/Dockerfile` to improve the setup process for SNMP discovery by adding a new directory and copying necessary files.

Setup improvements for SNMP discovery:

* [`agent/docker/Dockerfile`](diffhunk://#diff-213bb5537c1a11cdd5ad4d1df9042b68b951353a130b68b8de9ce2973d45f372R52-R55): Added a `RUN` command to create the `/etc/snmp-discovery/lookup-extensions` directory and updated the `COPY` command to include files from `snmp-discovery` into this directory.