### PR TITLE
doc: updates docs to clarify the lookup_extensions_dir property

### DIFF
--- a/docs/config_samples.md
+++ b/docs/config_samples.md
@@ -195,7 +195,7 @@ orb:
           device:
             description: "SNMP discovered device"
             comments: "Automatically discovered via SNMP"
-        lookup_extensions_dir: "/opt/orb/snmp-extensions" # Specifies a directory containing device data yaml files (see below)
+        # lookup_extensions_dir: "/opt/orb/snmp-extensions" # Specifies an override for the directory containing device data yaml files (see below)
       scope:
         targets:
           - host: "192.168.1.1"
@@ -230,7 +230,7 @@ orb:
 ```
 
 ### Device Model Lookup
-The `lookup_extensions_dir` specifies a directory containing device data YAML files that map SNMP device ObjectIds (from querying `.1.3.6.1.2.1.1.2.0`) to human-readable device names. This allows snmp-discovery to provide meaningful device identification instead of raw ObjectId values.
+The `lookup_extensions_dir` specifies a directory containing device data YAML files that map SNMP device ObjectIds (from querying `.1.3.6.1.2.1.1.2.0`) to human-readable device names. This allows snmp-discovery to provide meaningful device identification instead of raw ObjectId values. This only needs to be set if additional or modified files are being provided instead of the ones that are included with orb-discovery and orb-agent.
 
 Device model lookup files to put in the `lookup_extenions_dir` are available from the [`orb-discovery` repository](https://github.com/netboxlabs/orb-discovery/tree/release/snmp-discovery/lookup_extension). More details about the file format and adding devices that aren't already covered are [available here](https://github.com/netboxlabs/orb-discovery/blob/release/snmp-discovery/README.md#device-model-lookup).
 


### PR DESCRIPTION
This pull request updates the documentation for the `orb` project to clarify the usage of the `lookup_extensions_dir` configuration parameter. It modifies comments and descriptions to emphasize that the parameter is optional and only needed for custom or additional device data files.

### Documentation updates:

* [`docs/config_samples.md`](diffhunk://#diff-c89006d67ac3f5e07361eb1d39ebf0cc2af11b0dab0a2ec0e09a4eb33a55bcd6L198-R198): Updated the inline comment for the `lookup_extensions_dir` parameter to specify that it is an override for the default directory containing device data YAML files.
* [`docs/config_samples.md`](diffhunk://#diff-c89006d67ac3f5e07361eb1d39ebf0cc2af11b0dab0a2ec0e09a4eb33a55bcd6L233-R233): Expanded the description of the `lookup_extensions_dir` parameter to clarify that it is only required if additional or modified files are provided, rather than using the default files included with `orb-discovery` and `orb-agent`.