### PR TITLE
feat: proper semantic release major tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,7 @@ jobs:
                     { "message": "*", "release": "patch"},
                     { "message": "fix*", "release": "patch" },
                     { "message": "feat*", "release": "minor" },
-                    { "message": "perf*",  "release": "major" }
+                    { "message": "major*",  "release": "major" }
                   ]
                 }],
                 "@semantic-release/release-notes-generator",
@@ -210,7 +210,7 @@ jobs:
                     { "message": "*", "release": "patch"},
                     { "message": "fix*", "release": "patch" },
                     { "message": "feat*", "release": "minor" },
-                    { "message": "perf*",  "release": "major" }
+                    { "message": "major*",  "release": "major" }
                   ]
                 }],
                 "@semantic-release/release-notes-generator",

--- a/agent/backend/devicediscovery/device_discovery_test.go
+++ b/agent/backend/devicediscovery/device_discovery_test.go
@@ -33,7 +33,7 @@ func TestDeviceDiscoveryBackendStart(t *testing.T) {
 
 		if r.URL.Path == "/api/v1/status" {
 			response := StatusResponse{
-				Version:   "1.3.4",
+				Version:   "1.3.5",
 				StartTime: "2023-10-01T12:00:00Z",
 				UpTime:    123.456,
 			}


### PR DESCRIPTION
This pull request includes updates to the release workflow configuration and a minor version change in a test file. The most important changes involve adjusting the semantic release rules and updating the version in a test response.

### Release Workflow Updates:
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL68-R68): Changed the semantic release rule for messages starting with `perf*` to `major*`, ensuring that performance-related changes are categorized as major releases. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL68-R68) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL213-R213)

### Test File Update:
* [`agent/backend/devicediscovery/device_discovery_test.go`](diffhunk://#diff-d8cd58f53782228d6e966e2617d17185d5c43c3e13354103f356c6ceeb179132L36-R36): Updated the `Version` field in the `StatusResponse` mock to `1.3.5` from `1.3.4` in the `TestDeviceDiscoveryBackendStart` test function.