### PR TITLE
feat: support diode dryrun mode in device_discovery and worker backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ diode/
 orb-configs/
 build/
 .coverage/
+.vscode/

--- a/agent/backend/devicediscovery/device_discovery.go
+++ b/agent/backend/devicediscovery/device_discovery.go
@@ -39,11 +39,13 @@ type deviceDiscoveryBackend struct {
 	apiPort     string
 	apiProtocol string
 
-	diodeTarget        string
-	diodeClientID      string
-	diodeClientSecret  string
-	diodeAppNamePrefix string
-	diodeOtelEndpoint  string
+	diodeTarget          string
+	diodeClientID        string
+	diodeClientSecret    string
+	diodeAppNamePrefix   string
+	diodeOtelEndpoint    string
+	diodeDryRun          bool
+	diodeDryRunOutputDir string
 
 	startTime  time.Time
 	proc       backend.Commander
@@ -84,6 +86,27 @@ func (d *deviceDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Po
 	d.diodeClientID = common.Diode.ClientID
 	d.diodeClientSecret = common.Diode.ClientSecret
 	d.diodeAppNamePrefix = common.Diode.AgentName
+	d.diodeDryRun = common.Diode.DryRun
+	d.diodeDryRunOutputDir = common.Diode.DryRunOutputDir
+
+	if target, prs := config["target"].(string); prs {
+		d.diodeTarget = target
+	}
+	if clientID, prs := config["client_id"].(string); prs {
+		d.diodeClientID = clientID
+	}
+	if clientSecret, prs := config["client_secret"].(string); prs {
+		d.diodeClientSecret = clientSecret
+	}
+	if agentName, prs := config["agent_name"].(string); prs {
+		d.diodeAppNamePrefix = agentName
+	}
+	if dryRun, prs := config["dry_run"].(bool); prs {
+		d.diodeDryRun = dryRun
+	}
+	if dryRunOutputDir, prs := config["dry_run_output_dir"].(string); prs {
+		d.diodeDryRunOutputDir = dryRunOutputDir
+	}
 
 	if common.Otel.Grpc != "" {
 		d.diodeOtelEndpoint = common.Otel.Grpc
@@ -110,13 +133,22 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 	d.cancelFunc = cancelFunc
 	d.ctx = ctx
 
-	pvOptions := []string{
-		"--host", d.apiHost,
-		"--port", d.apiPort,
-		"--diode-target", d.diodeTarget,
-		"--diode-client-id", d.diodeClientID,
-		"--diode-client-secret", "********",
-		"--diode-app-name-prefix", d.diodeAppNamePrefix,
+	var pvOptions []string
+	if d.diodeDryRun {
+		pvOptions = []string{
+			"--dry-run",
+			"--dry-run-output-dir", d.diodeDryRunOutputDir,
+			"--diode-app-name-prefix", d.diodeAppNamePrefix,
+		}
+	} else {
+		pvOptions = []string{
+			"--host", d.apiHost,
+			"--port", d.apiPort,
+			"--diode-target", d.diodeTarget,
+			"--diode-client-id", d.diodeClientID,
+			"--diode-client-secret", "********",
+			"--diode-app-name-prefix", d.diodeAppNamePrefix,
+		}
 	}
 
 	if d.diodeOtelEndpoint != "" {

--- a/agent/backend/devicediscovery/device_discovery.go
+++ b/agent/backend/devicediscovery/device_discovery.go
@@ -157,7 +157,9 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 
 	d.logger.Info("device-discovery startup", slog.Any("arguments", pvOptions))
 
-	pvOptions[9] = d.diodeClientSecret
+	if !d.diodeDryRun && len(pvOptions) > 9 {
+		pvOptions[9] = d.diodeClientSecret
+	}
 
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,

--- a/agent/backend/devicediscovery/device_discovery_test.go
+++ b/agent/backend/devicediscovery/device_discovery_test.go
@@ -231,12 +231,20 @@ func TestDeviceDiscoveryBackendDryRun(t *testing.T) {
 	mocks.SetupSuccessfulProcess(mockCmd, 12345)
 
 	originalNewCmdOptions := backend.NewCmdOptions
-	var capturedArgs []string
+	defer func() {
+		backend.NewCmdOptions = originalNewCmdOptions
+	}()
+
 	backend.NewCmdOptions = func(options backend.CmdOptions, name string, args ...string) backend.Commander {
-		capturedArgs = args
+		assert.Equal(t, "device-discovery", name, "Expected command name to be device-discovery")
+		assert.Contains(t, args, "--dry-run")
+		assert.Contains(t, args, "--dry-run-output-dir")
+		assert.NotContains(t, args, "--host")
+		assert.NotContains(t, args, "--port")
+		assert.False(t, options.Buffered, "Expected buffered to be false")
+		assert.True(t, options.Streaming, "Expected streaming to be true")
 		return mockCmd
 	}
-	defer func() { backend.NewCmdOptions = originalNewCmdOptions }()
 
 	assert.True(t, devicediscovery.Register())
 	be := backend.GetBackend("device_discovery")
@@ -264,11 +272,6 @@ func TestDeviceDiscoveryBackendDryRun(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	err = be.Start(ctx, cancel)
 	assert.NoError(t, err)
-
-	assert.Contains(t, capturedArgs, "--dry-run")
-	assert.Contains(t, capturedArgs, "--dry-run-output-dir")
-	assert.NotContains(t, capturedArgs, "--host")
-	assert.NotContains(t, capturedArgs, "--port")
 
 	assert.False(t, be.GetStartTime().IsZero())
 

--- a/agent/backend/devicediscovery/device_discovery_test.go
+++ b/agent/backend/devicediscovery/device_discovery_test.go
@@ -201,3 +201,82 @@ func TestDeviceDiscoveryBackendCompleted(t *testing.T) {
 
 	assert.Error(t, err)
 }
+
+func TestDeviceDiscoveryBackendDryRun(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/status":
+			response := StatusResponse{Version: "1.3.5", StartTime: "2023-10-01T12:00:00Z", UpTime: 123.456}
+			_ = json.NewEncoder(w).Encode(response)
+		case r.URL.Path == "/api/v1/capabilities":
+			capabilities := map[string]any{"capability": true}
+			_ = json.NewEncoder(w).Encode(capabilities)
+		case strings.HasPrefix(r.URL.Path, "/api/v1/policies"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	repo, err := policies.NewMemRepo()
+	assert.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 12345)
+
+	originalNewCmdOptions := backend.NewCmdOptions
+	var capturedArgs []string
+	backend.NewCmdOptions = func(options backend.CmdOptions, name string, args ...string) backend.Commander {
+		capturedArgs = args
+		return mockCmd
+	}
+	defer func() { backend.NewCmdOptions = originalNewCmdOptions }()
+
+	assert.True(t, devicediscovery.Register())
+	be := backend.GetBackend("device_discovery")
+
+	beCommons := config.BackendCommons{
+		Diode: struct {
+			Target          string `yaml:"target"`
+			ClientID        string `yaml:"client_id"`
+			ClientSecret    string `yaml:"client_secret"`
+			AgentName       string `yaml:"agent_name"`
+			DryRun          bool   `yaml:"dry_run"`
+			DryRunOutputDir string `yaml:"dry_run_output_dir"`
+		}{
+			DryRun:          true,
+			DryRunOutputDir: "/tmp/dry-run-output",
+		},
+	}
+
+	err = be.Configure(logger, repo, map[string]any{
+		"host": serverURL.Hostname(),
+		"port": serverURL.Port(),
+	}, beCommons)
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err = be.Start(ctx, cancel)
+	assert.NoError(t, err)
+
+	assert.Contains(t, capturedArgs, "--dry-run")
+	assert.Contains(t, capturedArgs, "--dry-run-output-dir")
+	assert.NotContains(t, capturedArgs, "--host")
+	assert.NotContains(t, capturedArgs, "--port")
+
+	assert.False(t, be.GetStartTime().IsZero())
+
+	err = be.RemovePolicy(policies.PolicyData{ID: "1", Name: "policy", Data: map[string]any{"k": "v"}})
+	assert.NoError(t, err)
+
+	err = be.Stop(context.WithValue(context.Background(), config.ContextKey("routine"), "test"))
+	assert.NoError(t, err)
+
+	mockCmd.AssertExpectations(t)
+}

--- a/agent/backend/worker/worker.go
+++ b/agent/backend/worker/worker.go
@@ -157,7 +157,9 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 
 	d.logger.Info("worker startup", slog.Any("arguments", pvOptions))
 
-	pvOptions[9] = d.diodeClientSecret
+	if !d.diodeDryRun && len(pvOptions) > 9 {
+		pvOptions[9] = d.diodeClientSecret
+	}
 
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,
@@ -177,7 +179,7 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 		stderr := d.proc.GetStderr()
 		for stdout != nil || stderr != nil {
 			select {
-			case line, open := <-stderr:
+			case line, open := <-stdout:
 				if !open {
 					stdout = nil
 					continue

--- a/agent/backend/worker/worker.go
+++ b/agent/backend/worker/worker.go
@@ -39,11 +39,13 @@ type workerBackend struct {
 	apiPort     string
 	apiProtocol string
 
-	diodeTarget        string
-	diodeClientID      string
-	diodeClientSecret  string
-	diodeAppNamePrefix string
-	diodeOtelEndpoint  string
+	diodeTarget          string
+	diodeClientID        string
+	diodeClientSecret    string
+	diodeAppNamePrefix   string
+	diodeOtelEndpoint    string
+	diodeDryRun          bool
+	diodeDryRunOutputDir string
 
 	startTime  time.Time
 	proc       backend.Commander
@@ -84,6 +86,27 @@ func (d *workerBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	d.diodeClientID = common.Diode.ClientID
 	d.diodeClientSecret = common.Diode.ClientSecret
 	d.diodeAppNamePrefix = common.Diode.AgentName
+	d.diodeDryRun = common.Diode.DryRun
+	d.diodeDryRunOutputDir = common.Diode.DryRunOutputDir
+
+	if target, prs := config["target"].(string); prs {
+		d.diodeTarget = target
+	}
+	if clientID, prs := config["client_id"].(string); prs {
+		d.diodeClientID = clientID
+	}
+	if clientSecret, prs := config["client_secret"].(string); prs {
+		d.diodeClientSecret = clientSecret
+	}
+	if agentName, prs := config["agent_name"].(string); prs {
+		d.diodeAppNamePrefix = agentName
+	}
+	if dryRun, prs := config["dry_run"].(bool); prs {
+		d.diodeDryRun = dryRun
+	}
+	if dryRunOutputDir, prs := config["dry_run_output_dir"].(string); prs {
+		d.diodeDryRunOutputDir = dryRunOutputDir
+	}
 
 	if common.Otel.Grpc != "" {
 		d.diodeOtelEndpoint = common.Otel.Grpc
@@ -110,13 +133,22 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 	d.cancelFunc = cancelFunc
 	d.ctx = ctx
 
-	pvOptions := []string{
-		"--host", d.apiHost,
-		"--port", d.apiPort,
-		"--diode-target", d.diodeTarget,
-		"--diode-client-id", d.diodeClientID,
-		"--diode-client-secret", "********",
-		"--diode-app-name-prefix", d.diodeAppNamePrefix,
+	var pvOptions []string
+	if d.diodeDryRun {
+		pvOptions = []string{
+			"--dry-run",
+			"--dry-run-output-dir", d.diodeDryRunOutputDir,
+			"--diode-app-name-prefix", d.diodeAppNamePrefix,
+		}
+	} else {
+		pvOptions = []string{
+			"--host", d.apiHost,
+			"--port", d.apiPort,
+			"--diode-target", d.diodeTarget,
+			"--diode-client-id", d.diodeClientID,
+			"--diode-client-secret", "********",
+			"--diode-app-name-prefix", d.diodeAppNamePrefix,
+		}
 	}
 
 	if d.diodeOtelEndpoint != "" {

--- a/agent/backend/worker/worker_test.go
+++ b/agent/backend/worker/worker_test.go
@@ -231,12 +231,20 @@ func TestWorkerBackendDryRun(t *testing.T) {
 	mocks.SetupSuccessfulProcess(mockCmd, 12345)
 
 	originalNewCmdOptions := backend.NewCmdOptions
-	var capturedArgs []string
+	defer func() {
+		backend.NewCmdOptions = originalNewCmdOptions
+	}()
+
 	backend.NewCmdOptions = func(options backend.CmdOptions, name string, args ...string) backend.Commander {
-		capturedArgs = args
+		assert.Equal(t, "orb-worker", name, "Expected command name to be orb-worker")
+		assert.Contains(t, args, "--dry-run")
+		assert.Contains(t, args, "--dry-run-output-dir")
+		assert.NotContains(t, args, "--host")
+		assert.NotContains(t, args, "--port")
+		assert.False(t, options.Buffered, "Expected buffered to be false")
+		assert.True(t, options.Streaming, "Expected streaming to be true")
 		return mockCmd
 	}
-	defer func() { backend.NewCmdOptions = originalNewCmdOptions }()
 
 	assert.True(t, worker.Register())
 	be := backend.GetBackend("worker")
@@ -264,11 +272,6 @@ func TestWorkerBackendDryRun(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	err = be.Start(ctx, cancel)
 	assert.NoError(t, err)
-
-	assert.Contains(t, capturedArgs, "--dry-run")
-	assert.Contains(t, capturedArgs, "--dry-run-output-dir")
-	assert.NotContains(t, capturedArgs, "--host")
-	assert.NotContains(t, capturedArgs, "--port")
 
 	assert.False(t, be.GetStartTime().IsZero())
 

--- a/agent/backend/worker/worker_test.go
+++ b/agent/backend/worker/worker_test.go
@@ -201,3 +201,82 @@ func TestWorkerBackendCompleted(t *testing.T) {
 
 	assert.Error(t, err)
 }
+
+func TestWorkerBackendDryRun(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/status":
+			response := StatusResponse{Version: "1.3.4", StartTime: "2023-10-01T12:00:00Z", UpTime: 123.456}
+			_ = json.NewEncoder(w).Encode(response)
+		case r.URL.Path == "/api/v1/capabilities":
+			capabilities := map[string]any{"capability": true}
+			_ = json.NewEncoder(w).Encode(capabilities)
+		case strings.HasPrefix(r.URL.Path, "/api/v1/policies"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	repo, err := policies.NewMemRepo()
+	assert.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 12345)
+
+	originalNewCmdOptions := backend.NewCmdOptions
+	var capturedArgs []string
+	backend.NewCmdOptions = func(options backend.CmdOptions, name string, args ...string) backend.Commander {
+		capturedArgs = args
+		return mockCmd
+	}
+	defer func() { backend.NewCmdOptions = originalNewCmdOptions }()
+
+	assert.True(t, worker.Register())
+	be := backend.GetBackend("worker")
+
+	beCommons := config.BackendCommons{
+		Diode: struct {
+			Target          string `yaml:"target"`
+			ClientID        string `yaml:"client_id"`
+			ClientSecret    string `yaml:"client_secret"`
+			AgentName       string `yaml:"agent_name"`
+			DryRun          bool   `yaml:"dry_run"`
+			DryRunOutputDir string `yaml:"dry_run_output_dir"`
+		}{
+			DryRun:          true,
+			DryRunOutputDir: "/tmp/dry-run-output",
+		},
+	}
+
+	err = be.Configure(logger, repo, map[string]any{
+		"host": serverURL.Hostname(),
+		"port": serverURL.Port(),
+	}, beCommons)
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err = be.Start(ctx, cancel)
+	assert.NoError(t, err)
+
+	assert.Contains(t, capturedArgs, "--dry-run")
+	assert.Contains(t, capturedArgs, "--dry-run-output-dir")
+	assert.NotContains(t, capturedArgs, "--host")
+	assert.NotContains(t, capturedArgs, "--port")
+
+	assert.False(t, be.GetStartTime().IsZero())
+
+	err = be.RemovePolicy(policies.PolicyData{ID: "1", Name: "policy", Data: map[string]any{"k": "v"}})
+	assert.NoError(t, err)
+
+	err = be.Stop(context.WithValue(context.Background(), config.ContextKey("routine"), "test"))
+	assert.NoError(t, err)
+
+	mockCmd.AssertExpectations(t)
+}

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -74,10 +74,12 @@ type BackendCommons struct {
 		AgentLabels map[string]string `yaml:"agent_labels"`
 	} `yaml:"otel"`
 	Diode struct {
-		Target       string `yaml:"target"`
-		ClientID     string `yaml:"client_id"`
-		ClientSecret string `yaml:"client_secret"`
-		AgentName    string `yaml:"agent_name"`
+		Target          string `yaml:"target"`
+		ClientID        string `yaml:"client_id"`
+		ClientSecret    string `yaml:"client_secret"`
+		AgentName       string `yaml:"agent_name"`
+		DryRun          bool   `yaml:"dry_run"`
+		DryRunOutputDir string `yaml:"dry_run_output_dir"`
 	}
 }
 


### PR DESCRIPTION
This pull request introduces support for a "dry-run" mode in both the `deviceDiscoveryBackend` and `workerBackend` components. The changes include adding new configuration fields, updating the `Configure` methods to handle these fields, and modifying the `Start` methods to conditionally apply dry-run options based on the configuration. Additionally, the `BackendCommons` struct has been updated to include dry-run-related fields.


## Result
Running orb-agent with proper mounted volume, allows setting it as output dir without any setup changes:
![Screenshot from 2025-06-24 11-59-43](https://github.com/user-attachments/assets/88880b71-34d9-4418-91b6-54626a1ce538)


### Backend updates for dry-run mode:

#### Changes to `deviceDiscoveryBackend`:

* Added `diodeDryRun` and `diodeDryRunOutputDir` fields to the `deviceDiscoveryBackend` struct to support dry-run functionality. (`agent/backend/devicediscovery/device_discovery.go`, [agent/backend/devicediscovery/device_discovery.goR47-R48](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02R47-R48))
* Updated the `Configure` method to populate the new dry-run fields from the configuration and handle additional configuration overrides. (`agent/backend/devicediscovery/device_discovery.go`, [agent/backend/devicediscovery/device_discovery.goR89-R109](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02R89-R109))
* Modified the `Start` method to conditionally include dry-run options in the `pvOptions` array based on the `diodeDryRun` flag. (`agent/backend/devicediscovery/device_discovery.go`, [agent/backend/devicediscovery/device_discovery.goL113-R152](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L113-R152))

#### Changes to `workerBackend`:

* Added `diodeDryRun` and `diodeDryRunOutputDir` fields to the `workerBackend` struct to support dry-run functionality. (`agent/backend/worker/worker.go`, [agent/backend/worker/worker.goR47-R48](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcR47-R48))
* Updated the `Configure` method to populate the new dry-run fields from the configuration and handle additional configuration overrides. (`agent/backend/worker/worker.go`, [agent/backend/worker/worker.goR89-R109](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcR89-R109))
* Modified the `Start` method to conditionally include dry-run options in the `pvOptions` array based on the `diodeDryRun` flag. (`agent/backend/worker/worker.go`, [agent/backend/worker/worker.goL113-R152](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcL113-R152))

### Configuration updates:

* Added `DryRun` and `DryRunOutputDir` fields to the `BackendCommons` struct to enable dry-run configuration at a higher level. (`agent/config/types.go`, [agent/config/types.goR81-R82](diffhunk://#diff-fa50c62688210fe1e87f900fd800e4984fcda45ea46a9ea08ff29558e33f17dbR81-R82))