### PR TITLE
feat: don't add extensions from snmp image to orb agent

### DIFF
--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -50,9 +50,7 @@ COPY --from=otlpinf /exe /usr/local/bin/otlpinf
 
 COPY --from=network-discovery /usr/local/bin/network-discovery /usr/local/bin/network-discovery
 
-RUN mkdir -p /etc/snmp-discovery/lookup-extensions
 COPY --from=snmp-discovery /usr/local/bin/snmp-discovery /usr/local/bin/snmp-discovery
-COPY --from=snmp-discovery /etc/snmp-discovery/lookup-extensions /etc/snmp-discovery/lookup-extensions
 
 RUN pip3 install netboxlabs-device-discovery netboxlabs-orb-worker
 

--- a/docs/config_samples.md
+++ b/docs/config_samples.md
@@ -195,7 +195,7 @@ orb:
           device:
             description: "SNMP discovered device"
             comments: "Automatically discovered via SNMP"
-        # lookup_extensions_dir: "/opt/orb/snmp-extensions" # Specifies an override for the directory containing device data yaml files (see below)
+        # lookup_extensions_dir: "/opt/orb/snmp-extensions" # Specifies aa directory containing additional device data yaml files (see below)
       scope:
         targets:
           - host: "192.168.1.1"
@@ -230,9 +230,9 @@ orb:
 ```
 
 ### Device Model Lookup
-The `lookup_extensions_dir` specifies a directory containing device data YAML files that map SNMP device ObjectIds (from querying `.1.3.6.1.2.1.1.2.0`) to human-readable device names. This allows snmp-discovery to provide meaningful device identification instead of raw ObjectId values. This only needs to be set if additional or modified files are being provided instead of the ones that are included with orb-discovery and orb-agent.
+The `lookup_extensions_dir` specifies a directory containing device data YAML files that map SNMP device ObjectIds (from querying `.1.3.6.1.2.1.1.2.0`) to human-readable device names. This allows snmp-discovery to provide meaningful device identification instead of raw ObjectId values. This only needs to be set if additional or modified files are being provided in addition the ones that are included with orb-discovery and orb-agent.
 
-Device model lookup files to put in the `lookup_extenions_dir` are available from the [`orb-discovery` repository](https://github.com/netboxlabs/orb-discovery/tree/release/snmp-discovery/lookup_extension). More details about the file format and adding devices that aren't already covered are [available here](https://github.com/netboxlabs/orb-discovery/blob/release/snmp-discovery/README.md#device-model-lookup).
+More details about the file format and adding devices that aren't already covered are [available here](https://github.com/netboxlabs/orb-discovery/blob/release/snmp-discovery/README.md#device-model-lookup).
 
 ### Running the SNMP Discovery Backend
 


### PR DESCRIPTION
This pull request includes updates to the SNMP discovery functionality and documentation. The most important changes involve removing unused code related to SNMP lookup extensions in the Dockerfile and improving the documentation for the `lookup_extensions_dir` configuration.

### SNMP Discovery Code Updates:
* [`agent/docker/Dockerfile`](diffhunk://#diff-213bb5537c1a11cdd5ad4d1df9042b68b951353a130b68b8de9ce2973d45f372L53-L55): Removed unused code for creating and copying the `lookup-extensions` directory, which is no longer required for SNMP discovery.

### Documentation Improvements:
* [`docs/config_samples.md`](diffhunk://#diff-c89006d67ac3f5e07361eb1d39ebf0cc2af11b0dab0a2ec0e09a4eb33a55bcd6L198-R198): Corrected typos and clarified the description of the `lookup_extensions_dir` configuration to better explain its purpose and usage. [[1]](diffhunk://#diff-c89006d67ac3f5e07361eb1d39ebf0cc2af11b0dab0a2ec0e09a4eb33a55bcd6L198-R198) [[2]](diffhunk://#diff-c89006d67ac3f5e07361eb1d39ebf0cc2af11b0dab0a2ec0e09a4eb33a55bcd6L233-R235)