### PR TITLE
feat: add dry run mode support to network and snmp discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ A special `common` subsection under `backends` defines configuration settings th
           client_id: ${DIODE_CLIENT_ID}
           client_secret: ${DIODE_CLIENT_SECRET}
           agent_name: agent01
-          dry_run: False
+          dry_run: false
           dry_run_output_dir: /opt/orb
 ```
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ A special `common` subsection under `backends` defines configuration settings th
           client_id: ${DIODE_CLIENT_ID}
           client_secret: ${DIODE_CLIENT_SECRET}
           agent_name: agent01
+          dry_run: False
+          dry_run_output_dir: /opt/orb
 ```
 
 ### Policies

--- a/agent/backend/networkdiscovery/network_discovery.go
+++ b/agent/backend/networkdiscovery/network_discovery.go
@@ -39,11 +39,13 @@ type networkDiscoveryBackend struct {
 	apiPort     string
 	apiProtocol string
 
-	diodeTarget        string
-	diodeClientID      string
-	diodeClientSecret  string
-	diodeAppNamePrefix string
-	diodeOtelEndpoint  string
+	diodeTarget          string
+	diodeClientID        string
+	diodeClientSecret    string
+	diodeAppNamePrefix   string
+	diodeOtelEndpoint    string
+	diodeDryRun          bool
+	diodeDryRunOutputDir string
 
 	startTime  time.Time
 	proc       backend.Commander
@@ -84,6 +86,27 @@ func (d *networkDiscoveryBackend) Configure(logger *slog.Logger, repo policies.P
 	d.diodeClientID = common.Diode.ClientID
 	d.diodeClientSecret = common.Diode.ClientSecret
 	d.diodeAppNamePrefix = common.Diode.AgentName
+	d.diodeDryRun = common.Diode.DryRun
+	d.diodeDryRunOutputDir = common.Diode.DryRunOutputDir
+
+	if target, prs := config["target"].(string); prs {
+		d.diodeTarget = target
+	}
+	if clientID, prs := config["client_id"].(string); prs {
+		d.diodeClientID = clientID
+	}
+	if clientSecret, prs := config["client_secret"].(string); prs {
+		d.diodeClientSecret = clientSecret
+	}
+	if agentName, prs := config["agent_name"].(string); prs {
+		d.diodeAppNamePrefix = agentName
+	}
+	if dryRun, prs := config["dry_run"].(bool); prs {
+		d.diodeDryRun = dryRun
+	}
+	if dryRunOutputDir, prs := config["dry_run_output_dir"].(string); prs {
+		d.diodeDryRunOutputDir = dryRunOutputDir
+	}
 
 	if common.Otel.Grpc != "" {
 		d.diodeOtelEndpoint = common.Otel.Grpc
@@ -110,13 +133,22 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 	d.cancelFunc = cancelFunc
 	d.ctx = ctx
 
-	pvOptions := []string{
-		"--host", d.apiHost,
-		"--port", d.apiPort,
-		"--diode-target", d.diodeTarget,
-		"--diode-client-id", d.diodeClientID,
-		"--diode-client-secret", "********",
-		"--diode-app-name-prefix", d.diodeAppNamePrefix,
+	var pvOptions []string
+	if d.diodeDryRun {
+		pvOptions = []string{
+			"--dry-run",
+			"--dry-run-output-dir", d.diodeDryRunOutputDir,
+			"--diode-app-name-prefix", d.diodeAppNamePrefix,
+		}
+	} else {
+		pvOptions = []string{
+			"--host", d.apiHost,
+			"--port", d.apiPort,
+			"--diode-target", d.diodeTarget,
+			"--diode-client-id", d.diodeClientID,
+			"--diode-client-secret", "********",
+			"--diode-app-name-prefix", d.diodeAppNamePrefix,
+		}
 	}
 
 	if d.diodeOtelEndpoint != "" {
@@ -125,7 +157,9 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 
 	d.logger.Info("network-discovery startup", slog.Any("arguments", pvOptions))
 
-	pvOptions[9] = d.diodeClientSecret
+	if !d.diodeDryRun && len(pvOptions) > 9 {
+		pvOptions[9] = d.diodeClientSecret
+	}
 
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,

--- a/agent/backend/networkdiscovery/network_discovery_test.go
+++ b/agent/backend/networkdiscovery/network_discovery_test.go
@@ -201,3 +201,85 @@ func TestNetworkDiscoveryBackendCompleted(t *testing.T) {
 
 	assert.Error(t, err)
 }
+
+func TestNetworkDiscoveryBackendDryRun(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/status":
+			response := StatusResponse{Version: "1.3.5", StartTime: "2023-10-01T12:00:00Z", UpTime: 123.456}
+			_ = json.NewEncoder(w).Encode(response)
+		case r.URL.Path == "/api/v1/capabilities":
+			capabilities := map[string]any{"capability": true}
+			_ = json.NewEncoder(w).Encode(capabilities)
+		case strings.HasPrefix(r.URL.Path, "/api/v1/policies"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	repo, err := policies.NewMemRepo()
+	assert.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 12345)
+
+	originalNewCmdOptions := backend.NewCmdOptions
+	defer func() {
+		backend.NewCmdOptions = originalNewCmdOptions
+	}()
+
+	backend.NewCmdOptions = func(options backend.CmdOptions, name string, args ...string) backend.Commander {
+		assert.Equal(t, "network-discovery", name, "Expected command name to be network-discovery")
+		assert.Contains(t, args, "--dry-run")
+		assert.Contains(t, args, "--dry-run-output-dir")
+		assert.NotContains(t, args, "--host")
+		assert.NotContains(t, args, "--port")
+		assert.False(t, options.Buffered, "Expected buffered to be false")
+		assert.True(t, options.Streaming, "Expected streaming to be true")
+		return mockCmd
+	}
+
+	assert.True(t, networkdiscovery.Register())
+	be := backend.GetBackend("network_discovery")
+
+	beCommons := config.BackendCommons{
+		Diode: struct {
+			Target          string `yaml:"target"`
+			ClientID        string `yaml:"client_id"`
+			ClientSecret    string `yaml:"client_secret"`
+			AgentName       string `yaml:"agent_name"`
+			DryRun          bool   `yaml:"dry_run"`
+			DryRunOutputDir string `yaml:"dry_run_output_dir"`
+		}{
+			DryRun:          true,
+			DryRunOutputDir: "/tmp/dry-run-output",
+		},
+	}
+
+	err = be.Configure(logger, repo, map[string]any{
+		"host": serverURL.Hostname(),
+		"port": serverURL.Port(),
+	}, beCommons)
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err = be.Start(ctx, cancel)
+	assert.NoError(t, err)
+
+	assert.False(t, be.GetStartTime().IsZero())
+
+	err = be.RemovePolicy(policies.PolicyData{ID: "1", Name: "policy", Data: map[string]any{"k": "v"}})
+	assert.NoError(t, err)
+
+	err = be.Stop(context.WithValue(context.Background(), config.ContextKey("routine"), "test"))
+	assert.NoError(t, err)
+
+	mockCmd.AssertExpectations(t)
+}

--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -39,10 +39,13 @@ type snmpDiscoveryBackend struct {
 	apiPort     string
 	apiProtocol string
 
-	diodeTarget        string
-	diodeClientID      string
-	diodeClientSecret  string
-	diodeAppNamePrefix string
+	diodeTarget          string
+	diodeClientID        string
+	diodeClientSecret    string
+	diodeAppNamePrefix   string
+	diodeOtelEndpoint    string
+	diodeDryRun          bool
+	diodeDryRunOutputDir string
 
 	startTime  time.Time
 	proc       backend.Commander
@@ -83,6 +86,33 @@ func (d *snmpDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Poli
 	d.diodeClientID = common.Diode.ClientID
 	d.diodeClientSecret = common.Diode.ClientSecret
 	d.diodeAppNamePrefix = common.Diode.AgentName
+	d.diodeDryRun = common.Diode.DryRun
+	d.diodeDryRunOutputDir = common.Diode.DryRunOutputDir
+
+	if target, prs := config["target"].(string); prs {
+		d.diodeTarget = target
+	}
+	if clientID, prs := config["client_id"].(string); prs {
+		d.diodeClientID = clientID
+	}
+	if clientSecret, prs := config["client_secret"].(string); prs {
+		d.diodeClientSecret = clientSecret
+	}
+	if agentName, prs := config["agent_name"].(string); prs {
+		d.diodeAppNamePrefix = agentName
+	}
+	if dryRun, prs := config["dry_run"].(bool); prs {
+		d.diodeDryRun = dryRun
+	}
+	if dryRunOutputDir, prs := config["dry_run_output_dir"].(string); prs {
+		d.diodeDryRunOutputDir = dryRunOutputDir
+	}
+
+	if common.Otel.Grpc != "" {
+		d.diodeOtelEndpoint = common.Otel.Grpc
+		d.logger.Info("snmp-discovery using OTLP metrics endpoint",
+			slog.String("endpoint", d.diodeOtelEndpoint))
+	}
 
 	return nil
 }
@@ -103,18 +133,33 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 	d.cancelFunc = cancelFunc
 	d.ctx = ctx
 
-	pvOptions := []string{
-		"--host", d.apiHost,
-		"--port", d.apiPort,
-		"--diode-target", d.diodeTarget,
-		"--diode-client-id", d.diodeClientID,
-		"--diode-client-secret", "********",
-		"--diode-app-name-prefix", d.diodeAppNamePrefix,
+	var pvOptions []string
+	if d.diodeDryRun {
+		pvOptions = []string{
+			"--dry-run",
+			"--dry-run-output-dir", d.diodeDryRunOutputDir,
+			"--diode-app-name-prefix", d.diodeAppNamePrefix,
+		}
+	} else {
+		pvOptions = []string{
+			"--host", d.apiHost,
+			"--port", d.apiPort,
+			"--diode-target", d.diodeTarget,
+			"--diode-client-id", d.diodeClientID,
+			"--diode-client-secret", "********",
+			"--diode-app-name-prefix", d.diodeAppNamePrefix,
+		}
+	}
+
+	if d.diodeOtelEndpoint != "" {
+		pvOptions = append(pvOptions, "--otel-endpoint", d.diodeOtelEndpoint)
 	}
 
 	d.logger.Info("snmp-discovery startup", slog.Any("arguments", pvOptions))
 
-	pvOptions[9] = d.diodeClientSecret
+	if !d.diodeDryRun && len(pvOptions) > 9 {
+		pvOptions[9] = d.diodeClientSecret
+	}
 
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,

--- a/agent/backend/snmpdiscovery/snmp_discovery_test.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery_test.go
@@ -201,3 +201,85 @@ func TestSNMPDiscoveryBackendCompleted(t *testing.T) {
 
 	assert.Error(t, err)
 }
+
+func TestNetworkDiscoveryBackendDryRun(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/status":
+			response := StatusResponse{Version: "1.3.5", StartTime: "2023-10-01T12:00:00Z", UpTime: 123.456}
+			_ = json.NewEncoder(w).Encode(response)
+		case r.URL.Path == "/api/v1/capabilities":
+			capabilities := map[string]any{"capability": true}
+			_ = json.NewEncoder(w).Encode(capabilities)
+		case strings.HasPrefix(r.URL.Path, "/api/v1/policies"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	repo, err := policies.NewMemRepo()
+	assert.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 12345)
+
+	originalNewCmdOptions := backend.NewCmdOptions
+	defer func() {
+		backend.NewCmdOptions = originalNewCmdOptions
+	}()
+
+	backend.NewCmdOptions = func(options backend.CmdOptions, name string, args ...string) backend.Commander {
+		assert.Equal(t, "snmp-discovery", name, "Expected command name to be snmp-discovery")
+		assert.Contains(t, args, "--dry-run")
+		assert.Contains(t, args, "--dry-run-output-dir")
+		assert.NotContains(t, args, "--host")
+		assert.NotContains(t, args, "--port")
+		assert.False(t, options.Buffered, "Expected buffered to be false")
+		assert.True(t, options.Streaming, "Expected streaming to be true")
+		return mockCmd
+	}
+
+	assert.True(t, snmpdiscovery.Register())
+	be := backend.GetBackend("snmp_discovery")
+
+	beCommons := config.BackendCommons{
+		Diode: struct {
+			Target          string `yaml:"target"`
+			ClientID        string `yaml:"client_id"`
+			ClientSecret    string `yaml:"client_secret"`
+			AgentName       string `yaml:"agent_name"`
+			DryRun          bool   `yaml:"dry_run"`
+			DryRunOutputDir string `yaml:"dry_run_output_dir"`
+		}{
+			DryRun:          true,
+			DryRunOutputDir: "/tmp/dry-run-output",
+		},
+	}
+
+	err = be.Configure(logger, repo, map[string]any{
+		"host": serverURL.Hostname(),
+		"port": serverURL.Port(),
+	}, beCommons)
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	err = be.Start(ctx, cancel)
+	assert.NoError(t, err)
+
+	assert.False(t, be.GetStartTime().IsZero())
+
+	err = be.RemovePolicy(policies.PolicyData{ID: "1", Name: "policy", Data: map[string]any{"k": "v"}})
+	assert.NoError(t, err)
+
+	err = be.Stop(context.WithValue(context.Background(), config.ContextKey("routine"), "test"))
+	assert.NoError(t, err)
+
+	mockCmd.AssertExpectations(t)
+}

--- a/docs/config_samples.md
+++ b/docs/config_samples.md
@@ -247,3 +247,53 @@ docker run --net=host \
     netboxlabs/orb-agent:latest \
     run -c "/opt/orb/snmp-config.yaml"
 ```
+
+## Diode Dry Run Mode
+
+The Orb Agent supports a diode dry run mode that allows you to test your configuration without sending data to the Diode server. This is useful for debugging and validating your configuration.
+
+### Basic Configuration
+
+```yaml
+orb:
+  config_manager:
+    active: local
+  backends:
+    device_discovery:
+    common:
+      diode:
+        dry_run: true
+        dry_run_output_dir: /opt/orb/
+        # No need for target, client_id, client_secret when in dry_run mode
+        agent_name: agent01
+  policies:
+    device_discovery:
+      discovery_1:
+        config:
+          defaults:
+            site: New York NY
+        scope:
+          - driver: ios
+            hostname: 192.168.0.5
+            username: admin
+            password: ${PASS}
+            optional_args:
+              ssh_config_file: /opt/orb/ssh-napalm.conf
+```
+
+Run command:
+```sh
+docker run -v /local/orb:/opt/orb/ \
+-e PASS={DEVICE_PASSWORD} \
+-v /local/output:/opt/orb/output \
+netboxlabs/orb-agent:latest run -c /opt/orb/agent.yaml
+```
+
+When running in dry run mode, the agent will:
+1. Process all policies as usual
+2. Write the data that would be sent to Diode as JSON files in the specified output directory.
+3. For this sample policy, a file named `agent01_device-discovery_<timestamp>.json` will be generated in `/opt/orb` folder.
+4. No data will be sent to any remote server
+
+This allows you to inspect the data that would be collected and sent to Diode Server before configuring the actual connection.
+This feature is supported by the [Device Discovery](./backends/device_discovery.md), [Network Discovery](./backends/network_discovery.md), [Worker](./backends/worker.md) and [SNMP Discovery](./backends/snmp_discovery.md) backends.


### PR DESCRIPTION
This pull request introduces a "dry-run" mode to the `networkDiscoveryBackend` and `snmpDiscoveryBackend` components, enabling safer testing by simulating operations without executing them. It also adds corresponding configurations and unit tests to ensure the functionality works as expected.

### Backend Enhancements:
* Added `diodeDryRun` and `diodeDryRunOutputDir` fields to `networkDiscoveryBackend` and `snmpDiscoveryBackend` structs to support dry-run mode. (`agent/backend/networkdiscovery/network_discovery.go`: [[1]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854R47-R48) `agent/backend/snmpdiscovery/snmp_discovery.go`: [[2]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91R46-R48)
* Updated `Configure` methods to populate dry-run-related fields from configuration and handle optional parameters. (`agent/backend/networkdiscovery/network_discovery.go`: [[1]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854R89-R109) `agent/backend/snmpdiscovery/snmp_discovery.go`: [[2]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91R89-R115)
* Modified `Start` methods to adjust command-line arguments based on dry-run mode, ensuring safe execution and proper logging. (`agent/backend/networkdiscovery/network_discovery.go`: [[1]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L113-R162) `agent/backend/snmpdiscovery/snmp_discovery.go`: [[2]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91L106-R162)

### Testing Additions:
* Added unit tests for dry-run mode in `networkDiscoveryBackend` and `snmpDiscoveryBackend`, verifying configuration, startup behavior, and command-line arguments. (`agent/backend/networkdiscovery/network_discovery_test.go`: [[1]](diffhunk://#diff-6b6bc95e89f599a44ce52ca0b65600c07498fdec88d42c6e72a6b56a49e9967aR204-R285) `agent/backend/snmpdiscovery/snmp_discovery_test.go`: [[2]](diffhunk://#diff-d6f915c486f108a406be6c96e380a0aaa3a8d322203567fcf7bfc8f1d592af7cR204-R285)