### PR TITLE
doc: fixes typo in config samples

### DIFF
--- a/docs/config_samples.md
+++ b/docs/config_samples.md
@@ -195,7 +195,7 @@ orb:
           device:
             description: "SNMP discovered device"
             comments: "Automatically discovered via SNMP"
-        # lookup_extensions_dir: "/opt/orb/snmp-extensions" # Specifies aa directory containing additional device data yaml files (see below)
+        # lookup_extensions_dir: "/opt/orb/snmp-extensions" # Specifies a directory containing additional device data yaml files (see below)
       scope:
         targets:
           - host: "192.168.1.1"


### PR DESCRIPTION
This pull request includes a minor correction to a comment in the `docs/config_samples.md` file. The change fixes a typo in the description of the `lookup_extensions_dir` configuration option.