### PR TITLE
docs: corrects protocol versions

### DIFF
--- a/docs/config_samples.md
+++ b/docs/config_samples.md
@@ -204,7 +204,7 @@ orb:
           - host: "10.0.0.1"
             port: 162  # Non-standard SNMP port
         authentication:
-          protocol_version: "v2c"
+          protocol_version: "SNMPv2c"
           community: "public" # Also supports resolving values from environment variables eg ${SNMP_COMMUNITY}
           # For SNMPv3, use these fields instead:
           # security_level: "authPriv"
@@ -221,7 +221,7 @@ orb:
           - host: "192.168.100.50"
             port: 161
         authentication:
-          protocol_version: "v3"
+          protocol_version: "SNMPv3"
           security_level: "authPriv"
           username: "monitoring"
           auth_protocol: "SHA"


### PR DESCRIPTION
This pull request updates the SNMP protocol version configuration in the `docs/config_samples.md` file to use standardized naming conventions for clarity and consistency.

SNMP protocol version updates:

* [`docs/config_samples.md`](diffhunk://#diff-c89006d67ac3f5e07361eb1d39ebf0cc2af11b0dab0a2ec0e09a4eb33a55bcd6L207-R207): Changed `protocol_version` values from `"v2c"` to `"SNMPv2c"` for SNMPv2c configurations to align with standard naming conventions.
* [`docs/config_samples.md`](diffhunk://#diff-c89006d67ac3f5e07361eb1d39ebf0cc2af11b0dab0a2ec0e09a4eb33a55bcd6L224-R224): Changed `protocol_version` values from `"v3"` to `"SNMPv3"` for SNMPv3 configurations to align with standard naming conventions.