### PR TITLE
chore: adds otel metrics docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ A special `common` subsection under `backends` defines configuration settings th
           dry_run: false
           dry_run_output_dir: /opt/orb
         otel:
-          grpc: "grpc://otel-collector:4317" # or `http: "http://otel-collector:4318"`
+          grpc: "grpc://otel-collector:4317"
           agent_labels:
             environment: "production"
             datacenter: "us-east-1"

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Only the `network_discovery`, `device_discovery`, `worker` and `snmp_discovery` 
 - [SNMP Discovery](./docs/backends/snmp_discovery.md)
 
 #### Common
-A special `common` subsection under `backends` defines configuration settings that are shared with all backends. Currently, it supports passing [diode](https://github.com/netboxlabs/diode) server settings to all backends.
+A special `common` subsection under `backends` defines configuration settings that are shared with all backends. Currently, it supports passing [diode](https://github.com/netboxlabs/diode) server settings and OpenTelemetry configuration to all backends.
 
 ```yaml
   backends:
@@ -80,6 +80,12 @@ A special `common` subsection under `backends` defines configuration settings th
           agent_name: agent01
           dry_run: false
           dry_run_output_dir: /opt/orb
+        otel:
+          grpc: "grpc://otel-collector:4317" # or `http: "http://otel-collector:4318"`
+          agent_labels:
+            environment: "production"
+            datacenter: "us-east-1"
+            service: "network-monitoring"
 ```
 
 ### Policies

--- a/docs/config_samples.md
+++ b/docs/config_samples.md
@@ -324,18 +324,11 @@ orb:
     network_discovery:
     snmp_discovery:
     worker:
-    
-    # Packet capture backend that exports to OpenTelemetry via HTTP
-    pktvisor:
-      config_file: "/opt/orb/pktvisor.yaml"
-       
+          
     common:
       otel:
         # gRPC endpoint for discovery backends
         grpc: "grpc://otel-collector.monitoring.svc.cluster.local:4317"
-        
-        # HTTP endpoint for pktvisor backend  
-        http: "http://otel-collector.monitoring.svc.cluster.local:4318"
         
         # Labels attached to all telemetry data
         agent_labels:

--- a/docs/config_samples.md
+++ b/docs/config_samples.md
@@ -304,3 +304,70 @@ When running in dry run mode, the agent will:
 
 This allows you to inspect the data that would be collected and sent to Diode Server before configuring the actual connection.
 This feature is supported by the [Device Discovery](./backends/device_discovery.md), [Network Discovery](./backends/network_discovery.md), [Worker](./backends/worker.md) and [SNMP Discovery](./backends/snmp_discovery.md) backends.
+
+## Exporting OpenTelemetry Metrics
+
+The backends support exporting metrics using OpenTelemetry. The discovery backends do so over GRPC, and pktvisor does so over http.
+
+### Basic Configuration
+
+```yaml
+orb:
+  config_manager:
+    active: local
+  labels:
+    agent_id: "network-agent-001"
+    location: "datacenter-east"
+  backends:
+    # Discovery backends that export to OpenTelemetry via gRPC
+    device_discovery:
+    network_discovery:
+    snmp_discovery:
+    worker:
+    
+    # Packet capture backend that exports to OpenTelemetry via HTTP
+    pktvisor:
+      config_file: "/opt/orb/pktvisor.yaml"
+       
+    common:
+      otel:
+        # gRPC endpoint for discovery backends
+        grpc: "grpc://otel-collector.monitoring.svc.cluster.local:4317"
+        
+        # HTTP endpoint for pktvisor backend  
+        http: "http://otel-collector.monitoring.svc.cluster.local:4318"
+        
+        # Labels attached to all telemetry data
+        agent_labels:
+          environment: "production"
+          datacenter: "us-east-1"
+          cluster: "main"
+          service: "orb-agent"
+          version: "v2.0.0"
+          team: "platform"
+      
+      diode:
+        target: "grpc://diode.example.com:8080/diode"
+        client_id: "${DIODE_CLIENT_ID}"
+        client_secret: "${DIODE_CLIENT_SECRET}"
+        agent_name: "network-agent-001"
+  
+  policies:
+    device_discovery:
+      policy_1:
+        config:
+          schedule: "0 */6 * * *"
+        scope:
+          - driver: ios
+            hostname: "192.168.1.1"
+            username: "admin"
+            password: "${DEVICE_PASSWORD}"
+    
+    network_discovery:
+      policy_1:
+        config:
+          schedule: "0 */2 * * *"
+          timeout: 5
+        scope:
+          targets: [192.168.1.0, 192.168.1.1]
+```

--- a/docs/config_samples.md
+++ b/docs/config_samples.md
@@ -307,7 +307,7 @@ This feature is supported by the [Device Discovery](./backends/device_discovery.
 
 ## Exporting OpenTelemetry Metrics
 
-The backends support exporting metrics using OpenTelemetry. The discovery backends do so over GRPC, and pktvisor does so over http.
+The backends support exporting metrics using OpenTelemetryover GRPC.
 
 ### Basic Configuration
 


### PR DESCRIPTION
This pull request introduces support for exporting OpenTelemetry metrics across various backends and updates the documentation to reflect these changes. The most important updates include adding OpenTelemetry configuration options, providing an example configuration in the documentation, and updating relevant YAML samples.

### OpenTelemetry Integration:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L70-R70): Updated the description of the `common` subsection under `backends` to include support for OpenTelemetry configuration.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R83-R88): Added an example OpenTelemetry configuration, including gRPC endpoint and agent labels, to the YAML configuration sample.

### Documentation Enhancements:

* [`docs/config_samples.md`](diffhunk://#diff-c89006d67ac3f5e07361eb1d39ebf0cc2af11b0dab0a2ec0e09a4eb33a55bcd6R307-R366): Added a new section, "Exporting OpenTelemetry Metrics," with a detailed example of configuring OpenTelemetry for backends such as `device_discovery`, `network_discovery`, `snmp_discovery`, and `worker`.