### PR TITLE
chore: correct releaserc branch for PR semantic release check

### DIFF
--- a/.github/workflows/pr-semantic-release.yaml
+++ b/.github/workflows/pr-semantic-release.yaml
@@ -54,7 +54,7 @@ jobs:
           write-mode: overwrite
           contents: |
             {
-              "branches": "release_version_comment",
+              "branches": "release",
               "repositoryUrl": "https://github.com/netboxlabs/orb-agent",
               "debug": "true",
               "tagFormat": "v${version}",


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/pr-semantic-release.yaml` file. The change updates the `branches` value from `"release_version_comment"` to `"release"` in the workflow configuration.