### PR TITLE
chore: add scan for docker image

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -35,6 +35,22 @@ jobs:
             username: ${{ secrets.DOCKERHUB_USERNAME }}
             password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+        - name: Setup JFrog CLI
+          id: setup-jfrog-cli
+          uses: jfrog/setup-jfrog-cli@ff5cb544114ffc152db9cea1cd3d5978d5074946 # v4.5.11
+          env:
+            JF_URL: https://netboxlabs.jfrog.io
+            JF_PROJECT: obs
+          with:
+            oidc-provider-name: github-ci
+
+        - name: Login to JFrog Artifactory
+          uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3
+          with:
+            registry: netboxlabs.jfrog.io
+            username: ${{ steps.setup-jfrog-cli.outputs.oidc-user }}
+            password: ${{ steps.setup-jfrog-cli.outputs.oidc-token }}
+
         - name: Verify QEMU installation
           run: |
               docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
@@ -55,6 +71,8 @@ jobs:
             push: true
             cache-from: type=gha
             cache-to: type=gha,mode=max
-            tags: netboxlabs/orb-agent:develop
+            tags: |
+              netboxlabs/orb-agent:develop
+              netboxlabs.jfrog.io/obs-builds/orb-agent:develop
             build-args: |
               GO_VERSION=${{ env.GO_VERSION }}  

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -143,6 +143,22 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Setup JFrog CLI
+        id: setup-jfrog-cli
+        uses: jfrog/setup-jfrog-cli@ff5cb544114ffc152db9cea1cd3d5978d5074946 # v4.5.11
+        env:
+          JF_URL: https://netboxlabs.jfrog.io
+          JF_PROJECT: obs
+        with:
+          oidc-provider-name: github-ci
+
+      - name: Login to JFrog Artifactory
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3
+        with:
+          registry: netboxlabs.jfrog.io
+          username: ${{ steps.setup-jfrog-cli.outputs.oidc-user }}
+          password: ${{ steps.setup-jfrog-cli.outputs.oidc-token }}
+
       - name: Verify QEMU installation
         run: |
               docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
@@ -165,6 +181,8 @@ jobs:
           tags: |
             netboxlabs/${{ env.APP_NAME }}:latest
             netboxlabs/${{ env.APP_NAME }}:${{ env.BUILD_VERSION }}
+            netboxlabs.jfrog.io/obs-builds/${{ env.APP_NAME }}:latest
+            netboxlabs.jfrog.io/obs-builds/${{ env.APP_NAME }}:${{ env.BUILD_VERSION }}
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to integrate JFrog Artifactory for managing Docker image builds and pushes. The changes include setting up JFrog CLI, logging into JFrog Artifactory, and adding new tags for images hosted in the JFrog registry.

### Integration of JFrog Artifactory:

* [`.github/workflows/develop.yaml`](diffhunk://#diff-75eb13a90ba4bddf3480256b071d4609bebe36aac7675d2c293bbaf9b58868f6R38-R52): Added steps to set up JFrog CLI and log in to JFrog Artifactory using OIDC authentication. These steps ensure that Docker images can be pushed to the JFrog registry.
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR146-R161): Added similar steps to set up JFrog CLI and log in to JFrog Artifactory for the release workflow.

### Docker image tagging enhancements:

* [`.github/workflows/develop.yaml`](diffhunk://#diff-75eb13a90ba4bddf3480256b071d4609bebe36aac7675d2c293bbaf9b58868f6L58-R75): Updated the `tags` parameter in the Docker build step to include a new tag for the JFrog registry (`netboxlabs.jfrog.io/obs-builds/orb-agent:develop`).
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR184-R185): Updated the `tags` parameter to include additional tags for images hosted in the JFrog registry (`netboxlabs.jfrog.io/obs-builds/${{ env.APP_NAME }}:latest` and `netboxlabs.jfrog.io/obs-builds/${{ env.APP_NAME }}:${{ env.BUILD_VERSION }}`).