### PR TITLE
chore: add id-token write in GHA

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 env:
   GO_VERSION: '1.24'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 jobs:
   get-next-version:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to include the `id-token` permission, which is commonly used for securely authenticating with cloud services during workflow runs.

### Workflow updates:

* [`.github/workflows/develop.yaml`](diffhunk://#diff-75eb13a90ba4bddf3480256b071d4609bebe36aac7675d2c293bbaf9b58868f6R13): Added the `id-token: write` permission under the `permissions` section.
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR25): Added the `id-token: write` permission under the `permissions` section.