### PR TITLE
chore: update device_discovery and network_discovery docs

### DIFF
--- a/docs/backends/device_discovery.md
+++ b/docs/backends/device_discovery.md
@@ -46,6 +46,13 @@ Config defines data for the whole scope and is optional overall.
 |:---------:|:----:|:--------:|:-----------:|
 | schedule | cron format | no  |  If defined, it will execute scope following cron schedule time. If not defined, it will execute scope only once  |
 | defaults | map | no  |  key value pair that defines default values  |
+| options | map | no | key value pair that defines config options |
+
+#### Options
+Current supported options:
+|  Key  | Type |  Description  |
+|:-----:|:----:|:-------------:|
+| platform_omit_version  | bool | If True, only the driver name will be used as the NetBox platform name (defaults to 'False' if not specified) |
 
 #### Defaults
 Current supported defaults:
@@ -67,7 +74,8 @@ Current supported defaults:
 |-------------|------|---------------------------------|
 | device      | map  | Device-specific defaults        |
 | ├─ model | str  | Device type model (overrides the model automatically retrieved from NAPALM)   |
-| ├─ manufacturer | str  | Device manufacturer (overrides the defined/discovered NAPALM driver name) |
+| ├─ manufacturer | str  | Device manufacturer (overrides the vendor automatically retrieved from NAPALM) |
+| ├─ platform | str  | Device platform (overrides the defined/discovered NAPALM driver name and OS version) |
 | ├─ description | str  | Device description           |
 | ├─ comments   | str  | Device comments               |
 | ├─ tags       | list | Device tags                   |

--- a/docs/backends/network_discovery.md
+++ b/docs/backends/network_discovery.md
@@ -64,6 +64,9 @@ The scope defines a list of targets to be scanned.
 | dns_servers | list | no | Specify alternate DNS servers for DNS resolution (--dns-servers). |
 | os_detection | bool | no | Enables NMAP OS detection (-O). |
 | use_target_masks | bool | no | When enabled (default: True), applies the most specific subnet mask from the defined targets to discovered IPs. Only affects targets defined as subnets (e.g., 192.168.1.0/24), not ranges or individual IPs. |
+| icmp_echo      | bool | no | Enables ICMP Echo discovery (-PE). Sends ICMP Echo Request (ping) probes to detect live hosts. |
+| icmp_timestamp | bool | no | Enables ICMP Timestamp discovery (-PP). Uses ICMP Timestamp Requests to discover hosts that respond to this type of probe. |
+| icmp_netmask   | bool | no | Enables ICMP Netmask discovery (-PM). Sends ICMP Address Mask Request packets to identify responsive hosts. |
 
 ### Sample
 A sample policy including all parameters supported by the network discovery backend.


### PR DESCRIPTION
This pull request updates the documentation for device and network discovery backends, adding new configuration options and clarifying existing ones. The main changes improve flexibility for platform naming and device defaults, and introduce additional ICMP-based host discovery methods.

**Device Discovery Documentation Improvements:**

* Added an `options` section to the config, allowing for new configuration options such as `platform_omit_version`, which controls how platform names are generated for NetBox.
* Clarified the meaning of the `manufacturer` default and added a new `platform` default to provide more control over device identification.

**Network Discovery Documentation Enhancements:**

* Introduced three new configuration options: `icmp_echo`, `icmp_timestamp`, and `icmp_netmask`, enabling additional ICMP-based discovery probes for more comprehensive host detection.