### PR TITLE
feat: set backend log levels from config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ agent_bin:
 	echo "ORB_VERSION: $(ORB_VERSION)-$(COMMIT_HASH)"
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(GOARCH) GOARM=$(GOARM) go build -mod=mod -o ${BUILD_DIR}/orb-agent cmd/main.go
 
+.PHONY: test
+test:
+	@go test -race ./...
+
 .PHONY: test-coverage
 test-coverage:
 	@mkdir -p .coverage

--- a/agent/backend/backend.go
+++ b/agent/backend/backend.go
@@ -9,6 +9,9 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/policies"
 )
 
+// DefaultLogLevel is the default log level used for backend operations
+const DefaultLogLevel = "info"
+
 // Running Status types
 const (
 	Unknown RunningStatus = iota

--- a/agent/backend/backend.go
+++ b/agent/backend/backend.go
@@ -9,9 +9,6 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/policies"
 )
 
-// DefaultLogLevel is the default log level used for backend operations
-const DefaultLogLevel = "info"
-
 // Running Status types
 const (
 	Unknown RunningStatus = iota

--- a/agent/backend/networkdiscovery/network_discovery.go
+++ b/agent/backend/networkdiscovery/network_discovery.go
@@ -46,6 +46,7 @@ type networkDiscoveryBackend struct {
 	diodeOtelEndpoint    string
 	diodeDryRun          bool
 	diodeDryRunOutputDir string
+	diodeLogLevel        string
 
 	startTime  time.Time
 	proc       backend.Commander
@@ -88,6 +89,7 @@ func (d *networkDiscoveryBackend) Configure(logger *slog.Logger, repo policies.P
 	d.diodeAppNamePrefix = common.Diode.AgentName
 	d.diodeDryRun = common.Diode.DryRun
 	d.diodeDryRunOutputDir = common.Diode.DryRunOutputDir
+	d.diodeLogLevel = backend.DefaultLogLevel
 
 	if target, prs := config["target"].(string); prs {
 		d.diodeTarget = target
@@ -106,6 +108,9 @@ func (d *networkDiscoveryBackend) Configure(logger *slog.Logger, repo policies.P
 	}
 	if dryRunOutputDir, prs := config["dry_run_output_dir"].(string); prs {
 		d.diodeDryRunOutputDir = dryRunOutputDir
+	}
+	if logLevel, prs := config["log_level"].(string); prs {
+		d.diodeLogLevel = logLevel
 	}
 
 	if common.Otel.Grpc != "" {
@@ -139,6 +144,7 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 			"--dry-run",
 			"--dry-run-output-dir", d.diodeDryRunOutputDir,
 			"--diode-app-name-prefix", d.diodeAppNamePrefix,
+			"--log-level", d.diodeLogLevel,
 		}
 	} else {
 		pvOptions = []string{
@@ -148,6 +154,7 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 			"--diode-client-id", d.diodeClientID,
 			"--diode-client-secret", "********",
 			"--diode-app-name-prefix", d.diodeAppNamePrefix,
+			"--log-level", d.diodeLogLevel,
 		}
 	}
 

--- a/agent/backend/networkdiscovery/network_discovery.go
+++ b/agent/backend/networkdiscovery/network_discovery.go
@@ -89,7 +89,6 @@ func (d *networkDiscoveryBackend) Configure(logger *slog.Logger, repo policies.P
 	d.diodeAppNamePrefix = common.Diode.AgentName
 	d.diodeDryRun = common.Diode.DryRun
 	d.diodeDryRunOutputDir = common.Diode.DryRunOutputDir
-	d.diodeLogLevel = backend.DefaultLogLevel
 
 	if target, prs := config["target"].(string); prs {
 		d.diodeTarget = target
@@ -111,6 +110,8 @@ func (d *networkDiscoveryBackend) Configure(logger *slog.Logger, repo policies.P
 	}
 	if logLevel, prs := config["log_level"].(string); prs {
 		d.diodeLogLevel = logLevel
+	} else if debug, prs := config["debug"].(bool); prs && debug {
+		d.diodeLogLevel = "debug"
 	}
 
 	if common.Otel.Grpc != "" {
@@ -144,7 +145,6 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 			"--dry-run",
 			"--dry-run-output-dir", d.diodeDryRunOutputDir,
 			"--diode-app-name-prefix", d.diodeAppNamePrefix,
-			"--log-level", d.diodeLogLevel,
 		}
 	} else {
 		pvOptions = []string{
@@ -154,18 +154,31 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 			"--diode-client-id", d.diodeClientID,
 			"--diode-client-secret", "********",
 			"--diode-app-name-prefix", d.diodeAppNamePrefix,
-			"--log-level", d.diodeLogLevel,
 		}
+	}
+
+	if d.diodeLogLevel != "" {
+		pvOptions = append(pvOptions, "--log-level", d.diodeLogLevel)
+		d.logger.Info("network-discovery using log level",
+			slog.String("log_level", d.diodeLogLevel))
 	}
 
 	if d.diodeOtelEndpoint != "" {
 		pvOptions = append(pvOptions, "--otel-endpoint", d.diodeOtelEndpoint)
+		d.logger.Info("network-discovery using OTLP metrics endpoint",
+			slog.String("endpoint", d.diodeOtelEndpoint))
 	}
 
 	d.logger.Info("network-discovery startup", slog.Any("arguments", pvOptions))
 
-	if !d.diodeDryRun && len(pvOptions) > 9 {
-		pvOptions[9] = d.diodeClientSecret
+	if !d.diodeDryRun {
+		// Find and replace the masked client secret with the actual value
+		for i, arg := range pvOptions {
+			if arg == "********" {
+				pvOptions[i] = d.diodeClientSecret
+				break
+			}
+		}
 	}
 
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{

--- a/agent/backend/networkdiscovery/network_discovery_test.go
+++ b/agent/backend/networkdiscovery/network_discovery_test.go
@@ -303,7 +303,7 @@ func TestNetworkDiscoveryLogLevel(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Test default log level
-	t.Run("DefaultLogLevel", func(t *testing.T) {
+	t.Run("LogLevelNotSet", func(t *testing.T) {
 		logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 		repo, err := policies.NewMemRepo()
 		assert.NoError(t, err)
@@ -326,16 +326,9 @@ func TestNetworkDiscoveryLogLevel(t *testing.T) {
 			backend.NewCmdOptions = originalNewCmdOptions
 		}()
 
-		// Verify that default log level is used in command args
+		// Verify that log level is not set in command args
 		backend.NewCmdOptions = func(_ backend.CmdOptions, _ string, args ...string) backend.Commander {
-			assert.Contains(t, args, "--log-level")
-			// Find the index of --log-level and check the next argument
-			for i, arg := range args {
-				if arg == "--log-level" && i+1 < len(args) {
-					assert.Equal(t, backend.DefaultLogLevel, args[i+1])
-					break
-				}
-			}
+			assert.NotContains(t, args, "--log-level")
 			return mockCmd
 		}
 

--- a/agent/backend/networkdiscovery/network_discovery_test.go
+++ b/agent/backend/networkdiscovery/network_discovery_test.go
@@ -283,3 +283,206 @@ func TestNetworkDiscoveryBackendDryRun(t *testing.T) {
 
 	mockCmd.AssertExpectations(t)
 }
+
+func TestNetworkDiscoveryLogLevel(t *testing.T) {
+	// Create a test server for all log level tests
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/status" {
+			response := StatusResponse{
+				Version:   "1.3.4",
+				StartTime: "2023-10-01T12:00:00Z",
+				UpTime:    123.456,
+			}
+			_ = json.NewEncoder(w).Encode(response)
+		}
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+
+	// Test default log level
+	t.Run("DefaultLogLevel", func(t *testing.T) {
+		logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+		repo, err := policies.NewMemRepo()
+		assert.NoError(t, err)
+
+		assert.True(t, networkdiscovery.Register())
+		be := backend.GetBackend("network_discovery")
+
+		// Configure without log_level - should use default
+		err = be.Configure(logger, repo, map[string]any{
+			"host": serverURL.Hostname(),
+			"port": serverURL.Port(),
+		}, config.BackendCommons{})
+		assert.NoError(t, err)
+
+		mockCmd := &mocks.MockCmd{}
+		mocks.SetupSuccessfulProcess(mockCmd, 12345)
+
+		originalNewCmdOptions := backend.NewCmdOptions
+		defer func() {
+			backend.NewCmdOptions = originalNewCmdOptions
+		}()
+
+		// Verify that default log level is used in command args
+		backend.NewCmdOptions = func(_ backend.CmdOptions, _ string, args ...string) backend.Commander {
+			assert.Contains(t, args, "--log-level")
+			// Find the index of --log-level and check the next argument
+			for i, arg := range args {
+				if arg == "--log-level" && i+1 < len(args) {
+					assert.Equal(t, backend.DefaultLogLevel, args[i+1])
+					break
+				}
+			}
+			return mockCmd
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		err = be.Start(ctx, cancel)
+		assert.NoError(t, err)
+
+		// Stop the backend
+		_ = be.Stop(ctx)
+		mockCmd.AssertExpectations(t)
+	})
+
+	// Test custom log level
+	t.Run("CustomLogLevel", func(t *testing.T) {
+		logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+		repo, err := policies.NewMemRepo()
+		assert.NoError(t, err)
+
+		assert.True(t, networkdiscovery.Register())
+		be := backend.GetBackend("network_discovery")
+
+		customLogLevel := "debug"
+		// Configure with custom log_level
+		err = be.Configure(logger, repo, map[string]any{
+			"host":      serverURL.Hostname(),
+			"port":      serverURL.Port(),
+			"log_level": customLogLevel,
+		}, config.BackendCommons{})
+		assert.NoError(t, err)
+
+		mockCmd := &mocks.MockCmd{}
+		mocks.SetupSuccessfulProcess(mockCmd, 12345)
+
+		originalNewCmdOptions := backend.NewCmdOptions
+		defer func() {
+			backend.NewCmdOptions = originalNewCmdOptions
+		}()
+
+		// Verify that custom log level is used in command args
+		backend.NewCmdOptions = func(_ backend.CmdOptions, _ string, args ...string) backend.Commander {
+			assert.Contains(t, args, "--log-level")
+			// Find the index of --log-level and check the next argument
+			for i, arg := range args {
+				if arg == "--log-level" && i+1 < len(args) {
+					assert.Equal(t, customLogLevel, args[i+1])
+					break
+				}
+			}
+			return mockCmd
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		err = be.Start(ctx, cancel)
+		assert.NoError(t, err)
+
+		// Stop the backend
+		_ = be.Stop(ctx)
+		mockCmd.AssertExpectations(t)
+	})
+
+	// Test dry run mode includes log level
+	t.Run("DryRunWithLogLevel", func(t *testing.T) {
+		// Create a test server for dry run tests (even though dry run doesn't use HTTP, the backend still tries readiness checks)
+		dryRunServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case r.URL.Path == "/api/v1/status":
+				response := StatusResponse{Version: "1.3.5", StartTime: "2023-10-01T12:00:00Z", UpTime: 123.456}
+				_ = json.NewEncoder(w).Encode(response)
+			case r.URL.Path == "/api/v1/capabilities":
+				capabilities := map[string]any{"capability": true}
+				_ = json.NewEncoder(w).Encode(capabilities)
+			case strings.HasPrefix(r.URL.Path, "/api/v1/policies"):
+				_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer dryRunServer.Close()
+
+		dryRunServerURL, err := url.Parse(dryRunServer.URL)
+		assert.NoError(t, err)
+
+		logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+		repo, err := policies.NewMemRepo()
+		assert.NoError(t, err)
+
+		assert.True(t, networkdiscovery.Register())
+		be := backend.GetBackend("network_discovery")
+
+		beCommons := config.BackendCommons{
+			Diode: struct {
+				Target          string `yaml:"target"`
+				ClientID        string `yaml:"client_id"`
+				ClientSecret    string `yaml:"client_secret"`
+				AgentName       string `yaml:"agent_name"`
+				DryRun          bool   `yaml:"dry_run"`
+				DryRunOutputDir string `yaml:"dry_run_output_dir"`
+			}{
+				DryRun:          true,
+				DryRunOutputDir: "/tmp/dry-run-output",
+			},
+		}
+
+		customLogLevel := "debug"
+		err = be.Configure(logger, repo, map[string]any{
+			"host":      dryRunServerURL.Hostname(),
+			"port":      dryRunServerURL.Port(),
+			"log_level": customLogLevel,
+		}, beCommons)
+		assert.NoError(t, err)
+
+		mockCmd := &mocks.MockCmd{}
+		mocks.SetupSuccessfulProcess(mockCmd, 12345)
+
+		originalNewCmdOptions := backend.NewCmdOptions
+		defer func() {
+			backend.NewCmdOptions = originalNewCmdOptions
+		}()
+
+		// Verify that log level IS included in dry run mode
+		backend.NewCmdOptions = func(_ backend.CmdOptions, _ string, args ...string) backend.Commander {
+			assert.Contains(t, args, "--log-level")
+			// Find the index of --log-level and check the next argument
+			for i, arg := range args {
+				if arg == "--log-level" && i+1 < len(args) {
+					assert.Equal(t, customLogLevel, args[i+1])
+					break
+				}
+			}
+			// Verify dry run specific args are also present
+			assert.Contains(t, args, "--dry-run")
+			assert.Contains(t, args, "--dry-run-output-dir")
+			// Verify non-dry-run args are NOT present
+			assert.NotContains(t, args, "--host")
+			assert.NotContains(t, args, "--port")
+			assert.NotContains(t, args, "--diode-target")
+			return mockCmd
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		err = be.Start(ctx, cancel)
+		assert.NoError(t, err)
+
+		// Stop the backend
+		err = be.Stop(context.WithValue(context.Background(), config.ContextKey("routine"), "test"))
+		assert.NoError(t, err)
+		mockCmd.AssertExpectations(t)
+	})
+}

--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -46,6 +46,7 @@ type snmpDiscoveryBackend struct {
 	diodeOtelEndpoint    string
 	diodeDryRun          bool
 	diodeDryRunOutputDir string
+	diodeLogLevel        string
 
 	startTime  time.Time
 	proc       backend.Commander
@@ -88,6 +89,7 @@ func (d *snmpDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Poli
 	d.diodeAppNamePrefix = common.Diode.AgentName
 	d.diodeDryRun = common.Diode.DryRun
 	d.diodeDryRunOutputDir = common.Diode.DryRunOutputDir
+	d.diodeLogLevel = backend.DefaultLogLevel
 
 	if target, prs := config["target"].(string); prs {
 		d.diodeTarget = target
@@ -106,6 +108,9 @@ func (d *snmpDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Poli
 	}
 	if dryRunOutputDir, prs := config["dry_run_output_dir"].(string); prs {
 		d.diodeDryRunOutputDir = dryRunOutputDir
+	}
+	if logLevel, prs := config["log_level"].(string); prs {
+		d.diodeLogLevel = logLevel
 	}
 
 	if common.Otel.Grpc != "" {
@@ -139,6 +144,7 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 			"--dry-run",
 			"--dry-run-output-dir", d.diodeDryRunOutputDir,
 			"--diode-app-name-prefix", d.diodeAppNamePrefix,
+			"--log-level", d.diodeLogLevel,
 		}
 	} else {
 		pvOptions = []string{
@@ -148,6 +154,7 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 			"--diode-client-id", d.diodeClientID,
 			"--diode-client-secret", "********",
 			"--diode-app-name-prefix", d.diodeAppNamePrefix,
+			"--log-level", d.diodeLogLevel,
 		}
 	}
 

--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -89,7 +89,6 @@ func (d *snmpDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Poli
 	d.diodeAppNamePrefix = common.Diode.AgentName
 	d.diodeDryRun = common.Diode.DryRun
 	d.diodeDryRunOutputDir = common.Diode.DryRunOutputDir
-	d.diodeLogLevel = backend.DefaultLogLevel
 
 	if target, prs := config["target"].(string); prs {
 		d.diodeTarget = target
@@ -111,6 +110,8 @@ func (d *snmpDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Poli
 	}
 	if logLevel, prs := config["log_level"].(string); prs {
 		d.diodeLogLevel = logLevel
+	} else if debug, prs := config["debug"].(bool); prs && debug {
+		d.diodeLogLevel = "debug"
 	}
 
 	if common.Otel.Grpc != "" {
@@ -144,7 +145,6 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 			"--dry-run",
 			"--dry-run-output-dir", d.diodeDryRunOutputDir,
 			"--diode-app-name-prefix", d.diodeAppNamePrefix,
-			"--log-level", d.diodeLogLevel,
 		}
 	} else {
 		pvOptions = []string{
@@ -154,12 +154,19 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 			"--diode-client-id", d.diodeClientID,
 			"--diode-client-secret", "********",
 			"--diode-app-name-prefix", d.diodeAppNamePrefix,
-			"--log-level", d.diodeLogLevel,
 		}
+	}
+
+	if d.diodeLogLevel != "" {
+		pvOptions = append(pvOptions, "--log-level", d.diodeLogLevel)
+		d.logger.Info("snmp-discovery using log level",
+			slog.String("log_level", d.diodeLogLevel))
 	}
 
 	if d.diodeOtelEndpoint != "" {
 		pvOptions = append(pvOptions, "--otel-endpoint", d.diodeOtelEndpoint)
+		d.logger.Info("snmp-discovery using OTLP metrics endpoint",
+			slog.String("endpoint", d.diodeOtelEndpoint))
 	}
 
 	d.logger.Info("snmp-discovery startup", slog.Any("arguments", pvOptions))

--- a/agent/backend/snmpdiscovery/snmp_discovery_test.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery_test.go
@@ -303,7 +303,7 @@ func TestSNMPDiscoveryLogLevel(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Test default log level
-	t.Run("DefaultLogLevel", func(t *testing.T) {
+	t.Run("LogLevelNotSet", func(t *testing.T) {
 		logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 		repo, err := policies.NewMemRepo()
 		assert.NoError(t, err)
@@ -326,16 +326,9 @@ func TestSNMPDiscoveryLogLevel(t *testing.T) {
 			backend.NewCmdOptions = originalNewCmdOptions
 		}()
 
-		// Verify that default log level is used in command args
+		// Verify that log level is not set in command args
 		backend.NewCmdOptions = func(_ backend.CmdOptions, _ string, args ...string) backend.Commander {
-			assert.Contains(t, args, "--log-level")
-			// Find the index of --log-level and check the next argument
-			for i, arg := range args {
-				if arg == "--log-level" && i+1 < len(args) {
-					assert.Equal(t, backend.DefaultLogLevel, args[i+1])
-					break
-				}
-			}
+			assert.NotContains(t, args, "--log-level")
 			return mockCmd
 		}
 

--- a/agent/backend/snmpdiscovery/snmp_discovery_test.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery_test.go
@@ -283,3 +283,206 @@ func TestNetworkDiscoveryBackendDryRun(t *testing.T) {
 
 	mockCmd.AssertExpectations(t)
 }
+
+func TestSNMPDiscoveryLogLevel(t *testing.T) {
+	// Create a test server for all log level tests
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/status" {
+			response := StatusResponse{
+				Version:   "1.3.4",
+				StartTime: "2023-10-01T12:00:00Z",
+				UpTime:    123.456,
+			}
+			_ = json.NewEncoder(w).Encode(response)
+		}
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+
+	// Test default log level
+	t.Run("DefaultLogLevel", func(t *testing.T) {
+		logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+		repo, err := policies.NewMemRepo()
+		assert.NoError(t, err)
+
+		assert.True(t, snmpdiscovery.Register())
+		be := backend.GetBackend("snmp_discovery")
+
+		// Configure without log_level - should use default
+		err = be.Configure(logger, repo, map[string]any{
+			"host": serverURL.Hostname(),
+			"port": serverURL.Port(),
+		}, config.BackendCommons{})
+		assert.NoError(t, err)
+
+		mockCmd := &mocks.MockCmd{}
+		mocks.SetupSuccessfulProcess(mockCmd, 12345)
+
+		originalNewCmdOptions := backend.NewCmdOptions
+		defer func() {
+			backend.NewCmdOptions = originalNewCmdOptions
+		}()
+
+		// Verify that default log level is used in command args
+		backend.NewCmdOptions = func(_ backend.CmdOptions, _ string, args ...string) backend.Commander {
+			assert.Contains(t, args, "--log-level")
+			// Find the index of --log-level and check the next argument
+			for i, arg := range args {
+				if arg == "--log-level" && i+1 < len(args) {
+					assert.Equal(t, backend.DefaultLogLevel, args[i+1])
+					break
+				}
+			}
+			return mockCmd
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		err = be.Start(ctx, cancel)
+		assert.NoError(t, err)
+
+		// Stop the backend
+		_ = be.Stop(ctx)
+		mockCmd.AssertExpectations(t)
+	})
+
+	// Test custom log level
+	t.Run("CustomLogLevel", func(t *testing.T) {
+		logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+		repo, err := policies.NewMemRepo()
+		assert.NoError(t, err)
+
+		assert.True(t, snmpdiscovery.Register())
+		be := backend.GetBackend("snmp_discovery")
+
+		customLogLevel := "debug"
+		// Configure with custom log_level
+		err = be.Configure(logger, repo, map[string]any{
+			"host":      serverURL.Hostname(),
+			"port":      serverURL.Port(),
+			"log_level": customLogLevel,
+		}, config.BackendCommons{})
+		assert.NoError(t, err)
+
+		mockCmd := &mocks.MockCmd{}
+		mocks.SetupSuccessfulProcess(mockCmd, 12345)
+
+		originalNewCmdOptions := backend.NewCmdOptions
+		defer func() {
+			backend.NewCmdOptions = originalNewCmdOptions
+		}()
+
+		// Verify that custom log level is used in command args
+		backend.NewCmdOptions = func(_ backend.CmdOptions, _ string, args ...string) backend.Commander {
+			assert.Contains(t, args, "--log-level")
+			// Find the index of --log-level and check the next argument
+			for i, arg := range args {
+				if arg == "--log-level" && i+1 < len(args) {
+					assert.Equal(t, customLogLevel, args[i+1])
+					break
+				}
+			}
+			return mockCmd
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		err = be.Start(ctx, cancel)
+		assert.NoError(t, err)
+
+		// Stop the backend
+		_ = be.Stop(ctx)
+		mockCmd.AssertExpectations(t)
+	})
+
+	// Test dry run mode includes log level
+	t.Run("DryRunWithLogLevel", func(t *testing.T) {
+		// Create a test server for dry run tests (even though dry run doesn't use HTTP, the backend still tries readiness checks)
+		dryRunServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case r.URL.Path == "/api/v1/status":
+				response := StatusResponse{Version: "1.3.5", StartTime: "2023-10-01T12:00:00Z", UpTime: 123.456}
+				_ = json.NewEncoder(w).Encode(response)
+			case r.URL.Path == "/api/v1/capabilities":
+				capabilities := map[string]any{"capability": true}
+				_ = json.NewEncoder(w).Encode(capabilities)
+			case strings.HasPrefix(r.URL.Path, "/api/v1/policies"):
+				_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer dryRunServer.Close()
+
+		dryRunServerURL, err := url.Parse(dryRunServer.URL)
+		assert.NoError(t, err)
+
+		logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+		repo, err := policies.NewMemRepo()
+		assert.NoError(t, err)
+
+		assert.True(t, snmpdiscovery.Register())
+		be := backend.GetBackend("snmp_discovery")
+
+		beCommons := config.BackendCommons{
+			Diode: struct {
+				Target          string `yaml:"target"`
+				ClientID        string `yaml:"client_id"`
+				ClientSecret    string `yaml:"client_secret"`
+				AgentName       string `yaml:"agent_name"`
+				DryRun          bool   `yaml:"dry_run"`
+				DryRunOutputDir string `yaml:"dry_run_output_dir"`
+			}{
+				DryRun:          true,
+				DryRunOutputDir: "/tmp/dry-run-output",
+			},
+		}
+
+		customLogLevel := "debug"
+		err = be.Configure(logger, repo, map[string]any{
+			"host":      dryRunServerURL.Hostname(),
+			"port":      dryRunServerURL.Port(),
+			"log_level": customLogLevel,
+		}, beCommons)
+		assert.NoError(t, err)
+
+		mockCmd := &mocks.MockCmd{}
+		mocks.SetupSuccessfulProcess(mockCmd, 12345)
+
+		originalNewCmdOptions := backend.NewCmdOptions
+		defer func() {
+			backend.NewCmdOptions = originalNewCmdOptions
+		}()
+
+		// Verify that log level IS included in dry run mode
+		backend.NewCmdOptions = func(_ backend.CmdOptions, _ string, args ...string) backend.Commander {
+			assert.Contains(t, args, "--log-level")
+			// Find the index of --log-level and check the next argument
+			for i, arg := range args {
+				if arg == "--log-level" && i+1 < len(args) {
+					assert.Equal(t, customLogLevel, args[i+1])
+					break
+				}
+			}
+			// Verify dry run specific args are also present
+			assert.Contains(t, args, "--dry-run")
+			assert.Contains(t, args, "--dry-run-output-dir")
+			// Verify non-dry-run args are NOT present
+			assert.NotContains(t, args, "--host")
+			assert.NotContains(t, args, "--port")
+			assert.NotContains(t, args, "--diode-target")
+			return mockCmd
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		err = be.Start(ctx, cancel)
+		assert.NoError(t, err)
+
+		// Stop the backend
+		err = be.Stop(context.WithValue(context.Background(), config.ContextKey("routine"), "test"))
+		assert.NoError(t, err)
+		mockCmd.AssertExpectations(t)
+	})
+}


### PR DESCRIPTION
This pull request adds support for configurable log levels to both the network and SNMP discovery backends, allowing users to specify a custom log level via configuration or fall back to a default. It also ensures that the log level is passed correctly to the underlying command regardless of run mode (normal or dry run), and introduces comprehensive tests to verify this behavior. Additionally, a convenience `test` target is added to the `Makefile`.

### Log Level Configuration and Propagation

* Introduced a `diodeLogLevel` field in both `networkDiscoveryBackend` and `snmpDiscoveryBackend`, and ensured it is set to `DefaultLogLevel` unless overridden by configuration. The log level is now included in the command arguments for both normal and dry run modes. (`agent/backend/networkdiscovery/network_discovery.go`, `agent/backend/snmpdiscovery/snmp_discovery.go`) [[1]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854R49) [[2]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854R92) [[3]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854R112-R114) [[4]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854R147) [[5]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854R157) [[6]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91R49) [[7]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91R92) [[8]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91R112-R114) [[9]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91R147) [[10]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91R157)
* Defined a `DefaultLogLevel` constant in `backend.go` to centralize the default log level value. (`agent/backend/backend.go`)

### Testing

* Added new tests for both backends to verify that the default and custom log levels are correctly set and propagated, including in dry run mode. These tests assert that the correct log level is present in the command arguments and that dry run mode arguments are handled properly. (`agent/backend/networkdiscovery/network_discovery_test.go`, `agent/backend/snmpdiscovery/snmp_discovery_test.go`) [[1]](diffhunk://#diff-6b6bc95e89f599a44ce52ca0b65600c07498fdec88d42c6e72a6b56a49e9967aR286-R488) [[2]](diffhunk://#diff-d6f915c486f108a406be6c96e380a0aaa3a8d322203567fcf7bfc8f1d592af7cR286-R488)

### Developer Experience

* Added a `.PHONY` `test` target to the `Makefile` for easier running of Go tests with race detection. (`Makefile`)