### PR TITLE
Release :rocket: 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jajeffries @leoparente @mfiedorowicz @MicahParks

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 env:
   GO_VERSION: '1.24'

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -35,6 +35,22 @@ jobs:
             username: ${{ secrets.DOCKERHUB_USERNAME }}
             password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+        - name: Setup JFrog CLI
+          id: setup-jfrog-cli
+          uses: jfrog/setup-jfrog-cli@ff5cb544114ffc152db9cea1cd3d5978d5074946 # v4.5.11
+          env:
+            JF_URL: https://netboxlabs.jfrog.io
+            JF_PROJECT: obs
+          with:
+            oidc-provider-name: github-ci
+
+        - name: Login to JFrog Artifactory
+          uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3
+          with:
+            registry: netboxlabs.jfrog.io
+            username: ${{ steps.setup-jfrog-cli.outputs.oidc-user }}
+            password: ${{ steps.setup-jfrog-cli.outputs.oidc-token }}
+
         - name: Verify QEMU installation
           run: |
               docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
@@ -55,6 +71,8 @@ jobs:
             push: true
             cache-from: type=gha
             cache-to: type=gha,mode=max
-            tags: netboxlabs/orb-agent:develop
+            tags: |
+              netboxlabs/orb-agent:develop
+              netboxlabs.jfrog.io/obs-builds/orb-agent:develop
             build-args: |
               GO_VERSION=${{ env.GO_VERSION }}  

--- a/.github/workflows/pr-semantic-release.yaml
+++ b/.github/workflows/pr-semantic-release.yaml
@@ -43,6 +43,7 @@ jobs:
               "version": "1.0.0",
               "devDependencies": {
                 "semantic-release-export-data": "^1.0.1",
+                "semantic-release": "25.0.0-beta.6",
                 "@semantic-release/changelog": "^6.0.3"
               }
             }
@@ -90,7 +91,7 @@ jobs:
             }
 
       - name: Install dependencies
-        run: npm i
+        run: npm install --legacy-peer-deps
 
       - name: Run semantic-release dry-run
         id: semantic-release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,7 @@ jobs:
               "version": "1.0.0",
               "devDependencies": {
                 "semantic-release-export-data": "^1.0.1",
+                "semantic-release": "25.0.0-beta.6",
                 "@semantic-release/changelog": "^6.0.3"
               }
             }
@@ -90,7 +91,7 @@ jobs:
               ]
             }
       - name: setup semantic-release
-        run: npm i
+        run: npm install --legacy-peer-deps
       - name: release dry-run
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_SEMANTIC_RELEASE_WEBHOOK }}
@@ -208,6 +209,7 @@ jobs:
               "version": "1.0.0",
               "devDependencies": {
                 "semantic-release-export-data": "^1.0.1",
+                "semantic-release": "25.0.0-beta.6",
                 "@semantic-release/changelog": "^6.0.3"
               }
             }
@@ -253,7 +255,7 @@ jobs:
               ]
             }
       - name: setup semantic-release
-        run: npm i
+        run: npm install --legacy-peer-deps
       - name: Release
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_OBSERVABILITY_RELEASE_WEBHOOK }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -143,6 +143,22 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Setup JFrog CLI
+        id: setup-jfrog-cli
+        uses: jfrog/setup-jfrog-cli@ff5cb544114ffc152db9cea1cd3d5978d5074946 # v4.5.11
+        env:
+          JF_URL: https://netboxlabs.jfrog.io
+          JF_PROJECT: obs
+        with:
+          oidc-provider-name: github-ci
+
+      - name: Login to JFrog Artifactory
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3
+        with:
+          registry: netboxlabs.jfrog.io
+          username: ${{ steps.setup-jfrog-cli.outputs.oidc-user }}
+          password: ${{ steps.setup-jfrog-cli.outputs.oidc-token }}
+
       - name: Verify QEMU installation
         run: |
               docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
@@ -165,6 +181,8 @@ jobs:
           tags: |
             netboxlabs/${{ env.APP_NAME }}:latest
             netboxlabs/${{ env.APP_NAME }}:${{ env.BUILD_VERSION }}
+            netboxlabs.jfrog.io/obs-builds/${{ env.APP_NAME }}:latest
+            netboxlabs.jfrog.io/obs-builds/${{ env.APP_NAME }}:${{ env.BUILD_VERSION }}
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 jobs:
   get-next-version:

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ agent_bin:
 	echo "ORB_VERSION: $(ORB_VERSION)-$(COMMIT_HASH)"
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(GOARCH) GOARM=$(GOARM) go build -mod=mod -o ${BUILD_DIR}/orb-agent cmd/main.go
 
+.PHONY: test
+test:
+	@go test -race ./...
+
 .PHONY: test-coverage
 test-coverage:
 	@mkdir -p .coverage

--- a/README.md
+++ b/README.md
@@ -108,12 +108,12 @@ orb:
 To run `orb-agent`, use the following command from the directory where your created your `agent.yaml` file:
 
 ```sh
- docker run --net=host -v $(PWD):/opt/orb/ netboxlabs/orb-agent:latest run -c /opt/orb/agent.yaml
+ docker run --net=host -v ${PWD}:/opt/orb/ netboxlabs/orb-agent:latest run -c /opt/orb/agent.yaml
 ```
 The container needs sufficient permissions, to send `icmp` and `tcp` packets. This can either be achieved by setting the network-mode to `host` or by changing the container user to `root`: 
 
 ```sh
- docker run -u root -v $(PWD):/opt/orb/ netboxlabs/orb-agent:latest run -c /opt/orb/agent.yaml
+ docker run -u root -v ${PWD}:/opt/orb/ netboxlabs/orb-agent:latest run -c /opt/orb/agent.yaml
 ```
 
 ### Configuration samples

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Only the `network_discovery`, `device_discovery`, `worker` and `snmp_discovery` 
 - [SNMP Discovery](./docs/backends/snmp_discovery.md)
 
 #### Common
-A special `common` subsection under `backends` defines configuration settings that are shared with all backends. Currently, it supports passing [diode](https://github.com/netboxlabs/diode) server settings to all backends.
+A special `common` subsection under `backends` defines configuration settings that are shared with all backends. Currently, it supports passing [diode](https://github.com/netboxlabs/diode) server settings and OpenTelemetry configuration to all backends.
 
 ```yaml
   backends:
@@ -80,6 +80,12 @@ A special `common` subsection under `backends` defines configuration settings th
           agent_name: agent01
           dry_run: false
           dry_run_output_dir: /opt/orb
+        otel:
+          grpc: "grpc://otel-collector:4317"
+          agent_labels:
+            environment: "production"
+            datacenter: "us-east-1"
+            service: "network-monitoring"
 ```
 
 ### Policies

--- a/agent/backend/networkdiscovery/network_discovery.go
+++ b/agent/backend/networkdiscovery/network_discovery.go
@@ -46,6 +46,7 @@ type networkDiscoveryBackend struct {
 	diodeOtelEndpoint    string
 	diodeDryRun          bool
 	diodeDryRunOutputDir string
+	diodeLogLevel        string
 
 	startTime  time.Time
 	proc       backend.Commander
@@ -107,6 +108,11 @@ func (d *networkDiscoveryBackend) Configure(logger *slog.Logger, repo policies.P
 	if dryRunOutputDir, prs := config["dry_run_output_dir"].(string); prs {
 		d.diodeDryRunOutputDir = dryRunOutputDir
 	}
+	if logLevel, prs := config["log_level"].(string); prs {
+		d.diodeLogLevel = logLevel
+	} else if debug, prs := config["debug"].(bool); prs && debug {
+		d.diodeLogLevel = "debug"
+	}
 
 	if common.Otel.Grpc != "" {
 		d.diodeOtelEndpoint = common.Otel.Grpc
@@ -151,14 +157,28 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 		}
 	}
 
+	if d.diodeLogLevel != "" {
+		pvOptions = append(pvOptions, "--log-level", d.diodeLogLevel)
+		d.logger.Info("network-discovery using log level",
+			slog.String("log_level", d.diodeLogLevel))
+	}
+
 	if d.diodeOtelEndpoint != "" {
 		pvOptions = append(pvOptions, "--otel-endpoint", d.diodeOtelEndpoint)
+		d.logger.Info("network-discovery using OTLP metrics endpoint",
+			slog.String("endpoint", d.diodeOtelEndpoint))
 	}
 
 	d.logger.Info("network-discovery startup", slog.Any("arguments", pvOptions))
 
-	if !d.diodeDryRun && len(pvOptions) > 9 {
-		pvOptions[9] = d.diodeClientSecret
+	if !d.diodeDryRun {
+		// Find and replace the masked client secret with the actual value
+		for i, arg := range pvOptions {
+			if arg == "********" {
+				pvOptions[i] = d.diodeClientSecret
+				break
+			}
+		}
 	}
 
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{

--- a/agent/backend/networkdiscovery/network_discovery_test.go
+++ b/agent/backend/networkdiscovery/network_discovery_test.go
@@ -283,3 +283,199 @@ func TestNetworkDiscoveryBackendDryRun(t *testing.T) {
 
 	mockCmd.AssertExpectations(t)
 }
+
+func TestNetworkDiscoveryLogLevel(t *testing.T) {
+	// Create a test server for all log level tests
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/status" {
+			response := StatusResponse{
+				Version:   "1.3.4",
+				StartTime: "2023-10-01T12:00:00Z",
+				UpTime:    123.456,
+			}
+			_ = json.NewEncoder(w).Encode(response)
+		}
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+
+	// Test default log level
+	t.Run("LogLevelNotSet", func(t *testing.T) {
+		logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+		repo, err := policies.NewMemRepo()
+		assert.NoError(t, err)
+
+		assert.True(t, networkdiscovery.Register())
+		be := backend.GetBackend("network_discovery")
+
+		// Configure without log_level - should use default
+		err = be.Configure(logger, repo, map[string]any{
+			"host": serverURL.Hostname(),
+			"port": serverURL.Port(),
+		}, config.BackendCommons{})
+		assert.NoError(t, err)
+
+		mockCmd := &mocks.MockCmd{}
+		mocks.SetupSuccessfulProcess(mockCmd, 12345)
+
+		originalNewCmdOptions := backend.NewCmdOptions
+		defer func() {
+			backend.NewCmdOptions = originalNewCmdOptions
+		}()
+
+		// Verify that log level is not set in command args
+		backend.NewCmdOptions = func(_ backend.CmdOptions, _ string, args ...string) backend.Commander {
+			assert.NotContains(t, args, "--log-level")
+			return mockCmd
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		err = be.Start(ctx, cancel)
+		assert.NoError(t, err)
+
+		// Stop the backend
+		_ = be.Stop(ctx)
+		mockCmd.AssertExpectations(t)
+	})
+
+	// Test custom log level
+	t.Run("CustomLogLevel", func(t *testing.T) {
+		logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+		repo, err := policies.NewMemRepo()
+		assert.NoError(t, err)
+
+		assert.True(t, networkdiscovery.Register())
+		be := backend.GetBackend("network_discovery")
+
+		customLogLevel := "debug"
+		// Configure with custom log_level
+		err = be.Configure(logger, repo, map[string]any{
+			"host":      serverURL.Hostname(),
+			"port":      serverURL.Port(),
+			"log_level": customLogLevel,
+		}, config.BackendCommons{})
+		assert.NoError(t, err)
+
+		mockCmd := &mocks.MockCmd{}
+		mocks.SetupSuccessfulProcess(mockCmd, 12345)
+
+		originalNewCmdOptions := backend.NewCmdOptions
+		defer func() {
+			backend.NewCmdOptions = originalNewCmdOptions
+		}()
+
+		// Verify that custom log level is used in command args
+		backend.NewCmdOptions = func(_ backend.CmdOptions, _ string, args ...string) backend.Commander {
+			assert.Contains(t, args, "--log-level")
+			// Find the index of --log-level and check the next argument
+			for i, arg := range args {
+				if arg == "--log-level" && i+1 < len(args) {
+					assert.Equal(t, customLogLevel, args[i+1])
+					break
+				}
+			}
+			return mockCmd
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		err = be.Start(ctx, cancel)
+		assert.NoError(t, err)
+
+		// Stop the backend
+		_ = be.Stop(ctx)
+		mockCmd.AssertExpectations(t)
+	})
+
+	// Test dry run mode includes log level
+	t.Run("DryRunWithLogLevel", func(t *testing.T) {
+		// Create a test server for dry run tests (even though dry run doesn't use HTTP, the backend still tries readiness checks)
+		dryRunServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case r.URL.Path == "/api/v1/status":
+				response := StatusResponse{Version: "1.3.5", StartTime: "2023-10-01T12:00:00Z", UpTime: 123.456}
+				_ = json.NewEncoder(w).Encode(response)
+			case r.URL.Path == "/api/v1/capabilities":
+				capabilities := map[string]any{"capability": true}
+				_ = json.NewEncoder(w).Encode(capabilities)
+			case strings.HasPrefix(r.URL.Path, "/api/v1/policies"):
+				_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer dryRunServer.Close()
+
+		dryRunServerURL, err := url.Parse(dryRunServer.URL)
+		assert.NoError(t, err)
+
+		logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+		repo, err := policies.NewMemRepo()
+		assert.NoError(t, err)
+
+		assert.True(t, networkdiscovery.Register())
+		be := backend.GetBackend("network_discovery")
+
+		beCommons := config.BackendCommons{
+			Diode: struct {
+				Target          string `yaml:"target"`
+				ClientID        string `yaml:"client_id"`
+				ClientSecret    string `yaml:"client_secret"`
+				AgentName       string `yaml:"agent_name"`
+				DryRun          bool   `yaml:"dry_run"`
+				DryRunOutputDir string `yaml:"dry_run_output_dir"`
+			}{
+				DryRun:          true,
+				DryRunOutputDir: "/tmp/dry-run-output",
+			},
+		}
+
+		customLogLevel := "debug"
+		err = be.Configure(logger, repo, map[string]any{
+			"host":      dryRunServerURL.Hostname(),
+			"port":      dryRunServerURL.Port(),
+			"log_level": customLogLevel,
+		}, beCommons)
+		assert.NoError(t, err)
+
+		mockCmd := &mocks.MockCmd{}
+		mocks.SetupSuccessfulProcess(mockCmd, 12345)
+
+		originalNewCmdOptions := backend.NewCmdOptions
+		defer func() {
+			backend.NewCmdOptions = originalNewCmdOptions
+		}()
+
+		// Verify that log level IS included in dry run mode
+		backend.NewCmdOptions = func(_ backend.CmdOptions, _ string, args ...string) backend.Commander {
+			assert.Contains(t, args, "--log-level")
+			// Find the index of --log-level and check the next argument
+			for i, arg := range args {
+				if arg == "--log-level" && i+1 < len(args) {
+					assert.Equal(t, customLogLevel, args[i+1])
+					break
+				}
+			}
+			// Verify dry run specific args are also present
+			assert.Contains(t, args, "--dry-run")
+			assert.Contains(t, args, "--dry-run-output-dir")
+			// Verify non-dry-run args are NOT present
+			assert.NotContains(t, args, "--host")
+			assert.NotContains(t, args, "--port")
+			assert.NotContains(t, args, "--diode-target")
+			return mockCmd
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		err = be.Start(ctx, cancel)
+		assert.NoError(t, err)
+
+		// Stop the backend
+		err = be.Stop(context.WithValue(context.Background(), config.ContextKey("routine"), "test"))
+		assert.NoError(t, err)
+		mockCmd.AssertExpectations(t)
+	})
+}

--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -46,6 +46,7 @@ type snmpDiscoveryBackend struct {
 	diodeOtelEndpoint    string
 	diodeDryRun          bool
 	diodeDryRunOutputDir string
+	diodeLogLevel        string
 
 	startTime  time.Time
 	proc       backend.Commander
@@ -107,6 +108,11 @@ func (d *snmpDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Poli
 	if dryRunOutputDir, prs := config["dry_run_output_dir"].(string); prs {
 		d.diodeDryRunOutputDir = dryRunOutputDir
 	}
+	if logLevel, prs := config["log_level"].(string); prs {
+		d.diodeLogLevel = logLevel
+	} else if debug, prs := config["debug"].(bool); prs && debug {
+		d.diodeLogLevel = "debug"
+	}
 
 	if common.Otel.Grpc != "" {
 		d.diodeOtelEndpoint = common.Otel.Grpc
@@ -151,8 +157,16 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 		}
 	}
 
+	if d.diodeLogLevel != "" {
+		pvOptions = append(pvOptions, "--log-level", d.diodeLogLevel)
+		d.logger.Info("snmp-discovery using log level",
+			slog.String("log_level", d.diodeLogLevel))
+	}
+
 	if d.diodeOtelEndpoint != "" {
 		pvOptions = append(pvOptions, "--otel-endpoint", d.diodeOtelEndpoint)
+		d.logger.Info("snmp-discovery using OTLP metrics endpoint",
+			slog.String("endpoint", d.diodeOtelEndpoint))
 	}
 
 	d.logger.Info("snmp-discovery startup", slog.Any("arguments", pvOptions))

--- a/agent/backend/snmpdiscovery/snmp_discovery_test.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery_test.go
@@ -283,3 +283,199 @@ func TestNetworkDiscoveryBackendDryRun(t *testing.T) {
 
 	mockCmd.AssertExpectations(t)
 }
+
+func TestSNMPDiscoveryLogLevel(t *testing.T) {
+	// Create a test server for all log level tests
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/status" {
+			response := StatusResponse{
+				Version:   "1.3.4",
+				StartTime: "2023-10-01T12:00:00Z",
+				UpTime:    123.456,
+			}
+			_ = json.NewEncoder(w).Encode(response)
+		}
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+
+	// Test default log level
+	t.Run("LogLevelNotSet", func(t *testing.T) {
+		logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+		repo, err := policies.NewMemRepo()
+		assert.NoError(t, err)
+
+		assert.True(t, snmpdiscovery.Register())
+		be := backend.GetBackend("snmp_discovery")
+
+		// Configure without log_level - should use default
+		err = be.Configure(logger, repo, map[string]any{
+			"host": serverURL.Hostname(),
+			"port": serverURL.Port(),
+		}, config.BackendCommons{})
+		assert.NoError(t, err)
+
+		mockCmd := &mocks.MockCmd{}
+		mocks.SetupSuccessfulProcess(mockCmd, 12345)
+
+		originalNewCmdOptions := backend.NewCmdOptions
+		defer func() {
+			backend.NewCmdOptions = originalNewCmdOptions
+		}()
+
+		// Verify that log level is not set in command args
+		backend.NewCmdOptions = func(_ backend.CmdOptions, _ string, args ...string) backend.Commander {
+			assert.NotContains(t, args, "--log-level")
+			return mockCmd
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		err = be.Start(ctx, cancel)
+		assert.NoError(t, err)
+
+		// Stop the backend
+		_ = be.Stop(ctx)
+		mockCmd.AssertExpectations(t)
+	})
+
+	// Test custom log level
+	t.Run("CustomLogLevel", func(t *testing.T) {
+		logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+		repo, err := policies.NewMemRepo()
+		assert.NoError(t, err)
+
+		assert.True(t, snmpdiscovery.Register())
+		be := backend.GetBackend("snmp_discovery")
+
+		customLogLevel := "debug"
+		// Configure with custom log_level
+		err = be.Configure(logger, repo, map[string]any{
+			"host":      serverURL.Hostname(),
+			"port":      serverURL.Port(),
+			"log_level": customLogLevel,
+		}, config.BackendCommons{})
+		assert.NoError(t, err)
+
+		mockCmd := &mocks.MockCmd{}
+		mocks.SetupSuccessfulProcess(mockCmd, 12345)
+
+		originalNewCmdOptions := backend.NewCmdOptions
+		defer func() {
+			backend.NewCmdOptions = originalNewCmdOptions
+		}()
+
+		// Verify that custom log level is used in command args
+		backend.NewCmdOptions = func(_ backend.CmdOptions, _ string, args ...string) backend.Commander {
+			assert.Contains(t, args, "--log-level")
+			// Find the index of --log-level and check the next argument
+			for i, arg := range args {
+				if arg == "--log-level" && i+1 < len(args) {
+					assert.Equal(t, customLogLevel, args[i+1])
+					break
+				}
+			}
+			return mockCmd
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		err = be.Start(ctx, cancel)
+		assert.NoError(t, err)
+
+		// Stop the backend
+		_ = be.Stop(ctx)
+		mockCmd.AssertExpectations(t)
+	})
+
+	// Test dry run mode includes log level
+	t.Run("DryRunWithLogLevel", func(t *testing.T) {
+		// Create a test server for dry run tests (even though dry run doesn't use HTTP, the backend still tries readiness checks)
+		dryRunServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case r.URL.Path == "/api/v1/status":
+				response := StatusResponse{Version: "1.3.5", StartTime: "2023-10-01T12:00:00Z", UpTime: 123.456}
+				_ = json.NewEncoder(w).Encode(response)
+			case r.URL.Path == "/api/v1/capabilities":
+				capabilities := map[string]any{"capability": true}
+				_ = json.NewEncoder(w).Encode(capabilities)
+			case strings.HasPrefix(r.URL.Path, "/api/v1/policies"):
+				_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer dryRunServer.Close()
+
+		dryRunServerURL, err := url.Parse(dryRunServer.URL)
+		assert.NoError(t, err)
+
+		logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+		repo, err := policies.NewMemRepo()
+		assert.NoError(t, err)
+
+		assert.True(t, snmpdiscovery.Register())
+		be := backend.GetBackend("snmp_discovery")
+
+		beCommons := config.BackendCommons{
+			Diode: struct {
+				Target          string `yaml:"target"`
+				ClientID        string `yaml:"client_id"`
+				ClientSecret    string `yaml:"client_secret"`
+				AgentName       string `yaml:"agent_name"`
+				DryRun          bool   `yaml:"dry_run"`
+				DryRunOutputDir string `yaml:"dry_run_output_dir"`
+			}{
+				DryRun:          true,
+				DryRunOutputDir: "/tmp/dry-run-output",
+			},
+		}
+
+		customLogLevel := "debug"
+		err = be.Configure(logger, repo, map[string]any{
+			"host":      dryRunServerURL.Hostname(),
+			"port":      dryRunServerURL.Port(),
+			"log_level": customLogLevel,
+		}, beCommons)
+		assert.NoError(t, err)
+
+		mockCmd := &mocks.MockCmd{}
+		mocks.SetupSuccessfulProcess(mockCmd, 12345)
+
+		originalNewCmdOptions := backend.NewCmdOptions
+		defer func() {
+			backend.NewCmdOptions = originalNewCmdOptions
+		}()
+
+		// Verify that log level IS included in dry run mode
+		backend.NewCmdOptions = func(_ backend.CmdOptions, _ string, args ...string) backend.Commander {
+			assert.Contains(t, args, "--log-level")
+			// Find the index of --log-level and check the next argument
+			for i, arg := range args {
+				if arg == "--log-level" && i+1 < len(args) {
+					assert.Equal(t, customLogLevel, args[i+1])
+					break
+				}
+			}
+			// Verify dry run specific args are also present
+			assert.Contains(t, args, "--dry-run")
+			assert.Contains(t, args, "--dry-run-output-dir")
+			// Verify non-dry-run args are NOT present
+			assert.NotContains(t, args, "--host")
+			assert.NotContains(t, args, "--port")
+			assert.NotContains(t, args, "--diode-target")
+			return mockCmd
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		err = be.Start(ctx, cancel)
+		assert.NoError(t, err)
+
+		// Stop the backend
+		err = be.Stop(context.WithValue(context.Background(), config.ContextKey("routine"), "test"))
+		assert.NoError(t, err)
+		mockCmd.AssertExpectations(t)
+	})
+}

--- a/docs/backends/device_discovery.md
+++ b/docs/backends/device_discovery.md
@@ -46,6 +46,13 @@ Config defines data for the whole scope and is optional overall.
 |:---------:|:----:|:--------:|:-----------:|
 | schedule | cron format | no  |  If defined, it will execute scope following cron schedule time. If not defined, it will execute scope only once  |
 | defaults | map | no  |  key value pair that defines default values  |
+| options | map | no | key value pair that defines config options |
+
+#### Options
+Current supported options:
+|  Key  | Type |  Description  |
+|:-----:|:----:|:-------------:|
+| platform_omit_version  | bool | If True, only the driver name will be used as the NetBox platform name (defaults to 'False' if not specified) |
 
 #### Defaults
 Current supported defaults:
@@ -67,7 +74,8 @@ Current supported defaults:
 |-------------|------|---------------------------------|
 | device      | map  | Device-specific defaults        |
 | ├─ model | str  | Device type model (overrides the model automatically retrieved from NAPALM)   |
-| ├─ manufacturer | str  | Device manufacturer (overrides the defined/discovered NAPALM driver name) |
+| ├─ manufacturer | str  | Device manufacturer (overrides the vendor automatically retrieved from NAPALM) |
+| ├─ platform | str  | Device platform (overrides the defined/discovered NAPALM driver name and OS version) |
 | ├─ description | str  | Device description           |
 | ├─ comments   | str  | Device comments               |
 | ├─ tags       | list | Device tags                   |

--- a/docs/backends/network_discovery.md
+++ b/docs/backends/network_discovery.md
@@ -64,6 +64,9 @@ The scope defines a list of targets to be scanned.
 | dns_servers | list | no | Specify alternate DNS servers for DNS resolution (--dns-servers). |
 | os_detection | bool | no | Enables NMAP OS detection (-O). |
 | use_target_masks | bool | no | When enabled (default: True), applies the most specific subnet mask from the defined targets to discovered IPs. Only affects targets defined as subnets (e.g., 192.168.1.0/24), not ranges or individual IPs. |
+| icmp_echo      | bool | no | Enables ICMP Echo discovery (-PE). Sends ICMP Echo Request (ping) probes to detect live hosts. |
+| icmp_timestamp | bool | no | Enables ICMP Timestamp discovery (-PP). Uses ICMP Timestamp Requests to discover hosts that respond to this type of probe. |
+| icmp_netmask   | bool | no | Enables ICMP Netmask discovery (-PM). Sends ICMP Address Mask Request packets to identify responsive hosts. |
 
 ### Sample
 A sample policy including all parameters supported by the network discovery backend.

--- a/docs/config_samples.md
+++ b/docs/config_samples.md
@@ -304,3 +304,63 @@ When running in dry run mode, the agent will:
 
 This allows you to inspect the data that would be collected and sent to Diode Server before configuring the actual connection.
 This feature is supported by the [Device Discovery](./backends/device_discovery.md), [Network Discovery](./backends/network_discovery.md), [Worker](./backends/worker.md) and [SNMP Discovery](./backends/snmp_discovery.md) backends.
+
+## Exporting OpenTelemetry Metrics
+
+The backends support exporting metrics using OpenTelemetryover GRPC.
+
+### Basic Configuration
+
+```yaml
+orb:
+  config_manager:
+    active: local
+  labels:
+    agent_id: "network-agent-001"
+    location: "datacenter-east"
+  backends:
+    # Discovery backends that export to OpenTelemetry via gRPC
+    device_discovery:
+    network_discovery:
+    snmp_discovery:
+    worker:
+          
+    common:
+      otel:
+        # gRPC endpoint for discovery backends
+        grpc: "grpc://otel-collector.monitoring.svc.cluster.local:4317"
+        
+        # Labels attached to all telemetry data
+        agent_labels:
+          environment: "production"
+          datacenter: "us-east-1"
+          cluster: "main"
+          service: "orb-agent"
+          version: "v2.0.0"
+          team: "platform"
+      
+      diode:
+        target: "grpc://diode.example.com:8080/diode"
+        client_id: "${DIODE_CLIENT_ID}"
+        client_secret: "${DIODE_CLIENT_SECRET}"
+        agent_name: "network-agent-001"
+  
+  policies:
+    device_discovery:
+      policy_1:
+        config:
+          schedule: "0 */6 * * *"
+        scope:
+          - driver: ios
+            hostname: "192.168.1.1"
+            username: "admin"
+            password: "${DEVICE_PASSWORD}"
+    
+    network_discovery:
+      policy_1:
+        config:
+          schedule: "0 */2 * * *"
+          timeout: 5
+        scope:
+          targets: [192.168.1.0, 192.168.1.1]
+```

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.6.0 // indirect
-	github.com/docker/docker v27.2.1+incompatible // indirect
+	github.com/docker/docker v28.0.0+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/docker v27.2.1+incompatible h1:fQdiLfW7VLscyoeYEBz7/J8soYFDZV1u6VW6gJEjNMI=
-github.com/docker/docker v27.2.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v28.0.0+incompatible h1:Olh0KS820sJ7nPsBKChVhk5pzqcwDR15fumfAd/p9hM=
+github.com/docker/docker v28.0.0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=


### PR DESCRIPTION
This pull request introduces support for configurable log levels and enhanced OpenTelemetry settings in the agent backends, improves CI/CD workflows for Docker/JFrog integration, and adds related documentation and tests. The most important changes are grouped below:

**Agent Backend Improvements**

* Added support for configurable `log_level` (and fallback to debug via `debug: true`) in both `network_discovery` and `snmp_discovery` backends, including propagation to their respective command-line invocations. [[1]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854R49) [[2]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854R111-R115) [[3]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854R160-R181) [[4]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91R49) [[5]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91R111-R115) [[6]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91R160-R169)
* Added comprehensive tests for log level propagation and dry-run mode in `network_discovery` backend.

**Documentation Updates**

* Updated `README.md` to document OpenTelemetry configuration under the `common` section, and clarified Docker run commands. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L70-R70) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R83-R88) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L111-R122)

**CI/CD Workflow Enhancements**

* Integrated JFrog CLI setup and Artifactory login into GitHub Actions workflows for both develop and release pipelines, including OIDC authentication. [[1]](diffhunk://#diff-75eb13a90ba4bddf3480256b071d4609bebe36aac7675d2c293bbaf9b58868f6R13) [[2]](diffhunk://#diff-75eb13a90ba4bddf3480256b071d4609bebe36aac7675d2c293bbaf9b58868f6R39-R54) [[3]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR25) [[4]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR147-R162)
* Updated Docker build steps to push images to both DockerHub and JFrog Artifactory registries. [[1]](diffhunk://#diff-75eb13a90ba4bddf3480256b071d4609bebe36aac7675d2c293bbaf9b58868f6L58-R77) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR185-R186)

**Other Improvements**

* Added a `.PHONY` `test` target to the `Makefile` for running Go tests with race detection.
* Updated `.github/CODEOWNERS` to assign ownership to specific team members.