### PR TITLE
chore: upgrade semantic release

### DIFF
--- a/.github/workflows/pr-semantic-release.yaml
+++ b/.github/workflows/pr-semantic-release.yaml
@@ -43,6 +43,7 @@ jobs:
               "version": "1.0.0",
               "devDependencies": {
                 "semantic-release-export-data": "^1.0.1",
+                "semantic-release": "25.0.0-beta.6",
                 "@semantic-release/changelog": "^6.0.3"
               }
             }

--- a/.github/workflows/pr-semantic-release.yaml
+++ b/.github/workflows/pr-semantic-release.yaml
@@ -91,7 +91,7 @@ jobs:
             }
 
       - name: Install dependencies
-        run: npm i
+        run: npm install --legacy-peer-deps
 
       - name: Run semantic-release dry-run
         id: semantic-release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,7 @@ jobs:
               "version": "1.0.0",
               "devDependencies": {
                 "semantic-release-export-data": "^1.0.1",
+                "semantic-release": "25.0.0-beta.6",
                 "@semantic-release/changelog": "^6.0.3"
               }
             }
@@ -208,6 +209,7 @@ jobs:
               "version": "1.0.0",
               "devDependencies": {
                 "semantic-release-export-data": "^1.0.1",
+                "semantic-release": "25.0.0-beta.6",
                 "@semantic-release/changelog": "^6.0.3"
               }
             }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,7 +91,7 @@ jobs:
               ]
             }
       - name: setup semantic-release
-        run: npm i
+        run: npm install --legacy-peer-deps
       - name: release dry-run
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_SEMANTIC_RELEASE_WEBHOOK }}
@@ -255,7 +255,7 @@ jobs:
               ]
             }
       - name: setup semantic-release
-        run: npm i
+        run: npm install --legacy-peer-deps
       - name: Release
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_OBSERVABILITY_RELEASE_WEBHOOK }}


### PR DESCRIPTION
This pull request updates the semantic-release setup in both the `pr-semantic-release.yaml` and `release.yaml` GitHub workflow files. The main goals are to explicitly specify the semantic-release version and to ensure compatibility with dependencies during installation.

Dependency management improvements:

* Updated the `semantic-release` dependency to version `25.0.0-beta.6` in the `devDependencies` section of both `.github/workflows/pr-semantic-release.yaml` and `.github/workflows/release.yaml` to ensure a consistent and up-to-date release process. [[1]](diffhunk://#diff-2b8a61589bbbed0d699c69402ef9f749411e2571debddd27df6bda4e99154738R46) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR48) [[3]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR212)

Workflow installation steps:

* Changed the npm install commands to use `npm install --legacy-peer-deps` instead of `npm i` in both workflow files to avoid peer dependency conflicts and improve installation reliability. [[1]](diffhunk://#diff-2b8a61589bbbed0d699c69402ef9f749411e2571debddd27df6bda4e99154738L93-R94) F90326e0L91R91, [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL256-R258)