### PR TITLE
fix: corrects vault yaml config

### DIFF
--- a/agent/secretsmgr/vault_auth.go
+++ b/agent/secretsmgr/vault_auth.go
@@ -88,8 +88,8 @@ func (a *AuthToken) vaultAuthenticate(_ context.Context, cli *vault.Client) (*va
 type AuthAppRole struct {
 	RoleID        string  `yaml:"role_id"`
 	SecretID      string  `yaml:"secret_id"`
-	WrappingToken bool    `yaml:"wrapping_token,ommitempty"`
-	MountPath     *string `yaml:"mount_path,ommitempty"`
+	WrappingToken bool    `yaml:"wrapping_token,omitempty"`
+	MountPath     *string `yaml:"mount_path,omitempty"`
 }
 
 // UnmarshalYAML for AuthAppRole validates required fields after unmarshaling

--- a/agent/secretsmgr/vault_auth_test.go
+++ b/agent/secretsmgr/vault_auth_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 )
 
 func TestNewAuthentication(t *testing.T) {
@@ -64,4 +65,145 @@ func TestTokenAuth_Authenticate(t *testing.T) {
 	secret, err := auth.vaultAuthenticate(ctx, client)
 	assert.Error(t, err)
 	assert.Nil(t, secret)
+}
+
+func TestAuthAppRole_YAMLOmitEmpty(t *testing.T) {
+	tests := []struct {
+		name         string
+		authAppRole  AuthAppRole
+		expectedYAML string
+		description  string
+	}{
+		{
+			name: "with all fields",
+			authAppRole: AuthAppRole{
+				RoleID:        "test-role-id",
+				SecretID:      "test-secret-id",
+				WrappingToken: true,
+				MountPath:     stringPtr("custom-path"),
+			},
+			expectedYAML: `role_id: test-role-id
+secret_id: test-secret-id
+wrapping_token: true
+mount_path: custom-path
+`,
+			description: "All fields should be present in YAML",
+		},
+		{
+			name: "omit empty fields",
+			authAppRole: AuthAppRole{
+				RoleID:        "test-role-id",
+				SecretID:      "test-secret-id",
+				WrappingToken: false, // zero value should be omitted
+				MountPath:     nil,   // nil pointer should be omitted
+			},
+			expectedYAML: `role_id: test-role-id
+secret_id: test-secret-id
+`,
+			description: "Zero values should be omitted from YAML due to omitempty tag",
+		},
+		{
+			name: "omit empty mount_path only",
+			authAppRole: AuthAppRole{
+				RoleID:        "test-role-id",
+				SecretID:      "test-secret-id",
+				WrappingToken: true,
+				MountPath:     nil, // nil pointer should be omitted
+			},
+			expectedYAML: `role_id: test-role-id
+secret_id: test-secret-id
+wrapping_token: true
+`,
+			description: "Only nil mount_path should be omitted",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test marshaling (struct -> YAML)
+			yamlBytes, err := yaml.Marshal(tt.authAppRole)
+			assert.NoError(t, err, "Failed to marshal AuthAppRole to YAML")
+			assert.Equal(t, tt.expectedYAML, string(yamlBytes), tt.description)
+
+			// Test unmarshaling (YAML -> struct)
+			var unmarshaled AuthAppRole
+			err = yaml.Unmarshal([]byte(tt.expectedYAML), &unmarshaled)
+			assert.NoError(t, err, "Failed to unmarshal YAML to AuthAppRole")
+
+			// Compare the unmarshaled struct with expected values
+			assert.Equal(t, tt.authAppRole.RoleID, unmarshaled.RoleID, "RoleID should match")
+			assert.Equal(t, tt.authAppRole.SecretID, unmarshaled.SecretID, "SecretID should match")
+			assert.Equal(t, tt.authAppRole.WrappingToken, unmarshaled.WrappingToken, "WrappingToken should match")
+
+			if tt.authAppRole.MountPath == nil {
+				assert.Nil(t, unmarshaled.MountPath, "MountPath should be nil")
+			} else {
+				assert.NotNil(t, unmarshaled.MountPath, "MountPath should not be nil")
+				assert.Equal(t, *tt.authAppRole.MountPath, *unmarshaled.MountPath, "MountPath values should match")
+			}
+		})
+	}
+}
+
+func TestAuthAppRole_YAMLValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		yamlData  string
+		expectErr bool
+		errMsg    string
+	}{
+		{
+			name: "valid minimal config",
+			yamlData: `role_id: test-role-id
+secret_id: test-secret-id
+`,
+			expectErr: false,
+		},
+		{
+			name: "missing role_id",
+			yamlData: `secret_id: test-secret-id
+`,
+			expectErr: true,
+			errMsg:    "missing required field 'role_id'",
+		},
+		{
+			name: "missing secret_id",
+			yamlData: `role_id: test-role-id
+`,
+			expectErr: true,
+			errMsg:    "missing required field 'secret_id'",
+		},
+		{
+			name: "valid with optional fields",
+			yamlData: `role_id: test-role-id
+secret_id: test-secret-id
+wrapping_token: true
+mount_path: custom-mount
+`,
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var authAppRole AuthAppRole
+			err := yaml.Unmarshal([]byte(tt.yamlData), &authAppRole)
+
+			if tt.expectErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.NotEmpty(t, authAppRole.RoleID)
+				assert.NotEmpty(t, authAppRole.SecretID)
+			}
+		})
+	}
+}
+
+// Helper function to create a string pointer
+func stringPtr(s string) *string {
+	return &s
 }


### PR DESCRIPTION
Fixes #174

This pull request improves the handling and testing of YAML serialization and validation for the `AuthAppRole` struct in the Vault authentication code. The main focus is on ensuring that optional fields are correctly omitted from YAML output when empty and that required fields are validated during unmarshaling. Comprehensive unit tests have been added to verify these behaviors.

### Improvements to YAML serialization and validation

* Fixed the struct tags for `WrappingToken` and `MountPath` in `AuthAppRole` to use the correct `omitempty` option, ensuring empty values are omitted during YAML marshaling.

### Enhancements to unit testing

* Added new tests in `vault_auth_test.go` to verify that YAML marshaling omits empty fields and that unmarshaling correctly reconstructs the struct, including edge cases for optional and required fields.
* Added tests to validate that missing required fields (`role_id`, `secret_id`) in the YAML input result in appropriate errors during unmarshaling.

### Test infrastructure updates

* Imported the `yaml.v3` package to support YAML marshaling and unmarshaling in tests.
* Added a helper function `stringPtr` to simplify pointer creation for test cases.