### PR TITLE
feat: move to hard coded topics and move agent id into config

### DIFF
--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -35,15 +35,11 @@ type GitManager struct {
 
 // FleetManager represents the Orb ConfigManager configuration.
 type FleetManager struct {
-	URL               string `yaml:"url"`
-	TokenURL          string `yaml:"token_url"`
-	ClientID          string `yaml:"client_id"`
-	ClientSecret      string `yaml:"client_secret"`
-	MQTTURL           string `yaml:"mqtt_url,omitempty"`
-	HeartbeatTopic    string `yaml:"heartbeat_topic,omitempty"`
-	CapabilitiesTopic string `yaml:"capabilities_topic,omitempty"`
-	// TopicName is kept for backward compatibility
-	TopicName string `yaml:"topic_name,omitempty"`
+	URL          string `yaml:"url"`
+	TokenURL     string `yaml:"token_url"`
+	ClientID     string `yaml:"client_id"`
+	ClientSecret string `yaml:"client_secret"`
+	MQTTURL      string `yaml:"mqtt_url,omitempty"`
 }
 
 // Sources represents the configuration for manager sources, including cloud, local and git.

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -39,6 +39,7 @@ type FleetManager struct {
 	TokenURL     string `yaml:"token_url"`
 	ClientID     string `yaml:"client_id"`
 	ClientSecret string `yaml:"client_secret"`
+	AgentID      string `yaml:"agent_id"`
 	MQTTURL      string `yaml:"mqtt_url,omitempty"`
 }
 

--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -113,7 +113,7 @@ func (fleetManager *fleetConfigManager) Start(cfg config.Config, backends map[st
 	}
 
 	// generate topics from JWT claims and config agent_id using hardcoded templates
-	topics, err := GenerateTopicsFromTemplate(token.AccessToken, cfg.OrbAgent.ConfigManager.Sources.Fleet.AgentID)
+	topics, err := generateTopicsFromTemplate(token.AccessToken, cfg.OrbAgent.ConfigManager.Sources.Fleet.AgentID)
 	if err != nil {
 		return fmt.Errorf("failed to generate topics: %w", err)
 	}

--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -43,9 +43,9 @@ type heartbeater struct {
 	heartbeatCtx context.Context
 }
 
-func (hb *heartbeater) sendSingleHeartbeat(ctx context.Context, publishFunc func(ctx context.Context, payload []byte) error, _ time.Time, _ messages.HeartbeatState) {
+func (hb *heartbeater) sendSingleHeartbeat(ctx context.Context, publishFunc func(ctx context.Context, payload []byte) error, agentID string, _ time.Time, _ messages.HeartbeatState) {
 	hbData := messages.Heartbeat{
-		AgentID: "orb-agent",
+		AgentID: agentID,
 		Version: "1.0.0",
 	}
 
@@ -66,23 +66,23 @@ func (hb *heartbeater) sendSingleHeartbeat(ctx context.Context, publishFunc func
 // supplied context is cancelled.  The cancelFunc parameter is ignored by the
 // implementation but is accepted for backward-compatibility with unit tests
 // that expect to pass it.
-func (hb *heartbeater) sendHeartbeats(ctx context.Context, _ context.CancelFunc, publishFunc func(ctx context.Context, payload []byte) error) {
+func (hb *heartbeater) sendHeartbeats(ctx context.Context, _ context.CancelFunc, publishFunc func(ctx context.Context, payload []byte) error, agentID string) {
 	// Update our internal reference so other methods that read hb.heartbeatCtx
 	// (if any) remain accurate.
 	hb.heartbeatCtx = ctx
 
 	hb.logger.Debug("start heartbeats routine", slog.Any("routine", ctx.Value("routine")))
-	hb.sendSingleHeartbeat(ctx, publishFunc, time.Now(), messages.Online)
+	hb.sendSingleHeartbeat(ctx, publishFunc, agentID, time.Now(), messages.Online)
 
 	for {
 		select {
 		case <-ctx.Done():
 			hb.logger.Debug("context done, stopping heartbeats routine")
-			hb.sendSingleHeartbeat(ctx, publishFunc, time.Now(), messages.Offline)
+			hb.sendSingleHeartbeat(ctx, publishFunc, agentID, time.Now(), messages.Offline)
 			hb.heartbeatCtx = nil
 			return
 		case t := <-hb.hbTicker.C:
-			hb.sendSingleHeartbeat(ctx, publishFunc, t, messages.Online)
+			hb.sendSingleHeartbeat(ctx, publishFunc, agentID, t, messages.Online)
 		}
 	}
 }
@@ -112,13 +112,13 @@ func (fleetManager *fleetConfigManager) Start(cfg config.Config, backends map[st
 		return err
 	}
 
-	// generate topics from JWT claims using hardcoded templates
-	topics, err := GenerateTopicsFromTemplate(token.AccessToken)
+	// generate topics from JWT claims and config agent_id using hardcoded templates
+	topics, err := GenerateTopicsFromTemplate(token.AccessToken, cfg.OrbAgent.ConfigManager.Sources.Fleet.AgentID)
 	if err != nil {
-		return fmt.Errorf("failed to generate topics from JWT claims: %w", err)
+		return fmt.Errorf("failed to generate topics: %w", err)
 	}
 
-	fleetManager.logger.Info("generated topics from JWT claims",
+	fleetManager.logger.Info("generated topics from JWT org_id and config agent_id",
 		"heartbeat_topic", topics.Heartbeat,
 		"capabilities_topic", topics.Capabilities,
 		"inbox_topic", topics.Inbox,
@@ -131,14 +131,14 @@ func (fleetManager *fleetConfigManager) Start(cfg config.Config, backends map[st
 	}
 
 	// use the generated topics to connect over MQTT v5
-	err = fleetManager.connect(mqttURL, token.AccessToken, *topics, backends)
+	err = fleetManager.connect(mqttURL, token.AccessToken, *topics, backends, cfg.OrbAgent.ConfigManager.Sources.Fleet.AgentID)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (fleetManager *fleetConfigManager) connectWithContext(ctx context.Context, fleetMQTTURL, token string, topics tokenResponseTopics, backends map[string]backend.Backend) error {
+func (fleetManager *fleetConfigManager) connectWithContext(ctx context.Context, fleetMQTTURL, token string, topics tokenResponseTopics, backends map[string]backend.Backend, agentID string) error {
 	// Parse the ORB URL
 	serverURL, err := url.Parse(fleetMQTTURL)
 	if err != nil {
@@ -194,7 +194,7 @@ func (fleetManager *fleetConfigManager) connectWithContext(ctx context.Context, 
 					"payload", string(payload),
 				)
 				return nil
-			})
+			}, agentID)
 
 			go fleetManager.sendCapabilities(ctx, backends, func(ctx context.Context, payload []byte) error {
 				_, err := cm.Publish(ctx, &paho.Publish{
@@ -265,9 +265,9 @@ func (fleetManager *fleetConfigManager) connectWithContext(ctx context.Context, 
 }
 
 // connect is a backward-compatibility shim that invokes connectWithContext with
-// the fleet manager’s root context.
-func (fleetManager *fleetConfigManager) connect(fleetMQTTURL, token string, topics tokenResponseTopics, backends map[string]backend.Backend) error {
-	return fleetManager.connectWithContext(fleetManager.heartbeater.heartbeatCtx, fleetMQTTURL, token, topics, backends)
+// the fleet manager's root context.
+func (fleetManager *fleetConfigManager) connect(fleetMQTTURL, token string, topics tokenResponseTopics, backends map[string]backend.Backend, agentID string) error {
+	return fleetManager.connectWithContext(fleetManager.heartbeater.heartbeatCtx, fleetMQTTURL, token, topics, backends, agentID)
 }
 
 func (fleetManager *fleetConfigManager) sendCapabilities(ctx context.Context, backends map[string]backend.Backend, publishFunc func(ctx context.Context, payload []byte) error) {

--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -105,7 +105,10 @@ func newFleetConfigManager(ctx context.Context, logger *slog.Logger, pMgr policy
 func (fleetManager *fleetConfigManager) Start(cfg config.Config, backends map[string]backend.Backend) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+<<<<<<< HEAD
 
+=======
+>>>>>>> 263625a (simplify contexts)
 	// call the token url to get the token
 	token, err := fleetManager.getToken(ctx, cfg.OrbAgent.ConfigManager.Sources.Fleet.TokenURL, cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientID, cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientSecret)
 	if err != nil {

--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -105,75 +105,37 @@ func newFleetConfigManager(ctx context.Context, logger *slog.Logger, pMgr policy
 func (fleetManager *fleetConfigManager) Start(cfg config.Config, backends map[string]backend.Backend) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-<<<<<<< HEAD
 
-=======
->>>>>>> 263625a (simplify contexts)
 	// call the token url to get the token
 	token, err := fleetManager.getToken(ctx, cfg.OrbAgent.ConfigManager.Sources.Fleet.TokenURL, cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientID, cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientSecret)
 	if err != nil {
 		return err
 	}
 
-	// merge configuration values with token response values (config takes priority)
-	mqttURL, topics := fleetManager.mergeConfigWithTokenResponse(cfg.OrbAgent.ConfigManager.Sources.Fleet, token)
-
-	// use the merged configuration to connect over MQTT v5
-	err = fleetManager.connect(mqttURL, token.AccessToken, topics, backends)
+	// generate topics from JWT claims using hardcoded templates
+	topics, err := GenerateTopicsFromTemplate(token.AccessToken)
 	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// mergeConfigWithTokenResponse merges configuration values with token response values,
-// giving priority to token response values when they are provided
-func (fleetManager *fleetConfigManager) mergeConfigWithTokenResponse(fleetCfg config.FleetManager, token *tokenResponse) (string, tokenResponseTopics) {
-	// Start with configuration values as defaults
-	mqttURL := fleetCfg.MQTTURL
-	topics := tokenResponseTopics{
-		Heartbeat:    fleetCfg.HeartbeatTopic,
-		Capabilities: fleetCfg.CapabilitiesTopic,
+		return fmt.Errorf("failed to generate topics from JWT claims: %w", err)
 	}
 
-	// Handle legacy TopicName field for backward compatibility - only if specific topics aren't set
-	if fleetCfg.TopicName != "" && fleetCfg.HeartbeatTopic == "" && fleetCfg.CapabilitiesTopic == "" {
-		fleetManager.logger.Debug("using legacy topic name as base for heartbeat and capabilities", "topic", fleetCfg.TopicName)
-		topics.Heartbeat = fleetCfg.TopicName + "/heartbeat"
-		topics.Capabilities = fleetCfg.TopicName + "/capabilities"
-	}
-
-	// Override with token response values if provided (token takes priority)
-	if token.MQTTURL != "" {
-		fleetManager.logger.Debug("using MQTT URL from token response", "token_url", token.MQTTURL, "config_url", fleetCfg.MQTTURL)
-		mqttURL = token.MQTTURL
-	} else if mqttURL != "" {
-		fleetManager.logger.Debug("using MQTT URL from configuration", "config_url", mqttURL)
-	}
-
-	// Token response topics override configuration topics
-	if token.Topics.Heartbeat != "" {
-		fleetManager.logger.Debug("using heartbeat topic from token response", "token_topic", token.Topics.Heartbeat, "config_topic", topics.Heartbeat)
-		topics.Heartbeat = token.Topics.Heartbeat
-	}
-
-	if token.Topics.Capabilities != "" {
-		fleetManager.logger.Debug("using capabilities topic from token response", "token_topic", token.Topics.Capabilities, "config_topic", topics.Capabilities)
-		topics.Capabilities = token.Topics.Capabilities
-	}
-
-	// Token response always provides inbox/outbox topics
-	topics.Inbox = token.Topics.Inbox
-	topics.Outbox = token.Topics.Outbox
-
-	fleetManager.logger.Info("merged configuration and token response",
-		"mqtt_url", mqttURL,
+	fleetManager.logger.Info("generated topics from JWT claims",
 		"heartbeat_topic", topics.Heartbeat,
 		"capabilities_topic", topics.Capabilities,
 		"inbox_topic", topics.Inbox,
 		"outbox_topic", topics.Outbox)
 
-	return mqttURL, topics
+	// use MQTT URL from token response or fallback to config
+	mqttURL := token.MQTTURL
+	if mqttURL == "" {
+		mqttURL = cfg.OrbAgent.ConfigManager.Sources.Fleet.MQTTURL
+	}
+
+	// use the generated topics to connect over MQTT v5
+	err = fleetManager.connect(mqttURL, token.AccessToken, *topics, backends)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (fleetManager *fleetConfigManager) connectWithContext(ctx context.Context, fleetMQTTURL, token string, topics tokenResponseTopics, backends map[string]backend.Backend) error {
@@ -366,10 +328,9 @@ type tokenResponseTopics struct {
 }
 
 type tokenResponse struct {
-	AccessToken string              `json:"access_token"`
-	MQTTURL     string              `json:"mqtt_url"`
-	Topics      tokenResponseTopics `json:"topics"`
-	ExpiresIn   int                 `json:"expires_in"`
+	AccessToken string `json:"access_token"`
+	MQTTURL     string `json:"mqtt_url"`
+	ExpiresIn   int    `json:"expires_in"`
 }
 
 func (fleetManager *fleetConfigManager) getToken(ctx context.Context, tokenURL string, clientID string, clientSecret string) (*tokenResponse, error) {

--- a/agent/configmgr/fleet_test.go
+++ b/agent/configmgr/fleet_test.go
@@ -750,7 +750,7 @@ func TestFleetConfigManager_Integration_SuccessFlow(t *testing.T) {
 	assert.Equal(t, "mqtt://localhost:1883", token.MQTTURL)
 
 	// Test that topic generation works with the JWT
-	topics, err := GenerateTopicsFromTemplate(token.AccessToken, "test-agent-123")
+	topics, err := generateTopicsFromTemplate(token.AccessToken, "test-agent-123")
 	require.NoError(t, err)
 	assert.Equal(t, "/orgs/integration-org/agents/test-agent-123/inbox", topics.Inbox)
 	assert.Equal(t, "/orgs/integration-org/agents/test-agent-123/outbox", topics.Outbox)
@@ -1228,7 +1228,7 @@ func TestFleetConfigManager_Start_WithJWTTopicGeneration(t *testing.T) {
 	defer fleetManager.heartbeater.hbTicker.Stop()
 
 	// Create mock HTTP server that returns a JWT token
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		response := tokenResponse{
 			AccessToken: validJWT,
 			MQTTURL:     "mqtt://test.example.com:1883",
@@ -1309,7 +1309,7 @@ func TestGenerateTopicsFromTemplate_Integration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			topics, err := GenerateTopicsFromTemplate(tt.jwt, tt.expectedAgent)
+			topics, err := generateTopicsFromTemplate(tt.jwt, tt.expectedAgent)
 			require.NoError(t, err)
 
 			expectedTopics := &tokenResponseTopics{

--- a/agent/configmgr/fleet_test.go
+++ b/agent/configmgr/fleet_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -411,19 +412,13 @@ func TestFleetConfigManager_GetToken_Success(t *testing.T) {
 		err := r.ParseForm()
 		assert.NoError(t, err)
 		assert.Equal(t, "client_credentials", r.Form.Get("grant_type"))
-		assert.Contains(t, r.Form.Get("scope"), "orb.read")
-		assert.Contains(t, r.Form.Get("scope"), "orb.write")
-		assert.Contains(t, r.Form.Get("scope"), "orb.configure")
+		assert.Contains(t, r.Form.Get("scope"), "orb.mqtt")
 
-		// Return valid token response
+		// Return valid token response (no longer includes topics)
 		response := tokenResponse{
 			AccessToken: "test_access_token",
 			MQTTURL:     "mqtt://test.example.com:1883",
-			Topics: tokenResponseTopics{
-				Inbox:  "test/inbox",
-				Outbox: "test/outbox",
-			},
-			ExpiresIn: 3600,
+			ExpiresIn:   3600,
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -440,8 +435,6 @@ func TestFleetConfigManager_GetToken_Success(t *testing.T) {
 	assert.NotNil(t, token)
 	assert.Equal(t, "test_access_token", token.AccessToken)
 	assert.Equal(t, "mqtt://test.example.com:1883", token.MQTTURL)
-	assert.Equal(t, "test/inbox", token.Topics.Inbox)
-	assert.Equal(t, "test/outbox", token.Topics.Outbox)
 	assert.Equal(t, 3600, token.ExpiresIn)
 }
 
@@ -610,13 +603,9 @@ func TestFleetConfigManager_Start_ConnectError(t *testing.T) {
 	// Create mock HTTP server for token endpoint
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		response := tokenResponse{
-			AccessToken: "test_token",
-			MQTTURL:     "://invalid-mqtt-url", // Invalid MQTT URL
-			Topics: tokenResponseTopics{
-				Inbox:  "test/inbox",
-				Outbox: "test/outbox",
-			},
-			ExpiresIn: 3600,
+			AccessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJ0ZXN0LW9yZyIsImFnZW50X2lkIjoidGVzdC1hZ2VudC0xMjMiLCJpYXQiOjE1MTYyMzkwMjJ9.8U8W8j_2ZwV2GvO3QcI6LJl2a8XGrHPDYS9hM2y4k2I", // Valid JWT
+			MQTTURL:     "://invalid-mqtt-url",                                                                                                                                                       // Invalid MQTT URL
+			ExpiresIn:   3600,
 		}
 		_ = json.NewEncoder(w).Encode(response)
 	}))
@@ -691,11 +680,7 @@ func TestTokenResponse_Marshaling(t *testing.T) {
 	original := tokenResponse{
 		AccessToken: "test_token_123",
 		MQTTURL:     "mqtt://test.example.com:1883",
-		Topics: tokenResponseTopics{
-			Inbox:  "agent/inbox",
-			Outbox: "agent/outbox",
-		},
-		ExpiresIn: 7200,
+		ExpiresIn:   7200,
 	}
 
 	// Act - Marshal to JSON
@@ -710,8 +695,6 @@ func TestTokenResponse_Marshaling(t *testing.T) {
 	// Assert
 	assert.Equal(t, original.AccessToken, unmarshaled.AccessToken)
 	assert.Equal(t, original.MQTTURL, unmarshaled.MQTTURL)
-	assert.Equal(t, original.Topics.Inbox, unmarshaled.Topics.Inbox)
-	assert.Equal(t, original.Topics.Outbox, unmarshaled.Topics.Outbox)
 	assert.Equal(t, original.ExpiresIn, unmarshaled.ExpiresIn)
 }
 
@@ -748,13 +731,9 @@ func TestFleetConfigManager_Integration_SuccessFlow(t *testing.T) {
 	// Create mock HTTP server for successful token response
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		response := tokenResponse{
-			AccessToken: "integration_test_token",
-			MQTTURL:     "mqtt://localhost:1883", // Valid but non-existent
-			Topics: tokenResponseTopics{
-				Inbox:  "integration/inbox",
-				Outbox: "integration/outbox",
-			},
-			ExpiresIn: 3600,
+			AccessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJpbnRlZ3JhdGlvbi1vcmciLCJhZ2VudF9pZCI6InRlc3QtYWdlbnQtMTIzIiwiaWF0IjoxNTE2MjM5MDIyfQ.FY6z7lP4RwV3HvO5QfM8NLn2b8XHrIPDZT0hN4y6m3K", // Valid JWT with org_id="integration-org", agent_id="test-agent-123"
+			MQTTURL:     "mqtt://localhost:1883",                                                                                                                                                               // Valid but non-existent
+			ExpiresIn:   3600,
 		}
 		_ = json.NewEncoder(w).Encode(response)
 	}))
@@ -766,12 +745,18 @@ func TestFleetConfigManager_Integration_SuccessFlow(t *testing.T) {
 
 	// Assert - token retrieval should succeed
 	require.NoError(t, err)
-	assert.Equal(t, "integration_test_token", token.AccessToken)
+	expectedJWT := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJpbnRlZ3JhdGlvbi1vcmciLCJhZ2VudF9pZCI6InRlc3QtYWdlbnQtMTIzIiwiaWF0IjoxNTE2MjM5MDIyfQ.FY6z7lP4RwV3HvO5QfM8NLn2b8XHrIPDZT0hN4y6m3K"
+	assert.Equal(t, expectedJWT, token.AccessToken)
 	assert.Equal(t, "mqtt://localhost:1883", token.MQTTURL)
-	assert.Equal(t, "integration/inbox", token.Topics.Inbox)
+
+	// Test that topic generation works with the JWT
+	topics, err := GenerateTopicsFromTemplate(token.AccessToken)
+	require.NoError(t, err)
+	assert.Equal(t, "/orgs/integration-org/agents/test-agent-123/inbox", topics.Inbox)
+	assert.Equal(t, "/orgs/integration-org/agents/test-agent-123/outbox", topics.Outbox)
 
 	// Note: We don't test the full Start() method here because it would require
-	// a real MQTT broker, but we've verified the token retrieval part works
+	// a real MQTT broker, but we've verified the token retrieval and topic generation works
 }
 
 func TestFleetConfigManager_CompilerInterfaceCheck(t *testing.T) {
@@ -791,169 +776,6 @@ func TestFleetConfigManager_CompilerInterfaceCheck(t *testing.T) {
 	ctx := context.Background()
 	resultCtx := manager.GetContext(ctx)
 	assert.NotNil(t, resultCtx)
-}
-
-func TestFleetConfigManager_ConfigurationFallback(t *testing.T) {
-	// Test that token response values take priority over configuration values
-	ctx := context.Background()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	pMgr := &mockPolicyManagerForFleet{}
-
-	// Create fleet manager
-	fleetManager := newFleetConfigManager(ctx, logger, pMgr)
-	defer fleetManager.heartbeater.hbTicker.Stop()
-
-	// Test data
-	fleetCfg := config.FleetManager{
-		MQTTURL:           "mqtts://config-mqtt.example.com:8883",
-		HeartbeatTopic:    "config/heartbeat",
-		CapabilitiesTopic: "config/capabilities",
-	}
-
-	tokenResp := &tokenResponse{
-		AccessToken: "test-token",
-		MQTTURL:     "mqtts://token-mqtt.example.com:8883",
-		Topics: tokenResponseTopics{
-			Heartbeat:    "token/heartbeat",
-			Capabilities: "token/capabilities",
-			Inbox:        "token/inbox",
-			Outbox:       "token/outbox",
-		},
-	}
-
-	// Test merge functionality
-	mqttURL, topics := fleetManager.mergeConfigWithTokenResponse(fleetCfg, tokenResp)
-
-	// Verify token response values take priority
-	assert.Equal(t, "mqtts://token-mqtt.example.com:8883", mqttURL, "Token response MQTT URL should take priority")
-	assert.Equal(t, "token/heartbeat", topics.Heartbeat, "Token response heartbeat topic should take priority")
-	assert.Equal(t, "token/capabilities", topics.Capabilities, "Token response capabilities topic should take priority")
-
-	// Verify token response values are used for inbox/outbox
-	assert.Equal(t, "token/inbox", topics.Inbox, "Token response inbox topic should be used")
-	assert.Equal(t, "token/outbox", topics.Outbox, "Token response outbox topic should be used")
-}
-
-func TestFleetConfigManager_ConfigurationFallback_EmptyConfig(t *testing.T) {
-	// Test that token response values are used when configuration is empty
-	ctx := context.Background()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	pMgr := &mockPolicyManagerForFleet{}
-
-	// Create fleet manager
-	fleetManager := newFleetConfigManager(ctx, logger, pMgr)
-	defer fleetManager.heartbeater.hbTicker.Stop()
-
-	// Test data - empty configuration
-	fleetCfg := config.FleetManager{
-		TokenURL:     "https://auth.example.com/token",
-		ClientID:     "client-id",
-		ClientSecret: "client-secret",
-		// No MQTT URL or topics configured
-	}
-
-	tokenResp := &tokenResponse{
-		AccessToken: "test-token",
-		MQTTURL:     "mqtts://token-mqtt.example.com:8883",
-		Topics: tokenResponseTopics{
-			Heartbeat:    "token/heartbeat",
-			Capabilities: "token/capabilities",
-			Inbox:        "token/inbox",
-			Outbox:       "token/outbox",
-		},
-	}
-
-	// Test merge functionality
-	mqttURL, topics := fleetManager.mergeConfigWithTokenResponse(fleetCfg, tokenResp)
-
-	// Verify token response values are used when config is empty
-	assert.Equal(t, "mqtts://token-mqtt.example.com:8883", mqttURL, "Token response MQTT URL should be used when config is empty")
-	assert.Equal(t, "token/heartbeat", topics.Heartbeat, "Token response heartbeat topic should be used when config is empty")
-	assert.Equal(t, "token/capabilities", topics.Capabilities, "Token response capabilities topic should be used when config is empty")
-	assert.Equal(t, "token/inbox", topics.Inbox, "Token response inbox topic should be used")
-	assert.Equal(t, "token/outbox", topics.Outbox, "Token response outbox topic should be used")
-}
-
-func TestFleetConfigManager_ConfigurationFallback_LegacySupport(t *testing.T) {
-	// Test that legacy TopicName field works correctly
-	ctx := context.Background()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	pMgr := &mockPolicyManagerForFleet{}
-
-	// Create fleet manager
-	fleetManager := newFleetConfigManager(ctx, logger, pMgr)
-	defer fleetManager.heartbeater.hbTicker.Stop()
-
-	// Test data - legacy configuration
-	fleetCfg := config.FleetManager{
-		TokenURL:     "https://auth.example.com/token",
-		ClientID:     "client-id",
-		ClientSecret: "client-secret",
-		TopicName:    "legacy-topic", // Legacy field
-		// No specific heartbeat/capabilities topics
-	}
-
-	tokenResp := &tokenResponse{
-		AccessToken: "test-token",
-		MQTTURL:     "mqtts://token-mqtt.example.com:8883",
-		Topics: tokenResponseTopics{
-			Heartbeat:    "token/heartbeat",
-			Capabilities: "token/capabilities",
-			Inbox:        "token/inbox",
-			Outbox:       "token/outbox",
-		},
-	}
-
-	// Test merge functionality
-	mqttURL, topics := fleetManager.mergeConfigWithTokenResponse(fleetCfg, tokenResp)
-
-	// Verify token response topics override legacy configuration
-	assert.Equal(t, "mqtts://token-mqtt.example.com:8883", mqttURL, "Token response MQTT URL should be used")
-	assert.Equal(t, "token/heartbeat", topics.Heartbeat, "Token response should override legacy topic for heartbeat")
-	assert.Equal(t, "token/capabilities", topics.Capabilities, "Token response should override legacy topic for capabilities")
-	assert.Equal(t, "token/inbox", topics.Inbox, "Token response inbox topic should be used")
-	assert.Equal(t, "token/outbox", topics.Outbox, "Token response outbox topic should be used")
-}
-
-func TestFleetConfigManager_ConfigurationFallback_EmptyTokenResponse(t *testing.T) {
-	// Test that configuration values are used when token response values are empty
-	ctx := context.Background()
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	pMgr := &mockPolicyManagerForFleet{}
-
-	// Create fleet manager
-	fleetManager := newFleetConfigManager(ctx, logger, pMgr)
-	defer fleetManager.heartbeater.hbTicker.Stop()
-
-	// Test data - configuration has values, token response has empty values
-	fleetCfg := config.FleetManager{
-		MQTTURL:           "mqtts://config-mqtt.example.com:8883",
-		HeartbeatTopic:    "config/heartbeat",
-		CapabilitiesTopic: "config/capabilities",
-	}
-
-	tokenResp := &tokenResponse{
-		AccessToken: "test-token",
-		MQTTURL:     "", // Empty MQTT URL
-		Topics: tokenResponseTopics{
-			Heartbeat:    "", // Empty heartbeat topic
-			Capabilities: "", // Empty capabilities topic
-			Inbox:        "token/inbox",
-			Outbox:       "token/outbox",
-		},
-	}
-
-	// Test merge functionality
-	mqttURL, topics := fleetManager.mergeConfigWithTokenResponse(fleetCfg, tokenResp)
-
-	// Verify configuration values are used when token response is empty
-	assert.Equal(t, "mqtts://config-mqtt.example.com:8883", mqttURL, "Configuration MQTT URL should be used when token response is empty")
-	assert.Equal(t, "config/heartbeat", topics.Heartbeat, "Configuration heartbeat topic should be used when token response is empty")
-	assert.Equal(t, "config/capabilities", topics.Capabilities, "Configuration capabilities topic should be used when token response is empty")
-
-	// Verify token response values are still used for inbox/outbox
-	assert.Equal(t, "token/inbox", topics.Inbox, "Token response inbox topic should be used")
-	assert.Equal(t, "token/outbox", topics.Outbox, "Token response outbox topic should be used")
 }
 
 // Test edge cases for heartbeater ticker cleanup
@@ -1389,4 +1211,114 @@ func TestFleetConfigManager_SendCapabilities_CapabilitiesStructure(t *testing.T)
 	assert.IsType(t, map[string]interface{}{}, backendInfo.Data["object_val"])
 
 	mockBackend1.AssertExpectations(t)
+}
+
+func TestFleetConfigManager_Start_WithJWTTopicGeneration(t *testing.T) {
+	// This test verifies that the Start method correctly generates topics from JWT claims
+
+	// Create a valid JWT token with org_id and agent_id claims
+	// Header: {"alg":"HS256","typ":"JWT"}
+	// Payload: {"org_id":"integration-org","agent_id":"test-agent-123","iat":1516239022}
+	// Secret: "your-256-bit-secret"
+	validJWT := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJpbnRlZ3JhdGlvbi1vcmciLCJhZ2VudF9pZCI6InRlc3QtYWdlbnQtMTIzIiwiaWF0IjoxNTE2MjM5MDIyfQ.FY6z7lP4RwV3HvO5QfM8NLn2b8XHrIPDZT0hN4y6m3K"
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	mockPMgr := &mockPolicyManagerForFleet{}
+	fleetManager := newFleetConfigManager(context.Background(), logger, mockPMgr)
+	defer fleetManager.heartbeater.hbTicker.Stop()
+
+	// Create mock HTTP server that returns a JWT token
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := tokenResponse{
+			AccessToken: validJWT,
+			MQTTURL:     "mqtt://test.example.com:1883",
+			ExpiresIn:   3600,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	// Create test config
+	cfg := config.Config{
+		OrbAgent: config.OrbAgent{
+			ConfigManager: config.ManagerConfig{
+				Sources: config.Sources{
+					Fleet: config.FleetManager{
+						TokenURL:     server.URL,
+						ClientID:     "test_client_id",
+						ClientSecret: "test_client_secret",
+						MQTTURL:      "mqtt://fallback.example.com:1883",
+					},
+				},
+			},
+		},
+	}
+
+	// Mock backends
+	backends := make(map[string]backend.Backend)
+
+	// Since we can't easily mock the MQTT connection in this test,
+	// we expect the Start method to fail at the MQTT connection step,
+	// but succeed in generating topics from JWT claims
+	err := fleetManager.Start(cfg, backends)
+
+	// We expect an error because we can't actually connect to MQTT,
+	// but we want to verify that topic generation succeeded
+	// (The error should be related to MQTT connection, not JWT parsing)
+	require.Error(t, err)
+	// The error could be connection-related (mqtt, tcp, timeout, etc.)
+	errorMsg := strings.ToLower(err.Error())
+	assert.True(t,
+		strings.Contains(errorMsg, "mqtt") ||
+			strings.Contains(errorMsg, "connection") ||
+			strings.Contains(errorMsg, "timeout") ||
+			strings.Contains(errorMsg, "deadline"),
+		"Expected connection-related error, got: %s", err.Error())
+}
+
+func TestGenerateTopicsFromTemplate_Integration(t *testing.T) {
+	// Test the integration of JWT parsing with topic generation using real JWT
+	tests := []struct {
+		name          string
+		jwt           string
+		expectedOrg   string
+		expectedAgent string
+	}{
+		{
+			name: "production-like JWT",
+			// Header: {"alg":"HS256","typ":"JWT"}
+			// Payload: {"org_id":"acme-corp","agent_id":"agent-prod-456","iat":1516239022}
+			// Secret: "your-256-bit-secret"
+			jwt:           "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJhY21lLWNvcnAiLCJhZ2VudF9pZCI6ImFnZW50LXByb2QtNDU2IiwiaWF0IjoxNTE2MjM5MDIyfQ.P5LwR7mKzYt4PxV9QgN3OMo8c2fJsHGF3bU6pR7z9nL",
+			expectedOrg:   "acme-corp",
+			expectedAgent: "agent-prod-456",
+		},
+		{
+			name: "development JWT with different values",
+			// Header: {"alg":"HS256","typ":"JWT"}
+			// Payload: {"org_id":"dev-123","agent_id":"dev-agent-789","iat":1516239022}
+			// Secret: "your-256-bit-secret"
+			jwt:           "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJkZXYtMTIzIiwiYWdlbnRfaWQiOiJkZXYtYWdlbnQtNzg5IiwiaWF0IjoxNTE2MjM5MDIyfQ.M8PzT6qL3YuR5NvW1QnJ4Opr9e3aKtHIE4cV7sR8mON",
+			expectedOrg:   "dev-123",
+			expectedAgent: "dev-agent-789",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			topics, err := GenerateTopicsFromTemplate(tt.jwt)
+			require.NoError(t, err)
+
+			expectedTopics := &tokenResponseTopics{
+				Heartbeat:    fmt.Sprintf("/orgs/%s/agents/%s/heartbeat", tt.expectedOrg, tt.expectedAgent),
+				Capabilities: fmt.Sprintf("/orgs/%s/agents/%s/capabilities", tt.expectedOrg, tt.expectedAgent),
+				Inbox:        fmt.Sprintf("/orgs/%s/agents/%s/inbox", tt.expectedOrg, tt.expectedAgent),
+				Outbox:       fmt.Sprintf("/orgs/%s/agents/%s/outbox", tt.expectedOrg, tt.expectedAgent),
+			}
+
+			assert.Equal(t, expectedTopics, topics)
+		})
+	}
 }

--- a/agent/configmgr/fleet_test.go
+++ b/agent/configmgr/fleet_test.go
@@ -93,7 +93,7 @@ func TestHeartbeater_SendSingleHeartbeat_Success(t *testing.T) {
 
 	// Expected heartbeat data
 	expectedHeartbeat := messages.Heartbeat{
-		AgentID: "orb-agent",
+		AgentID: "test-agent-id",
 		Version: "1.0.0",
 	}
 	expectedPayload, _ := json.Marshal(expectedHeartbeat)
@@ -102,7 +102,7 @@ func TestHeartbeater_SendSingleHeartbeat_Success(t *testing.T) {
 	mockPublish.On("Publish", ctx, expectedPayload).Return(nil)
 
 	// Act
-	hb.sendSingleHeartbeat(ctx, mockPublish.Publish, testTime, messages.Online)
+	hb.sendSingleHeartbeat(ctx, mockPublish.Publish, "test-agent-id", testTime, messages.Online)
 
 	// Assert
 	mockPublish.AssertExpectations(t)
@@ -122,7 +122,7 @@ func TestHeartbeater_SendSingleHeartbeat_PublishError(t *testing.T) {
 	mockPublish.On("Publish", ctx, mock.AnythingOfType("[]uint8")).Return(publishError)
 
 	// Act - should not panic despite publish error
-	hb.sendSingleHeartbeat(ctx, mockPublish.Publish, testTime, messages.Online)
+	hb.sendSingleHeartbeat(ctx, mockPublish.Publish, "test-agent-id", testTime, messages.Online)
 
 	// Assert
 	mockPublish.AssertExpectations(t)
@@ -143,7 +143,7 @@ func TestHeartbeater_SendSingleHeartbeat_HeartbeatContent(t *testing.T) {
 	testTime := time.Now()
 
 	// Act
-	hb.sendSingleHeartbeat(ctx, publishFunc, testTime, messages.Online)
+	hb.sendSingleHeartbeat(ctx, publishFunc, "test-agent-id", testTime, messages.Online)
 
 	// Assert
 	require.NotNil(t, capturedPayload)
@@ -152,7 +152,7 @@ func TestHeartbeater_SendSingleHeartbeat_HeartbeatContent(t *testing.T) {
 	err := json.Unmarshal(capturedPayload, &heartbeat)
 	require.NoError(t, err)
 
-	assert.Equal(t, "orb-agent", heartbeat.AgentID)
+	assert.Equal(t, "test-agent-id", heartbeat.AgentID)
 	assert.Equal(t, "1.0.0", heartbeat.Version)
 }
 
@@ -172,7 +172,7 @@ func TestHeartbeater_SendHeartbeats_InitialHeartbeat(t *testing.T) {
 	mockPublish.On("Publish", ctx, mock.AnythingOfType("[]uint8")).Return(nil).Once()
 
 	// Act
-	go hb.sendHeartbeats(ctx, cancel, mockPublish.Publish)
+	go hb.sendHeartbeats(ctx, cancel, mockPublish.Publish, "test-agent-id")
 
 	// Give some time for initial heartbeat
 	time.Sleep(10 * time.Millisecond)
@@ -200,7 +200,7 @@ func TestHeartbeater_SendHeartbeats_PeriodicHeartbeats(t *testing.T) {
 	mockPublish.On("Publish", ctx, mock.AnythingOfType("[]uint8")).Return(nil).Times(4)
 
 	// Act
-	go hb.sendHeartbeats(ctx, cancel, mockPublish.Publish)
+	go hb.sendHeartbeats(ctx, cancel, mockPublish.Publish, "test-agent-id")
 
 	// Wait for some periodic heartbeats (ticker is 50ms in test)
 	time.Sleep(120 * time.Millisecond)
@@ -236,7 +236,7 @@ func TestHeartbeater_SendHeartbeats_ContextCancellation(t *testing.T) {
 
 	// Act
 	go func() {
-		hb.sendHeartbeats(ctx, cancel, publishFunc)
+		hb.sendHeartbeats(ctx, cancel, publishFunc, "test-agent-id")
 		done <- true
 	}()
 
@@ -272,7 +272,7 @@ func TestHeartbeater_SendHeartbeats_PublishErrors(t *testing.T) {
 	mockPublish.On("Publish", ctx, mock.AnythingOfType("[]uint8")).Return(publishError).Times(4)
 
 	// Act
-	go hb.sendHeartbeats(ctx, cancel, mockPublish.Publish)
+	go hb.sendHeartbeats(ctx, cancel, mockPublish.Publish, "test-agent-id")
 
 	// Wait for some heartbeats with errors
 	time.Sleep(120 * time.Millisecond)
@@ -300,7 +300,7 @@ func TestHeartbeater_SendHeartbeats_ConcurrentCancellation(t *testing.T) {
 	mockPublish.On("Publish", ctx, mock.AnythingOfType("[]uint8")).Return(nil).Maybe()
 
 	// Act - start heartbeats
-	go hb.sendHeartbeats(ctx, cancel, mockPublish.Publish)
+	go hb.sendHeartbeats(ctx, cancel, mockPublish.Publish, "test-agent-id")
 
 	// Cancel immediately in a separate goroutine
 	go func() {
@@ -344,7 +344,7 @@ func TestHeartbeater_SendHeartbeats_HeartbeatStates(t *testing.T) {
 
 	// Act
 	go func() {
-		hb.sendHeartbeats(ctx, cancel, publishFunc)
+		hb.sendHeartbeats(ctx, cancel, publishFunc, "test-agent-id")
 		done <- true
 	}()
 
@@ -370,7 +370,7 @@ func TestHeartbeater_SendHeartbeats_HeartbeatStates(t *testing.T) {
 		var heartbeat messages.Heartbeat
 		err := json.Unmarshal(payload, &heartbeat)
 		require.NoError(t, err, "Heartbeat %d should be valid JSON", i)
-		assert.Equal(t, "orb-agent", heartbeat.AgentID)
+		assert.Equal(t, "test-agent-id", heartbeat.AgentID)
 		assert.Equal(t, "1.0.0", heartbeat.Version)
 	}
 }
@@ -530,7 +530,7 @@ func TestFleetConfigManager_Connect_InvalidURL(t *testing.T) {
 	// Act with invalid URL
 	backends := make(map[string]backend.Backend)
 	trt := tokenResponseTopics{Inbox: "test/topic"}
-	err := fleetManager.connect("://invalid-url", "test_token", trt, backends)
+	err := fleetManager.connect("://invalid-url", "test_token", trt, backends, "test-agent-id")
 
 	// Assert
 	assert.Error(t, err)
@@ -548,7 +548,7 @@ func TestFleetConfigManager_Connect_ValidURL(t *testing.T) {
 	// since we don't have a real MQTT server
 	backends := make(map[string]backend.Backend)
 	trt2 := tokenResponseTopics{Inbox: "test/topic"}
-	err := fleetManager.connect("mqtt://localhost:1883", "test_token", trt2, backends)
+	err := fleetManager.connect("mqtt://localhost:1883", "test_token", trt2, backends, "test-agent-id")
 
 	// Assert - we expect connection to fail since no server is running,
 	// but URL parsing should succeed
@@ -750,7 +750,7 @@ func TestFleetConfigManager_Integration_SuccessFlow(t *testing.T) {
 	assert.Equal(t, "mqtt://localhost:1883", token.MQTTURL)
 
 	// Test that topic generation works with the JWT
-	topics, err := GenerateTopicsFromTemplate(token.AccessToken)
+	topics, err := GenerateTopicsFromTemplate(token.AccessToken, "test-agent-123")
 	require.NoError(t, err)
 	assert.Equal(t, "/orgs/integration-org/agents/test-agent-123/inbox", topics.Inbox)
 	assert.Equal(t, "/orgs/integration-org/agents/test-agent-123/outbox", topics.Outbox)
@@ -1249,6 +1249,7 @@ func TestFleetConfigManager_Start_WithJWTTopicGeneration(t *testing.T) {
 						TokenURL:     server.URL,
 						ClientID:     "test_client_id",
 						ClientSecret: "test_client_secret",
+						AgentID:      "test-agent-123",
 						MQTTURL:      "mqtt://fallback.example.com:1883",
 					},
 				},
@@ -1308,7 +1309,7 @@ func TestGenerateTopicsFromTemplate_Integration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			topics, err := GenerateTopicsFromTemplate(tt.jwt)
+			topics, err := GenerateTopicsFromTemplate(tt.jwt, tt.expectedAgent)
 			require.NoError(t, err)
 
 			expectedTopics := &tokenResponseTopics{

--- a/agent/configmgr/fleet_test.go
+++ b/agent/configmgr/fleet_test.go
@@ -2,6 +2,7 @@ package configmgr
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -70,6 +71,19 @@ func (m *mockPolicyManagerForFleet) RemoveBackendPolicies(be backend.Backend, pe
 func (m *mockPolicyManagerForFleet) RemovePolicy(policyID string, policyName string, beName string) error {
 	args := m.Called(policyID, policyName, beName)
 	return args.Error(0)
+}
+
+// rawJWTWithClaims builds a raw JWT string with the given claims.
+// Signature is a dummy value; ParseUnverified only inspects header/payload.
+func rawJWTWithClaims(claims map[string]any) string {
+	header := map[string]any{
+		"alg": "RS256",
+		"kid": "test-key",
+		"typ": "JWT",
+	}
+	h, _ := json.Marshal(header)
+	p, _ := json.Marshal(claims)
+	return base64.RawURLEncoding.EncodeToString(h) + "." + base64.RawURLEncoding.EncodeToString(p) + ".sig"
 }
 
 // Test helper to create a heartbeater instance for testing
@@ -603,9 +617,13 @@ func TestFleetConfigManager_Start_ConnectError(t *testing.T) {
 	// Create mock HTTP server for token endpoint
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		response := tokenResponse{
-			AccessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJ0ZXN0LW9yZyIsImFnZW50X2lkIjoidGVzdC1hZ2VudC0xMjMiLCJpYXQiOjE1MTYyMzkwMjJ9.8U8W8j_2ZwV2GvO3QcI6LJl2a8XGrHPDYS9hM2y4k2I", // Valid JWT
-			MQTTURL:     "://invalid-mqtt-url",                                                                                                                                                       // Invalid MQTT URL
-			ExpiresIn:   3600,
+			AccessToken: rawJWTWithClaims(map[string]any{
+				"org_id":   "test-org",
+				"agent_id": "test-agent-123",
+				"iat":      1516239022,
+			}),
+			MQTTURL:   "://invalid-mqtt-url", // Invalid MQTT URL
+			ExpiresIn: 3600,
 		}
 		_ = json.NewEncoder(w).Encode(response)
 	}))
@@ -731,9 +749,13 @@ func TestFleetConfigManager_Integration_SuccessFlow(t *testing.T) {
 	// Create mock HTTP server for successful token response
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		response := tokenResponse{
-			AccessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJpbnRlZ3JhdGlvbi1vcmciLCJhZ2VudF9pZCI6InRlc3QtYWdlbnQtMTIzIiwiaWF0IjoxNTE2MjM5MDIyfQ.FY6z7lP4RwV3HvO5QfM8NLn2b8XHrIPDZT0hN4y6m3K", // Valid JWT with org_id="integration-org", agent_id="test-agent-123"
-			MQTTURL:     "mqtt://localhost:1883",                                                                                                                                                               // Valid but non-existent
-			ExpiresIn:   3600,
+			AccessToken: rawJWTWithClaims(map[string]any{
+				"org_id":   "integration-org",
+				"agent_id": "test-agent-123",
+				"iat":      1516239022,
+			}),
+			MQTTURL:   "mqtt://localhost:1883", // Valid but non-existent
+			ExpiresIn: 3600,
 		}
 		_ = json.NewEncoder(w).Encode(response)
 	}))
@@ -745,7 +767,11 @@ func TestFleetConfigManager_Integration_SuccessFlow(t *testing.T) {
 
 	// Assert - token retrieval should succeed
 	require.NoError(t, err)
-	expectedJWT := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJpbnRlZ3JhdGlvbi1vcmciLCJhZ2VudF9pZCI6InRlc3QtYWdlbnQtMTIzIiwiaWF0IjoxNTE2MjM5MDIyfQ.FY6z7lP4RwV3HvO5QfM8NLn2b8XHrIPDZT0hN4y6m3K"
+	expectedJWT := rawJWTWithClaims(map[string]any{
+		"org_id":   "integration-org",
+		"agent_id": "test-agent-123",
+		"iat":      1516239022,
+	})
 	assert.Equal(t, expectedJWT, token.AccessToken)
 	assert.Equal(t, "mqtt://localhost:1883", token.MQTTURL)
 
@@ -1217,10 +1243,11 @@ func TestFleetConfigManager_Start_WithJWTTopicGeneration(t *testing.T) {
 	// This test verifies that the Start method correctly generates topics from JWT claims
 
 	// Create a valid JWT token with org_id and agent_id claims
-	// Header: {"alg":"HS256","typ":"JWT"}
-	// Payload: {"org_id":"integration-org","agent_id":"test-agent-123","iat":1516239022}
-	// Secret: "your-256-bit-secret"
-	validJWT := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJpbnRlZ3JhdGlvbi1vcmciLCJhZ2VudF9pZCI6InRlc3QtYWdlbnQtMTIzIiwiaWF0IjoxNTE2MjM5MDIyfQ.FY6z7lP4RwV3HvO5QfM8NLn2b8XHrIPDZT0hN4y6m3K"
+	validJWT := rawJWTWithClaims(map[string]any{
+		"org_id":   "integration-org",
+		"agent_id": "test-agent-123",
+		"iat":      1516239022,
+	})
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	mockPMgr := &mockPolicyManagerForFleet{}
@@ -1289,19 +1316,21 @@ func TestGenerateTopicsFromTemplate_Integration(t *testing.T) {
 	}{
 		{
 			name: "production-like JWT",
-			// Header: {"alg":"HS256","typ":"JWT"}
-			// Payload: {"org_id":"acme-corp","agent_id":"agent-prod-456","iat":1516239022}
-			// Secret: "your-256-bit-secret"
-			jwt:           "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJhY21lLWNvcnAiLCJhZ2VudF9pZCI6ImFnZW50LXByb2QtNDU2IiwiaWF0IjoxNTE2MjM5MDIyfQ.P5LwR7mKzYt4PxV9QgN3OMo8c2fJsHGF3bU6pR7z9nL",
+			jwt: rawJWTWithClaims(map[string]any{
+				"org_id":   "acme-corp",
+				"agent_id": "agent-prod-456",
+				"iat":      1516239022,
+			}),
 			expectedOrg:   "acme-corp",
 			expectedAgent: "agent-prod-456",
 		},
 		{
 			name: "development JWT with different values",
-			// Header: {"alg":"HS256","typ":"JWT"}
-			// Payload: {"org_id":"dev-123","agent_id":"dev-agent-789","iat":1516239022}
-			// Secret: "your-256-bit-secret"
-			jwt:           "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJkZXYtMTIzIiwiYWdlbnRfaWQiOiJkZXYtYWdlbnQtNzg5IiwiaWF0IjoxNTE2MjM5MDIyfQ.M8PzT6qL3YuR5NvW1QnJ4Opr9e3aKtHIE4cV7sR8mON",
+			jwt: rawJWTWithClaims(map[string]any{
+				"org_id":   "dev-123",
+				"agent_id": "dev-agent-789",
+				"iat":      1516239022,
+			}),
 			expectedOrg:   "dev-123",
 			expectedAgent: "dev-agent-789",
 		},

--- a/agent/configmgr/jwt_claims.go
+++ b/agent/configmgr/jwt_claims.go
@@ -1,0 +1,104 @@
+package configmgr
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+)
+
+// JWTClaims represents the JWT claims we extract for topic templating
+type JWTClaims struct {
+	OrgID string `json:"org_id"`
+}
+
+// TopicClaims combines org_id from JWT with agent_id from config
+type TopicClaims struct {
+	OrgID   string
+	AgentID string
+}
+
+// TopicTemplates defines hardcoded topic name patterns with placeholders
+type TopicTemplates struct {
+	Heartbeat    string
+	Capabilities string
+	Inbox        string
+	Outbox       string
+}
+
+// DefaultTopicTemplates returns the hardcoded topic templates
+func DefaultTopicTemplates() TopicTemplates {
+	return TopicTemplates{
+		Heartbeat:    "/orgs/{org_id}/agents/{agent_id}/heartbeat",
+		Capabilities: "/orgs/{org_id}/agents/{agent_id}/capabilities",
+		Inbox:        "/orgs/{org_id}/agents/{agent_id}/inbox",
+		Outbox:       "/orgs/{org_id}/agents/{agent_id}/outbox",
+	}
+}
+
+// parseJWTClaims extracts org_id claim from a JWT token
+func parseJWTClaims(tokenString string) (*JWTClaims, error) {
+	if tokenString == "" {
+		return nil, fmt.Errorf("empty token string")
+	}
+
+	// Parse the JWT token without verification (since we already trust it from the token endpoint)
+	// We accept common signature algorithms used in JWTs
+	token, err := jwt.ParseSigned(tokenString, []jose.SignatureAlgorithm{jose.HS256, jose.HS384, jose.HS512, jose.RS256, jose.RS384, jose.RS512, jose.ES256, jose.ES384, jose.ES512})
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse JWT token: %w", err)
+	}
+
+	var claims jwt.Claims
+	var customClaims map[string]interface{}
+
+	// Extract both standard and custom claims without verification
+	if err := token.UnsafeClaimsWithoutVerification(&claims, &customClaims); err != nil {
+		return nil, fmt.Errorf("failed to extract claims from JWT: %w", err)
+	}
+
+	// Extract org_id from custom claims
+	jwtClaims := &JWTClaims{}
+
+	if orgID, ok := customClaims["org_id"].(string); ok {
+		jwtClaims.OrgID = orgID
+	} else {
+		return nil, fmt.Errorf("org_id claim not found or not a string in JWT token")
+	}
+
+	return jwtClaims, nil
+}
+
+// fillTopicTemplate replaces placeholders in a topic template with actual values
+func fillTopicTemplate(template string, claims *TopicClaims) string {
+	result := template
+	result = strings.ReplaceAll(result, "{org_id}", claims.OrgID)
+	result = strings.ReplaceAll(result, "{agent_id}", claims.AgentID)
+	return result
+}
+
+// GenerateTopicsFromTemplate creates actual topic names from templates using JWT claims and config agent_id
+func GenerateTopicsFromTemplate(tokenString string, agentID string) (*tokenResponseTopics, error) {
+	jwtClaims, err := parseJWTClaims(tokenString)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse JWT claims: %w", err)
+	}
+
+	// Combine JWT org_id with config agent_id
+	topicClaims := &TopicClaims{
+		OrgID:   jwtClaims.OrgID,
+		AgentID: agentID,
+	}
+
+	templates := DefaultTopicTemplates()
+
+	topics := &tokenResponseTopics{
+		Heartbeat:    fillTopicTemplate(templates.Heartbeat, topicClaims),
+		Capabilities: fillTopicTemplate(templates.Capabilities, topicClaims),
+		Inbox:        fillTopicTemplate(templates.Inbox, topicClaims),
+		Outbox:       fillTopicTemplate(templates.Outbox, topicClaims),
+	}
+
+	return topics, nil
+}

--- a/agent/configmgr/jwt_claims.go
+++ b/agent/configmgr/jwt_claims.go
@@ -78,8 +78,8 @@ func fillTopicTemplate(template string, claims *TopicClaims) string {
 	return result
 }
 
-// GenerateTopicsFromTemplate creates actual topic names from templates using JWT claims and config agent_id
-func GenerateTopicsFromTemplate(tokenString string, agentID string) (*tokenResponseTopics, error) {
+// generateTopicsFromTemplate creates actual topic names from templates using JWT claims and config agent_id
+func generateTopicsFromTemplate(tokenString string, agentID string) (*tokenResponseTopics, error) {
 	jwtClaims, err := parseJWTClaims(tokenString)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse JWT claims: %w", err)

--- a/agent/configmgr/jwt_claims_test.go
+++ b/agent/configmgr/jwt_claims_test.go
@@ -177,7 +177,7 @@ func TestGenerateTopicsFromTemplate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			topics, err := GenerateTopicsFromTemplate(tt.tokenString, "test-agent-123")
+			topics, err := generateTopicsFromTemplate(tt.tokenString, "test-agent-123")
 
 			if tt.expectedErr != "" {
 				require.Error(t, err)

--- a/agent/configmgr/jwt_claims_test.go
+++ b/agent/configmgr/jwt_claims_test.go
@@ -1,0 +1,214 @@
+package configmgr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultTopicTemplates(t *testing.T) {
+	templates := DefaultTopicTemplates()
+
+	assert.Equal(t, "/orgs/{org_id}/agents/{agent_id}/heartbeat", templates.Heartbeat)
+	assert.Equal(t, "/orgs/{org_id}/agents/{agent_id}/capabilities", templates.Capabilities)
+	assert.Equal(t, "/orgs/{org_id}/agents/{agent_id}/inbox", templates.Inbox)
+	assert.Equal(t, "/orgs/{org_id}/agents/{agent_id}/outbox", templates.Outbox)
+}
+
+func TestFillTopicTemplate(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		claims   *TopicClaims
+		expected string
+	}{
+		{
+			name:     "basic substitution",
+			template: "/orgs/{org_id}/agents/{agent_id}/test",
+			claims: &TopicClaims{
+				OrgID:   "org123",
+				AgentID: "agent-456",
+			},
+			expected: "/orgs/org123/agents/agent-456/test",
+		},
+		{
+			name:     "multiple occurrences",
+			template: "{org_id}/data/{org_id}/{agent_id}",
+			claims: &TopicClaims{
+				OrgID:   "company1",
+				AgentID: "agent-789",
+			},
+			expected: "company1/data/company1/agent-789",
+		},
+		{
+			name:     "no placeholders",
+			template: "static/topic/name",
+			claims: &TopicClaims{
+				OrgID:   "org123",
+				AgentID: "agent-456",
+			},
+			expected: "static/topic/name",
+		},
+		{
+			name:     "empty claims",
+			template: "/orgs/{org_id}/agents/{agent_id}/test",
+			claims: &TopicClaims{
+				OrgID:   "",
+				AgentID: "",
+			},
+			expected: "/orgs//agents//test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := fillTopicTemplate(tt.template, tt.claims)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseJWTClaims(t *testing.T) {
+	tests := []struct {
+		name        string
+		tokenString string
+		expectedErr string
+		expected    *JWTClaims
+	}{
+		{
+			name:        "empty token",
+			tokenString: "",
+			expectedErr: "empty token string",
+		},
+		{
+			name:        "invalid JWT format",
+			tokenString: "not.a.jwt",
+			expectedErr: "failed to parse JWT token",
+		},
+		{
+			name: "valid JWT with org_id",
+			// This is a sample JWT with the claims we need (created using jwt.io)
+			// Header: {"alg":"HS256","typ":"JWT"}
+			// Payload: {"org_id":"test-org","agent_id":"test-agent-123","iat":1516239022}
+			// Secret: "your-256-bit-secret"
+			tokenString: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJ0ZXN0LW9yZyIsImFnZW50X2lkIjoidGVzdC1hZ2VudC0xMjMiLCJpYXQiOjE1MTYyMzkwMjJ9.8U8W8j_2ZwV2GvO3QcI6LJl2a8XGrHPDYS9hM2y4k2I",
+			expected: &JWTClaims{
+				OrgID: "test-org",
+			},
+		},
+		{
+			name: "JWT missing org_id",
+			// Header: {"alg":"HS256","typ":"JWT"}
+			// Payload: {"agent_id":"test-agent-123","iat":1516239022}
+			// Secret: "your-256-bit-secret"
+			tokenString: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhZ2VudF9pZCI6InRlc3QtYWdlbnQtMTIzIiwiaWF0IjoxNTE2MjM5MDIyfQ.QZ3K8j9QqgV2HvP4RdJ7MKm3b9YHsIPEZT0iN3z5l3J",
+			expectedErr: "org_id claim not found",
+		},
+		{
+			name: "JWT with non-string org_id",
+			// Header: {"alg":"HS256","typ":"JWT"}
+			// Payload: {"org_id":123,"agent_id":"test-agent-123","iat":1516239022}
+			// Secret: "your-256-bit-secret"
+			tokenString: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOjEyMywiYWdlbnRfaWQiOiJ0ZXN0LWFnZW50LTEyMyIsImlhdCI6MTUxNjIzOTAyMn0.Vh9X8l2LwO6PvR5QfK9NMn4c0ZIsJGF1aU3oO4z6m5K",
+			expectedErr: "org_id claim not found or not a string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			claims, err := parseJWTClaims(tt.tokenString)
+
+			if tt.expectedErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+				assert.Nil(t, claims)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, claims)
+			}
+		})
+	}
+}
+
+func TestGenerateTopicsFromTemplate(t *testing.T) {
+	tests := []struct {
+		name        string
+		tokenString string
+		expectedErr string
+		expected    *tokenResponseTopics
+	}{
+		{
+			name:        "empty token",
+			tokenString: "",
+			expectedErr: "failed to parse JWT claims",
+		},
+		{
+			name:        "invalid token",
+			tokenString: "invalid.token",
+			expectedErr: "failed to parse JWT claims",
+		},
+		{
+			name: "valid token generates correct topics",
+			// Valid JWT with org_id="test-org" and agent_id="test-agent-123"
+			tokenString: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJ0ZXN0LW9yZyIsImFnZW50X2lkIjoidGVzdC1hZ2VudC0xMjMiLCJpYXQiOjE1MTYyMzkwMjJ9.8U8W8j_2ZwV2GvO3QcI6LJl2a8XGrHPDYS9hM2y4k2I",
+			expected: &tokenResponseTopics{
+				Heartbeat:    "/orgs/test-org/agents/test-agent-123/heartbeat",
+				Capabilities: "/orgs/test-org/agents/test-agent-123/capabilities",
+				Inbox:        "/orgs/test-org/agents/test-agent-123/inbox",
+				Outbox:       "/orgs/test-org/agents/test-agent-123/outbox",
+			},
+		},
+		{
+			name: "different org and agent values",
+			// JWT with org_id="prod-company" and agent_id="agent-456"
+			// Header: {"alg":"HS256","typ":"JWT"}
+			// Payload: {"org_id":"prod-company","agent_id":"agent-456","iat":1516239022}
+			// Secret: "your-256-bit-secret"
+			tokenString: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJwcm9kLWNvbXBhbnkiLCJhZ2VudF9pZCI6ImFnZW50LTQ1NiIsImlhdCI6MTUxNjIzOTAyMn0.KJ2NtX5zY8R9LwP3QfM6NOn5d1aJsHGE2bV4oQ6z7mL",
+			expected: &tokenResponseTopics{
+				Heartbeat:    "/orgs/prod-company/agents/test-agent-123/heartbeat",
+				Capabilities: "/orgs/prod-company/agents/test-agent-123/capabilities",
+				Inbox:        "/orgs/prod-company/agents/test-agent-123/inbox",
+				Outbox:       "/orgs/prod-company/agents/test-agent-123/outbox",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			topics, err := GenerateTopicsFromTemplate(tt.tokenString, "test-agent-123")
+
+			if tt.expectedErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+				assert.Nil(t, topics)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, topics)
+			}
+		})
+	}
+}
+
+func TestJWTClaimsStruct(t *testing.T) {
+	claims := JWTClaims{
+		OrgID: "test-org-id",
+	}
+
+	assert.Equal(t, "test-org-id", claims.OrgID)
+}
+
+func TestTopicTemplatesStruct(t *testing.T) {
+	templates := TopicTemplates{
+		Heartbeat:    "custom/heartbeat/{org_id}",
+		Capabilities: "custom/capabilities/{agent_id}",
+		Inbox:        "custom/inbox",
+		Outbox:       "custom/outbox",
+	}
+
+	assert.Equal(t, "custom/heartbeat/{org_id}", templates.Heartbeat)
+	assert.Equal(t, "custom/capabilities/{agent_id}", templates.Capabilities)
+	assert.Equal(t, "custom/inbox", templates.Inbox)
+	assert.Equal(t, "custom/outbox", templates.Outbox)
+}

--- a/docs/sample-fleet-config.yaml
+++ b/docs/sample-fleet-config.yaml
@@ -7,6 +7,7 @@ orb:
         token_url: "http://0.0.0.0:8080/auth/token"
         client_id: "${FLEET_CLIENT_ID}"
         client_secret: "${FLEET_CLIENT_SECRET}"
+        agent_id: "my-fleet-agent-001"
   backends:
     network_discovery:
     common:


### PR DESCRIPTION
This pull request refactors how the agent's ID and MQTT topics are managed and used throughout the fleet manager and heartbeater components. The changes remove legacy topic configuration fields, introduce a dedicated `agent_id` field, and update how topics are generated and passed between components. Unit tests are updated to reflect these changes and ensure correct agent ID handling in heartbeat messages.

**Configuration and Topic Management Updates:**

* Removed legacy topic configuration fields (`HeartbeatTopic`, `CapabilitiesTopic`, `TopicName`) from the `FleetManager` struct and added a new `AgentID` field for explicit agent identification. (`agent/config/types.go`)
* Refactored topic generation: now topics are derived using a new template function based on JWT claims and the configured `agent_id`, instead of merging configuration and token response values. (`agent/configmgr/fleet.go`)

**Heartbeater and Fleet Manager Refactoring:**

* Updated `sendSingleHeartbeat` and `sendHeartbeats` methods to accept and use the `agentID` parameter, ensuring heartbeats carry the correct agent identity. (`agent/configmgr/fleet.go`) [[1]](diffhunk://#diff-b0dddd7590e09bc17b468db04b48a21f0d508a17eca4c086eb98c87325e5ba98L46-R48) [[2]](diffhunk://#diff-b0dddd7590e09bc17b468db04b48a21f0d508a17eca4c086eb98c87325e5ba98L69-R85)
* Changed fleet manager connection logic to propagate `agentID` through all relevant calls, including MQTT connection setup. (`agent/configmgr/fleet.go`) [[1]](diffhunk://#diff-b0dddd7590e09bc17b468db04b48a21f0d508a17eca4c086eb98c87325e5ba98L115-R141) [[2]](diffhunk://#diff-b0dddd7590e09bc17b468db04b48a21f0d508a17eca4c086eb98c87325e5ba98L232-R197) [[3]](diffhunk://#diff-b0dddd7590e09bc17b468db04b48a21f0d508a17eca4c086eb98c87325e5ba98L303-R270)

**Token Response Structure Changes:**

* Removed the `Topics` field from the `tokenResponse` struct, as topic information is now generated separately from JWT and configuration. (`agent/configmgr/fleet.go`)

**Unit Test Updates:**

* Updated all heartbeater and fleet manager tests to pass and assert the correct `agent_id` value, and removed references to legacy topic fields and token response topics. (`agent/configmgr/fleet_test.go`) [[1]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL95-R96) [[2]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL104-R105) [[3]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL124-R125) [[4]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL145-R146) [[5]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL154-R155) [[6]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL174-R175) [[7]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL202-R203) [[8]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL238-R239) [[9]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL274-R275) [[10]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL302-R303) [[11]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL346-R347) [[12]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL372-R373) [[13]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL414-L425) [[14]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL443-L444) [[15]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL540-R533) [[16]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL558-R551) [[17]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL613-L618) [[18]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL694-L697) [[19]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL713-L714)