### PR TITLE
chore: rename otel tag and backend

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -105,7 +105,7 @@ func (a *orbAgent) startBackends(agentCtx context.Context, cfgBackends map[strin
 	} else {
 		commonConfig = config.BackendCommons{}
 	}
-	commonConfig.Otel.AgentLabels = labels
+	commonConfig.Otlp.AgentLabels = labels
 	a.backendsCommon = commonConfig
 	delete(cfgBackends, "common")
 

--- a/agent/backend/devicediscovery/device_discovery.go
+++ b/agent/backend/devicediscovery/device_discovery.go
@@ -108,8 +108,8 @@ func (d *deviceDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Po
 		d.diodeDryRunOutputDir = dryRunOutputDir
 	}
 
-	if common.Otel.Grpc != "" {
-		d.diodeOtelEndpoint = common.Otel.Grpc
+	if common.Otlp.Grpc != "" {
+		d.diodeOtelEndpoint = common.Otlp.Grpc
 		d.logger.Info("device-discovery using OTLP metrics endpoint",
 			slog.String("endpoint", d.diodeOtelEndpoint))
 	}

--- a/agent/backend/networkdiscovery/network_discovery.go
+++ b/agent/backend/networkdiscovery/network_discovery.go
@@ -114,8 +114,8 @@ func (d *networkDiscoveryBackend) Configure(logger *slog.Logger, repo policies.P
 		d.diodeLogLevel = "debug"
 	}
 
-	if common.Otel.Grpc != "" {
-		d.diodeOtelEndpoint = common.Otel.Grpc
+	if common.Otlp.Grpc != "" {
+		d.diodeOtelEndpoint = common.Otlp.Grpc
 		d.logger.Info("network-discovery using OTLP metrics endpoint",
 			slog.String("endpoint", d.diodeOtelEndpoint))
 	}

--- a/agent/backend/opentelemetryinfinity/opentelemetry_infinity.go
+++ b/agent/backend/opentelemetryinfinity/opentelemetry_infinity.go
@@ -1,4 +1,4 @@
-package otel
+package opentelemetryinfinity
 
 import (
 	"bytes"
@@ -25,7 +25,6 @@ const (
 	versionTimeout      = 5
 	capabilitiesTimeout = 5
 	readinessBackoff    = 10
-	readinessTimeout    = 10
 	applyPolicyTimeout  = 10
 	removePolicyTimeout = 20
 )
@@ -55,7 +54,7 @@ type info struct {
 
 // Register registers otel backend
 func Register() bool {
-	backend.Register("otel", &openTelemetryBackend{
+	backend.Register("opentelemetry_infinity", &openTelemetryBackend{
 		apiProtocol: "http",
 		exec:        defaultExec,
 	})
@@ -77,7 +76,7 @@ func (o *openTelemetryBackend) Configure(logger *slog.Logger, repo policies.Poli
 		o.apiPort = defaultAPIPort
 	}
 
-	o.agentLabels = common.Otel.AgentLabels
+	o.agentLabels = common.Otlp.AgentLabels
 
 	return nil
 }

--- a/agent/backend/opentelemetryinfinity/opentelemetry_infinity_test.go
+++ b/agent/backend/opentelemetryinfinity/opentelemetry_infinity_test.go
@@ -1,5 +1,4 @@
-// otel_test.go
-package otel_test
+package opentelemetryinfinity_test
 
 import (
 	"context"
@@ -16,7 +15,7 @@ import (
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/backend/mocks"
-	"github.com/netboxlabs/orb-agent/agent/backend/otel"
+	"github.com/netboxlabs/orb-agent/agent/backend/opentelemetryinfinity"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/policies"
 )
@@ -117,11 +116,11 @@ func TestOpenTelemetryBackendStart(t *testing.T) {
 		return mockCmd
 	}
 
-	assert.True(t, otel.Register(), "Failed to register OpenTelemetry backend")
+	assert.True(t, opentelemetryinfinity.Register(), "Failed to register OpenTelemetry backend")
 
-	assert.True(t, backend.HaveBackend("otel"), "Failed to get OpenTelemetry backend")
+	assert.True(t, backend.HaveBackend("opentelemetry_infinity"), "Failed to get OpenTelemetry backend")
 
-	be := backend.GetBackend("otel")
+	be := backend.GetBackend("opentelemetry_infinity")
 
 	// Configure backend
 	err = be.Configure(logger, repo, map[string]any{
@@ -183,11 +182,11 @@ func TestOpenTelemetryBackendCompleted(t *testing.T) {
 		return mockCmd
 	}
 
-	assert.True(t, otel.Register(), "Failed to register Opentelemetry backend")
+	assert.True(t, opentelemetryinfinity.Register(), "Failed to register Opentelemetry backend")
 
-	assert.True(t, backend.HaveBackend("otel"), "Failed to get Opentelemetry backend")
+	assert.True(t, backend.HaveBackend("opentelemetry_infinity"), "Failed to get Opentelemetry backend")
 
-	be := backend.GetBackend("otel")
+	be := backend.GetBackend("opentelemetry_infinity")
 
 	// Configure backend with invalid parameters
 	err := be.Configure(slog.Default(), nil, map[string]any{

--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -244,7 +244,7 @@ func (p *pktvisorBackend) Configure(logger *slog.Logger, repo policies.PolicyRep
 	p.binary = defaultBinary
 	p.adminAPIHost = defaultAPIHost
 	p.adminAPIPort = defaultAPIPort
-	p.agentLabels = common.Otel.AgentLabels
+	p.agentLabels = common.Otlp.AgentLabels
 
 	// Create temp config file
 	tmpDir := os.TempDir()
@@ -303,18 +303,18 @@ func (p *pktvisorBackend) Configure(logger *slog.Logger, repo policies.PolicyRep
 
 	p.configFile = tmpFile.Name()
 
-	if common.Otel.HTTP != "" {
-		uri, err := url.Parse(common.Otel.HTTP)
+	if common.Otlp.HTTP != "" {
+		uri, err := url.Parse(common.Otlp.HTTP)
 		if err != nil {
-			return fmt.Errorf("failed to parse otel receiver http url: %w", err)
+			return fmt.Errorf("failed to parse otlp receiver http url: %w", err)
 		}
 		p.otelReceiverHost = uri.Hostname()
 		port, err := strconv.Atoi(uri.Port())
 		if err != nil {
-			return fmt.Errorf("failed to parse otel receiver port: %w", err)
+			return fmt.Errorf("failed to parse otlp receiver port: %w", err)
 		}
 		p.otelReceiverPort = port
-		p.logger.Info("configured otel receiver host", slog.String("host", p.otelReceiverHost),
+		p.logger.Info("configured otlp receiver host", slog.String("host", p.otelReceiverHost),
 			slog.Int("port", p.otelReceiverPort))
 	}
 

--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -114,8 +114,8 @@ func (d *snmpDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Poli
 		d.diodeLogLevel = "debug"
 	}
 
-	if common.Otel.Grpc != "" {
-		d.diodeOtelEndpoint = common.Otel.Grpc
+	if common.Otlp.Grpc != "" {
+		d.diodeOtelEndpoint = common.Otlp.Grpc
 		d.logger.Info("snmp-discovery using OTLP metrics endpoint",
 			slog.String("endpoint", d.diodeOtelEndpoint))
 	}

--- a/agent/backend/worker/worker.go
+++ b/agent/backend/worker/worker.go
@@ -108,8 +108,8 @@ func (d *workerBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 		d.diodeDryRunOutputDir = dryRunOutputDir
 	}
 
-	if common.Otel.Grpc != "" {
-		d.diodeOtelEndpoint = common.Otel.Grpc
+	if common.Otlp.Grpc != "" {
+		d.diodeOtelEndpoint = common.Otlp.Grpc
 		d.logger.Info("orb-worker using OTLP metrics endpoint",
 			slog.String("endpoint", d.diodeOtelEndpoint))
 	}

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -68,11 +68,11 @@ type ManagerSecrets struct {
 
 // BackendCommons represents common configuration for backends
 type BackendCommons struct {
-	Otel struct {
+	Otlp struct {
 		Grpc        string            `yaml:"grpc"`
 		HTTP        string            `yaml:"http"`
 		AgentLabels map[string]string `yaml:"agent_labels"`
-	} `yaml:"otel"`
+	} `yaml:"otlp"`
 	Diode struct {
 		Target          string `yaml:"target"`
 		ClientID        string `yaml:"client_id"`

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/netboxlabs/orb-agent/agent"
 	"github.com/netboxlabs/orb-agent/agent/backend/devicediscovery"
 	"github.com/netboxlabs/orb-agent/agent/backend/networkdiscovery"
-	"github.com/netboxlabs/orb-agent/agent/backend/otel"
+	"github.com/netboxlabs/orb-agent/agent/backend/opentelemetryinfinity"
 	"github.com/netboxlabs/orb-agent/agent/backend/pktvisor"
 	"github.com/netboxlabs/orb-agent/agent/backend/snmpdiscovery"
 	"github.com/netboxlabs/orb-agent/agent/backend/worker"
@@ -34,7 +34,7 @@ var (
 func init() {
 	devicediscovery.Register()
 	networkdiscovery.Register()
-	otel.Register()
+	opentelemetryinfinity.Register()
 	snmpdiscovery.Register()
 	pktvisor.Register()
 	worker.Register()


### PR DESCRIPTION
This pull request refactors the OpenTelemetry backend integration in the agent codebase, standardizing naming to `opentelemetryinfinity` and updating configuration references from `Otel` to `Otlp`. The changes improve code clarity and consistency, especially around backend registration and configuration, and ensure all references and tests are updated accordingly.

**Backend Refactor and Renaming**
* Renamed the backend package and files from `otel` to `opentelemetryinfinity`, including both implementation (`otel.go` → `opentelemetry_infinity.go`) and tests (`otel_test.go` → `opentelemetry_infinity_test.go`). [[1]](diffhunk://#diff-4f8fe6510b95d5f5cdbdd374873257ed0d9c97e9832444329d7cc35cea08e041L1-R1) [[2]](diffhunk://#diff-aff005981725fd3f8acd9b978b8255940fbb4a2c539882a89a1e169a1766b741L1-R1)
* Changed backend registration and usage throughout the codebase to use the new name `opentelemetryinfinity` instead of `otel`. [[1]](diffhunk://#diff-4f8fe6510b95d5f5cdbdd374873257ed0d9c97e9832444329d7cc35cea08e041L58-R57) [[2]](diffhunk://#diff-aff005981725fd3f8acd9b978b8255940fbb4a2c539882a89a1e169a1766b741L120-R123) [[3]](diffhunk://#diff-aff005981725fd3f8acd9b978b8255940fbb4a2c539882a89a1e169a1766b741L186-R189) [[4]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L17-R17) [[5]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L37-R37)

**Configuration Standardization**
* Updated the configuration struct in `types.go` to rename `Otel` to `Otlp` and all associated fields and YAML tags, ensuring consistent naming for gRPC, HTTP, and agent labels.
* Refactored all backend configuration logic to use `Otlp` instead of `Otel` for accessing agent labels, gRPC, and HTTP endpoints in device discovery, network discovery, SNMP discovery, worker, and pktvisor backends. [[1]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL108-R108) [[2]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L111-R112) [[3]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L117-R118) [[4]](diffhunk://#diff-a3efed70ceda5dfeee2a24c126eae9180ce3866c316f85a0b436c0fadae66c19L247-R247) [[5]](diffhunk://#diff-a3efed70ceda5dfeee2a24c126eae9180ce3866c316f85a0b436c0fadae66c19L306-R317) [[6]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91L117-R118) [[7]](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcL111-R112) [[8]](diffhunk://#diff-4f8fe6510b95d5f5cdbdd374873257ed0d9c97e9832444329d7cc35cea08e041L80-R79)

**Test and Logging Updates**
* Updated all test imports, backend registration, and assertions to use the new `opentelemetryinfinity` backend name. [[1]](diffhunk://#diff-aff005981725fd3f8acd9b978b8255940fbb4a2c539882a89a1e169a1766b741L19-R18) [[2]](diffhunk://#diff-aff005981725fd3f8acd9b978b8255940fbb4a2c539882a89a1e169a1766b741L120-R123) [[3]](diffhunk://#diff-aff005981725fd3f8acd9b978b8255940fbb4a2c539882a89a1e169a1766b741L186-R189)
* Adjusted logging and error messages to reflect the new naming and configuration fields, improving clarity in logs and error handling.

These changes ensure a consistent and clear approach to OpenTelemetry backend integration across the agent codebase.