### PR TITLE
chore: skip otlpinf timestamp

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -18,8 +18,6 @@ env:
 jobs:
     build-and-push:
       runs-on: ubuntu-latest
-      strategy:
-        fail-fast: false
       steps:
         - name: Checkout
           uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,8 +123,6 @@ jobs:
     name: Build
     needs: get-next-version
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     if: needs.get-next-version.outputs.new-release-published == 'true'
     env:
       BUILD_VERSION: ${{ needs.get-next-version.outputs.new-release-version }}

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ A special `common` subsection under `backends` defines configuration settings th
           agent_name: agent01
           dry_run: false
           dry_run_output_dir: /opt/orb
-        otel:
+        otlp:
           grpc: "grpc://otel-collector:4317"
           agent_labels:
             environment: "production"

--- a/agent/backend/opentelemetryinfinity/opentelemetry_infinity.go
+++ b/agent/backend/opentelemetryinfinity/opentelemetry_infinity.go
@@ -3,6 +3,7 @@ package opentelemetryinfinity
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -105,7 +106,7 @@ func (o *openTelemetryBackend) Start(ctx context.Context, cancelFunc context.Can
 		"run",
 		"--server_host", o.apiHost,
 		"--server_port", o.apiPort,
-		"--log_timestamp", "false",
+		"--log_timestamp=false",
 	}
 
 	o.logger.Info("opentelemetry infinity startup", slog.Any("arguments", pvOptions))
@@ -133,13 +134,13 @@ func (o *openTelemetryBackend) Start(ctx context.Context, cancelFunc context.Can
 					stdout = nil
 					continue
 				}
-				o.logger.Info("opentelemetry infinity stdout", slog.String("log", line))
+				o.logCollectorLine("stdout", line)
 			case line, open := <-stderr:
 				if !open {
 					stderr = nil
 					continue
 				}
-				o.logger.Info("opentelemetry infinity stderr", slog.String("log", line))
+				o.logCollectorLine("stderr", line)
 			}
 		}
 	}()
@@ -189,6 +190,16 @@ func (o *openTelemetryBackend) Start(ctx context.Context, cancelFunc context.Can
 	}
 
 	return nil
+}
+
+func (o *openTelemetryBackend) logCollectorLine(stream, line string) {
+	logKey := fmt.Sprintf("opentelemetry infinity %s", stream)
+	raw := []byte(line)
+	if json.Valid(raw) {
+		o.logger.Info(logKey, slog.Any("log", json.RawMessage(raw)))
+		return
+	}
+	o.logger.Info(logKey, slog.String("log", line))
 }
 
 func (o *openTelemetryBackend) Stop(ctx context.Context) error {

--- a/agent/backend/opentelemetryinfinity/opentelemetry_infinity.go
+++ b/agent/backend/opentelemetryinfinity/opentelemetry_infinity.go
@@ -105,6 +105,7 @@ func (o *openTelemetryBackend) Start(ctx context.Context, cancelFunc context.Can
 		"run",
 		"--server_host", o.apiHost,
 		"--server_port", o.apiPort,
+		"--log_timestamp", "false",
 	}
 
 	o.logger.Info("opentelemetry infinity startup", slog.Any("arguments", pvOptions))


### PR DESCRIPTION
This pull request introduces improvements to the OpenTelemetry backend integration and makes minor configuration and workflow updates. The most significant changes include enhanced log handling for the OpenTelemetry Infinity backend, a configuration key rename in the documentation, and cleanup of CI workflow strategies.

**OpenTelemetry backend improvements:**

* Introduced a new `logCollectorLine` method in `opentelemetry_infinity.go` to handle log output from the OpenTelemetry Infinity process. This method detects if log lines are valid JSON and logs them accordingly, improving log readability and structure. [[1]](diffhunk://#diff-4f8fe6510b95d5f5cdbdd374873257ed0d9c97e9832444329d7cc35cea08e041L135-R143) [[2]](diffhunk://#diff-4f8fe6510b95d5f5cdbdd374873257ed0d9c97e9832444329d7cc35cea08e041R195-R204)
* Added the `--log_timestamp=false` option to the OpenTelemetry Infinity process startup arguments to control log timestamp formatting.
* Imported the `encoding/json` package to support JSON validation in log handling.

**Documentation update:**

* Renamed the configuration key from `otel` to `otlp` in the `README.md` to accurately reflect the backend configuration for OpenTelemetry.

**CI workflow cleanup:**

* Removed the unused `strategy.fail-fast` configuration from both `develop.yaml` and `release.yaml` workflow files to simplify CI job definitions. [[1]](diffhunk://#diff-75eb13a90ba4bddf3480256b071d4609bebe36aac7675d2c293bbaf9b58868f6L21-L22) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL126-L127)