### PR TITLE
chore: add parameter for image tag

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -61,6 +61,6 @@ jobs:
             push: true
             cache-from: type=gha
             cache-to: type=gha,mode=max
-            tags: netboxlabs/orb-agent:${{ github.event.inputs.docker_tag }}
+            tags: netboxlabs/orb-agent:${{ github.event.inputs.docker_tag || 'develop' }}
             build-args: |
               GO_VERSION=${{ env.GO_VERSION }}  

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -1,6 +1,12 @@
 name: Orb Agent - develop
 on:
   workflow_dispatch:
+    inputs:
+      docker_tag:
+        description: 'Docker tag to use for the image'
+        required: false
+        default: 'develop'
+        type: string
   push:
     branches: [ develop ]
     paths:
@@ -55,6 +61,6 @@ jobs:
             push: true
             cache-from: type=gha
             cache-to: type=gha,mode=max
-            tags: netboxlabs/orb-agent:develop
+            tags: netboxlabs/orb-agent:${{ github.event.inputs.docker_tag }}
             build-args: |
               GO_VERSION=${{ env.GO_VERSION }}  


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for the Orb Agent's `develop` branch to make the Docker tag configurable when manually triggering the workflow. The main change is allowing users to specify a custom Docker tag, improving flexibility for development and testing.

Workflow improvements:

* Added a new input parameter `docker_tag` to the `workflow_dispatch` event, enabling users to set the Docker image tag when manually running the workflow.
* Updated the Docker build step to use the specified `docker_tag` input instead of the hardcoded `develop` tag, ensuring the built image is tagged as requested.