### PR TITLE
feat: make tls configurable

### DIFF
--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -37,6 +37,8 @@ type GitManager struct {
 type FleetManager struct {
 	URL          string `yaml:"url"`
 	TokenURL     string `yaml:"token_url"`
+	Timeout      *int   `yaml:"timeout,omitempty"`
+	SkipTLS      bool   `yaml:"skip_tls"`
 	ClientID     string `yaml:"client_id"`
 	ClientSecret string `yaml:"client_secret"`
 	AgentID      string `yaml:"agent_id"`

--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -106,9 +106,20 @@ func newFleetConfigManager(ctx context.Context, logger *slog.Logger, pMgr policy
 func (fleetManager *fleetConfigManager) Start(cfg config.Config, backends map[string]backend.Backend) error {
 	ctx := context.Background()
 
-	fleetManager.logger.Info("starting fleet config manager", "token_url", cfg.OrbAgent.ConfigManager.Sources.Fleet.TokenURL, "client_id", cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientID, "client_secret", cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientSecret)
+	fleetManager.logger.Info("starting fleet config manager", "token_url",
+		cfg.OrbAgent.ConfigManager.Sources.Fleet.TokenURL, "client_id",
+		cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientID, "client_secret",
+		cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientSecret)
 	// call the token url to get the token
-	token, err := fleetManager.getToken(ctx, cfg.OrbAgent.ConfigManager.Sources.Fleet.TokenURL, cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientID, cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientSecret)
+	timeout := 30 * time.Second
+	if cfg.OrbAgent.ConfigManager.Sources.Fleet.Timeout != nil && *cfg.OrbAgent.ConfigManager.Sources.Fleet.Timeout > 0 {
+		timeout = time.Duration(*cfg.OrbAgent.ConfigManager.Sources.Fleet.Timeout) * time.Second
+	}
+	token, err := fleetManager.getToken(ctx,
+		cfg.OrbAgent.ConfigManager.Sources.Fleet.TokenURL,
+		cfg.OrbAgent.ConfigManager.Sources.Fleet.SkipTLS, timeout,
+		cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientID,
+		cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientSecret)
 	if err != nil {
 		return err
 	}
@@ -330,7 +341,7 @@ type tokenResponse struct {
 	ExpiresIn   int    `json:"expires_in"`
 }
 
-func (fleetManager *fleetConfigManager) getToken(ctx context.Context, tokenURL string, clientID string, clientSecret string) (*tokenResponse, error) {
+func (fleetManager *fleetConfigManager) getToken(ctx context.Context, tokenURL string, skipTLS bool, timeout time.Duration, clientID string, clientSecret string) (*tokenResponse, error) {
 	// Input validation
 	if tokenURL == "" {
 		return nil, fmt.Errorf("token URL cannot be empty")
@@ -367,9 +378,9 @@ func (fleetManager *fleetConfigManager) getToken(ctx context.Context, tokenURL s
 
 	// HTTP client with configurable timeout and TLS settings
 	httpClient := &http.Client{
-		Timeout: 30 * time.Second, // TODO: make configurable
+		Timeout: timeout,
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // TODO: make configurable
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: skipTLS},
 		},
 	}
 

--- a/agent/configmgr/fleet_test.go
+++ b/agent/configmgr/fleet_test.go
@@ -446,7 +446,7 @@ func TestFleetConfigManager_GetToken_Success(t *testing.T) {
 
 	// Act
 	ctx := context.Background()
-	token, err := fleetManager.getToken(ctx, server.URL, "test_client_id", "test_client_secret")
+	token, err := fleetManager.getToken(ctx, server.URL, true, 60*time.Second, "test_client_id", "test_client_secret")
 
 	// Assert
 	require.NoError(t, err)
@@ -472,7 +472,7 @@ func TestFleetConfigManager_GetToken_HTTPError(t *testing.T) {
 
 	// Act
 	ctx := context.Background()
-	token, err := fleetManager.getToken(ctx, server.URL, "invalid_client", "invalid_secret")
+	token, err := fleetManager.getToken(ctx, server.URL, true, 60*time.Second, "invalid_client", "invalid_secret")
 
 	// Assert
 	assert.Error(t, err)
@@ -496,7 +496,7 @@ func TestFleetConfigManager_GetToken_InvalidJSON(t *testing.T) {
 
 	// Act
 	ctx := context.Background()
-	token, err := fleetManager.getToken(ctx, server.URL, "test_client", "test_secret")
+	token, err := fleetManager.getToken(ctx, server.URL, true, 60*time.Second, "test_client", "test_secret")
 
 	// Assert
 	assert.Error(t, err)
@@ -513,7 +513,7 @@ func TestFleetConfigManager_GetToken_NetworkError(t *testing.T) {
 
 	// Act with invalid URL
 	ctx := context.Background()
-	token, err := fleetManager.getToken(ctx, "http://invalid.nonexistent.url:99999", "test", "test")
+	token, err := fleetManager.getToken(ctx, "http://invalid.nonexistent.url:99999", false, 60*time.Second, "test", "test")
 
 	// Assert
 	assert.Error(t, err)
@@ -530,7 +530,7 @@ func TestFleetConfigManager_GetToken_InvalidURL(t *testing.T) {
 
 	// Act with malformed URL
 	ctx := context.Background()
-	token, err := fleetManager.getToken(ctx, "://invalid-url", "test", "test")
+	token, err := fleetManager.getToken(ctx, "://invalid-url", false, 60*time.Second, "test", "test")
 
 	// Assert
 	assert.Error(t, err)
@@ -1177,6 +1177,7 @@ func TestFleetConfigManager_Start_WithJWTTopicGeneration(t *testing.T) {
 				Sources: config.Sources{
 					Fleet: config.FleetManager{
 						TokenURL:     server.URL,
+						SkipTLS:      true,
 						ClientID:     "test_client_id",
 						ClientSecret: "test_client_secret",
 						AgentID:      "test-agent-123",


### PR DESCRIPTION
This pull request enhances the configuration options for the Fleet Manager by introducing support for customizable HTTP timeouts and TLS verification skipping when fetching tokens. These updates improve flexibility and security for deployments, and the changes are reflected in both the main implementation and the corresponding test cases.

Configuration enhancements:
* Added `Timeout` (optional) and `SkipTLS` (boolean) fields to the `FleetManager` struct in `types.go`, allowing users to configure HTTP request timeout and whether to skip TLS verification.

Fleet Manager logic updates:
* Updated the `getToken` method signature to accept `skipTLS` and `timeout` parameters, and refactored its usage to apply these settings to the HTTP client. [[1]](diffhunk://#diff-b0dddd7590e09bc17b468db04b48a21f0d508a17eca4c086eb98c87325e5ba98L333-R344) [[2]](diffhunk://#diff-b0dddd7590e09bc17b468db04b48a21f0d508a17eca4c086eb98c87325e5ba98L370-R383)
* Modified the `Start` method to pass the new configuration options when calling `getToken`, defaulting to a 30-second timeout if not set.

Test improvements:
* Updated all relevant test cases in `fleet_test.go` to use the new `getToken` signature and configuration options, ensuring coverage for custom timeout and TLS settings. [[1]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL449-R449) [[2]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL475-R475) [[3]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL499-R499) [[4]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL516-R516) [[5]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL533-R533)
* Added the `SkipTLS` field to the FleetManager configuration in test setup for JWT topic generation.