### PR TITLE
chore: tidy up contexts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,10 +54,6 @@ test-coverage:
 	@cat .coverage/cover.out.tmp | grep -Ev "cmd" > .coverage/cover.out
 	@go tool cover -func=.coverage/cover.out | grep total | awk '{print substr($$3, 1, length($$3)-1)}' > .coverage/coverage.txt
 
-.PHONY: test
-test:
-	@go test -race ./... 
-
 .PHONY: lint
 lint:
 	@golangci-lint run ./... --config .github/golangci.yaml

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -57,10 +57,7 @@ func New(logger *slog.Logger, c config.Config) (Agent, error) {
 		return nil, err
 	}
 
-	// Pass a background context to the config manager at construction time. The
-	// manager keeps its own copy and later derives child contexts from the
-	// runtime context supplied in Agent.Start.
-	cm := configmgr.New(context.Background(), logger, pm, c.OrbAgent.ConfigManager.Active)
+	cm := configmgr.New(logger, pm, c.OrbAgent.ConfigManager.Active)
 
 	return &orbAgent{
 		logger:         logger,

--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -88,7 +88,7 @@ func (hb *heartbeater) sendHeartbeats(ctx context.Context, _ context.CancelFunc,
 	}
 }
 
-func newFleetConfigManager(ctx context.Context, logger *slog.Logger, pMgr policymgr.PolicyManager) *fleetConfigManager {
+func newFleetConfigManager(logger *slog.Logger, pMgr policymgr.PolicyManager) *fleetConfigManager {
 	// The passed ctx represents the lifecycle of the fleet configuration
 	// manager.  All child goroutines (heartbeat, MQTT, etc.) inherit from it so
 	// that a single cancellation propagates everywhere.
@@ -98,7 +98,7 @@ func newFleetConfigManager(ctx context.Context, logger *slog.Logger, pMgr policy
 		heartbeater: &heartbeater{
 			logger:       logger,
 			hbTicker:     time.NewTicker(heartbeatFreq),
-			heartbeatCtx: ctx,
+			heartbeatCtx: context.Background(),
 		},
 	}
 }

--- a/agent/configmgr/fleet_test.go
+++ b/agent/configmgr/fleet_test.go
@@ -399,7 +399,7 @@ func TestNewFleetConfigManager_HeartbeaterInitialization(t *testing.T) {
 	mockPMgr := &mockPolicyManagerForFleet{}
 
 	// Act
-	fleetManager := newFleetConfigManager(context.Background(), logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr)
 
 	// Assert
 	assert.NotNil(t, fleetManager)
@@ -417,7 +417,7 @@ func TestFleetConfigManager_GetToken_Success(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(context.Background(), logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr)
 	defer fleetManager.heartbeater.hbTicker.Stop()
 
 	// Create mock HTTP server
@@ -460,7 +460,7 @@ func TestFleetConfigManager_GetToken_HTTPError(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(context.Background(), logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr)
 	defer fleetManager.heartbeater.hbTicker.Stop()
 
 	// Create mock HTTP server that returns error
@@ -484,7 +484,7 @@ func TestFleetConfigManager_GetToken_InvalidJSON(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(context.Background(), logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr)
 	defer fleetManager.heartbeater.hbTicker.Stop()
 
 	// Create mock HTTP server that returns invalid JSON
@@ -508,7 +508,7 @@ func TestFleetConfigManager_GetToken_NetworkError(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(context.Background(), logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr)
 	defer fleetManager.heartbeater.hbTicker.Stop()
 
 	// Act with invalid URL
@@ -525,7 +525,7 @@ func TestFleetConfigManager_GetToken_InvalidURL(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(context.Background(), logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr)
 	defer fleetManager.heartbeater.hbTicker.Stop()
 
 	// Act with malformed URL
@@ -542,7 +542,7 @@ func TestFleetConfigManager_Connect_InvalidURL(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(context.Background(), logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr)
 	defer fleetManager.heartbeater.hbTicker.Stop()
 
 	// Act with invalid URL
@@ -559,7 +559,7 @@ func TestFleetConfigManager_Connect_ValidURL(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(context.Background(), logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr)
 	defer fleetManager.heartbeater.hbTicker.Stop()
 
 	// Act with valid URL but don't expect successful connection
@@ -587,7 +587,7 @@ func TestFleetConfigManager_Start_TokenError(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(context.Background(), logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr)
 	defer fleetManager.heartbeater.hbTicker.Stop()
 
 	// Create config with invalid token URL
@@ -618,7 +618,7 @@ func TestFleetConfigManager_Start_ConnectError(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(context.Background(), logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr)
 	defer fleetManager.heartbeater.hbTicker.Stop()
 
 	// Create mock HTTP server for token endpoint
@@ -662,7 +662,7 @@ func TestFleetConfigManager_DispatchToHandlers(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(context.Background(), logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr)
 	defer fleetManager.heartbeater.hbTicker.Stop()
 
 	// Act - currently this method is a TODO, so it should not panic
@@ -681,7 +681,7 @@ func TestFleetConfigManager_GetContext(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(context.Background(), logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr)
 	defer fleetManager.heartbeater.hbTicker.Stop()
 
 	originalCtx := context.Background()
@@ -729,7 +729,7 @@ func TestFleetConfigManager_HeartbeaterTickerCleanup(t *testing.T) {
 	mockPMgr := &mockPolicyManagerForFleet{}
 
 	// Act
-	fleetManager := newFleetConfigManager(context.Background(), logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr)
 
 	// Verify ticker is created
 	assert.NotNil(t, fleetManager.heartbeater.hbTicker)
@@ -805,7 +805,7 @@ func TestFleetConfigManager_SendCapabilities_Success(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(context.Background(), logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr)
 	defer fleetManager.heartbeater.hbTicker.Stop()
 
 	// Create mock backends
@@ -877,7 +877,7 @@ func TestFleetConfigManager_SendCapabilities_BackendVersionError(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(context.Background(), logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr)
 	defer fleetManager.heartbeater.hbTicker.Stop()
 
 	// Create mock backends - one succeeds, one fails on version
@@ -925,7 +925,7 @@ func TestFleetConfigManager_SendCapabilities_BackendCapabilitiesError(t *testing
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(context.Background(), logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr)
 	defer fleetManager.heartbeater.hbTicker.Stop()
 
 	// Create mock backends - one succeeds, one fails on capabilities
@@ -974,7 +974,7 @@ func TestFleetConfigManager_SendCapabilities_PublishError(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(context.Background(), logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr)
 	defer fleetManager.heartbeater.hbTicker.Stop()
 
 	mockBackend1 := &mockBackend{}
@@ -1005,7 +1005,7 @@ func TestFleetConfigManager_SendCapabilities_EmptyBackends(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(context.Background(), logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr)
 	defer fleetManager.heartbeater.hbTicker.Stop()
 
 	backends := map[string]backend.Backend{} // Empty backends
@@ -1037,7 +1037,7 @@ func TestFleetConfigManager_SendCapabilities_AllBackendsFail(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(context.Background(), logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr)
 	defer fleetManager.heartbeater.hbTicker.Stop()
 
 	// All backends fail
@@ -1082,7 +1082,7 @@ func TestFleetConfigManager_SendCapabilities_CapabilitiesStructure(t *testing.T)
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(context.Background(), logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr)
 	defer fleetManager.heartbeater.hbTicker.Stop()
 
 	mockBackend1 := &mockBackend{}
@@ -1154,7 +1154,7 @@ func TestFleetConfigManager_Start_WithJWTTopicGeneration(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(context.Background(), logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr)
 	defer fleetManager.heartbeater.hbTicker.Stop()
 
 	// Create mock HTTP server that returns a JWT token

--- a/agent/configmgr/git_test.go
+++ b/agent/configmgr/git_test.go
@@ -1,7 +1,6 @@
 package configmgr_test
 
 import (
-	"context"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -104,7 +103,7 @@ backend1:
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	// Instantiate the gitConfigManager.
-	gc := configmgr.New(context.Background(), logger, pMgr, cfg.OrbAgent.ConfigManager.Active)
+	gc := configmgr.New(logger, pMgr, cfg.OrbAgent.ConfigManager.Active)
 
 	// Call Start
 	backends := map[string]backend.Backend{

--- a/agent/configmgr/local_test.go
+++ b/agent/configmgr/local_test.go
@@ -1,7 +1,6 @@
 package configmgr_test
 
 import (
-	"context"
 	"log/slog"
 	"os"
 	"testing"
@@ -51,7 +50,7 @@ func TestLocalConfigManager(t *testing.T) {
 		})).Return()
 
 		// Create and start the manager
-		mgr := configmgr.New(context.Background(), logger, pMgr, cfg.Active)
+		mgr := configmgr.New(logger, pMgr, cfg.Active)
 		err := mgr.Start(testConfig, backends)
 
 		// Verify
@@ -70,7 +69,7 @@ func TestLocalConfigManager(t *testing.T) {
 		backends := map[string]backend.Backend{}
 
 		// Create the manager
-		mgr := configmgr.New(context.Background(), logger, pMgr, cfg.Active)
+		mgr := configmgr.New(logger, pMgr, cfg.Active)
 		err := mgr.Start(testConfig, backends)
 
 		// Should return an error
@@ -99,7 +98,7 @@ func TestLocalConfigManager(t *testing.T) {
 		backends := map[string]backend.Backend{}
 
 		// Create the manager
-		mgr := configmgr.New(context.Background(), logger, pMgr, cfg.Active)
+		mgr := configmgr.New(logger, pMgr, cfg.Active)
 		err := mgr.Start(testConfig, backends)
 
 		// Should return an error

--- a/agent/configmgr/manager.go
+++ b/agent/configmgr/manager.go
@@ -17,14 +17,14 @@ type Manager interface {
 
 // New creates a new instance of ConfigManager that is bound to the
 // supplied context.
-func New(ctx context.Context, logger *slog.Logger, pMgr policymgr.PolicyManager, active string) Manager {
+func New(logger *slog.Logger, pMgr policymgr.PolicyManager, active string) Manager {
 	switch active {
 	case "local":
 		return &localConfigManager{logger: logger, pMgr: pMgr}
 	case "git":
 		return &gitConfigManager{logger: logger, pMgr: pMgr}
 	case "fleet":
-		return newFleetConfigManager(ctx, logger, pMgr)
+		return newFleetConfigManager(logger, pMgr)
 	default:
 		return &localConfigManager{logger: logger, pMgr: pMgr}
 	}

--- a/agent/configmgr/manager_test.go
+++ b/agent/configmgr/manager_test.go
@@ -132,7 +132,7 @@ func TestManagerNew(t *testing.T) {
 			},
 		}
 
-		mgr := configmgr.New(context.Background(), logger, pMgr, cfg.Active)
+		mgr := configmgr.New(logger, pMgr, cfg.Active)
 		assert.NotNil(t, mgr)
 		// Check we got the expected implementation
 		ctx := context.Background()
@@ -150,7 +150,7 @@ func TestManagerNew(t *testing.T) {
 			},
 		}
 
-		mgr := configmgr.New(context.Background(), logger, pMgr, cfg.Active)
+		mgr := configmgr.New(logger, pMgr, cfg.Active)
 		assert.NotNil(t, mgr)
 		// Check we got the expected implementation
 		ctx := context.Background()
@@ -163,7 +163,7 @@ func TestManagerNew(t *testing.T) {
 			Active: "unknown",
 		}
 
-		mgr := configmgr.New(context.Background(), logger, pMgr, cfg.Active)
+		mgr := configmgr.New(logger, pMgr, cfg.Active)
 		assert.NotNil(t, mgr)
 		// Check we got the local implementation
 		ctx := context.Background()

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-cmd/cmd v1.4.3
 	github.com/go-co-op/gocron/v2 v2.15.0
 	github.com/go-git/go-git/v5 v5.14.0
+	github.com/go-jose/go-jose/v4 v4.1.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/vault/api v1.20.0
 	github.com/hashicorp/vault/api/auth/approle v0.10.0
@@ -39,7 +40,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect


### PR DESCRIPTION
This pull request refactors how context is managed and passed to configuration managers in the agent codebase. The main change is the removal of the explicit `context.Context` parameter from the constructors of `configmgr.New` and `newFleetConfigManager`, simplifying their signatures and usage throughout the code. The context is now managed internally, with child goroutines using `context.Background()` instead of inheriting from a parent context. All affected tests and call sites have been updated to match the new constructor signatures.

### Refactoring context management in configuration managers

* Removed the explicit `context.Context` parameter from `configmgr.New` and `newFleetConfigManager` constructors, simplifying their signatures and usage. Context is now managed internally using `context.Background()` for child goroutines. (`agent/configmgr/manager.go`, `agent/configmgr/fleet.go`, [[1]](diffhunk://#diff-db6e6c9eaab0d3a219d5d1db022c410881d9f0da9aa4418a8a61aa7616844ba7L20-R27) [[2]](diffhunk://#diff-b0dddd7590e09bc17b468db04b48a21f0d508a17eca4c086eb98c87325e5ba98L91-R91) [[3]](diffhunk://#diff-b0dddd7590e09bc17b468db04b48a21f0d508a17eca4c086eb98c87325e5ba98L101-R101)
* Updated all call sites in production code (`agent/agent.go`, `agent/configmgr/git_test.go`, `agent/configmgr/local_test.go`) and tests to use the new constructor signatures without passing a context. (`[[1]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL60-R60)`, `[[2]](diffhunk://#diff-3a39dfacd0a00ac0e483cd96bb09ac2ac5ab2359de72d070003cbc58e258c7d7L107-R106)`, `[[3]](diffhunk://#diff-784dcb7f0bd64b27855731f040668c884bf7fdd11999420f3aed0615ebfb263fL54-R53)`, `[[4]](diffhunk://#diff-784dcb7f0bd64b27855731f040668c884bf7fdd11999420f3aed0615ebfb263fL73-R72)`, `[[5]](diffhunk://#diff-784dcb7f0bd64b27855731f040668c884bf7fdd11999420f3aed0615ebfb263fL102-R101)`)
* Modified all relevant unit tests in `agent/configmgr/fleet_test.go` and `agent/configmgr/manager_test.go` to remove context arguments when creating configuration manager instances. (`[[1]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL402-R402)`, `[[2]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL420-R420)`, `[[3]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL463-R463)`, `[[4]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL487-R487)`, `[[5]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL511-R511)`, `[[6]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL528-R528)`, `[[7]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL545-R545)`, `[[8]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL562-R562)`, `[[9]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL590-R590)`, `[[10]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL621-R621)`, `[[11]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL665-R665)`, `[[12]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL684-R684)`, `[[13]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL732-R732)`, `[[14]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL808-R808)`, `[[15]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL880-R880)`, `[[16]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL928-R928)`, `[[17]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL977-R977)`, `[[18]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL1008-R1008)`, `[[19]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL1040-R1040)`, `[[20]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL1085-R1085)`, `[[21]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL1157-R1157)`, `[[22]](diffhunk://#diff-b28e8d5bc7de32a3de39c1dfee8712ffa3be423216d8358bb12821ac8eb13380L135-R135)`)
* Removed unnecessary `context` imports from test files where they are no longer needed. (`[[1]](diffhunk://#diff-3a39dfacd0a00ac0e483cd96bb09ac2ac5ab2359de72d070003cbc58e258c7d7L4)`, `[[2]](diffhunk://#diff-784dcb7f0bd64b27855731f040668c884bf7fdd11999420f3aed0615ebfb263fL4)`)

### Miscellaneous cleanup

* Removed the unused `test` target from the `Makefile`. (`[MakefileL57-L60](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L57-L60)`)