### PR TITLE
feat: refactor backend state management and send in heartbeat

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -20,6 +20,8 @@ import (
 
 const routineKey config.ContextKey = "routine"
 
+const restartBackendChanSize = 5
+
 // Agent is the interface that all agents must implement
 type Agent interface {
 	Start(ctx context.Context, cancelFunc context.CancelFunc) error
@@ -32,14 +34,15 @@ type orbAgent struct {
 	logger         *slog.Logger
 	config         config.Config
 	backends       map[string]backend.Backend
-	backendState   map[string]*backend.State
 	backendsCommon config.BackendCommons
 	ctx            context.Context
 	cancelFunction context.CancelFunc
 
-	policyManager  policymgr.PolicyManager
-	configManager  configmgr.Manager
-	secretsManager secretsmgr.Manager
+	policyManager       policymgr.PolicyManager
+	configManager       configmgr.Manager
+	secretsManager      secretsmgr.Manager
+	backendStateManager *backend.BackendStateManager
+	restartBackendChan  chan string
 }
 
 var _ Agent = (*orbAgent)(nil)
@@ -57,17 +60,22 @@ func New(logger *slog.Logger, c config.Config) (Agent, error) {
 		return nil, err
 	}
 
+	restartBackendChan := make(chan string, restartBackendChanSize)
+
+	backendStateManager := backend.NewBackendStateManager(logger, restartBackendChan)
 	// Pass a background context to the config manager at construction time. The
 	// manager keeps its own copy and later derives child contexts from the
 	// runtime context supplied in Agent.Start.
-	cm := configmgr.New(logger, pm, c.OrbAgent.ConfigManager.Active)
+	cm := configmgr.New(logger, pm, c.OrbAgent.ConfigManager.Active, backendStateManager)
 
 	return &orbAgent{
-		logger:         logger,
-		config:         c,
-		policyManager:  pm,
-		configManager:  cm,
-		secretsManager: sm,
+		logger:              logger,
+		config:              c,
+		policyManager:       pm,
+		configManager:       cm,
+		secretsManager:      sm,
+		backendStateManager: backendStateManager,
+		restartBackendChan:  restartBackendChan,
 	}, nil
 }
 
@@ -78,7 +86,6 @@ func (a *orbAgent) startBackends(agentCtx context.Context, cfgBackends map[strin
 	}
 	a.ctx = agentCtx
 	a.backends = make(map[string]backend.Backend, len(cfgBackends))
-	a.backendState = make(map[string]*backend.State)
 
 	var commonConfig config.BackendCommons
 	if v, prs := cfgBackends["common"]; prs {
@@ -119,29 +126,33 @@ func (a *orbAgent) startBackends(agentCtx context.Context, cfgBackends map[strin
 		backendCtx := context.WithValue(agentCtx, routineKey, name)
 		backendCtx = a.configManager.GetContext(backendCtx)
 		a.backends[name] = be
-		initialState := be.GetInitialState()
-		a.backendState[name] = &backend.State{
-			Status:        initialState,
-			LastRestartTS: time.Now(),
-		}
 		// Create a cancellable context for the backend and ensure we pass both
 		// the context and its cancel function to Start, matching the Backend
 		// interface.
 		runCtx, cancel := context.WithCancel(backendCtx)
 		if err := be.Start(runCtx, cancel); err != nil {
 			var errMessage string
-			if initialState == backend.BackendError {
+			if be.GetInitialState() == backend.BackendError {
 				errMessage = err.Error()
 			}
-			a.backendState[name] = &backend.State{
-				Status:        initialState,
-				LastError:     errMessage,
-				LastRestartTS: time.Now(),
-			}
+			a.backendStateManager.RegisterError(name, errMessage)
 			return err
 		}
+		a.backendStateManager.StartBackendMonitor(name, be)
+
+		go a.waitForRestartRequests()
 	}
 	return nil
+}
+
+func (a *orbAgent) waitForRestartRequests() {
+	for name := range a.restartBackendChan {
+		a.logger.Info("restarting backend", slog.String("backend", name))
+		err := a.RestartBackend(a.ctx, name, "restart requested by fleet")
+		if err != nil {
+			a.logger.Error("failed to restart backend", slog.String("backend", name), slog.Any("error", err))
+		}
+	}
 }
 
 func (a *orbAgent) Start(ctx context.Context, cancelFunc context.CancelFunc) error {
@@ -198,9 +209,7 @@ func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason strin
 
 	be := a.backends[name]
 	a.logger.Info("restarting backend", slog.String("backend", name), slog.String("reason", reason))
-	a.backendState[name].RestartCount++
-	a.backendState[name].LastRestartTS = time.Now()
-	a.backendState[name].LastRestartReason = reason
+	a.backendStateManager.RegisterRestart(name, reason)
 	a.logger.Info("removing policies", slog.String("backend", name))
 	if err := a.policyManager.RemoveBackendPolicies(be, true); err != nil {
 		a.logger.Error("failed to remove policies", slog.String("backend", name), slog.Any("error", err))
@@ -219,8 +228,7 @@ func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason strin
 	a.logger.Info("resetting backend", slog.String("backend", name))
 
 	if err := be.FullReset(ctx); err != nil {
-		a.backendState[name].LastError = fmt.Sprintf("failed to reset backend: %v", err)
-		a.logger.Error("failed to reset backend", slog.String("backend", name), slog.Any("error", err))
+		a.backendStateManager.RegisterError(name, fmt.Sprintf("failed to reset backend: %v", err))
 	}
 
 	return nil

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -41,7 +41,7 @@ type orbAgent struct {
 	policyManager       policymgr.PolicyManager
 	configManager       configmgr.Manager
 	secretsManager      secretsmgr.Manager
-	backendStateManager *backend.StateManager
+	backendStateManager backend.StateManager
 	restartBackendChan  chan string
 }
 
@@ -62,7 +62,7 @@ func New(logger *slog.Logger, c config.Config) (Agent, error) {
 
 	restartBackendChan := make(chan string, restartBackendChanSize)
 
-	backendStateManager := backend.NewStateManager(logger, restartBackendChan)
+	backendStateManager := backend.NewStateManager(c.OrbAgent.ConfigManager.Active, logger, restartBackendChan)
 	// Pass a background context to the config manager at construction time. The
 	// manager keeps its own copy and later derives child contexts from the
 	// runtime context supplied in Agent.Start.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -41,7 +41,7 @@ type orbAgent struct {
 	policyManager       policymgr.PolicyManager
 	configManager       configmgr.Manager
 	secretsManager      secretsmgr.Manager
-	backendStateManager *backend.BackendStateManager
+	backendStateManager *backend.StateManager
 	restartBackendChan  chan string
 }
 
@@ -62,7 +62,7 @@ func New(logger *slog.Logger, c config.Config) (Agent, error) {
 
 	restartBackendChan := make(chan string, restartBackendChanSize)
 
-	backendStateManager := backend.NewBackendStateManager(logger, restartBackendChan)
+	backendStateManager := backend.NewStateManager(logger, restartBackendChan)
 	// Pass a background context to the config manager at construction time. The
 	// manager keeps its own copy and later derives child contexts from the
 	// runtime context supplied in Agent.Start.

--- a/agent/backend/backend_state.go
+++ b/agent/backend/backend_state.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 )
 
@@ -21,6 +22,7 @@ type BackendState interface {
 //nolint:revive // BackendStateManager is intentionally named to distinguish from the State struct
 type BackendStateManager struct {
 	backendState       map[string]*State
+	mu                 sync.RWMutex
 	ticker             *time.Ticker
 	logger             *slog.Logger
 	restartBackendChan chan string
@@ -38,13 +40,18 @@ func NewBackendStateManager(logger *slog.Logger, restartBackendChan chan string)
 
 // StartBackendMonitor starts monitoring a backend and manages its state
 func (manager *BackendStateManager) StartBackendMonitor(name string, be Backend) {
+	manager.mu.Lock()
 	manager.backendState[name] = &State{
 		Status:        be.GetInitialState(),
 		LastRestartTS: time.Now(),
 	}
+	manager.mu.Unlock()
+
 	go func() {
 		for range manager.ticker.C {
 			backendStatus, errMsg, err := be.GetRunningStatus()
+
+			manager.mu.Lock()
 			manager.backendState[name].Status = backendStatus
 			if backendStatus != Running {
 				if err != nil {
@@ -52,6 +59,8 @@ func (manager *BackendStateManager) StartBackendMonitor(name string, be Backend)
 				} else if errMsg != "" {
 					manager.backendState[name].LastError = errMsg
 				}
+				manager.mu.Unlock()
+
 				// status is not running so we have a current error
 				if time.Since(be.GetStartTime()) >= MinRestartTime {
 					manager.restartBackendChan <- name
@@ -62,6 +71,8 @@ func (manager *BackendStateManager) StartBackendMonitor(name string, be Backend)
 					remainingSecondsUntilRestart := MinRestartTime - time.Since(be.GetStartTime())
 					manager.logger.Info("waiting to attempt backend restart due to failed status", "remaining_secs", remainingSecondsUntilRestart)
 				}
+			} else {
+				manager.mu.Unlock()
 			}
 		}
 	}()
@@ -70,6 +81,8 @@ func (manager *BackendStateManager) StartBackendMonitor(name string, be Backend)
 // RegisterError registers an error for a backend and updates its state
 func (manager *BackendStateManager) RegisterError(name string, errMessage string) {
 	manager.logger.Error(errMessage, slog.String("backend", name))
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
 	manager.backendState[name] = &State{
 		Status:        BackendError,
 		LastError:     errMessage,
@@ -79,6 +92,8 @@ func (manager *BackendStateManager) RegisterError(name string, errMessage string
 
 // RegisterRestart registers a restart event for a backend
 func (manager *BackendStateManager) RegisterRestart(name string, reason string) {
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
 	manager.backendState[name].RestartCount++
 	manager.backendState[name].LastRestartTS = time.Now()
 	manager.backendState[name].LastRestartReason = reason
@@ -86,5 +101,15 @@ func (manager *BackendStateManager) RegisterRestart(name string, reason string) 
 
 // Get returns the current state of all backends
 func (manager *BackendStateManager) Get() map[string]*State {
-	return manager.backendState
+	manager.mu.RLock()
+	defer manager.mu.RUnlock()
+
+	// Return a copy of the map to prevent external modification
+	result := make(map[string]*State, len(manager.backendState))
+	for k, v := range manager.backendState {
+		// Copy the state to prevent external modification
+		stateCopy := *v
+		result[k] = &stateCopy
+	}
+	return result
 }

--- a/agent/backend/backend_state.go
+++ b/agent/backend/backend_state.go
@@ -18,8 +18,16 @@ type StateRetriever interface {
 	Get() map[string]*State
 }
 
+// StateManager provides an interface for managing backend state information
+type StateManager interface {
+	StateRetriever
+	StartBackendMonitor(name string, be Backend)
+	RegisterError(name string, errMessage string)
+	RegisterRestart(name string, reason string)
+}
+
 // StateManager manages the state and monitoring of backends
-type StateManager struct {
+type stateManager struct {
 	backendState       map[string]*State
 	mu                 sync.RWMutex
 	ticker             *time.Ticker
@@ -28,17 +36,38 @@ type StateManager struct {
 }
 
 // NewStateManager creates a new StateManager with the given logger and restart channel
-func NewStateManager(logger *slog.Logger, restartBackendChan chan string) *StateManager {
-	return &StateManager{
-		backendState:       make(map[string]*State),
-		ticker:             time.NewTicker(BackendMonitorInterval),
-		logger:             logger,
-		restartBackendChan: restartBackendChan,
+func NewStateManager(activeConfigMgr string, logger *slog.Logger, restartBackendChan chan string) StateManager {
+	if configMgrSupportsStateMonitoring(activeConfigMgr) {
+		return &stateManager{
+			backendState:       make(map[string]*State),
+			ticker:             time.NewTicker(BackendMonitorInterval),
+			logger:             logger,
+			restartBackendChan: restartBackendChan,
+		}
 	}
+	return nullStateManager{}
 }
 
+func configMgrSupportsStateMonitoring(activeConfigMgr string) bool {
+	return activeConfigMgr == "fleet"
+}
+
+type nullStateManager struct{}
+
+var _ StateManager = nullStateManager{}
+
+func (n nullStateManager) Get() map[string]*State {
+	return make(map[string]*State)
+}
+
+func (n nullStateManager) StartBackendMonitor(_ string, _ Backend) {}
+
+func (n nullStateManager) RegisterError(_ string, _ string) {}
+
+func (n nullStateManager) RegisterRestart(_ string, _ string) {}
+
 // StartBackendMonitor starts monitoring a backend and manages its state
-func (manager *StateManager) StartBackendMonitor(name string, be Backend) {
+func (manager *stateManager) StartBackendMonitor(name string, be Backend) {
 	manager.mu.Lock()
 	manager.backendState[name] = &State{
 		Status:        be.GetInitialState(),
@@ -75,7 +104,7 @@ func (manager *StateManager) StartBackendMonitor(name string, be Backend) {
 }
 
 // RegisterError registers an error for a backend and updates its state
-func (manager *StateManager) RegisterError(name string, errMessage string) {
+func (manager *stateManager) RegisterError(name string, errMessage string) {
 	manager.logger.Error(errMessage, slog.String("backend", name))
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
@@ -87,7 +116,7 @@ func (manager *StateManager) RegisterError(name string, errMessage string) {
 }
 
 // RegisterRestart registers a restart event for a backend
-func (manager *StateManager) RegisterRestart(name string, reason string) {
+func (manager *stateManager) RegisterRestart(name string, reason string) {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
 	manager.backendState[name].RestartCount++
@@ -96,7 +125,7 @@ func (manager *StateManager) RegisterRestart(name string, reason string) {
 }
 
 // Get returns the current state of all backends
-func (manager *StateManager) Get() map[string]*State {
+func (manager *stateManager) Get() map[string]*State {
 	manager.mu.RLock()
 	defer manager.mu.RUnlock()
 

--- a/agent/backend/backend_state.go
+++ b/agent/backend/backend_state.go
@@ -10,6 +10,9 @@ import (
 // MinRestartTime is the minimum time to wait between restarts
 const MinRestartTime = 5 * time.Minute
 
+// BackendMonitorInterval is the interval at which to monitor backends
+const BackendMonitorInterval = 10 * time.Second
+
 // StateRetriever provides an interface for accessing backend state information
 type StateRetriever interface {
 	Get() map[string]*State
@@ -28,7 +31,7 @@ type StateManager struct {
 func NewStateManager(logger *slog.Logger, restartBackendChan chan string) *StateManager {
 	return &StateManager{
 		backendState:       make(map[string]*State),
-		ticker:             time.NewTicker(10 * time.Second),
+		ticker:             time.NewTicker(BackendMonitorInterval),
 		logger:             logger,
 		restartBackendChan: restartBackendChan,
 	}

--- a/agent/backend/backend_state.go
+++ b/agent/backend/backend_state.go
@@ -45,9 +45,8 @@ func (manager *StateManager) StartBackendMonitor(name string, be Backend) {
 
 	go func() {
 		for range manager.ticker.C {
-			backendStatus, errMsg, err := be.GetRunningStatus()
-
 			manager.mu.Lock()
+			backendStatus, errMsg, err := be.GetRunningStatus()
 			manager.backendState[name].Status = backendStatus
 			if backendStatus != Running {
 				if err != nil {
@@ -55,7 +54,6 @@ func (manager *StateManager) StartBackendMonitor(name string, be Backend) {
 				} else if errMsg != "" {
 					manager.backendState[name].LastError = errMsg
 				}
-				manager.mu.Unlock()
 
 				// status is not running so we have a current error
 				if time.Since(be.GetStartTime()) >= MinRestartTime {
@@ -67,9 +65,8 @@ func (manager *StateManager) StartBackendMonitor(name string, be Backend) {
 					remainingSecondsUntilRestart := MinRestartTime - time.Since(be.GetStartTime())
 					manager.logger.Info("waiting to attempt backend restart due to failed status", "remaining_secs", remainingSecondsUntilRestart)
 				}
-			} else {
-				manager.mu.Unlock()
 			}
+			manager.mu.Unlock()
 		}
 	}()
 }

--- a/agent/backend/backend_state.go
+++ b/agent/backend/backend_state.go
@@ -10,17 +10,13 @@ import (
 // MinRestartTime is the minimum time to wait between restarts
 const MinRestartTime = 5 * time.Minute
 
-// BackendState provides an interface for accessing backend state information
-//
-//nolint:revive // BackendState is intentionally named to distinguish from the State struct
-type BackendState interface {
+// StateRetriever provides an interface for accessing backend state information
+type StateRetriever interface {
 	Get() map[string]*State
 }
 
-// BackendStateManager manages the state and monitoring of backends
-//
-//nolint:revive // BackendStateManager is intentionally named to distinguish from the State struct
-type BackendStateManager struct {
+// StateManager manages the state and monitoring of backends
+type StateManager struct {
 	backendState       map[string]*State
 	mu                 sync.RWMutex
 	ticker             *time.Ticker
@@ -28,9 +24,9 @@ type BackendStateManager struct {
 	restartBackendChan chan string
 }
 
-// NewBackendStateManager creates a new BackendStateManager with the given logger and restart channel
-func NewBackendStateManager(logger *slog.Logger, restartBackendChan chan string) *BackendStateManager {
-	return &BackendStateManager{
+// NewStateManager creates a new StateManager with the given logger and restart channel
+func NewStateManager(logger *slog.Logger, restartBackendChan chan string) *StateManager {
+	return &StateManager{
 		backendState:       make(map[string]*State),
 		ticker:             time.NewTicker(10 * time.Second),
 		logger:             logger,
@@ -39,7 +35,7 @@ func NewBackendStateManager(logger *slog.Logger, restartBackendChan chan string)
 }
 
 // StartBackendMonitor starts monitoring a backend and manages its state
-func (manager *BackendStateManager) StartBackendMonitor(name string, be Backend) {
+func (manager *StateManager) StartBackendMonitor(name string, be Backend) {
 	manager.mu.Lock()
 	manager.backendState[name] = &State{
 		Status:        be.GetInitialState(),
@@ -79,7 +75,7 @@ func (manager *BackendStateManager) StartBackendMonitor(name string, be Backend)
 }
 
 // RegisterError registers an error for a backend and updates its state
-func (manager *BackendStateManager) RegisterError(name string, errMessage string) {
+func (manager *StateManager) RegisterError(name string, errMessage string) {
 	manager.logger.Error(errMessage, slog.String("backend", name))
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
@@ -91,7 +87,7 @@ func (manager *BackendStateManager) RegisterError(name string, errMessage string
 }
 
 // RegisterRestart registers a restart event for a backend
-func (manager *BackendStateManager) RegisterRestart(name string, reason string) {
+func (manager *StateManager) RegisterRestart(name string, reason string) {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
 	manager.backendState[name].RestartCount++
@@ -100,7 +96,7 @@ func (manager *BackendStateManager) RegisterRestart(name string, reason string) 
 }
 
 // Get returns the current state of all backends
-func (manager *BackendStateManager) Get() map[string]*State {
+func (manager *StateManager) Get() map[string]*State {
 	manager.mu.RLock()
 	defer manager.mu.RUnlock()
 

--- a/agent/backend/backend_state.go
+++ b/agent/backend/backend_state.go
@@ -1,0 +1,90 @@
+package backend
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// MinRestartTime is the minimum time to wait between restarts
+const MinRestartTime = 5 * time.Minute
+
+// BackendState provides an interface for accessing backend state information
+//
+//nolint:revive // BackendState is intentionally named to distinguish from the State struct
+type BackendState interface {
+	Get() map[string]*State
+}
+
+// BackendStateManager manages the state and monitoring of backends
+//
+//nolint:revive // BackendStateManager is intentionally named to distinguish from the State struct
+type BackendStateManager struct {
+	backendState       map[string]*State
+	ticker             *time.Ticker
+	logger             *slog.Logger
+	restartBackendChan chan string
+}
+
+// NewBackendStateManager creates a new BackendStateManager with the given logger and restart channel
+func NewBackendStateManager(logger *slog.Logger, restartBackendChan chan string) *BackendStateManager {
+	return &BackendStateManager{
+		backendState:       make(map[string]*State),
+		ticker:             time.NewTicker(10 * time.Second),
+		logger:             logger,
+		restartBackendChan: restartBackendChan,
+	}
+}
+
+// StartBackendMonitor starts monitoring a backend and manages its state
+func (manager *BackendStateManager) StartBackendMonitor(name string, be Backend) {
+	manager.backendState[name] = &State{
+		Status:        be.GetInitialState(),
+		LastRestartTS: time.Now(),
+	}
+	go func() {
+		for range manager.ticker.C {
+			backendStatus, errMsg, err := be.GetRunningStatus()
+			manager.backendState[name].Status = backendStatus
+			if backendStatus != Running {
+				if err != nil {
+					manager.backendState[name].LastError = fmt.Sprintf("failed to retrieve backend status: %v", err)
+				} else if errMsg != "" {
+					manager.backendState[name].LastError = errMsg
+				}
+				// status is not running so we have a current error
+				if time.Since(be.GetStartTime()) >= MinRestartTime {
+					manager.restartBackendChan <- name
+					if err != nil {
+						manager.logger.Error("failed to restart backend", "error", err, "backend", name)
+					}
+				} else {
+					remainingSecondsUntilRestart := MinRestartTime - time.Since(be.GetStartTime())
+					manager.logger.Info("waiting to attempt backend restart due to failed status", "remaining_secs", remainingSecondsUntilRestart)
+				}
+			}
+		}
+	}()
+}
+
+// RegisterError registers an error for a backend and updates its state
+func (manager *BackendStateManager) RegisterError(name string, errMessage string) {
+	manager.logger.Error(errMessage, slog.String("backend", name))
+	manager.backendState[name] = &State{
+		Status:        BackendError,
+		LastError:     errMessage,
+		LastRestartTS: time.Now(),
+	}
+}
+
+// RegisterRestart registers a restart event for a backend
+func (manager *BackendStateManager) RegisterRestart(name string, reason string) {
+	manager.backendState[name].RestartCount++
+	manager.backendState[name].LastRestartTS = time.Now()
+	manager.backendState[name].LastRestartReason = reason
+}
+
+// Get returns the current state of all backends
+func (manager *BackendStateManager) Get() map[string]*State {
+	return manager.backendState
+}

--- a/agent/backend/backend_state_test.go
+++ b/agent/backend/backend_state_test.go
@@ -1,0 +1,450 @@
+package backend_test
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/backend"
+)
+
+func TestNewBackendStateManager_Initialization(t *testing.T) {
+	// Arrange
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	restartChan := make(chan string, 5)
+
+	// Act
+	manager := backend.NewStateManager(logger, restartChan)
+
+	// Assert
+	assert.NotNil(t, manager)
+	assert.NotNil(t, manager.Get())
+	assert.Empty(t, manager.Get())
+}
+
+func TestBackendStateManager_RegisterError(t *testing.T) {
+	// Arrange
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	restartChan := make(chan string, 5)
+	manager := backend.NewStateManager(logger, restartChan)
+
+	backendName := "test-backend"
+	errorMsg := "test error message"
+
+	// Act
+	manager.RegisterError(backendName, errorMsg)
+
+	// Assert
+	state := manager.Get()
+	require.Contains(t, state, backendName)
+	assert.Equal(t, backend.BackendError, state[backendName].Status)
+	assert.Equal(t, errorMsg, state[backendName].LastError)
+	assert.False(t, state[backendName].LastRestartTS.IsZero())
+}
+
+func TestBackendStateManager_RegisterRestart(t *testing.T) {
+	// Arrange
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	restartChan := make(chan string, 5)
+	manager := backend.NewStateManager(logger, restartChan)
+
+	backendName := "test-backend"
+
+	// Initialize backend state first
+	mockBe := &mockBackend{}
+	mockBe.On("GetInitialState").Return(backend.Running)
+	mockBe.On("GetStartTime").Return(time.Now())
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+
+	manager.StartBackendMonitor(backendName, mockBe)
+
+	initialState := manager.Get()[backendName]
+	initialRestartCount := initialState.RestartCount
+
+	reason := "test restart reason"
+
+	// Act
+	manager.RegisterRestart(backendName, reason)
+
+	// Assert
+	state := manager.Get()
+	require.Contains(t, state, backendName)
+	assert.Equal(t, initialRestartCount+1, state[backendName].RestartCount)
+	assert.Equal(t, reason, state[backendName].LastRestartReason)
+	assert.False(t, state[backendName].LastRestartTS.IsZero())
+}
+
+func TestBackendStateManager_RegisterRestart_MultipleRestarts(t *testing.T) {
+	// Arrange
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	restartChan := make(chan string, 5)
+	manager := backend.NewStateManager(logger, restartChan)
+
+	backendName := "test-backend"
+
+	// Initialize backend state first
+	mockBe := &mockBackend{}
+	mockBe.On("GetInitialState").Return(backend.Running)
+	mockBe.On("GetStartTime").Return(time.Now())
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+
+	manager.StartBackendMonitor(backendName, mockBe)
+
+	// Act - Register multiple restarts
+	manager.RegisterRestart(backendName, "first restart")
+	manager.RegisterRestart(backendName, "second restart")
+	manager.RegisterRestart(backendName, "third restart")
+
+	// Assert
+	state := manager.Get()
+	require.Contains(t, state, backendName)
+	assert.Equal(t, int64(3), state[backendName].RestartCount)
+	assert.Equal(t, "third restart", state[backendName].LastRestartReason)
+}
+
+func TestBackendStateManager_Get_EmptyState(t *testing.T) {
+	// Arrange
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	restartChan := make(chan string, 5)
+	manager := backend.NewStateManager(logger, restartChan)
+
+	// Act
+	state := manager.Get()
+
+	// Assert
+	assert.NotNil(t, state)
+	assert.Empty(t, state)
+}
+
+func TestBackendStateManager_Get_WithMultipleBackends(t *testing.T) {
+	// Arrange
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	restartChan := make(chan string, 5)
+	manager := backend.NewStateManager(logger, restartChan)
+
+	// Add multiple backends
+	manager.RegisterError("backend1", "error1")
+	manager.RegisterError("backend2", "error2")
+	manager.RegisterError("backend3", "error3")
+
+	// Act
+	state := manager.Get()
+
+	// Assert
+	assert.Len(t, state, 3)
+	assert.Contains(t, state, "backend1")
+	assert.Contains(t, state, "backend2")
+	assert.Contains(t, state, "backend3")
+}
+
+func TestBackendStateManager_StartBackendMonitor_InitialState(t *testing.T) {
+	// Arrange
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	restartChan := make(chan string, 5)
+	manager := backend.NewStateManager(logger, restartChan)
+
+	mockBe := &mockBackend{}
+	mockBe.On("GetInitialState").Return(backend.Running)
+	mockBe.On("GetStartTime").Return(time.Now())
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+
+	backendName := "test-backend"
+
+	// Act
+	manager.StartBackendMonitor(backendName, mockBe)
+
+	// Allow some time for goroutine to start
+	time.Sleep(10 * time.Millisecond)
+
+	// Assert
+	state := manager.Get()
+	require.Contains(t, state, backendName)
+	assert.Equal(t, backend.Running, state[backendName].Status)
+	assert.False(t, state[backendName].LastRestartTS.IsZero())
+	mockBe.AssertCalled(t, "GetInitialState")
+}
+
+func TestBackendStateManager_StartBackendMonitor_StatusUpdate_Running(t *testing.T) {
+	// Arrange
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	restartChan := make(chan string, 5)
+	manager := backend.NewStateManager(logger, restartChan)
+
+	mockBe := &mockBackend{}
+	mockBe.On("GetInitialState").Return(backend.Running)
+	mockBe.On("GetStartTime").Return(time.Now())
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil)
+
+	backendName := "test-backend"
+
+	// Act
+	manager.StartBackendMonitor(backendName, mockBe)
+
+	// Wait for at least one status check
+	time.Sleep(15 * time.Millisecond)
+
+	// Assert
+	state := manager.Get()
+	require.Contains(t, state, backendName)
+	assert.Equal(t, backend.Running, state[backendName].Status)
+
+	// Should not trigger restart for running backend
+	select {
+	case <-restartChan:
+		t.Error("Should not have triggered restart for running backend")
+	default:
+		// Expected - no restart triggered
+	}
+}
+
+func TestBackendStateManager_StartBackendMonitor_StatusUpdate_Error(t *testing.T) {
+	// Note: This test verifies the initial state is set correctly.
+	// The periodic status checking requires waiting 10+ seconds for the ticker,
+	// which is too slow for unit tests. The monitoring logic is tested via
+	// integration or by verifying the goroutine is started.
+
+	// Arrange
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	restartChan := make(chan string, 5)
+	manager := backend.NewStateManager(logger, restartChan)
+
+	// Backend that started long enough ago to allow restart
+	startTime := time.Now().Add(-10 * time.Minute)
+
+	mockBe := &mockBackend{}
+	mockBe.On("GetInitialState").Return(backend.BackendError)
+	mockBe.On("GetStartTime").Return(startTime)
+	mockBe.On("GetRunningStatus").Return(backend.BackendError, "backend failed", nil).Maybe()
+
+	backendName := "test-backend"
+
+	// Act
+	manager.StartBackendMonitor(backendName, mockBe)
+
+	// Allow goroutine to start
+	time.Sleep(10 * time.Millisecond)
+
+	// Assert - Verify initial state is set from GetInitialState
+	state := manager.Get()
+	require.Contains(t, state, backendName)
+	assert.Equal(t, backend.BackendError, state[backendName].Status)
+	assert.False(t, state[backendName].LastRestartTS.IsZero())
+}
+
+func TestBackendStateManager_StartBackendMonitor_StatusUpdate_ErrorWithException(t *testing.T) {
+	// Note: This test verifies the initial state is set correctly.
+	// The periodic status checking logic is verified indirectly by confirming
+	// the monitoring goroutine is started.
+
+	// Arrange
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	restartChan := make(chan string, 5)
+	manager := backend.NewStateManager(logger, restartChan)
+
+	// Backend that started long enough ago to allow restart
+	startTime := time.Now().Add(-10 * time.Minute)
+
+	mockBe := &mockBackend{}
+	mockBe.On("GetInitialState").Return(backend.BackendError)
+	mockBe.On("GetStartTime").Return(startTime)
+	statusErr := errors.New("status check failed")
+	mockBe.On("GetRunningStatus").Return(backend.BackendError, "", statusErr).Maybe()
+
+	backendName := "test-backend"
+
+	// Act
+	manager.StartBackendMonitor(backendName, mockBe)
+
+	// Allow goroutine to start
+	time.Sleep(10 * time.Millisecond)
+
+	// Assert - Verify initial state
+	state := manager.Get()
+	require.Contains(t, state, backendName)
+	assert.Equal(t, backend.BackendError, state[backendName].Status)
+	assert.False(t, state[backendName].LastRestartTS.IsZero())
+}
+
+func TestBackendStateManager_StartBackendMonitor_ErrorBeforeMinRestartTime(t *testing.T) {
+	// This test verifies the initial state setup works correctly.
+	// The restart timing logic requires waiting 10+ seconds for ticker which is
+	// impractical for unit tests.
+
+	// Arrange
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	restartChan := make(chan string, 5)
+	manager := backend.NewStateManager(logger, restartChan)
+
+	// Backend that started recently (less than MinRestartTime ago)
+	startTime := time.Now().Add(-1 * time.Minute)
+
+	mockBe := &mockBackend{}
+	mockBe.On("GetInitialState").Return(backend.Running)
+	mockBe.On("GetStartTime").Return(startTime)
+	mockBe.On("GetRunningStatus").Return(backend.BackendError, "backend failed", nil).Maybe()
+
+	backendName := "test-backend"
+
+	// Act
+	manager.StartBackendMonitor(backendName, mockBe)
+
+	// Allow goroutine to start
+	time.Sleep(10 * time.Millisecond)
+
+	// Assert - Verify initial state
+	state := manager.Get()
+	require.Contains(t, state, backendName)
+	assert.Equal(t, backend.Running, state[backendName].Status)
+	assert.False(t, state[backendName].LastRestartTS.IsZero())
+}
+
+func TestBackendStateManager_StartBackendMonitor_MultipleBackends(t *testing.T) {
+	// Arrange
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	restartChan := make(chan string, 10)
+	manager := backend.NewStateManager(logger, restartChan)
+
+	mockBe1 := &mockBackend{}
+	mockBe1.On("GetInitialState").Return(backend.Running)
+	mockBe1.On("GetStartTime").Return(time.Now())
+	mockBe1.On("GetRunningStatus").Return(backend.Running, "", nil)
+
+	mockBe2 := &mockBackend{}
+	mockBe2.On("GetInitialState").Return(backend.Waiting)
+	mockBe2.On("GetStartTime").Return(time.Now())
+	mockBe2.On("GetRunningStatus").Return(backend.Waiting, "", nil)
+
+	mockBe3 := &mockBackend{}
+	mockBe3.On("GetInitialState").Return(backend.Running)
+	mockBe3.On("GetStartTime").Return(time.Now())
+	mockBe3.On("GetRunningStatus").Return(backend.Running, "", nil)
+
+	// Act
+	manager.StartBackendMonitor("backend1", mockBe1)
+	manager.StartBackendMonitor("backend2", mockBe2)
+	manager.StartBackendMonitor("backend3", mockBe3)
+
+	// Wait for status checks
+	time.Sleep(15 * time.Millisecond)
+
+	// Assert
+	state := manager.Get()
+	assert.Len(t, state, 3)
+	assert.Contains(t, state, "backend1")
+	assert.Contains(t, state, "backend2")
+	assert.Contains(t, state, "backend3")
+	assert.Equal(t, backend.Running, state["backend1"].Status)
+	assert.Equal(t, backend.Waiting, state["backend2"].Status)
+	assert.Equal(t, backend.Running, state["backend3"].Status)
+}
+
+func TestBackendStateManager_Interface_Implementation(t *testing.T) {
+	// Verify that BackendStateManager implements BackendState interface
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	restartChan := make(chan string, 5)
+	manager := backend.NewStateManager(logger, restartChan)
+
+	// Should be assignable to BackendState interface
+	var _ backend.StateRetriever = manager
+
+	// Should be able to call Get through interface
+	state := manager.Get()
+	assert.NotNil(t, state)
+}
+
+func TestBackendStateManager_RegisterError_OverwritesExistingState(t *testing.T) {
+	// Arrange
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	restartChan := make(chan string, 5)
+	manager := backend.NewStateManager(logger, restartChan)
+
+	backendName := "test-backend"
+
+	// Set initial state
+	mockBe := &mockBackend{}
+	mockBe.On("GetInitialState").Return(backend.Running)
+	mockBe.On("GetStartTime").Return(time.Now())
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+
+	manager.StartBackendMonitor(backendName, mockBe)
+	manager.RegisterRestart(backendName, "test restart")
+
+	initialRestartCount := manager.Get()[backendName].RestartCount
+
+	// Act - RegisterError should overwrite the state
+	errorMsg := "critical error"
+	manager.RegisterError(backendName, errorMsg)
+
+	// Assert
+	state := manager.Get()
+	require.Contains(t, state, backendName)
+	assert.Equal(t, backend.BackendError, state[backendName].Status)
+	assert.Equal(t, errorMsg, state[backendName].LastError)
+	// RestartCount should be reset to 0 because RegisterError creates a new State
+	assert.Equal(t, int64(0), state[backendName].RestartCount)
+	assert.NotEqual(t, initialRestartCount, state[backendName].RestartCount)
+}
+
+func TestBackendStateManager_MinRestartTime_Constant(t *testing.T) {
+	// Verify the MinRestartTime constant is set correctly
+	assert.Equal(t, 5*time.Minute, backend.MinRestartTime)
+}
+
+func TestBackendStateManager_ConcurrentAccess(t *testing.T) {
+	// Test concurrent access to BackendStateManager
+	// Arrange
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	restartChan := make(chan string, 50)
+	manager := backend.NewStateManager(logger, restartChan)
+
+	// Act - Simulate concurrent operations
+	done := make(chan bool)
+
+	// Goroutine 1: Register errors
+	go func() {
+		for i := 0; i < 10; i++ {
+			manager.RegisterError("backend1", "error message")
+			time.Sleep(1 * time.Millisecond)
+		}
+		done <- true
+	}()
+
+	// Goroutine 2: Register restarts
+	go func() {
+		// Initialize backend first
+		mockBe := &mockBackend{}
+		mockBe.On("GetInitialState").Return(backend.Running)
+		mockBe.On("GetStartTime").Return(time.Now())
+		mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+		manager.StartBackendMonitor("backend2", mockBe)
+
+		for i := 0; i < 10; i++ {
+			manager.RegisterRestart("backend2", "restart reason")
+			time.Sleep(1 * time.Millisecond)
+		}
+		done <- true
+	}()
+
+	// Goroutine 3: Read state
+	go func() {
+		for i := 0; i < 10; i++ {
+			_ = manager.Get()
+			time.Sleep(1 * time.Millisecond)
+		}
+		done <- true
+	}()
+
+	// Wait for all goroutines
+	<-done
+	<-done
+	<-done
+
+	// Assert - Should not panic or race
+	state := manager.Get()
+	assert.NotNil(t, state)
+}

--- a/agent/backend/backend_state_test.go
+++ b/agent/backend/backend_state_test.go
@@ -19,7 +19,7 @@ func TestNewBackendStateManager_Initialization(t *testing.T) {
 	restartChan := make(chan string, 5)
 
 	// Act
-	manager := backend.NewStateManager(logger, restartChan)
+	manager := backend.NewStateManager("fleet", logger, restartChan)
 
 	// Assert
 	assert.NotNil(t, manager)
@@ -31,7 +31,7 @@ func TestBackendStateManager_RegisterError(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	restartChan := make(chan string, 5)
-	manager := backend.NewStateManager(logger, restartChan)
+	manager := backend.NewStateManager("fleet", logger, restartChan)
 
 	backendName := "test-backend"
 	errorMsg := "test error message"
@@ -51,7 +51,7 @@ func TestBackendStateManager_RegisterRestart(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	restartChan := make(chan string, 5)
-	manager := backend.NewStateManager(logger, restartChan)
+	manager := backend.NewStateManager("fleet", logger, restartChan)
 
 	backendName := "test-backend"
 
@@ -83,7 +83,7 @@ func TestBackendStateManager_RegisterRestart_MultipleRestarts(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	restartChan := make(chan string, 5)
-	manager := backend.NewStateManager(logger, restartChan)
+	manager := backend.NewStateManager("fleet", logger, restartChan)
 
 	backendName := "test-backend"
 
@@ -111,7 +111,7 @@ func TestBackendStateManager_Get_EmptyState(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	restartChan := make(chan string, 5)
-	manager := backend.NewStateManager(logger, restartChan)
+	manager := backend.NewStateManager("fleet", logger, restartChan)
 
 	// Act
 	state := manager.Get()
@@ -125,7 +125,7 @@ func TestBackendStateManager_Get_WithMultipleBackends(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	restartChan := make(chan string, 5)
-	manager := backend.NewStateManager(logger, restartChan)
+	manager := backend.NewStateManager("fleet", logger, restartChan)
 
 	// Add multiple backends
 	manager.RegisterError("backend1", "error1")
@@ -146,7 +146,7 @@ func TestBackendStateManager_StartBackendMonitor_InitialState(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	restartChan := make(chan string, 5)
-	manager := backend.NewStateManager(logger, restartChan)
+	manager := backend.NewStateManager("fleet", logger, restartChan)
 
 	mockBe := &mockBackend{}
 	mockBe.On("GetInitialState").Return(backend.Running)
@@ -173,7 +173,7 @@ func TestBackendStateManager_StartBackendMonitor_StatusUpdate_Running(t *testing
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	restartChan := make(chan string, 5)
-	manager := backend.NewStateManager(logger, restartChan)
+	manager := backend.NewStateManager("fleet", logger, restartChan)
 
 	mockBe := &mockBackend{}
 	mockBe.On("GetInitialState").Return(backend.Running)
@@ -211,7 +211,7 @@ func TestBackendStateManager_StartBackendMonitor_StatusUpdate_Error(t *testing.T
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	restartChan := make(chan string, 5)
-	manager := backend.NewStateManager(logger, restartChan)
+	manager := backend.NewStateManager("fleet", logger, restartChan)
 
 	// Backend that started long enough ago to allow restart
 	startTime := time.Now().Add(-10 * time.Minute)
@@ -244,7 +244,7 @@ func TestBackendStateManager_StartBackendMonitor_StatusUpdate_ErrorWithException
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	restartChan := make(chan string, 5)
-	manager := backend.NewStateManager(logger, restartChan)
+	manager := backend.NewStateManager("fleet", logger, restartChan)
 
 	// Backend that started long enough ago to allow restart
 	startTime := time.Now().Add(-10 * time.Minute)
@@ -278,7 +278,7 @@ func TestBackendStateManager_StartBackendMonitor_ErrorBeforeMinRestartTime(t *te
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	restartChan := make(chan string, 5)
-	manager := backend.NewStateManager(logger, restartChan)
+	manager := backend.NewStateManager("fleet", logger, restartChan)
 
 	// Backend that started recently (less than MinRestartTime ago)
 	startTime := time.Now().Add(-1 * time.Minute)
@@ -307,7 +307,7 @@ func TestBackendStateManager_StartBackendMonitor_MultipleBackends(t *testing.T) 
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	restartChan := make(chan string, 10)
-	manager := backend.NewStateManager(logger, restartChan)
+	manager := backend.NewStateManager("fleet", logger, restartChan)
 
 	mockBe1 := &mockBackend{}
 	mockBe1.On("GetInitialState").Return(backend.Running)
@@ -347,7 +347,7 @@ func TestBackendStateManager_Interface_Implementation(t *testing.T) {
 	// Verify that BackendStateManager implements BackendState interface
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	restartChan := make(chan string, 5)
-	manager := backend.NewStateManager(logger, restartChan)
+	manager := backend.NewStateManager("fleet", logger, restartChan)
 
 	// Should be assignable to BackendState interface
 	var _ backend.StateRetriever = manager
@@ -361,7 +361,7 @@ func TestBackendStateManager_RegisterError_OverwritesExistingState(t *testing.T)
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	restartChan := make(chan string, 5)
-	manager := backend.NewStateManager(logger, restartChan)
+	manager := backend.NewStateManager("fleet", logger, restartChan)
 
 	backendName := "test-backend"
 
@@ -400,7 +400,7 @@ func TestBackendStateManager_ConcurrentAccess(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	restartChan := make(chan string, 50)
-	manager := backend.NewStateManager(logger, restartChan)
+	manager := backend.NewStateManager("fleet", logger, restartChan)
 
 	// Act - Simulate concurrent operations
 	done := make(chan bool)

--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -20,15 +20,17 @@ type fleetConfigManager struct {
 	connection       *fleet.MQTTConnection
 	authTokenManager *fleet.AuthTokenManager
 	resetChan        chan struct{}
+	backendState     backend.BackendState
 }
 
-func newFleetConfigManager(logger *slog.Logger, pMgr policymgr.PolicyManager) *fleetConfigManager {
+func newFleetConfigManager(logger *slog.Logger, pMgr policymgr.PolicyManager, backendState backend.BackendState) *fleetConfigManager {
 	resetChan := make(chan struct{}, 1)
 	return &fleetConfigManager{
 		logger:           logger,
-		connection:       fleet.NewMQTTConnection(logger, pMgr, resetChan),
+		connection:       fleet.NewMQTTConnection(logger, pMgr, resetChan, backendState),
 		authTokenManager: fleet.NewAuthTokenManager(logger),
 		resetChan:        resetChan,
+		backendState:     backendState,
 	}
 }
 

--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -20,10 +20,10 @@ type fleetConfigManager struct {
 	connection       *fleet.MQTTConnection
 	authTokenManager *fleet.AuthTokenManager
 	resetChan        chan struct{}
-	backendState     backend.BackendState
+	backendState     backend.StateRetriever
 }
 
-func newFleetConfigManager(logger *slog.Logger, pMgr policymgr.PolicyManager, backendState backend.BackendState) *fleetConfigManager {
+func newFleetConfigManager(logger *slog.Logger, pMgr policymgr.PolicyManager, backendState backend.StateRetriever) *fleetConfigManager {
 	resetChan := make(chan struct{}, 1)
 	return &fleetConfigManager{
 		logger:           logger,

--- a/agent/configmgr/fleet/connection.go
+++ b/agent/configmgr/fleet/connection.go
@@ -25,11 +25,11 @@ type MQTTConnection struct {
 }
 
 // NewMQTTConnection creates a new MQTTConnection
-func NewMQTTConnection(logger *slog.Logger, pMgr policymgr.PolicyManager, resetChan chan struct{}) *MQTTConnection {
+func NewMQTTConnection(logger *slog.Logger, pMgr policymgr.PolicyManager, resetChan chan struct{}, backendState backend.BackendState) *MQTTConnection {
 	return &MQTTConnection{
 		connectionManager: nil,
 		logger:            logger,
-		heartbeater:       newHeartbeater(logger),
+		heartbeater:       newHeartbeater(logger, backendState),
 		messaging:         NewMessaging(logger, pMgr, resetChan),
 		resetChan:         resetChan,
 	}

--- a/agent/configmgr/fleet/connection.go
+++ b/agent/configmgr/fleet/connection.go
@@ -25,7 +25,7 @@ type MQTTConnection struct {
 }
 
 // NewMQTTConnection creates a new MQTTConnection
-func NewMQTTConnection(logger *slog.Logger, pMgr policymgr.PolicyManager, resetChan chan struct{}, backendState backend.BackendState) *MQTTConnection {
+func NewMQTTConnection(logger *slog.Logger, pMgr policymgr.PolicyManager, resetChan chan struct{}, backendState backend.StateRetriever) *MQTTConnection {
 	return &MQTTConnection{
 		connectionManager: nil,
 		logger:            logger,

--- a/agent/configmgr/fleet/connection_test.go
+++ b/agent/configmgr/fleet/connection_test.go
@@ -54,12 +54,23 @@ func (m *mockPolicyManagerForFleet) RemovePolicy(policyID string, policyName str
 	return args.Error(0)
 }
 
+type mockBackendState struct {
+	backendState map[string]*backend.State
+}
+
+func (m *mockBackendState) Get() map[string]*backend.State {
+	if m.backendState == nil {
+		return map[string]*backend.State{}
+	}
+	return m.backendState
+}
+
 func TestFleetConfigManager_Connect_InvalidURL(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
 	resetChan := make(chan struct{}, 1)
-	connection := NewMQTTConnection(logger, mockPMgr, resetChan)
+	connection := NewMQTTConnection(logger, mockPMgr, resetChan, &mockBackendState{})
 
 	// Act with invalid URL
 	backends := make(map[string]backend.Backend)
@@ -76,7 +87,7 @@ func TestFleetConfigManager_Connect_ValidURL(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
 	resetChan := make(chan struct{}, 1)
-	connection := NewMQTTConnection(logger, mockPMgr, resetChan)
+	connection := NewMQTTConnection(logger, mockPMgr, resetChan, &mockBackendState{})
 
 	// Act with valid URL but don't expect successful connection
 	// since we don't have a real MQTT server

--- a/agent/configmgr/fleet/heartbeats.go
+++ b/agent/configmgr/fleet/heartbeats.go
@@ -18,10 +18,10 @@ type heartbeater struct {
 	logger       *slog.Logger
 	hbTicker     *time.Ticker
 	heartbeatCtx context.Context
-	backendState backend.BackendState
+	backendState backend.StateRetriever
 }
 
-func newHeartbeater(logger *slog.Logger, backendState backend.BackendState) *heartbeater {
+func newHeartbeater(logger *slog.Logger, backendState backend.StateRetriever) *heartbeater {
 	return &heartbeater{
 		logger:       logger,
 		hbTicker:     time.NewTicker(heartbeatFreq),

--- a/agent/configmgr/fleet/heartbeats.go
+++ b/agent/configmgr/fleet/heartbeats.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/configmgr/fleet/messages"
 )
 
@@ -17,13 +18,15 @@ type heartbeater struct {
 	logger       *slog.Logger
 	hbTicker     *time.Ticker
 	heartbeatCtx context.Context
+	backendState backend.BackendState
 }
 
-func newHeartbeater(logger *slog.Logger) *heartbeater {
+func newHeartbeater(logger *slog.Logger, backendState backend.BackendState) *heartbeater {
 	return &heartbeater{
 		logger:       logger,
 		hbTicker:     time.NewTicker(heartbeatFreq),
 		heartbeatCtx: context.Background(),
+		backendState: backendState,
 	}
 }
 
@@ -37,6 +40,9 @@ func (hb *heartbeater) sendSingleHeartbeat(ctx context.Context, heartbeatTopic s
 		SchemaVersion: messages.CurrentHeartbeatSchemaVersion,
 		TimeStamp:     time.Now().UTC(),
 		State:         messages.State(messages.Online),
+		BackendState:  hb.getBackendState(),
+		PolicyState:   make(map[string]messages.PolicyStateInfo),
+		GroupState:    make(map[string]messages.GroupStateInfo),
 	}
 
 	body, err := json.Marshal(hbData)
@@ -50,6 +56,22 @@ func (hb *heartbeater) sendSingleHeartbeat(ctx context.Context, heartbeatTopic s
 	} else {
 		hb.logger.Debug("heartbeat sent", "payload", string(body))
 	}
+}
+
+func (hb *heartbeater) getBackendState() map[string]messages.BackendStateInfo {
+	bes := make(map[string]messages.BackendStateInfo)
+	backendStates := hb.backendState.Get()
+	for name, state := range backendStates {
+		bes[name] = messages.BackendStateInfo{
+			State:             state.Status.String(),
+			Error:             state.LastError,
+			RestartCount:      state.RestartCount,
+			LastError:         state.LastError,
+			LastRestartTS:     state.LastRestartTS,
+			LastRestartReason: state.LastRestartReason,
+		}
+	}
+	return bes
 }
 
 // sendHeartbeats starts a goroutine that periodically issues heartbeats until the

--- a/agent/configmgr/fleet/heartbeats_test.go
+++ b/agent/configmgr/fleet/heartbeats_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/configmgr/fleet/messages"
 )
 
@@ -34,6 +35,17 @@ func createTestHeartbeater() *heartbeater {
 		logger:       logger,
 		hbTicker:     time.NewTicker(50 * time.Millisecond), // Short interval for testing
 		heartbeatCtx: context.Background(),
+		backendState: &mockBackendState{},
+	}
+}
+
+func createTestHeartbeaterWithBackendState(backendState *mockBackendState) *heartbeater {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	return &heartbeater{
+		logger:       logger,
+		hbTicker:     time.NewTicker(50 * time.Millisecond), // Short interval for testing
+		heartbeatCtx: context.Background(),
+		backendState: backendState,
 	}
 }
 
@@ -54,7 +66,8 @@ func TestNewHeartbeater_HeartbeaterInitialization(t *testing.T) {
 
 func TestHeartbeater_SendSingleHeartbeat_Success(t *testing.T) {
 	// Arrange
-	hb := createTestHeartbeater()
+	backendState := &mockBackendState{}
+	hb := createTestHeartbeaterWithBackendState(backendState)
 	defer hb.hbTicker.Stop()
 
 	mockPublish := &mockPublishFunc{}
@@ -445,4 +458,194 @@ func TestHeartbeater_Stop_HeartbeatContent(t *testing.T) {
 	// The stop method sends an Offline heartbeat, but the implementation currently sends Online (1)
 	assert.Equal(t, messages.State(1), heartbeat.State)
 	assert.False(t, heartbeat.TimeStamp.IsZero())
+}
+
+func TestHeartbeater_SendSingleHeartbeat_WithBackendState(t *testing.T) {
+	testTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	backendState := &mockBackendState{
+		backendState: map[string]*backend.State{
+			"pktvisor": {
+				Status:            backend.Running,
+				RestartCount:      3,
+				LastError:         "connection timeout",
+				LastRestartTS:     testTime,
+				LastRestartReason: "policy update",
+			},
+			"snmp_discovery": {
+				Status:            backend.BackendError,
+				RestartCount:      1,
+				LastError:         "initialization failed",
+				LastRestartTS:     testTime.Add(-1 * time.Hour),
+				LastRestartReason: "startup",
+			},
+		},
+	}
+	// Arrange
+	hb := createTestHeartbeaterWithBackendState(backendState)
+	defer hb.hbTicker.Stop()
+
+	var capturedPayload []byte
+	testTopic := "test/heartbeat"
+	publishFunc := func(_ context.Context, _ string, payload []byte) error {
+		capturedPayload = payload
+		return nil
+	}
+
+	ctx := context.Background()
+
+	// Act
+	hb.sendSingleHeartbeat(ctx, testTopic, publishFunc, "test-agent-id", testTime, messages.Online)
+
+	// Assert
+	require.NotNil(t, capturedPayload)
+
+	var heartbeat messages.Heartbeat
+	err := json.Unmarshal(capturedPayload, &heartbeat)
+	require.NoError(t, err)
+
+	// Verify backend state is populated
+	assert.NotNil(t, heartbeat.BackendState)
+	assert.Len(t, heartbeat.BackendState, 2)
+
+	// Check pktvisor backend state
+	pktvisorState, ok := heartbeat.BackendState["pktvisor"]
+	assert.True(t, ok)
+	assert.Equal(t, "running", pktvisorState.State)
+	assert.Equal(t, int64(3), pktvisorState.RestartCount)
+	assert.Equal(t, "connection timeout", pktvisorState.LastError)
+	assert.Equal(t, testTime, pktvisorState.LastRestartTS)
+	assert.Equal(t, "policy update", pktvisorState.LastRestartReason)
+
+	// Check snmp_discovery backend state
+	snmpState, ok := heartbeat.BackendState["snmp_discovery"]
+	assert.True(t, ok)
+	assert.Equal(t, "backend_error", snmpState.State)
+	assert.Equal(t, int64(1), snmpState.RestartCount)
+	assert.Equal(t, "initialization failed", snmpState.LastError)
+	assert.Equal(t, testTime.Add(-1*time.Hour), snmpState.LastRestartTS)
+	assert.Equal(t, "startup", snmpState.LastRestartReason)
+
+	// Verify policy and group states are empty maps
+	assert.NotNil(t, heartbeat.PolicyState)
+	assert.Empty(t, heartbeat.PolicyState)
+	assert.NotNil(t, heartbeat.GroupState)
+	assert.Empty(t, heartbeat.GroupState)
+}
+
+func TestHeartbeater_SendSingleHeartbeat_WithoutBackendState(t *testing.T) {
+	// Arrange
+	hb := createTestHeartbeater()
+	defer hb.hbTicker.Stop()
+
+	// Do not set backend state function
+	var capturedPayload []byte
+	testTopic := "test/heartbeat"
+	publishFunc := func(_ context.Context, _ string, payload []byte) error {
+		capturedPayload = payload
+		return nil
+	}
+
+	ctx := context.Background()
+	testTime := time.Now()
+
+	// Act
+	hb.sendSingleHeartbeat(ctx, testTopic, publishFunc, "test-agent-id", testTime, messages.Online)
+
+	// Assert
+	require.NotNil(t, capturedPayload)
+
+	var heartbeat messages.Heartbeat
+	err := json.Unmarshal(capturedPayload, &heartbeat)
+	require.NoError(t, err)
+
+	// Verify backend state is empty but not nil
+	assert.NotNil(t, heartbeat.BackendState)
+	assert.Empty(t, heartbeat.BackendState)
+}
+
+func TestHeartbeater_SendSingleHeartbeat_WithEmptyBackendState(t *testing.T) {
+	// Arrange
+	hb := createTestHeartbeater()
+	defer hb.hbTicker.Stop()
+
+	var capturedPayload []byte
+	testTopic := "test/heartbeat"
+	publishFunc := func(_ context.Context, _ string, payload []byte) error {
+		capturedPayload = payload
+		return nil
+	}
+
+	ctx := context.Background()
+	testTime := time.Now()
+
+	// Act
+	hb.sendSingleHeartbeat(ctx, testTopic, publishFunc, "test-agent-id", testTime, messages.Online)
+
+	// Assert
+	require.NotNil(t, capturedPayload)
+
+	var heartbeat messages.Heartbeat
+	err := json.Unmarshal(capturedPayload, &heartbeat)
+	require.NoError(t, err)
+
+	// Verify backend state is empty
+	assert.NotNil(t, heartbeat.BackendState)
+	assert.Empty(t, heartbeat.BackendState)
+}
+
+func TestHeartbeater_SendSingleHeartbeat_BackendStateAllStatuses(t *testing.T) {
+	// Test all possible backend statuses
+	testCases := []struct {
+		name           string
+		status         backend.RunningStatus
+		expectedString string
+	}{
+		{"Unknown", backend.Unknown, "unknown"},
+		{"Running", backend.Running, "running"},
+		{"BackendError", backend.BackendError, "backend_error"},
+		{"AgentError", backend.AgentError, "agent_error"},
+		{"Offline", backend.Offline, "offline"},
+		{"Waiting", backend.Waiting, "waiting"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			backendState := &mockBackendState{
+				backendState: map[string]*backend.State{
+					"test-backend": {
+						Status:       tc.status,
+						RestartCount: 0,
+						LastError:    "",
+					},
+				},
+			}
+			hb := createTestHeartbeaterWithBackendState(backendState)
+			defer hb.hbTicker.Stop()
+
+			var capturedPayload []byte
+			testTopic := "test/heartbeat"
+			publishFunc := func(_ context.Context, _ string, payload []byte) error {
+				capturedPayload = payload
+				return nil
+			}
+
+			ctx := context.Background()
+			testTime := time.Now()
+
+			// Act
+			hb.sendSingleHeartbeat(ctx, testTopic, publishFunc, "test-agent-id", testTime, messages.Online)
+
+			// Assert
+			require.NotNil(t, capturedPayload)
+
+			var heartbeat messages.Heartbeat
+			err := json.Unmarshal(capturedPayload, &heartbeat)
+			require.NoError(t, err)
+
+			assert.Len(t, heartbeat.BackendState, 1)
+			actualState := heartbeat.BackendState["test-backend"]
+			assert.Equal(t, tc.expectedString, actualState.State)
+		})
+	}
 }

--- a/agent/configmgr/fleet_test.go
+++ b/agent/configmgr/fleet_test.go
@@ -58,11 +58,19 @@ func (m *mockPolicyManagerForFleet) RemovePolicy(policyID string, policyName str
 	return args.Error(0)
 }
 
+type mockBackendState struct {
+	mock.Mock
+}
+
+func (m *mockBackendState) Get() map[string]*backend.State {
+	return m.Called().Get(0).(map[string]*backend.State)
+}
+
 func TestFleetConfigManager_Start_TokenError(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{})
 
 	// Create config with invalid token URL
 	cfg := config.Config{
@@ -92,7 +100,7 @@ func TestFleetConfigManager_Start_ConnectError(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{})
 
 	// Create mock HTTP server for token endpoint
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -132,7 +140,7 @@ func TestFleetConfigManager_GetContext(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{})
 
 	originalCtx := context.Background()
 	type contextKey string
@@ -167,7 +175,7 @@ func TestFleetConfigManager_Start_WithJWTTopicGeneration(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(logger, mockPMgr)
+	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{})
 
 	// Create mock HTTP server that returns a JWT token
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/agent/configmgr/git_test.go
+++ b/agent/configmgr/git_test.go
@@ -103,7 +103,7 @@ backend1:
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	// Instantiate the gitConfigManager.
-	gc := configmgr.New(logger, pMgr, cfg.OrbAgent.ConfigManager.Active)
+	gc := configmgr.New(logger, pMgr, cfg.OrbAgent.ConfigManager.Active, &mockBackendState{})
 
 	// Call Start
 	backends := map[string]backend.Backend{

--- a/agent/configmgr/local_test.go
+++ b/agent/configmgr/local_test.go
@@ -50,7 +50,7 @@ func TestLocalConfigManager(t *testing.T) {
 		})).Return()
 
 		// Create and start the manager
-		mgr := configmgr.New(logger, pMgr, cfg.Active)
+		mgr := configmgr.New(logger, pMgr, cfg.Active, &mockBackendState{})
 		err := mgr.Start(testConfig, backends)
 
 		// Verify
@@ -69,7 +69,7 @@ func TestLocalConfigManager(t *testing.T) {
 		backends := map[string]backend.Backend{}
 
 		// Create the manager
-		mgr := configmgr.New(logger, pMgr, cfg.Active)
+		mgr := configmgr.New(logger, pMgr, cfg.Active, &mockBackendState{})
 		err := mgr.Start(testConfig, backends)
 
 		// Should return an error
@@ -98,7 +98,7 @@ func TestLocalConfigManager(t *testing.T) {
 		backends := map[string]backend.Backend{}
 
 		// Create the manager
-		mgr := configmgr.New(logger, pMgr, cfg.Active)
+		mgr := configmgr.New(logger, pMgr, cfg.Active, &mockBackendState{})
 		err := mgr.Start(testConfig, backends)
 
 		// Should return an error

--- a/agent/configmgr/manager.go
+++ b/agent/configmgr/manager.go
@@ -17,7 +17,7 @@ type Manager interface {
 
 // New creates a new instance of ConfigManager that is bound to the
 // supplied context.
-func New(logger *slog.Logger, pMgr policymgr.PolicyManager, active string, backendState backend.BackendState) Manager {
+func New(logger *slog.Logger, pMgr policymgr.PolicyManager, active string, backendState backend.StateRetriever) Manager {
 	switch active {
 	case "local":
 		return &localConfigManager{logger: logger, pMgr: pMgr}

--- a/agent/configmgr/manager.go
+++ b/agent/configmgr/manager.go
@@ -17,14 +17,14 @@ type Manager interface {
 
 // New creates a new instance of ConfigManager that is bound to the
 // supplied context.
-func New(logger *slog.Logger, pMgr policymgr.PolicyManager, active string) Manager {
+func New(logger *slog.Logger, pMgr policymgr.PolicyManager, active string, backendState backend.BackendState) Manager {
 	switch active {
 	case "local":
 		return &localConfigManager{logger: logger, pMgr: pMgr}
 	case "git":
 		return &gitConfigManager{logger: logger, pMgr: pMgr}
 	case "fleet":
-		return newFleetConfigManager(logger, pMgr)
+		return newFleetConfigManager(logger, pMgr, backendState)
 	default:
 		return &localConfigManager{logger: logger, pMgr: pMgr}
 	}

--- a/agent/configmgr/manager_test.go
+++ b/agent/configmgr/manager_test.go
@@ -119,6 +119,14 @@ func (m *mockBackend) RemovePolicy(policy policies.PolicyData) error {
 	return args.Error(0)
 }
 
+type mockBackendState struct {
+	mock.Mock
+}
+
+func (m *mockBackendState) Get() map[string]*backend.State {
+	return m.Called().Get(0).(map[string]*backend.State)
+}
+
 // Test the manager.New function
 func TestManagerNew(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
@@ -132,7 +140,7 @@ func TestManagerNew(t *testing.T) {
 			},
 		}
 
-		mgr := configmgr.New(logger, pMgr, cfg.Active)
+		mgr := configmgr.New(logger, pMgr, cfg.Active, &mockBackendState{})
 		assert.NotNil(t, mgr)
 		// Check we got the expected implementation
 		ctx := context.Background()
@@ -150,7 +158,7 @@ func TestManagerNew(t *testing.T) {
 			},
 		}
 
-		mgr := configmgr.New(logger, pMgr, cfg.Active)
+		mgr := configmgr.New(logger, pMgr, cfg.Active, &mockBackendState{})
 		assert.NotNil(t, mgr)
 		// Check we got the expected implementation
 		ctx := context.Background()
@@ -163,7 +171,7 @@ func TestManagerNew(t *testing.T) {
 			Active: "unknown",
 		}
 
-		mgr := configmgr.New(logger, pMgr, cfg.Active)
+		mgr := configmgr.New(logger, pMgr, cfg.Active, &mockBackendState{})
 		assert.NotNil(t, mgr)
 		// Check we got the local implementation
 		ctx := context.Background()

--- a/agent/configmgr/manager_test.go
+++ b/agent/configmgr/manager_test.go
@@ -166,6 +166,27 @@ func TestManagerNew(t *testing.T) {
 		assert.Equal(t, ctx, resultCtx)
 	})
 
+	t.Run("FleetManager", func(t *testing.T) {
+		cfg := config.ManagerConfig{
+			Active: "fleet",
+			Sources: config.Sources{
+				Fleet: config.FleetManager{
+					TokenURL:     "https://example.com/token",
+					ClientID:     "test_client",
+					ClientSecret: "test_secret",
+				},
+			},
+		}
+
+		mockBackendState := &mockBackendState{}
+		mgr := configmgr.New(logger, pMgr, cfg.Active, mockBackendState)
+		assert.NotNil(t, mgr)
+		// Check we got the expected implementation
+		ctx := context.Background()
+		resultCtx := mgr.GetContext(ctx)
+		assert.Equal(t, ctx, resultCtx)
+	})
+
 	t.Run("DefaultToLocalManager", func(t *testing.T) {
 		cfg := config.ManagerConfig{
 			Active: "unknown",


### PR DESCRIPTION
This pull request introduces a significant refactor to how backend state is managed and monitored in the agent. The main improvement is the introduction of a centralized `StateManager` for backend state, which enables more robust monitoring, error handling, and reporting, including integration with the Fleet heartbeat. The changes also propagate backend state information into heartbeats sent to Fleet, improving observability. Several interfaces and constructors are updated to support this new state management approach.

Key changes include:

**Backend State Management Refactor:**

* Introduced `backend.StateManager` in `agent/backend/backend_state.go`, which centralizes backend state tracking, periodic monitoring, error registration, and restart logic. The manager uses a dedicated goroutine to monitor each backend and triggers restarts if a backend is unhealthy and the minimum restart interval has elapsed. (`[agent/backend/backend_state.goR1-R111](diffhunk://#diff-6301055a8fa5f25637f457f26fa4d9556ff42cfe18d83199b773f78de9332819R1-R111)`)
* Replaced the direct use of `backendState` map in `agent/agent.go` with the new `StateManager`, updating all relevant methods to interact with the manager for backend state, error, and restart registration. (`[[1]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL35-R45)`, `[[2]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bR63-R78)`, `[[3]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL81)`, `[[4]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL122-R157)`, `[[5]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL201-R212)`, `[[6]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL222-R231)`)

**Fleet Integration and Heartbeats:**

* Extended heartbeats sent to Fleet to include detailed backend state, by passing the `StateManager` (as a `StateRetriever` interface) down through the config manager and MQTT connection layers, and updating the heartbeat payload to include backend status, errors, and restart information. (`[[1]](diffhunk://#diff-b0dddd7590e09bc17b468db04b48a21f0d508a17eca4c086eb98c87325e5ba98R23-R33)`, `[[2]](diffhunk://#diff-1783db06b73b72c164682aec902cffc352ef29c1eee8cd92929e7637e72f8047L28-R32)`, `[[3]](diffhunk://#diff-796a5a43e9dd714c20b0d1863be358a6f2b4f3d5035e9ab9c4303f61fb2f24f2R9)`, `[[4]](diffhunk://#diff-796a5a43e9dd714c20b0d1863be358a6f2b4f3d5035e9ab9c4303f61fb2f24f2R21-R29)`, `[[5]](diffhunk://#diff-796a5a43e9dd714c20b0d1863be358a6f2b4f3d5035e9ab9c4303f61fb2f24f2R43-R45)`, `[[6]](diffhunk://#diff-796a5a43e9dd714c20b0d1863be358a6f2b4f3d5035e9ab9c4303f61fb2f24f2R61-R76)`)

**Testing and Mocking Updates:**

* Updated tests and mocks to accommodate the new backend state interface, including providing mock implementations and updating constructors in test files. (`[[1]](diffhunk://#diff-e8832cdc90dafca1118e69654b2c59f5c6c3e40fbee158eaafba88b3d7243232R57-R73)`, `[[2]](diffhunk://#diff-e8832cdc90dafca1118e69654b2c59f5c6c3e40fbee158eaafba88b3d7243232L79-R90)`, `[[3]](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72R17)`, `[[4]](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72R38-R48)`, `[[5]](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72L57-R70)`)

These changes lay the groundwork for more reliable backend lifecycle management and improved system observability.

**Backend State Management:**
- Added `backend.StateManager` to centralize backend state tracking, monitoring, and restart logic, replacing per-backend state maps. (`[agent/backend/backend_state.goR1-R111](diffhunk://#diff-6301055a8fa5f25637f457f26fa4d9556ff42cfe18d83199b773f78de9332819R1-R111)`)
- Updated `agent/agent.go` to use `StateManager` for backend lifecycle events, error registration, and restart handling. (`[[1]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL35-R45)`, `[[2]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bR63-R78)`, `[[3]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL81)`, `[[4]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL122-R157)`, `[[5]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL201-R212)`, `[[6]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL222-R231)`)

**Fleet Heartbeat and Config Integration:**
- Passed `StateManager` through config and MQTT layers to allow heartbeats to report backend state to Fleet. (`[[1]](diffhunk://#diff-b0dddd7590e09bc17b468db04b48a21f0d508a17eca4c086eb98c87325e5ba98R23-R33)`, `[[2]](diffhunk://#diff-1783db06b73b72c164682aec902cffc352ef29c1eee8cd92929e7637e72f8047L28-R32)`)
- Extended heartbeat payloads to include backend state information, improving Fleet-side observability. (`[[1]](diffhunk://#diff-796a5a43e9dd714c20b0d1863be358a6f2b4f3d5035e9ab9c4303f61fb2f24f2R9)`, `[[2]](diffhunk://#diff-796a5a43e9dd714c20b0d1863be358a6f2b4f3d5035e9ab9c4303f61fb2f24f2R21-R29)`, `[[3]](diffhunk://#diff-796a5a43e9dd714c20b0d1863be358a6f2b4f3d5035e9ab9c4303f61fb2f24f2R43-R45)`, `[[4]](diffhunk://#diff-796a5a43e9dd714c20b0d1863be358a6f2b4f3d5035e9ab9c4303f61fb2f24f2R61-R76)`)

**Testing Improvements:**
- Updated tests and mocks to work with the new backend state interface, ensuring test coverage for the new architecture. (`[[1]](diffhunk://#diff-e8832cdc90dafca1118e69654b2c59f5c6c3e40fbee158eaafba88b3d7243232R57-R73)`, `[[2]](diffhunk://#diff-e8832cdc90dafca1118e69654b2c59f5c6c3e40fbee158eaafba88b3d7243232L79-R90)`, `[[3]](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72R17)`, `[[4]](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72R38-R48)`, `[[5]](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72L57-R70)`)This pull request introduces a new `BackendStateManager` to centralize and improve backend state tracking, error handling, and automated restart logic. It refactors how backend state is managed, replacing direct state maps with a dedicated manager, and enhances the reporting of backend status in fleet heartbeats. The changes also ensure that backend state is accessible throughout various components, including configuration management and fleet communication.

Backend state management and monitoring:

* Introduced `BackendStateManager` in `agent/backend/backend_state.go` to handle backend state, monitor backend health, trigger restarts when necessary, and provide a unified interface for accessing backend state. This includes automated backend monitoring, error registration, and restart logic.
* Refactored `orbAgent` in `agent/agent.go` to use `BackendStateManager` instead of a local `backendState` map, and to start backend monitors and handle restart requests through a channel. [[1]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bR23-R24) [[2]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL35-R45) [[3]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bR63-R78) [[4]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL81) [[5]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL122-R157) [[6]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL201-R212) [[7]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL222-R231)

Integration with configuration management and fleet communication:

* Updated `configmgr` and fleet-related components to accept and use the new `BackendStateManager` for backend state, including changes to constructors and dependency injection in `agent/configmgr/fleet.go` and `agent/configmgr/fleet/connection.go`. [[1]](diffhunk://#diff-b0dddd7590e09bc17b468db04b48a21f0d508a17eca4c086eb98c87325e5ba98R23-R33) [[2]](diffhunk://#diff-1783db06b73b72c164682aec902cffc352ef29c1eee8cd92929e7637e72f8047L28-R32)
* Modified the heartbeater in `agent/configmgr/fleet/heartbeats.go` to include backend state in heartbeat messages, providing richer status information to fleet. [[1]](diffhunk://#diff-796a5a43e9dd714c20b0d1863be358a6f2b4f3d5035e9ab9c4303f61fb2f24f2R9) [[2]](diffhunk://#diff-796a5a43e9dd714c20b0d1863be358a6f2b4f3d5035e9ab9c4303f61fb2f24f2R21-R29) [[3]](diffhunk://#diff-796a5a43e9dd714c20b0d1863be358a6f2b4f3d5035e9ab9c4303f61fb2f24f2R43-R45) [[4]](diffhunk://#diff-796a5a43e9dd714c20b0d1863be358a6f2b4f3d5035e9ab9c4303f61fb2f24f2R61-R76)

Testing and mocks:

* Updated and extended tests and mocks to support the new backend state interface and manager, ensuring continued test coverage and correct initialization in `agent/configmgr/fleet/connection_test.go` and `agent/configmgr/fleet/heartbeats_test.go`. [[1]](diffhunk://#diff-e8832cdc90dafca1118e69654b2c59f5c6c3e40fbee158eaafba88b3d7243232R57-R73) [[2]](diffhunk://#diff-e8832cdc90dafca1118e69654b2c59f5c6c3e40fbee158eaafba88b3d7243232L79-R90) [[3]](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72R17) [[4]](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72R38-R48) [[5]](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72L57-R70)