### PR TITLE
feat: Add policy state to heartbeat and tidy up unused code

### DIFF
--- a/agent/configmgr/fleet/connection.go
+++ b/agent/configmgr/fleet/connection.go
@@ -29,7 +29,7 @@ func NewMQTTConnection(logger *slog.Logger, pMgr policymgr.PolicyManager, resetC
 	return &MQTTConnection{
 		connectionManager: nil,
 		logger:            logger,
-		heartbeater:       newHeartbeater(logger, backendState),
+		heartbeater:       newHeartbeater(logger, backendState, pMgr),
 		messaging:         NewMessaging(logger, pMgr, resetChan),
 		resetChan:         resetChan,
 	}

--- a/agent/configmgr/fleet/heartbeats.go
+++ b/agent/configmgr/fleet/heartbeats.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/configmgr/fleet/messages"
+	"github.com/netboxlabs/orb-agent/agent/policymgr"
 )
 
 const (
@@ -15,18 +16,20 @@ const (
 )
 
 type heartbeater struct {
-	logger       *slog.Logger
-	hbTicker     *time.Ticker
-	heartbeatCtx context.Context
-	backendState backend.StateRetriever
+	logger        *slog.Logger
+	hbTicker      *time.Ticker
+	heartbeatCtx  context.Context
+	backendState  backend.StateRetriever
+	policyManager policymgr.PolicyManager
 }
 
-func newHeartbeater(logger *slog.Logger, backendState backend.StateRetriever) *heartbeater {
+func newHeartbeater(logger *slog.Logger, backendState backend.StateRetriever, policyManager policymgr.PolicyManager) *heartbeater {
 	return &heartbeater{
-		logger:       logger,
-		hbTicker:     time.NewTicker(heartbeatFreq),
-		heartbeatCtx: context.Background(),
-		backendState: backendState,
+		logger:        logger,
+		hbTicker:      time.NewTicker(heartbeatFreq),
+		heartbeatCtx:  context.Background(),
+		backendState:  backendState,
+		policyManager: policyManager,
 	}
 }
 
@@ -41,7 +44,7 @@ func (hb *heartbeater) sendSingleHeartbeat(ctx context.Context, heartbeatTopic s
 		TimeStamp:     time.Now().UTC(),
 		State:         messages.State(messages.Online),
 		BackendState:  hb.getBackendState(),
-		PolicyState:   make(map[string]messages.PolicyStateInfo),
+		PolicyState:   hb.getPolicyState(),
 		GroupState:    make(map[string]messages.GroupStateInfo),
 	}
 
@@ -72,6 +75,26 @@ func (hb *heartbeater) getBackendState() map[string]messages.BackendStateInfo {
 		}
 	}
 	return bes
+}
+
+func (hb *heartbeater) getPolicyState() map[string]messages.PolicyStateInfo {
+	policyStates, err := hb.policyManager.GetPolicyState()
+	if err != nil {
+		hb.logger.Error("error getting policy state", "error", err)
+		return make(map[string]messages.PolicyStateInfo)
+	}
+	ps := make(map[string]messages.PolicyStateInfo)
+	for _, policyState := range policyStates {
+		ps[policyState.ID] = messages.PolicyStateInfo{
+			Name:     policyState.Name,
+			Datasets: policyState.GetDatasetIDs(),
+			State:    policyState.State.String(),
+			Error:    policyState.BackendErr,
+			Version:  policyState.Version,
+			Backend:  policyState.Backend,
+		}
+	}
+	return ps
 }
 
 // sendHeartbeats starts a goroutine that periodically issues heartbeats until the

--- a/agent/configmgr/fleet/heartbeats_test.go
+++ b/agent/configmgr/fleet/heartbeats_test.go
@@ -15,7 +15,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/configmgr/fleet/messages"
+	"github.com/netboxlabs/orb-agent/agent/policies"
 )
 
 // mockPublishFunc is a testify mock for the publish function
@@ -28,24 +30,79 @@ func (m *mockPublishFunc) Publish(ctx context.Context, topic string, payload []b
 	return args.Error(0)
 }
 
+// mockPolicyManagerForHeartbeat implements the PolicyManager interface for heartbeat testing
+type mockPolicyManagerForHeartbeat struct {
+	mock.Mock
+}
+
+func (m *mockPolicyManagerForHeartbeat) ManagePolicy(payload config.PolicyPayload) {
+	m.Called(payload)
+}
+
+func (m *mockPolicyManagerForHeartbeat) RemovePolicyDataset(policyID string, datasetID string, be backend.Backend) {
+	m.Called(policyID, datasetID, be)
+}
+
+func (m *mockPolicyManagerForHeartbeat) GetPolicyState() ([]policies.PolicyData, error) {
+	args := m.Called()
+	return args.Get(0).([]policies.PolicyData), args.Error(1)
+}
+
+func (m *mockPolicyManagerForHeartbeat) GetRepo() policies.PolicyRepo {
+	args := m.Called()
+	return args.Get(0).(policies.PolicyRepo)
+}
+
+func (m *mockPolicyManagerForHeartbeat) ApplyBackendPolicies(be backend.Backend) error {
+	args := m.Called(be)
+	return args.Error(0)
+}
+
+func (m *mockPolicyManagerForHeartbeat) RemoveBackendPolicies(be backend.Backend, permanently bool) error {
+	args := m.Called(be, permanently)
+	return args.Error(0)
+}
+
+func (m *mockPolicyManagerForHeartbeat) RemovePolicy(policyID string, policyName string, beName string) error {
+	args := m.Called(policyID, policyName, beName)
+	return args.Error(0)
+}
+
 // Test helper to create a heartbeater instance for testing
 func createTestHeartbeater() *heartbeater {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mockPMgr := &mockPolicyManagerForHeartbeat{}
+	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{}, nil).Maybe()
 	return &heartbeater{
-		logger:       logger,
-		hbTicker:     time.NewTicker(50 * time.Millisecond), // Short interval for testing
-		heartbeatCtx: context.Background(),
-		backendState: &mockBackendState{},
+		logger:        logger,
+		hbTicker:      time.NewTicker(50 * time.Millisecond), // Short interval for testing
+		heartbeatCtx:  context.Background(),
+		backendState:  &mockBackendState{},
+		policyManager: mockPMgr,
 	}
 }
 
 func createTestHeartbeaterWithBackendState(backendState *mockBackendState) *heartbeater {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mockPMgr := &mockPolicyManagerForHeartbeat{}
+	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{}, nil).Maybe()
 	return &heartbeater{
-		logger:       logger,
-		hbTicker:     time.NewTicker(50 * time.Millisecond), // Short interval for testing
-		heartbeatCtx: context.Background(),
-		backendState: backendState,
+		logger:        logger,
+		hbTicker:      time.NewTicker(50 * time.Millisecond), // Short interval for testing
+		heartbeatCtx:  context.Background(),
+		backendState:  backendState,
+		policyManager: mockPMgr,
+	}
+}
+
+func createTestHeartbeaterWithPolicyManager(backendState *mockBackendState, policyManager *mockPolicyManagerForHeartbeat) *heartbeater {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	return &heartbeater{
+		logger:        logger,
+		hbTicker:      time.NewTicker(50 * time.Millisecond), // Short interval for testing
+		heartbeatCtx:  context.Background(),
+		backendState:  backendState,
+		policyManager: policyManager,
 	}
 }
 
@@ -525,9 +582,8 @@ func TestHeartbeater_SendSingleHeartbeat_WithBackendState(t *testing.T) {
 	assert.Equal(t, testTime.Add(-1*time.Hour), snmpState.LastRestartTS)
 	assert.Equal(t, "startup", snmpState.LastRestartReason)
 
-	// Verify policy and group states are empty maps
+	// Verify policy and group states are present (may be empty based on mock)
 	assert.NotNil(t, heartbeat.PolicyState)
-	assert.Empty(t, heartbeat.PolicyState)
 	assert.NotNil(t, heartbeat.GroupState)
 	assert.Empty(t, heartbeat.GroupState)
 }
@@ -648,4 +704,324 @@ func TestHeartbeater_SendSingleHeartbeat_BackendStateAllStatuses(t *testing.T) {
 			assert.Equal(t, tc.expectedString, actualState.State)
 		})
 	}
+}
+
+func TestHeartbeater_GetPolicyState_Success(t *testing.T) {
+	// Arrange
+	mockPMgr := &mockPolicyManagerForHeartbeat{}
+	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{
+		{
+			ID:         "policy-1",
+			Name:       "Test Policy 1",
+			Backend:    "pktvisor",
+			Version:    1,
+			State:      policies.Running,
+			BackendErr: "",
+			Datasets:   map[string]bool{"dataset-1": true, "dataset-2": true},
+		},
+		{
+			ID:         "policy-2",
+			Name:       "Test Policy 2",
+			Backend:    "snmp_discovery",
+			Version:    2,
+			State:      policies.FailedToApply,
+			BackendErr: "connection timeout",
+			Datasets:   map[string]bool{"dataset-3": true},
+		},
+	}, nil)
+
+	hb := createTestHeartbeaterWithPolicyManager(&mockBackendState{}, mockPMgr)
+	defer hb.hbTicker.Stop()
+
+	// Act
+	policyState := hb.getPolicyState()
+
+	// Assert
+	assert.Len(t, policyState, 2)
+
+	// Verify policy-1
+	policy1, ok := policyState["policy-1"]
+	assert.True(t, ok)
+	assert.Equal(t, "Test Policy 1", policy1.Name)
+	assert.Equal(t, "pktvisor", policy1.Backend)
+	assert.Equal(t, int32(1), policy1.Version)
+	assert.Equal(t, "running", policy1.State)
+	assert.Equal(t, "", policy1.Error)
+	assert.Len(t, policy1.Datasets, 2)
+	assert.Contains(t, policy1.Datasets, "dataset-1")
+	assert.Contains(t, policy1.Datasets, "dataset-2")
+
+	// Verify policy-2
+	policy2, ok := policyState["policy-2"]
+	assert.True(t, ok)
+	assert.Equal(t, "Test Policy 2", policy2.Name)
+	assert.Equal(t, "snmp_discovery", policy2.Backend)
+	assert.Equal(t, int32(2), policy2.Version)
+	assert.Equal(t, "failed_to_apply", policy2.State)
+	assert.Equal(t, "connection timeout", policy2.Error)
+	assert.Len(t, policy2.Datasets, 1)
+	assert.Contains(t, policy2.Datasets, "dataset-3")
+
+	mockPMgr.AssertExpectations(t)
+}
+
+func TestHeartbeater_GetPolicyState_Error(t *testing.T) {
+	// Arrange
+	mockPMgr := &mockPolicyManagerForHeartbeat{}
+	expectedErr := errors.New("failed to retrieve policy state")
+	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{}, expectedErr)
+
+	hb := createTestHeartbeaterWithPolicyManager(&mockBackendState{}, mockPMgr)
+	defer hb.hbTicker.Stop()
+
+	// Act
+	policyState := hb.getPolicyState()
+
+	// Assert - should return empty map on error
+	assert.NotNil(t, policyState)
+	assert.Empty(t, policyState)
+	mockPMgr.AssertExpectations(t)
+}
+
+func TestHeartbeater_GetPolicyState_EmptyPolicies(t *testing.T) {
+	// Arrange
+	mockPMgr := &mockPolicyManagerForHeartbeat{}
+	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{}, nil)
+
+	hb := createTestHeartbeaterWithPolicyManager(&mockBackendState{}, mockPMgr)
+	defer hb.hbTicker.Stop()
+
+	// Act
+	policyState := hb.getPolicyState()
+
+	// Assert
+	assert.NotNil(t, policyState)
+	assert.Empty(t, policyState)
+	mockPMgr.AssertExpectations(t)
+}
+
+func TestHeartbeater_GetPolicyState_AllPolicyStates(t *testing.T) {
+	// Test all possible policy states
+	testCases := []struct {
+		name           string
+		state          policies.PolicyState
+		expectedString string
+	}{
+		{"Unknown", policies.Unknown, "unknown"},
+		{"Running", policies.Running, "running"},
+		{"FailedToApply", policies.FailedToApply, "failed_to_apply"},
+		{"Offline", policies.Offline, "offline"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			mockPMgr := &mockPolicyManagerForHeartbeat{}
+			mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{
+				{
+					ID:       "test-policy",
+					Name:     "Test Policy",
+					Backend:  "pktvisor",
+					Version:  1,
+					State:    tc.state,
+					Datasets: map[string]bool{"dataset-1": true},
+				},
+			}, nil)
+
+			hb := createTestHeartbeaterWithPolicyManager(&mockBackendState{}, mockPMgr)
+			defer hb.hbTicker.Stop()
+
+			// Act
+			policyState := hb.getPolicyState()
+
+			// Assert
+			assert.Len(t, policyState, 1)
+			actualState := policyState["test-policy"]
+			assert.Equal(t, tc.expectedString, actualState.State)
+			mockPMgr.AssertExpectations(t)
+		})
+	}
+}
+
+func TestHeartbeater_SendSingleHeartbeat_WithPolicyState(t *testing.T) {
+	// Arrange
+	testTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	mockPMgr := &mockPolicyManagerForHeartbeat{}
+	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{
+		{
+			ID:         "policy-1",
+			Name:       "Test Policy 1",
+			Backend:    "pktvisor",
+			Version:    1,
+			State:      policies.Running,
+			BackendErr: "",
+			Datasets:   map[string]bool{"dataset-1": true, "dataset-2": true},
+		},
+		{
+			ID:         "policy-2",
+			Name:       "Test Policy 2",
+			Backend:    "snmp_discovery",
+			Version:    3,
+			State:      policies.FailedToApply,
+			BackendErr: "no interface match",
+			Datasets:   map[string]bool{"dataset-3": true},
+		},
+	}, nil)
+
+	backendState := &mockBackendState{
+		backendState: map[string]*backend.State{
+			"pktvisor": {
+				Status:       backend.Running,
+				RestartCount: 0,
+				LastError:    "",
+			},
+		},
+	}
+
+	hb := createTestHeartbeaterWithPolicyManager(backendState, mockPMgr)
+	defer hb.hbTicker.Stop()
+
+	var capturedPayload []byte
+	testTopic := "test/heartbeat"
+	publishFunc := func(_ context.Context, _ string, payload []byte) error {
+		capturedPayload = payload
+		return nil
+	}
+
+	ctx := context.Background()
+
+	// Act
+	hb.sendSingleHeartbeat(ctx, testTopic, publishFunc, "test-agent-id", testTime, messages.Online)
+
+	// Assert
+	require.NotNil(t, capturedPayload)
+
+	var heartbeat messages.Heartbeat
+	err := json.Unmarshal(capturedPayload, &heartbeat)
+	require.NoError(t, err)
+
+	// Verify policy state is populated
+	assert.NotNil(t, heartbeat.PolicyState)
+	assert.Len(t, heartbeat.PolicyState, 2)
+
+	// Check policy-1
+	policy1, ok := heartbeat.PolicyState["policy-1"]
+	assert.True(t, ok)
+	assert.Equal(t, "Test Policy 1", policy1.Name)
+	assert.Equal(t, "pktvisor", policy1.Backend)
+	assert.Equal(t, int32(1), policy1.Version)
+	assert.Equal(t, "running", policy1.State)
+	assert.Equal(t, "", policy1.Error)
+	assert.Len(t, policy1.Datasets, 2)
+	assert.Contains(t, policy1.Datasets, "dataset-1")
+	assert.Contains(t, policy1.Datasets, "dataset-2")
+
+	// Check policy-2
+	policy2, ok := heartbeat.PolicyState["policy-2"]
+	assert.True(t, ok)
+	assert.Equal(t, "Test Policy 2", policy2.Name)
+	assert.Equal(t, "snmp_discovery", policy2.Backend)
+	assert.Equal(t, int32(3), policy2.Version)
+	assert.Equal(t, "failed_to_apply", policy2.State)
+	assert.Equal(t, "no interface match", policy2.Error)
+	assert.Len(t, policy2.Datasets, 1)
+	assert.Contains(t, policy2.Datasets, "dataset-3")
+
+	// Verify backend state is also present
+	assert.NotNil(t, heartbeat.BackendState)
+	assert.Len(t, heartbeat.BackendState, 1)
+
+	mockPMgr.AssertExpectations(t)
+}
+
+func TestHeartbeater_SendSingleHeartbeat_WithPolicyStateError(t *testing.T) {
+	// Arrange
+	mockPMgr := &mockPolicyManagerForHeartbeat{}
+	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{}, errors.New("policy manager error"))
+
+	hb := createTestHeartbeaterWithPolicyManager(&mockBackendState{}, mockPMgr)
+	defer hb.hbTicker.Stop()
+
+	var capturedPayload []byte
+	testTopic := "test/heartbeat"
+	publishFunc := func(_ context.Context, _ string, payload []byte) error {
+		capturedPayload = payload
+		return nil
+	}
+
+	ctx := context.Background()
+	testTime := time.Now()
+
+	// Act - should not panic despite policy state error
+	hb.sendSingleHeartbeat(ctx, testTopic, publishFunc, "test-agent-id", testTime, messages.Online)
+
+	// Assert
+	require.NotNil(t, capturedPayload)
+
+	var heartbeat messages.Heartbeat
+	err := json.Unmarshal(capturedPayload, &heartbeat)
+	require.NoError(t, err)
+
+	// Verify policy state is empty but not nil
+	assert.NotNil(t, heartbeat.PolicyState)
+	assert.Empty(t, heartbeat.PolicyState)
+
+	mockPMgr.AssertExpectations(t)
+}
+
+func TestHeartbeater_SendSingleHeartbeat_WithEmptyPolicyState(t *testing.T) {
+	// Arrange
+	mockPMgr := &mockPolicyManagerForHeartbeat{}
+	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{}, nil)
+
+	hb := createTestHeartbeaterWithPolicyManager(&mockBackendState{}, mockPMgr)
+	defer hb.hbTicker.Stop()
+
+	var capturedPayload []byte
+	testTopic := "test/heartbeat"
+	publishFunc := func(_ context.Context, _ string, payload []byte) error {
+		capturedPayload = payload
+		return nil
+	}
+
+	ctx := context.Background()
+	testTime := time.Now()
+
+	// Act
+	hb.sendSingleHeartbeat(ctx, testTopic, publishFunc, "test-agent-id", testTime, messages.Online)
+
+	// Assert
+	require.NotNil(t, capturedPayload)
+
+	var heartbeat messages.Heartbeat
+	err := json.Unmarshal(capturedPayload, &heartbeat)
+	require.NoError(t, err)
+
+	// Verify policy state is empty
+	assert.NotNil(t, heartbeat.PolicyState)
+	assert.Empty(t, heartbeat.PolicyState)
+
+	mockPMgr.AssertExpectations(t)
+}
+
+func TestNewHeartbeater_WithPolicyManager(t *testing.T) {
+	// Arrange
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	backendState := &mockBackendState{}
+	mockPMgr := &mockPolicyManagerForHeartbeat{}
+
+	// Act
+	hb := newHeartbeater(logger, backendState, mockPMgr)
+
+	// Assert
+	assert.NotNil(t, hb)
+	assert.NotNil(t, hb.logger)
+	assert.NotNil(t, hb.hbTicker)
+	assert.NotNil(t, hb.heartbeatCtx)
+	assert.NotNil(t, hb.backendState)
+	assert.NotNil(t, hb.policyManager)
+	assert.Equal(t, mockPMgr, hb.policyManager)
+
+	// Clean up ticker
+	hb.hbTicker.Stop()
 }

--- a/agent/configmgr/fleet/messages/fleet_messages.go
+++ b/agent/configmgr/fleet/messages/fleet_messages.go
@@ -32,14 +32,12 @@ type BackendStateInfo struct {
 
 // PolicyStateInfo contains state information for a policy
 type PolicyStateInfo struct {
-	Name            string    `json:"name"`
-	Datasets        []string  `json:"datasets,omitempty"`
-	State           string    `json:"state"`
-	Error           string    `json:"error,omitempty"`
-	Version         int32     `json:"version"`
-	LastScrapeBytes int64     `json:"last_scrape_bytes,omitempty"`
-	LastScrapeTS    time.Time `json:"last_scrape_ts,omitempty"`
-	Backend         string    `json:"backend,omitempty"`
+	Name     string   `json:"name"`
+	Datasets []string `json:"datasets,omitempty"`
+	State    string   `json:"state"`
+	Error    string   `json:"error,omitempty"`
+	Version  int32    `json:"version,omitempty"`
+	Backend  string   `json:"backend,omitempty"`
 }
 
 // GroupStateInfo contains state information for a group

--- a/agent/policies/types.go
+++ b/agent/policies/types.go
@@ -2,7 +2,6 @@ package policies
 
 import (
 	"database/sql/driver"
-	"time"
 )
 
 // PolicyData represents a policy
@@ -16,8 +15,6 @@ type PolicyData struct {
 	Data               any
 	State              PolicyState
 	BackendErr         string
-	LastScrapeBytes    int64
-	LastScrapeTS       time.Time
 	PreviousPolicyData *PolicyData
 }
 

--- a/agent/policies/types.go
+++ b/agent/policies/types.go
@@ -36,7 +36,6 @@ const (
 	Running
 	FailedToApply
 	Offline
-	NoTapMatch
 )
 
 // PolicyState represents the state of a policy
@@ -47,7 +46,6 @@ var policyStateMap = [...]string{
 	"running",
 	"failed_to_apply",
 	"offline",
-	"no_tap_match",
 }
 
 var policyStateRevMap = map[string]PolicyState{
@@ -55,7 +53,6 @@ var policyStateRevMap = map[string]PolicyState{
 	"running":         Running,
 	"failed_to_apply": FailedToApply,
 	"offline":         Offline,
-	"no_tap_match":    NoTapMatch,
 }
 
 func (s PolicyState) String() string {

--- a/agent/policies/types_test.go
+++ b/agent/policies/types_test.go
@@ -18,7 +18,6 @@ func TestPolicyStateString(t *testing.T) {
 		{policies.Running, "running"},
 		{policies.FailedToApply, "failed_to_apply"},
 		{policies.Offline, "offline"},
-		{policies.NoTapMatch, "no_tap_match"},
 	}
 
 	for _, tc := range testCases {
@@ -35,7 +34,6 @@ func TestPolicyStateScan(t *testing.T) {
 		{[]byte("running"), policies.Running},
 		{[]byte("failed_to_apply"), policies.FailedToApply},
 		{[]byte("offline"), policies.Offline},
-		{[]byte("no_tap_match"), policies.NoTapMatch},
 	}
 
 	for _, tc := range testCases {
@@ -56,7 +54,6 @@ func TestPolicyStateValue(t *testing.T) {
 		{policies.Running, "running"},
 		{policies.FailedToApply, "failed_to_apply"},
 		{policies.Offline, "offline"},
-		{policies.NoTapMatch, "no_tap_match"},
 	}
 
 	for _, tc := range testCases {

--- a/agent/policymgr/manager.go
+++ b/agent/policymgr/manager.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/config"
@@ -207,12 +206,7 @@ func (a *policyManager) applyPolicy(payload config.PolicyPayload, be backend.Bac
 	err := be.ApplyPolicy(*pd, updatePolicy)
 	if err != nil {
 		a.logger.Warn("policy failed to apply", slog.String("policy_id", payload.ID), slog.String("policy_name", payload.Name), slog.Any("error", err))
-		switch {
-		case strings.Contains(err.Error(), "422"):
-			pd.State = policies.NoTapMatch
-		default:
-			pd.State = policies.FailedToApply
-		}
+		pd.State = policies.FailedToApply
 		pd.BackendErr = err.Error()
 	} else {
 		a.logger.Info("policy applied successfully", slog.String("policy_id", payload.ID), slog.String("policy_name", payload.Name))


### PR DESCRIPTION
This pull request enhances the agent's heartbeat mechanism to include detailed policy state information in the heartbeat payloads. It introduces a new integration between the heartbeater and the policy manager, ensuring that the current state of all managed policies is reported with each heartbeat. The update also includes comprehensive unit tests for the new functionality and cleans up some legacy fields.

Key changes:

**Heartbeat Payload Enhancements:**

* The `heartbeater` now queries the `PolicyManager` for current policy states and includes this information in the `PolicyState` field of each heartbeat message, replacing the previous placeholder with actual policy data. (`agent/configmgr/fleet/heartbeats.go`, `agent/configmgr/fleet/connection.go`, [[1]](diffhunk://#diff-796a5a43e9dd714c20b0d1863be358a6f2b4f3d5035e9ab9c4303f61fb2f24f2L44-R47) [[2]](diffhunk://#diff-1783db06b73b72c164682aec902cffc352ef29c1eee8cd92929e7637e72f8047L32-R32)
* The `PolicyStateInfo` struct in `fleet_messages.go` is simplified, removing unused fields (`LastScrapeBytes`, `LastScrapeTS`) and making `Version` optional, to better reflect the actual policy data. (`agent/configmgr/fleet/messages/fleet_messages.go`, [agent/configmgr/fleet/messages/fleet_messages.goL39-R39](diffhunk://#diff-593a16290809c4abe2c77d31d9f8c4517d5f81da75110e1e7b8acf2f8ee5eaa2L39-R39))
* The `PolicyData` struct in `policies/types.go` is updated to remove the now-unused scrape fields. (`agent/policies/types.go`, [agent/policies/types.goL19-L20](diffhunk://#diff-3756c4912ae518f3709738a5a117bb71904dce0f6558faa03d75f5bbad152c4fL19-L20))

**Heartbeater and PolicyManager Integration:**

* The `heartbeater` struct now holds a reference to the `PolicyManager`, and its constructor and related calls are updated accordingly. (`agent/configmgr/fleet/heartbeats.go`, `agent/configmgr/fleet/connection.go`, [[1]](diffhunk://#diff-796a5a43e9dd714c20b0d1863be358a6f2b4f3d5035e9ab9c4303f61fb2f24f2R23-R32) [[2]](diffhunk://#diff-1783db06b73b72c164682aec902cffc352ef29c1eee8cd92929e7637e72f8047L32-R32)
* The `getPolicyState` method is added to the `heartbeater`, which retrieves policy states and logs errors if retrieval fails, ensuring robust error handling. (`agent/configmgr/fleet/heartbeats.go`, [agent/configmgr/fleet/heartbeats.goR80-R99](diffhunk://#diff-796a5a43e9dd714c20b0d1863be358a6f2b4f3d5035e9ab9c4303f61fb2f24f2R80-R99))

**Testing Improvements:**

* Extensive unit tests are added for the new policy state reporting, covering success, error, empty, and all policy state scenarios, as well as integration with the heartbeat payload. (`agent/configmgr/fleet/heartbeats_test.go`, [[1]](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72R33-R105) [[2]](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72R708-R1027)
* A mock implementation of `PolicyManager` is introduced for testing purposes. (`agent/configmgr/fleet/heartbeats_test.go`, [agent/configmgr/fleet/heartbeats_test.goR33-R105](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72R33-R105))

**Other Cleanups:**

* Removes unnecessary imports and legacy handling logic, such as string matching for error codes in policy application. (`agent/policymgr/manager.go`, [[1]](diffhunk://#diff-0f9fcdb61f9ab8b82a1bcda4a290fef646aa62d5b387480feef469dc3b1bf1f0L7) [[2]](diffhunk://#diff-0f9fcdb61f9ab8b82a1bcda4a290fef646aa62d5b387480feef469dc3b1bf1f0L210-L215)
* Minor adjustments to imports to support new test and policy manager functionality. (`agent/configmgr/fleet/heartbeats.go`, [agent/configmgr/fleet/heartbeats_test.goR18-R20](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72R18-R20))

These changes collectively improve the observability and reliability of policy management reporting in the agent's heartbeat messages.