### PR TITLE
chore: improve logs readability for each backend

### DIFF
--- a/agent/backend/devicediscovery/device_discovery.go
+++ b/agent/backend/devicediscovery/device_discovery.go
@@ -22,7 +22,6 @@ const (
 	versionTimeout      = 2
 	capabilitiesTimeout = 5
 	readinessBackoff    = 10
-	readinessTimeout    = 10
 	applyPolicyTimeout  = 10
 	removePolicyTimeout = 20
 	defaultExec         = "device-discovery"
@@ -71,7 +70,7 @@ func Register() bool {
 func (d *deviceDiscoveryBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	config map[string]any, common config.BackendCommons,
 ) error {
-	d.logger = logger
+	d.logger = logger.With(slog.String("backend", "device_discovery"))
 	d.policyRepo = repo
 
 	var prs bool
@@ -186,13 +185,13 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 					stdout = nil
 					continue
 				}
-				d.logger.Info("device-discovery stdout", slog.String("log", line))
+				d.logger.Info(line)
 			case line, open := <-stderr:
 				if !open {
 					stderr = nil
 					continue
 				}
-				d.logger.Info("device-discovery stderr", slog.String("log", line))
+				d.logger.Error(line)
 			}
 		}
 	}()

--- a/agent/backend/networkdiscovery/network_discovery.go
+++ b/agent/backend/networkdiscovery/network_discovery.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sort"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -22,7 +24,6 @@ const (
 	versionTimeout      = 2
 	capabilitiesTimeout = 5
 	readinessBackoff    = 10
-	readinessTimeout    = 10
 	applyPolicyTimeout  = 10
 	removePolicyTimeout = 20
 	defaultExec         = "network-discovery"
@@ -72,7 +73,7 @@ func Register() bool {
 func (d *networkDiscoveryBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	config map[string]any, common config.BackendCommons,
 ) error {
-	d.logger = logger
+	d.logger = logger.With(slog.String("backend", "network_discovery"))
 	d.policyRepo = repo
 
 	var prs bool
@@ -206,13 +207,13 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 					stdout = nil
 					continue
 				}
-				d.logger.Info("network-discovery stdout", slog.String("log", line))
+				d.logNetworkDiscoveryOutput(line, slog.LevelInfo)
 			case line, open := <-stderr:
 				if !open {
 					stderr = nil
 					continue
 				}
-				d.logger.Info("network-discovery stderr", slog.String("log", line))
+				d.logNetworkDiscoveryOutput(line, slog.LevelError)
 			}
 		}
 	}()
@@ -269,6 +270,30 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 	}
 
 	return nil
+}
+
+func (d *networkDiscoveryBackend) logNetworkDiscoveryOutput(line string, fallback slog.Level) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return
+	}
+
+	msg := trimmed
+	attrs := []slog.Attr(nil)
+	level := fallback
+
+	if parsedMsg, parsedAttrs, parsedLevel, ok := normalizeNetworkDiscoveryLine(trimmed, fallback); ok {
+		msg = parsedMsg
+		attrs = parsedAttrs
+		level = parsedLevel
+	}
+
+	ctx := d.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	d.logger.LogAttrs(ctx, level, msg, attrs...)
 }
 
 func (d *networkDiscoveryBackend) Stop(ctx context.Context) error {
@@ -386,4 +411,162 @@ func (d *networkDiscoveryBackend) RemovePolicy(data policies.PolicyData) error {
 		return err
 	}
 	return nil
+}
+
+func normalizeNetworkDiscoveryLine(line string, fallback slog.Level) (string, []slog.Attr, slog.Level, bool) {
+	fields, ok := parseNetworkDiscoveryLogfmt(line)
+	if !ok {
+		return "", nil, fallback, false
+	}
+
+	msg, ok := fields["msg"]
+	if !ok || strings.TrimSpace(msg) == "" {
+		return "", nil, fallback, false
+	}
+
+	level := fallback
+	if lvlValue, exists := fields["level"]; exists {
+		if parsedLevel, levelOK := parseNetworkDiscoveryLevel(lvlValue); levelOK {
+			level = parsedLevel
+		}
+	}
+
+	delete(fields, "msg")
+	delete(fields, "level")
+	delete(fields, "time")
+
+	if len(fields) == 0 {
+		return msg, nil, level, true
+	}
+
+	keys := make([]string, 0, len(fields))
+	for key := range fields {
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+		keys = append(keys, key)
+	}
+
+	if len(keys) == 0 {
+		return msg, nil, level, true
+	}
+
+	sort.Strings(keys)
+
+	attrs := make([]slog.Attr, 0, len(keys))
+	for _, key := range keys {
+		attrs = append(attrs, slog.String(key, fields[key]))
+	}
+
+	return msg, attrs, level, true
+}
+
+func parseNetworkDiscoveryLevel(value string) (slog.Level, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "debug":
+		return slog.LevelDebug, true
+	case "info":
+		return slog.LevelInfo, true
+	case "warn", "warning":
+		return slog.LevelWarn, true
+	case "error", "err":
+		return slog.LevelError, true
+	default:
+		return 0, false
+	}
+}
+
+func parseNetworkDiscoveryLogfmt(line string) (map[string]string, bool) {
+	result := make(map[string]string)
+	runes := []rune(line)
+	length := len(runes)
+	index := 0
+
+	for index < length {
+		for index < length && runes[index] == ' ' {
+			index++
+		}
+		if index >= length {
+			break
+		}
+
+		keyStart := index
+		for index < length && runes[index] != '=' && runes[index] != ' ' {
+			index++
+		}
+		if index >= length || runes[index] != '=' {
+			return nil, false
+		}
+
+		key := strings.TrimSpace(string(runes[keyStart:index]))
+		index++ // skip '='
+
+		value, nextIndex, ok := readLogfmtValue(runes, index)
+		if !ok {
+			return nil, false
+		}
+
+		result[key] = value
+		index = nextIndex
+	}
+
+	if len(result) == 0 {
+		return nil, false
+	}
+
+	return result, true
+}
+
+func readLogfmtValue(runes []rune, start int) (string, int, bool) {
+	length := len(runes)
+	if start >= length {
+		return "", start, true
+	}
+
+	switch runes[start] {
+	case '"', '\'':
+		return readQuotedValue(runes, start)
+	default:
+		return readUnquotedValue(runes, start)
+	}
+}
+
+func readQuotedValue(runes []rune, start int) (string, int, bool) {
+	length := len(runes)
+	quote := runes[start]
+	index := start + 1
+	var builder strings.Builder
+
+	for index < length {
+		char := runes[index]
+		if char == '\\' && index+1 < length {
+			builder.WriteRune(runes[index+1])
+			index += 2
+			continue
+		}
+		if char == quote {
+			index++
+			for index < length && runes[index] == ' ' {
+				index++
+			}
+			return builder.String(), index, true
+		}
+		builder.WriteRune(char)
+		index++
+	}
+
+	return "", length, false
+}
+
+func readUnquotedValue(runes []rune, start int) (string, int, bool) {
+	length := len(runes)
+	index := start
+	for index < length && runes[index] != ' ' {
+		index++
+	}
+	value := string(runes[start:index])
+	for index < length && runes[index] == ' ' {
+		index++
+	}
+	return value, index, true
 }

--- a/agent/backend/opentelemetryinfinity/opentelemetry_infinity.go
+++ b/agent/backend/opentelemetryinfinity/opentelemetry_infinity.go
@@ -3,7 +3,6 @@ package opentelemetryinfinity
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -66,7 +65,7 @@ func Register() bool {
 func (o *openTelemetryBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	config map[string]any, common config.BackendCommons,
 ) error {
-	o.logger = logger
+	o.logger = logger.With(slog.String("backend", "opentelemetry_infinity"))
 	o.policyRepo = repo
 
 	var prs bool
@@ -135,13 +134,13 @@ func (o *openTelemetryBackend) Start(ctx context.Context, cancelFunc context.Can
 					stdout = nil
 					continue
 				}
-				o.logCollectorLine("stdout", line)
+				o.logger.Info(line)
 			case line, open := <-stderr:
 				if !open {
 					stderr = nil
 					continue
 				}
-				o.logCollectorLine("stderr", line)
+				o.logger.Error(line)
 			}
 		}
 	}()
@@ -198,16 +197,6 @@ func (o *openTelemetryBackend) Start(ctx context.Context, cancelFunc context.Can
 	}
 
 	return nil
-}
-
-func (o *openTelemetryBackend) logCollectorLine(stream, line string) {
-	logKey := fmt.Sprintf("opentelemetry infinity %s", stream)
-	raw := []byte(line)
-	if json.Valid(raw) {
-		o.logger.Info(logKey, slog.Any("log", json.RawMessage(raw)))
-		return
-	}
-	o.logger.Info(logKey, slog.String("log", line))
 }
 
 func (o *openTelemetryBackend) Stop(ctx context.Context) error {

--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -29,7 +30,6 @@ const (
 	applyPolicyTimeout  = 10
 	removePolicyTimeout = 20
 	versionTimeout      = 2
-	scrapeTimeout       = 5
 	tapsTimeout         = 5
 	defaultAPIHost      = "localhost"
 	defaultAPIPort      = "10853"
@@ -160,13 +160,13 @@ func (p *pktvisorBackend) Start(ctx context.Context, cancelFunc context.CancelFu
 					stdout = nil
 					continue
 				}
-				p.logger.Info("pktvisor stdout", slog.String("log", line))
+				p.logPktvisorOutput(line, slog.LevelInfo)
 			case line, open := <-stderr:
 				if !open {
 					stderr = nil
 					continue
 				}
-				p.logger.Info("pktvisor stderr", slog.String("log", line))
+				p.logPktvisorOutput(line, slog.LevelError)
 			}
 		}
 	}()
@@ -227,6 +227,90 @@ func (p *pktvisorBackend) Start(ctx context.Context, cancelFunc context.CancelFu
 	return nil
 }
 
+func (p *pktvisorBackend) logPktvisorOutput(line string, level slog.Level) {
+	if strings.TrimSpace(line) == "" {
+		return
+	}
+
+	msg, attrs := normalizePktvisorLine(line)
+	if msg == "" {
+		msg = line
+	}
+
+	ctx := p.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	p.logger.LogAttrs(ctx, level, msg, attrs...)
+}
+
+func normalizePktvisorLine(line string) (string, []slog.Attr) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return "", nil
+	}
+
+	cleaned := stripPktvisorPrefix(trimmed)
+	if cleaned == "" {
+		cleaned = trimmed
+	}
+
+	msg := cleaned
+	attrs := make([]slog.Attr, 0, 2)
+
+	if entity, name, rest, ok := parsePktvisorEntity(cleaned); ok {
+		attrs = append(attrs, slog.String(entity, name))
+		if rest != "" {
+			msg = fmt.Sprintf("%s %s", entity, rest)
+		} else {
+			msg = entity
+		}
+	}
+
+	return msg, attrs
+}
+
+func stripPktvisorPrefix(line string) string {
+	trimmed := strings.TrimSpace(line)
+	for strings.HasPrefix(trimmed, "[") {
+		closeIdx := strings.Index(trimmed, "]")
+		if closeIdx == -1 {
+			break
+		}
+		trimmed = strings.TrimSpace(trimmed[closeIdx+1:])
+	}
+	return trimmed
+}
+
+func parsePktvisorEntity(line string) (entity, name, rest string, ok bool) {
+	for _, candidate := range []string{"tap", "policy"} {
+		prefix := candidate + " ["
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+
+		remainder := line[len(prefix):]
+		closeIdx := strings.Index(remainder, "]")
+		if closeIdx == -1 {
+			return "", "", "", false
+		}
+
+		name = remainder[:closeIdx]
+		rest = strings.TrimSpace(remainder[closeIdx+1:])
+		rest = strings.TrimPrefix(rest, ":")
+		rest = strings.TrimSpace(rest)
+
+		if name != "" {
+			return candidate, name, rest, true
+		}
+
+		return "", "", "", false
+	}
+
+	return "", "", "", false
+}
+
 func (p *pktvisorBackend) Stop(ctx context.Context) error {
 	p.logger.Info("routine call to stop pktvisor", slog.Any("routine", ctx.Value(config.ContextKey("routine"))))
 	defer p.cancelFunc()
@@ -245,7 +329,7 @@ func (p *pktvisorBackend) Stop(ctx context.Context) error {
 func (p *pktvisorBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	config map[string]any, common config.BackendCommons,
 ) error {
-	p.logger = logger
+	p.logger = logger.With(slog.String("backend", "pktvisor"))
 	p.policyRepo = repo
 
 	p.binary = defaultBinary

--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -22,7 +22,6 @@ const (
 	versionTimeout      = 2
 	capabilitiesTimeout = 5
 	readinessBackoff    = 10
-	readinessTimeout    = 10
 	applyPolicyTimeout  = 10
 	removePolicyTimeout = 20
 	defaultExec         = "snmp-discovery"
@@ -72,7 +71,7 @@ func Register() bool {
 func (d *snmpDiscoveryBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	config map[string]any, common config.BackendCommons,
 ) error {
-	d.logger = logger
+	d.logger = logger.With(slog.String("backend", "snmp_discovery"))
 	d.policyRepo = repo
 
 	var prs bool
@@ -200,13 +199,13 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 					stdout = nil
 					continue
 				}
-				d.logger.Info("snmp-discovery stdout", slog.String("log", line))
+				d.logger.Info(line)
 			case line, open := <-stderr:
 				if !open {
 					stderr = nil
 					continue
 				}
-				d.logger.Info("snmp-discovery stderr", slog.String("log", line))
+				d.logger.Error(line)
 			}
 		}
 	}()

--- a/agent/backend/worker/worker.go
+++ b/agent/backend/worker/worker.go
@@ -22,7 +22,6 @@ const (
 	versionTimeout      = 2
 	capabilitiesTimeout = 5
 	readinessBackoff    = 10
-	readinessTimeout    = 10
 	applyPolicyTimeout  = 10
 	removePolicyTimeout = 20
 	defaultExec         = "orb-worker"

--- a/agent/backend/worker/worker.go
+++ b/agent/backend/worker/worker.go
@@ -70,7 +70,7 @@ func Register() bool {
 func (d *workerBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	config map[string]any, common config.BackendCommons,
 ) error {
-	d.logger = logger
+	d.logger = logger.With(slog.String("backend", "worker"))
 	d.policyRepo = repo
 
 	var prs bool

--- a/agent/policymgr/manager.go
+++ b/agent/policymgr/manager.go
@@ -205,11 +205,13 @@ func (a *policyManager) RemovePolicyDataset(policyID string, datasetID string, b
 func (a *policyManager) applyPolicy(payload config.PolicyPayload, be backend.Backend, pd *policies.PolicyData, updatePolicy bool) {
 	err := be.ApplyPolicy(*pd, updatePolicy)
 	if err != nil {
-		a.logger.Warn("policy failed to apply", slog.String("policy_id", payload.ID), slog.String("policy_name", payload.Name), slog.Any("error", err))
+		a.logger.Warn("policy failed to apply", slog.String("policy_id", payload.ID), slog.String("policy_name", payload.Name),
+			slog.String("backend", pd.Backend), slog.Any("error", err))
 		pd.State = policies.FailedToApply
 		pd.BackendErr = err.Error()
 	} else {
-		a.logger.Info("policy applied successfully", slog.String("policy_id", payload.ID), slog.String("policy_name", payload.Name))
+		a.logger.Info("policy applied successfully", slog.String("policy_id", payload.ID), slog.String("policy_name", payload.Name),
+			slog.String("backend", pd.Backend))
 		pd.State = policies.Running
 		pd.BackendErr = ""
 	}


### PR DESCRIPTION
This pull request enhances logging consistency and clarity across several backend components, introduces improved log parsing for `pktvisor` and `networkdiscovery`, and removes unused or redundant timeouts. The most significant changes are the normalization and structured logging of subprocess outputs, which will make logs easier to analyze and debug.

**Logging improvements and normalization:**

* Added backend-specific context to logger initialization in all backends for clearer log attribution (`device_discovery.go`, `network_discovery.go`, `snmp_discovery.go`, `pktvisor.go`, `opentelemetry_infinity.go`). [[1]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L74-R73) [[2]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L75-R76) [[3]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91L75-R74) [[4]](diffhunk://#diff-a3efed70ceda5dfeee2a24c126eae9180ce3866c316f85a0b436c0fadae66c19L248-R332) [[5]](diffhunk://#diff-4f8fe6510b95d5f5cdbdd374873257ed0d9c97e9832444329d7cc35cea08e041L69-R68)
* Changed logging of subprocess output in `pktvisor` and `networkdiscovery` backends to use new normalization functions, extracting structured attributes and improving message clarity. [[1]](diffhunk://#diff-a3efed70ceda5dfeee2a24c126eae9180ce3866c316f85a0b436c0fadae66c19L163-R169) [[2]](diffhunk://#diff-a3efed70ceda5dfeee2a24c126eae9180ce3866c316f85a0b436c0fadae66c19R230-R313) [[3]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L209-R216) [[4]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854R275-R298) [[5]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854R415-R572)
* Simplified subprocess output logging in `device_discovery`, `snmp_discovery`, and `opentelemetry_infinity` backends to log raw lines at appropriate log levels, removing unnecessary wrappers and JSON handling. [[1]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L189-R194) [[2]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91L203-R208) [[3]](diffhunk://#diff-4f8fe6510b95d5f5cdbdd374873257ed0d9c97e9832444329d7cc35cea08e041L138-R143) [[4]](diffhunk://#diff-4f8fe6510b95d5f5cdbdd374873257ed0d9c97e9832444329d7cc35cea08e041L203-L212)

**Timeout cleanup:**

* Removed unused `readinessTimeout` and `scrapeTimeout` constants from backend files, improving code clarity. [[1]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L25) [[2]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L25) [[3]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91L25) [[4]](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcL25) [[5]](diffhunk://#diff-a3efed70ceda5dfeee2a24c126eae9180ce3866c316f85a0b436c0fadae66c19L32)

**Policy manager logging:**

* Enhanced policy application logging to include backend name for better traceability.

**Dependency and import adjustments:**

* Removed unused `encoding/json` import from `opentelemetry_infinity.go` and added necessary imports for new log parsing logic. [[1]](diffhunk://#diff-4f8fe6510b95d5f5cdbdd374873257ed0d9c97e9832444329d7cc35cea08e041L6) [[2]](diffhunk://#diff-a3efed70ceda5dfeee2a24c126eae9180ce3866c316f85a0b436c0fadae66c19R14) [[3]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854R10-R11)

These changes collectively improve the maintainability and usefulness of logs, making it easier to diagnose issues and trace events across different backends.