### PR TITLE
chore: improve readability of python backends logs

### DIFF
--- a/agent/backend/devicediscovery/device_discovery.go
+++ b/agent/backend/devicediscovery/device_discovery.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -185,13 +186,13 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 					stdout = nil
 					continue
 				}
-				d.logger.Info(line)
+				d.logDeviceDiscoveryOutput(line, slog.LevelInfo)
 			case line, open := <-stderr:
 				if !open {
 					stderr = nil
 					continue
 				}
-				d.logger.Error(line)
+				d.logDeviceDiscoveryOutput(line, slog.LevelError)
 			}
 		}
 	}()
@@ -248,6 +249,30 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 	}
 
 	return nil
+}
+
+func (d *deviceDiscoveryBackend) logDeviceDiscoveryOutput(line string, fallback slog.Level) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return
+	}
+
+	msg := trimmed
+	attrs := []slog.Attr(nil)
+	level := fallback
+
+	if parsedMsg, parsedAttrs, parsedLevel, ok := normalizeDeviceDiscoveryLine(trimmed, fallback); ok {
+		msg = parsedMsg
+		attrs = parsedAttrs
+		level = parsedLevel
+	}
+
+	ctx := d.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	d.logger.LogAttrs(ctx, level, msg, attrs...)
 }
 
 func (d *deviceDiscoveryBackend) Stop(ctx context.Context) error {
@@ -366,4 +391,68 @@ func (d *deviceDiscoveryBackend) RemovePolicy(data policies.PolicyData) error {
 		return err
 	}
 	return nil
+}
+
+func normalizeDeviceDiscoveryLine(line string, fallback slog.Level) (string, []slog.Attr, slog.Level, bool) {
+	firstColon := strings.Index(line, ":")
+	if firstColon <= 0 {
+		return "", nil, fallback, false
+	}
+
+	levelCandidate := strings.TrimSpace(line[:firstColon])
+	level, ok := parseDeviceDiscoveryLevel(levelCandidate)
+	if !ok {
+		return "", nil, fallback, false
+	}
+
+	remainder := strings.TrimSpace(line[firstColon+1:])
+	if remainder == "" {
+		return strings.TrimSpace(line), nil, level, true
+	}
+
+	var attrs []slog.Attr
+	message := remainder
+
+	if secondColon := strings.Index(remainder, ":"); secondColon >= 0 {
+		moduleCandidate := strings.TrimSpace(remainder[:secondColon])
+		rest := strings.TrimSpace(remainder[secondColon+1:])
+
+		if moduleCandidate != "" && !strings.ContainsAny(moduleCandidate, " \t") {
+			attrs = append(attrs, slog.String("module", moduleCandidate))
+			if rest != "" {
+				message = rest
+			} else {
+				message = remainder
+			}
+		}
+	}
+
+	if message == "" {
+		message = strings.TrimSpace(line)
+	}
+
+	if message == "" {
+		return "", nil, level, false
+	}
+
+	return message, attrs, level, true
+}
+
+func parseDeviceDiscoveryLevel(value string) (slog.Level, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "trace":
+		return slog.LevelDebug, true
+	case "debug":
+		return slog.LevelDebug, true
+	case "info":
+		return slog.LevelInfo, true
+	case "warn", "warning":
+		return slog.LevelWarn, true
+	case "error", "err", "exception":
+		return slog.LevelError, true
+	case "critical", "fatal":
+		return slog.LevelError, true
+	default:
+		return 0, false
+	}
 }

--- a/agent/backend/worker/worker.go
+++ b/agent/backend/worker/worker.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -185,13 +186,13 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 					stdout = nil
 					continue
 				}
-				d.logger.Info("worker stdout", slog.String("log", line))
+				d.logWorkerOutput(line, slog.LevelInfo)
 			case line, open := <-stderr:
 				if !open {
 					stderr = nil
 					continue
 				}
-				d.logger.Info("worker stderr", slog.String("log", line))
+				d.logWorkerOutput(line, slog.LevelError)
 			}
 		}
 	}()
@@ -285,6 +286,30 @@ func (d *workerBackend) GetStartTime() time.Time {
 	return d.startTime
 }
 
+func (d *workerBackend) logWorkerOutput(line string, fallback slog.Level) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return
+	}
+
+	msg := trimmed
+	attrs := []slog.Attr(nil)
+	level := fallback
+
+	if parsedMsg, parsedAttrs, parsedLevel, ok := normalizeWorkerLine(trimmed, fallback); ok {
+		msg = parsedMsg
+		attrs = parsedAttrs
+		level = parsedLevel
+	}
+
+	ctx := d.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	d.logger.LogAttrs(ctx, level, msg, attrs...)
+}
+
 func (d *workerBackend) GetCapabilities() (map[string]any, error) {
 	caps := make(map[string]any)
 	url := fmt.Sprintf("%s://%s:%s/api/v1/capabilities", d.apiProtocol, d.apiHost, d.apiPort)
@@ -367,4 +392,68 @@ func (d *workerBackend) RemovePolicy(data policies.PolicyData) error {
 		return err
 	}
 	return nil
+}
+
+func normalizeWorkerLine(line string, fallback slog.Level) (string, []slog.Attr, slog.Level, bool) {
+	firstColon := strings.Index(line, ":")
+	if firstColon <= 0 {
+		return "", nil, fallback, false
+	}
+
+	levelCandidate := strings.TrimSpace(line[:firstColon])
+	level, ok := parseWorkerLevel(levelCandidate)
+	if !ok {
+		return "", nil, fallback, false
+	}
+
+	remainder := strings.TrimSpace(line[firstColon+1:])
+	if remainder == "" {
+		return strings.TrimSpace(line), nil, level, true
+	}
+
+	var attrs []slog.Attr
+	message := remainder
+
+	if secondColon := strings.Index(remainder, ":"); secondColon >= 0 {
+		moduleCandidate := strings.TrimSpace(remainder[:secondColon])
+		rest := strings.TrimSpace(remainder[secondColon+1:])
+
+		if moduleCandidate != "" && !strings.ContainsAny(moduleCandidate, " \t") {
+			attrs = append(attrs, slog.String("module", moduleCandidate))
+			if rest != "" {
+				message = rest
+			} else {
+				message = remainder
+			}
+		}
+	}
+
+	if message == "" {
+		message = strings.TrimSpace(line)
+	}
+
+	if message == "" {
+		return "", nil, level, false
+	}
+
+	return message, attrs, level, true
+}
+
+func parseWorkerLevel(value string) (slog.Level, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "trace":
+		return slog.LevelDebug, true
+	case "debug":
+		return slog.LevelDebug, true
+	case "info":
+		return slog.LevelInfo, true
+	case "warn", "warning":
+		return slog.LevelWarn, true
+	case "error", "err", "exception":
+		return slog.LevelError, true
+	case "critical", "fatal":
+		return slog.LevelError, true
+	default:
+		return 0, false
+	}
 }


### PR DESCRIPTION
This pull request introduces improved structured logging for both device discovery and worker backends. Instead of logging raw lines from subprocess output, the code now parses log lines for log level and module information, and logs them with appropriate structure and severity. This enhances log readability and makes it easier to filter and analyze logs.

The most important changes are:

**Structured Logging Enhancements:**

* Added `logDeviceDiscoveryOutput` and `logWorkerOutput` helper methods to parse and log lines with detected log level and module, falling back to default log levels if parsing fails. [[1]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L188-R195) [[2]](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcL188-R195) [[3]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02R254-R277) [[4]](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcR289-R312)
* Introduced `normalizeDeviceDiscoveryLine`/`normalizeWorkerLine` and corresponding level parsers to extract log level, module, and message from output lines, supporting common log level keywords. [[1]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02R395-R458) [[2]](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcR396-R459)

**Code Maintenance:**

* Updated imports in both `device_discovery.go` and `worker.go` to include the `strings` package, required for the new parsing logic. [[1]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02R10) [[2]](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcR10)

These changes make the logging output more consistent and structured, facilitating better monitoring and troubleshooting.