### PR TITLE
chore: improve logs for snmp discovery backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Only the `network_discovery`, `device_discovery`, `worker` and `snmp_discovery` 
 - [Worker](./docs/backends/worker.md)
 - [SNMP Discovery](./docs/backends/snmp_discovery.md)
 
-### Observability Backends
+#### Observability Backends
 Observability backends focus on collecting and exporting rich telemetry from network traffic or probes so you can feed metrics into your monitoring stack.
 
 - [pktvisor](./docs/backends/pktvisor.md)

--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sort"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -199,13 +201,13 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 					stdout = nil
 					continue
 				}
-				d.logger.Info(line)
+				d.logSnmpDiscoveryOutput(line, slog.LevelInfo)
 			case line, open := <-stderr:
 				if !open {
 					stderr = nil
 					continue
 				}
-				d.logger.Error(line)
+				d.logSnmpDiscoveryOutput(line, slog.LevelError)
 			}
 		}
 	}()
@@ -362,6 +364,188 @@ func (d *snmpDiscoveryBackend) ApplyPolicy(data policies.PolicyData, updatePolic
 	}
 
 	return nil
+}
+
+func (d *snmpDiscoveryBackend) logSnmpDiscoveryOutput(line string, fallback slog.Level) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return
+	}
+
+	msg := trimmed
+	attrs := []slog.Attr(nil)
+	level := fallback
+
+	if parsedMsg, parsedAttrs, parsedLevel, ok := normalizeSnmpDiscoveryLine(trimmed, fallback); ok {
+		msg = parsedMsg
+		attrs = parsedAttrs
+		level = parsedLevel
+	}
+
+	ctx := d.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	d.logger.LogAttrs(ctx, level, msg, attrs...)
+}
+
+func normalizeSnmpDiscoveryLine(line string, fallback slog.Level) (string, []slog.Attr, slog.Level, bool) {
+	fields, ok := parseSnmpDiscoveryLogfmt(line)
+	if !ok {
+		return "", nil, fallback, false
+	}
+
+	msg, ok := fields["msg"]
+	if !ok || strings.TrimSpace(msg) == "" {
+		return "", nil, fallback, false
+	}
+
+	level := fallback
+	if lvlValue, exists := fields["level"]; exists {
+		if parsedLevel, levelOK := parseSnmpDiscoveryLevel(lvlValue); levelOK {
+			level = parsedLevel
+		}
+	}
+
+	delete(fields, "msg")
+	delete(fields, "level")
+	delete(fields, "time")
+
+	if len(fields) == 0 {
+		return msg, nil, level, true
+	}
+
+	keys := make([]string, 0, len(fields))
+	for key := range fields {
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+		keys = append(keys, key)
+	}
+
+	if len(keys) == 0 {
+		return msg, nil, level, true
+	}
+
+	sort.Strings(keys)
+
+	attrs := make([]slog.Attr, 0, len(keys))
+	for _, key := range keys {
+		attrs = append(attrs, slog.String(key, fields[key]))
+	}
+
+	return msg, attrs, level, true
+}
+
+func parseSnmpDiscoveryLevel(value string) (slog.Level, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "debug":
+		return slog.LevelDebug, true
+	case "info":
+		return slog.LevelInfo, true
+	case "warn", "warning":
+		return slog.LevelWarn, true
+	case "error", "err":
+		return slog.LevelError, true
+	default:
+		return 0, false
+	}
+}
+
+func parseSnmpDiscoveryLogfmt(line string) (map[string]string, bool) {
+	result := make(map[string]string)
+	runes := []rune(line)
+	length := len(runes)
+	index := 0
+
+	for index < length {
+		for index < length && runes[index] == ' ' {
+			index++
+		}
+		if index >= length {
+			break
+		}
+
+		keyStart := index
+		for index < length && runes[index] != '=' && runes[index] != ' ' {
+			index++
+		}
+		if index >= length || runes[index] != '=' {
+			return nil, false
+		}
+
+		key := strings.TrimSpace(string(runes[keyStart:index]))
+		index++ // skip '='
+
+		value, nextIndex, ok := readSnmpLogfmtValue(runes, index)
+		if !ok {
+			return nil, false
+		}
+
+		result[key] = value
+		index = nextIndex
+	}
+
+	if len(result) == 0 {
+		return nil, false
+	}
+
+	return result, true
+}
+
+func readSnmpLogfmtValue(runes []rune, start int) (string, int, bool) {
+	length := len(runes)
+	if start >= length {
+		return "", start, true
+	}
+
+	switch runes[start] {
+	case '"', '\'':
+		return readSnmpQuotedValue(runes, start)
+	default:
+		return readSnmpUnquotedValue(runes, start)
+	}
+}
+
+func readSnmpQuotedValue(runes []rune, start int) (string, int, bool) {
+	length := len(runes)
+	quote := runes[start]
+	index := start + 1
+	var builder strings.Builder
+
+	for index < length {
+		char := runes[index]
+		if char == '\\' && index+1 < length {
+			builder.WriteRune(runes[index+1])
+			index += 2
+			continue
+		}
+		if char == quote {
+			index++
+			for index < length && runes[index] == ' ' {
+				index++
+			}
+			return builder.String(), index, true
+		}
+		builder.WriteRune(char)
+		index++
+	}
+
+	return "", length, false
+}
+
+func readSnmpUnquotedValue(runes []rune, start int) (string, int, bool) {
+	length := len(runes)
+	index := start
+	for index < length && runes[index] != ' ' {
+		index++
+	}
+	value := string(runes[start:index])
+	for index < length && runes[index] == ' ' {
+		index++
+	}
+	return value, index, true
 }
 
 func (d *snmpDiscoveryBackend) RemovePolicy(data policies.PolicyData) error {

--- a/docs/backends/snmp_discovery.md
+++ b/docs/backends/snmp_discovery.md
@@ -2,15 +2,15 @@
 The SNMP discovery backend leverages SNMP (Simple Network Management Protocol) to connect to network devices and collect network information.
 
 ## Diode Entities
-The SNMP discovery backend uses [Diode Python SDK](https://github.com/netboxlabs/diode-sdk-python) to ingest the following entities:
+The SNMP discovery backend uses [Diode Go SDK](https://github.com/netboxlabs/diode-sdk-go) to ingest the following entities:
 
-* [Device](https://github.com/netboxlabs/diode-sdk-python/blob/develop/docs/entities.md#device)
-* [Interface](https://github.com/netboxlabs/diode-sdk-python/blob/develop/docs/entities.md#interface)
-* [IP Address](https://github.com/netboxlabs/diode-sdk-python/blob/develop/docs/entities.md#ip-address)
-* [Mac Address](https://github.com/netboxlabs/diode-sdk-python/blob/develop/docs/entities.md#mac-address)
-* [Platform](https://github.com/netboxlabs/diode-sdk-python/blob/develop/docs/entities.md#platform)
-* [Manufacturer](https://github.com/netboxlabs/diode-sdk-python/blob/develop/docs/entities.md#manufacturer)
-* [Site](https://github.com/netboxlabs/diode-sdk-python/blob/develop/docs/entities.md#site)
+* [Device](https://github.com/netboxlabs/diode-sdk-go?tab=readme-ov-file#supported-entities-object-types)
+* [Interface](https://github.com/netboxlabs/diode-sdk-go?tab=readme-ov-file#supported-entities-object-types)
+* [IP Address](https://github.com/netboxlabs/diode-sdk-go?tab=readme-ov-file#supported-entities-object-types)
+* [Mac Address](https://github.com/netboxlabs/diode-sdk-go?tab=readme-ov-file#supported-entities-object-types)
+* [Platform](https://github.com/netboxlabs/diode-sdk-go?tab=readme-ov-file#supported-entities-object-types)
+* [Manufacturer](https://github.com/netboxlabs/diode-sdk-go?tab=readme-ov-file#supported-entities-object-types)
+* [Site](https://github.com/netboxlabs/diode-sdk-go?tab=readme-ov-file#supported-entities-object-types)
 
 ## Configuration
 The `snmp_discovery` backend does not require any special configuration in the backends section. The backend will use the `diode` settings specified in the `common` subsection to forward discovery results.


### PR DESCRIPTION
This pull request enhances the logging functionality for SNMP discovery output in the `snmp_discovery.go` backend. The main improvement is the introduction of structured log parsing and normalization, which allows log lines to be parsed for logfmt-formatted fields, extracting message, level, and attributes for more informative and consistent logging.

**Logging enhancements:**

* Replaced direct logging of stdout and stderr lines with a new method `logSnmpDiscoveryOutput`, which parses each line for logfmt fields and logs them with structured attributes and proper log levels.
* Added the `logSnmpDiscoveryOutput` method and supporting functions (`normalizeSnmpDiscoveryLine`, `parseSnmpDiscoveryLogfmt`, `parseSnmpDiscoveryLevel`, etc.) to parse, normalize, and structure log output, including extracting the message, log level, and additional attributes from logfmt-formatted strings.
* Imported additional packages (`sort`, `strings`) to support parsing and sorting log attributes.