### PR TITLE
feat: add default yaml config file for fleet config manager

### DIFF
--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -37,6 +37,20 @@ func newFleetConfigManager(logger *slog.Logger, pMgr policymgr.PolicyManager, ba
 func (fleetManager *fleetConfigManager) Start(cfg config.Config, backends map[string]backend.Backend) error {
 	ctx := context.Background()
 
+	var err error
+	cfg.OrbAgent.ConfigManager.Sources.Fleet.TokenURL, err = config.ResolveEnv(cfg.OrbAgent.ConfigManager.Sources.Fleet.TokenURL)
+	if err != nil {
+		return err
+	}
+	cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientID, err = config.ResolveEnv(cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientID)
+	if err != nil {
+		return err
+	}
+	cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientSecret, err = config.ResolveEnv(cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientSecret)
+	if err != nil {
+		return err
+	}
+
 	fleetManager.logger.Info("starting fleet config manager",
 		"token_url", cfg.OrbAgent.ConfigManager.Sources.Fleet.TokenURL,
 		"client_id", cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientID)

--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -53,6 +53,7 @@ RUN pip3 install netboxlabs-device-discovery netboxlabs-orb-worker
 COPY --from=builder /build/orb-agent /usr/local/bin/orb-agent
 COPY --from=builder /src/orb-agent/agent/docker/orb-agent-entry.sh /usr/local/bin/orb-agent-entry.sh
 COPY --from=builder /src/orb-agent/agent/docker/run-agent.sh /run-agent.sh
+COPY --from=builder /src/orb-agent/agent/docker/default_config.yaml /opt/orb/default_config.yaml
 
 RUN chmod a+x /run-agent.sh
 

--- a/agent/docker/default_config.yaml
+++ b/agent/docker/default_config.yaml
@@ -19,9 +19,7 @@ orb:
             iface: auto
     common:
       diode:
-        target: ${DIODE_TARGET}
-        client_id: ${DIODE_CLIENT_ID}
-        client_secret: ${DIODE_CLIENT_SECRET}
+        dry_run: true
       otlp:
-        http: http://localhost:4318
-        grpc: http://localhost:4317
+        http: http://localhost:4320
+        grpc: http://localhost:4321

--- a/agent/docker/default_config.yaml
+++ b/agent/docker/default_config.yaml
@@ -1,0 +1,27 @@
+orb:
+  config_manager:
+    active: fleet
+    sources:
+      orb:
+        token_url: ${FLEET_AUTH_URL}
+        client_id: ${FLEET_CLIENT_ID}
+        client_secret: ${FLEET_CLIENT_SECRET}
+  backends:
+    network_discovery:
+    device_discovery:
+    snmp_discovery:
+    opentelemetry_infinity:
+    pktvisor:
+      taps:
+        default:
+          input_type: pcap
+          config:
+            iface: auto
+    common:
+      diode:
+        target: ${DIODE_TARGET}
+        client_id: ${DIODE_CLIENT_ID}
+        client_secret: ${DIODE_CLIENT_SECRET}
+      otlp:
+        http: http://localhost:4318
+        grpc: http://localhost:4317

--- a/agent/docker/default_config.yaml
+++ b/agent/docker/default_config.yaml
@@ -10,16 +10,6 @@ orb:
     network_discovery:
     device_discovery:
     snmp_discovery:
-    opentelemetry_infinity:
-    pktvisor:
-      taps:
-        default:
-          input_type: pcap
-          config:
-            iface: auto
     common:
       diode:
         dry_run: true
-      otlp:
-        http: http://localhost:4320
-        grpc: http://localhost:4321

--- a/agent/docker/orb-agent-entry.sh
+++ b/agent/docker/orb-agent-entry.sh
@@ -35,6 +35,39 @@ if [ -f "asn.mmdb.gz" ]; then
 fi
 
 ## Agent Configuration ##
+DEFAULT_CONFIG_PATH="/opt/orb/default_config.yaml"
+agent_args=("$@")
+
+if [ -n "${FLEET_CLIENT_ID}" ] && [ -n "${FLEET_CLIENT_SECRET}" ]; then
+  # Use packaged default config when fleet credentials are provided without an explicit config file.
+  config_specified=false
+  for arg in "${agent_args[@]}"; do
+    case "${arg}" in
+      --config|--config=*|-c|-c=*)
+        config_specified=true
+        break
+        ;;
+    esac
+  done
+
+  if [ "${config_specified}" = false ]; then
+    if [ ${#agent_args[@]} -eq 0 ]; then
+      agent_args=(run -c "${DEFAULT_CONFIG_PATH}")
+    else
+      run_specified=false
+      for arg in "${agent_args[@]}"; do
+        if [ "${arg}" = "run" ]; then
+          run_specified=true
+          break
+        fi
+      done
+      if [ "${run_specified}" = true ]; then
+        agent_args+=("--config" "${DEFAULT_CONFIG_PATH}")
+      fi
+    fi
+  fi
+fi
+
 trap agentstop1 SIGINT
 trap agentstop2 SIGTERM
 
@@ -44,7 +77,7 @@ do
   # pid file dont exist
   if [ ! -f "/var/run/orb-agent.pid"  ]; then
     # running orb-agent in background
-    nohup /run-agent.sh "$@" &
+    nohup /run-agent.sh "${agent_args[@]}" &
     sleep 2
     if [ -d "/nohup.out" ]; then
        tail -f /nohup.out &

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,7 +29,6 @@ const (
 var (
 	cfgFiles []string
 	debug    bool
-	envFile  string
 )
 
 func init() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,7 +8,6 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/joho/godotenv"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
@@ -67,40 +66,9 @@ func loadConfig(path string, configData *config.Config) error {
 	return nil
 }
 
-func loadEnvFile(path string) (bool, error) {
-	if _, err := os.Stat(path); err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, fmt.Errorf("failed to access environment file %s: %w", path, err)
-	}
-
-	if err := godotenv.Load(path); err != nil {
-		return false, fmt.Errorf("failed to load environment file %s: %w", path, err)
-	}
-
-	return true, nil
-}
-
 // Run starts the agent
-func Run(cmd *cobra.Command, _ []string) {
+func Run(_ *cobra.Command, _ []string) {
 	var configData config.Config
-
-	defaultEnvFile := cmd.Flag("env-file").DefValue
-	envLoaded := false
-	if envFile != "" {
-		var err error
-		envLoaded, err = loadEnvFile(envFile)
-		if err != nil {
-			cobra.CheckErr(err)
-		}
-	}
-
-	if !envLoaded && envFile != defaultEnvFile {
-		if _, err := loadEnvFile(defaultEnvFile); err != nil {
-			cobra.CheckErr(err)
-		}
-	}
 
 	// Override with user-provided config files
 	for _, conf := range cfgFiles {
@@ -182,7 +150,6 @@ func main() {
 	}
 
 	runCmd.Flags().StringSliceVarP(&cfgFiles, "config", "c", []string{}, "Path to config files (may be specified multiple times)")
-	runCmd.Flags().StringVarP(&envFile, "env-file", "e", "/opt/orb/.env", "Path to environment file to load (falls back to /opt/orb/.env if not found)")
 	runCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "Enable verbose (debug level) output")
 
 	rootCmd.AddCommand(runCmd)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/joho/godotenv"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
@@ -29,6 +30,7 @@ const (
 var (
 	cfgFiles []string
 	debug    bool
+	envFile  string
 )
 
 func init() {
@@ -65,9 +67,40 @@ func loadConfig(path string, configData *config.Config) error {
 	return nil
 }
 
+func loadEnvFile(path string) (bool, error) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to access environment file %s: %w", path, err)
+	}
+
+	if err := godotenv.Load(path); err != nil {
+		return false, fmt.Errorf("failed to load environment file %s: %w", path, err)
+	}
+
+	return true, nil
+}
+
 // Run starts the agent
-func Run(_ *cobra.Command, _ []string) {
+func Run(cmd *cobra.Command, _ []string) {
 	var configData config.Config
+
+	defaultEnvFile := cmd.Flag("env-file").DefValue
+	envLoaded := false
+	if envFile != "" {
+		var err error
+		envLoaded, err = loadEnvFile(envFile)
+		if err != nil {
+			cobra.CheckErr(err)
+		}
+	}
+
+	if !envLoaded && envFile != defaultEnvFile {
+		if _, err := loadEnvFile(defaultEnvFile); err != nil {
+			cobra.CheckErr(err)
+		}
+	}
 
 	// Override with user-provided config files
 	for _, conf := range cfgFiles {
@@ -149,6 +182,7 @@ func main() {
 	}
 
 	runCmd.Flags().StringSliceVarP(&cfgFiles, "config", "c", []string{}, "Path to config files (may be specified multiple times)")
+	runCmd.Flags().StringVarP(&envFile, "env-file", "e", "/opt/orb/.env", "Path to environment file to load (falls back to /opt/orb/.env if not found)")
 	runCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "Enable verbose (debug level) output")
 
 	rootCmd.AddCommand(runCmd)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-co-op/gocron/v2 v2.15.0
 	github.com/go-git/go-git/v5 v5.14.0
 	github.com/go-jose/go-jose/v4 v4.1.1
+	github.com/joho/godotenv v1.5.1
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/vault/api v1.20.0
 	github.com/hashicorp/vault/api/auth/approle v0.10.0

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/go-co-op/gocron/v2 v2.15.0
 	github.com/go-git/go-git/v5 v5.14.0
 	github.com/go-jose/go-jose/v4 v4.1.1
-	github.com/joho/godotenv v1.5.1
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/vault/api v1.20.0
 	github.com/hashicorp/vault/api/auth/approle v0.10.0
@@ -21,10 +20,8 @@ require (
 	go.opentelemetry.io/contrib/bridges/otelslog v0.13.0
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.14.0
-	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.14.0
 	go.opentelemetry.io/otel/sdk v1.38.0
 	go.opentelemetry.io/otel/sdk/log v0.14.0
-	google.golang.org/grpc v1.75.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -113,6 +110,7 @@ require (
 	golang.org/x/time v0.11.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250825161204-c5933d9347a5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250825161204-c5933d9347a5 // indirect
+	google.golang.org/grpc v1.75.0 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gotest.tools/v3 v3.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,6 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
-github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
-github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
 github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
@@ -228,8 +226,6 @@ go.opentelemetry.io/otel v1.38.0 h1:RkfdswUDRimDg0m2Az18RKOsnI8UDzppJAtj01/Ymk8=
 go.opentelemetry.io/otel v1.38.0/go.mod h1:zcmtmQ1+YmQM9wrNsTGV/q/uyusom3P8RxwExxkZhjM=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.14.0 h1:OMqPldHt79PqWKOMYIAQs3CxAi7RLgPxwfFSwr4ZxtM=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.14.0/go.mod h1:1biG4qiqTxKiUCtoWDPpL3fB3KxVwCiGw81j3nKMuHE=
-go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.14.0 h1:QQqYw3lkrzwVsoEX0w//EhH/TCnpRdEenKBOOEIMjWc=
-go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.14.0/go.mod h1:gSVQcr17jk2ig4jqJ2DX30IdWH251JcNAecvrqTxH1s=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.37.0 h1:Ahq7pZmv87yiyn3jeFz/LekZmPLLdKejuO3NcK9MssM=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.37.0/go.mod h1:MJTqhM0im3mRLw1i8uGHnCvUEeS7VwRyxlLC78PA18M=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.37.0 h1:bDMKF3RUSxshZ5OjOTi8rsHGaPKsAt76FaqgvIUySLc=

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
 github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=


### PR DESCRIPTION
This pull request introduces a new default configuration file for the orb agent, updates the Docker image to include this file, and makes minor dependency adjustments in the Go module file. The main focus is on improving configuration management and ensuring the Docker image has the necessary defaults for deployment.

Configuration management improvements:

* Added a new `default_config.yaml` file that provides default configuration values for the orb agent, including config manager settings, backend definitions, and integration with external services using environment variables.
* Updated the Dockerfile to copy the new `default_config.yaml` into the Docker image at `/opt/orb/default_config.yaml`, ensuring the agent has access to default settings at runtime.

Dependency updates:

* Removed the direct dependency on `go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp` and made `google.golang.org/grpc` an indirect dependency in `go.mod` to clean up unused or unnecessary dependencies. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L23-L26) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R113)