### PR TITLE
fix: resolve envvar for git url

### DIFF
--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -343,6 +343,10 @@ func (gc *gitConfigManager) Start(cfg config.Config, backends map[string]backend
 	if gc.config.URL == "" {
 		return errors.New("URL is required for Git Config Manager")
 	}
+	gc.config.URL, err = config.ResolveEnv(gc.config.URL)
+	if err != nil {
+		return err
+	}
 
 	switch gc.config.Auth {
 	case "basic":


### PR DESCRIPTION
This pull request introduces an improvement to the `gitConfigManager` startup logic by ensuring that environment variables in the Git configuration URL are properly resolved before use.

Configuration handling:

* [`agent/configmgr/git.go`](diffhunk://#diff-2e7ff6a74db68db7bf67abb785553044c99821d929cf7e1d742485bc43decfe8R346-R349): Added a call to `config.ResolveEnv` to resolve environment variables in `gc.config.URL` and handle any errors that may occur during this process.