### PR TITLE
chore: improve slog messages

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -56,11 +56,11 @@ func New(logger *slog.Logger, c config.Config) (Agent, error) {
 	sm := secretsmgr.New(logger, c.OrbAgent.SecretsManager)
 	pm, err := policymgr.New(logger, sm, c)
 	if err != nil {
-		logger.Error("error during create policy manager, exiting", slog.Any("error", err))
+		logger.Error("error during create policy manager, exiting", "error", err)
 		return nil, err
 	}
 	if pm.GetRepo() == nil {
-		logger.Error("policy manager failed to get repository", slog.Any("error", err))
+		logger.Error("policy manager failed to get repository", "error", err)
 		return nil, err
 	}
 
@@ -84,7 +84,7 @@ func New(logger *slog.Logger, c config.Config) (Agent, error) {
 }
 
 func (a *orbAgent) startBackends(agentCtx context.Context, cfgBackends map[string]any, labels map[string]string) (err error) {
-	a.logger.Info("registered backends", slog.Any("values", backend.GetList()))
+	a.logger.Info("registered backends", "values", backend.GetList())
 	if len(cfgBackends) == 0 {
 		return errors.New("no backends specified")
 	}
@@ -101,7 +101,7 @@ func (a *orbAgent) startBackends(agentCtx context.Context, cfgBackends map[strin
 		}
 		err = yaml.Unmarshal(bytes, &commonConfig)
 		if err != nil {
-			a.logger.Info("failed to marshal common backend config", slog.Any("error", err))
+			a.logger.Info("failed to marshal common backend config", "error", err)
 			return err
 		}
 	} else {
@@ -114,7 +114,7 @@ func (a *orbAgent) startBackends(agentCtx context.Context, cfgBackends map[strin
 	if a.backendsCommon.Otlp.Grpc != "" {
 		a.logger, otlpShutdown, err = telemetry.BuildOTLPLogExporter(agentCtx, a.logger, a.backendsCommon)
 		if err != nil {
-			a.logger.Error("failed to create OTLP log exporter", slog.Any("error", err))
+			a.logger.Error("failed to create OTLP log exporter", "error", err)
 			return err
 		}
 		if otlpShutdown != nil {
@@ -142,7 +142,7 @@ func (a *orbAgent) startBackends(agentCtx context.Context, cfgBackends map[strin
 		be := backend.GetBackend(name)
 
 		if err := be.Configure(a.logger, a.policyManager.GetRepo(), cEntity, a.backendsCommon); err != nil {
-			a.logger.Info("failed to configure backend", slog.String("backend", name), slog.Any("error", err))
+			a.logger.Info("failed to configure backend", "backend", name, "error", err)
 			return err
 		}
 		backendCtx := context.WithValue(agentCtx, routineKey, name)
@@ -169,10 +169,10 @@ func (a *orbAgent) startBackends(agentCtx context.Context, cfgBackends map[strin
 
 func (a *orbAgent) waitForRestartRequests() {
 	for name := range a.restartBackendChan {
-		a.logger.Info("restarting backend", slog.String("backend", name))
+		a.logger.Info("restarting backend", "backend", name)
 		err := a.RestartBackend(a.ctx, name, "restart requested by fleet")
 		if err != nil {
-			a.logger.Error("failed to restart backend", slog.String("backend", name), slog.Any("error", err))
+			a.logger.Error("failed to restart backend", "backend", name, "error", err)
 		}
 	}
 }
@@ -180,15 +180,15 @@ func (a *orbAgent) waitForRestartRequests() {
 func (a *orbAgent) Start(ctx context.Context, cancelFunc context.CancelFunc) error {
 	startTime := time.Now()
 	defer func(t time.Time) {
-		a.logger.Debug("Startup of agent execution duration", slog.String("Start() execution duration", time.Since(t).String()))
+		a.logger.Debug("Startup of agent execution duration", "Start() execution duration", time.Since(t).String())
 	}(startTime)
 	agentCtx := context.WithValue(ctx, routineKey, "agentRoutine")
 	a.cancelFunction = cancelFunc
-	a.logger.Info("agent started", slog.String("version", version.GetBuildVersion()), slog.Any("routine", agentCtx.Value(routineKey)))
-	a.logger.Info("requested backends", slog.Any("values", a.config.OrbAgent.Backends))
+	a.logger.Info("agent started", "version", version.GetBuildVersion(), "routine", agentCtx.Value(routineKey))
+	a.logger.Info("requested backends", "values", a.config.OrbAgent.Backends)
 
 	if err := a.secretsManager.Start(ctx); err != nil {
-		a.logger.Error("error during start secrets manager", slog.Any("error", err))
+		a.logger.Error("error during start secrets manager", "error", err)
 		return err
 	}
 
@@ -211,17 +211,17 @@ func (a *orbAgent) Start(ctx context.Context, cancelFunc context.CancelFunc) err
 }
 
 func (a *orbAgent) Stop(ctx context.Context) {
-	a.logger.Info("routine call for stop agent", slog.Any("routine", ctx.Value(routineKey)))
+	a.logger.Info("routine call for stop agent", "routine", ctx.Value(routineKey))
 	for name, b := range a.backends {
 		if state, _, _ := b.GetRunningStatus(); state == backend.Running {
-			a.logger.Debug("stopping backend", slog.String("backend", name))
+			a.logger.Debug("stopping backend", "backend", name)
 			if err := b.Stop(ctx); err != nil {
-				a.logger.Error("error while stopping the backend", slog.String("backend", name))
+				a.logger.Error("error while stopping the backend", "backend", name)
 			}
 		}
 	}
 	a.shutdownOTLP(ctx)
-	a.logger.Debug("stopping agent with number of go routines and go calls", slog.Int("goroutines", runtime.NumGoroutine()), slog.Int64("gocalls", runtime.NumCgoCall()))
+	a.logger.Debug("stopping agent with number of go routines and go calls", "goroutines", runtime.NumGoroutine(), "gocalls", runtime.NumCgoCall())
 	defer a.cancelFunction()
 }
 
@@ -239,7 +239,7 @@ func (a *orbAgent) shutdownOTLP(ctx context.Context) {
 	defer cancel()
 
 	if err := shutdown(shutdownCtx); err != nil {
-		a.logger.Error("error while shutting down OTLP log exporter", slog.Any("error", err))
+		a.logger.Error("error while shutting down OTLP log exporter", "error", err)
 		return
 	}
 	a.logger.Debug("shut down OTLP log exporter")
@@ -251,11 +251,11 @@ func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason strin
 	}
 
 	be := a.backends[name]
-	a.logger.Info("restarting backend", slog.String("backend", name), slog.String("reason", reason))
+	a.logger.Info("restarting backend", "backend", name, "reason", reason)
 	a.backendStateManager.RegisterRestart(name, reason)
-	a.logger.Info("removing policies", slog.String("backend", name))
+	a.logger.Info("removing policies", "backend", name)
 	if err := a.policyManager.RemoveBackendPolicies(be, true); err != nil {
-		a.logger.Error("failed to remove policies", slog.String("backend", name), slog.Any("error", err))
+		a.logger.Error("failed to remove policies", "backend", name, "error", err)
 	}
 	var beConfig map[string]any
 	if a.config.OrbAgent.Backends[name] != nil {
@@ -268,7 +268,7 @@ func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason strin
 	if err := be.Configure(a.logger, a.policyManager.GetRepo(), beConfig, a.backendsCommon); err != nil {
 		return err
 	}
-	a.logger.Info("resetting backend", slog.String("backend", name))
+	a.logger.Info("resetting backend", "backend", name)
 
 	if err := be.FullReset(ctx); err != nil {
 		a.backendStateManager.RegisterError(name, fmt.Sprintf("failed to reset backend: %v", err))
@@ -279,12 +279,12 @@ func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason strin
 
 func (a *orbAgent) RestartAll(ctx context.Context, reason string) error {
 	ctx = a.configManager.GetContext(ctx)
-	a.logger.Info("restarting comms", slog.String("reason", reason))
+	a.logger.Info("restarting comms", "reason", reason)
 	for name := range a.backends {
-		a.logger.Info("restarting backend", slog.String("backend", name), slog.String("reason", reason))
+		a.logger.Info("restarting backend", "backend", name, "reason", reason)
 		err := a.RestartBackend(ctx, name, reason)
 		if err != nil {
-			a.logger.Error("failed to restart backend", slog.Any("error", err))
+			a.logger.Error("failed to restart backend", "error", err)
 		}
 	}
 	a.logger.Info("all backends and comms were restarted")

--- a/agent/backend/backend_state.go
+++ b/agent/backend/backend_state.go
@@ -105,7 +105,7 @@ func (manager *stateManager) StartBackendMonitor(name string, be Backend) {
 
 // RegisterError registers an error for a backend and updates its state
 func (manager *stateManager) RegisterError(name string, errMessage string) {
-	manager.logger.Error(errMessage, slog.String("backend", name))
+	manager.logger.Error(errMessage, "backend", name)
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
 	manager.backendState[name] = &State{

--- a/agent/backend/devicediscovery/device_discovery.go
+++ b/agent/backend/devicediscovery/device_discovery.go
@@ -71,7 +71,7 @@ func Register() bool {
 func (d *deviceDiscoveryBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	config map[string]any, common config.BackendCommons,
 ) error {
-	d.logger = logger.With(slog.String("backend", "device_discovery"))
+	d.logger = logger.With("backend", "device_discovery")
 	d.policyRepo = repo
 
 	var prs bool
@@ -113,7 +113,7 @@ func (d *deviceDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Po
 	if common.Otlp.Grpc != "" {
 		d.diodeOtelEndpoint = common.Otlp.Grpc
 		d.logger.Info("device-discovery using OTLP metrics endpoint",
-			slog.String("endpoint", d.diodeOtelEndpoint))
+			"endpoint", d.diodeOtelEndpoint)
 	}
 
 	return nil
@@ -157,7 +157,7 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 		pvOptions = append(pvOptions, "--otel-endpoint", d.diodeOtelEndpoint)
 	}
 
-	d.logger.Info("device-discovery startup", slog.Any("arguments", pvOptions))
+	d.logger.Info("device-discovery startup", "arguments", pvOptions)
 
 	if !d.diodeDryRun && len(pvOptions) > 9 {
 		pvOptions[9] = d.diodeClientSecret
@@ -203,19 +203,19 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 	status := d.proc.Status()
 
 	if status.Error != nil {
-		d.logger.Error("device-discovery startup error", slog.Any("error", status.Error))
+		d.logger.Error("device-discovery startup error", "error", status.Error)
 		return status.Error
 	}
 
 	if status.Complete {
 		err := d.proc.Stop()
 		if err != nil {
-			d.logger.Error("proc.Stop error", slog.Any("error", err))
+			d.logger.Error("proc.Stop error", "error", err)
 		}
 		return errors.New("device-discovery startup error, check log")
 	}
 
-	d.logger.Info("device-discovery process started", slog.Int("pid", status.PID))
+	d.logger.Info("device-discovery process started", "pid", status.PID)
 
 	var version string
 	var readinessErr error
@@ -223,27 +223,27 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 		if status := d.proc.Status(); status.Complete {
 			err := d.proc.Stop()
 			if err != nil {
-				d.logger.Error("proc.Stop error", slog.Any("error", err))
+				d.logger.Error("proc.Stop error", "error", err)
 			}
 			return errors.New("device-discovery process ended unexpectedly, check log")
 		}
 		version, readinessErr = d.Version()
 		if readinessErr == nil {
 			d.logger.Info("device-discovery readiness ok, got version ",
-				slog.String("device_discovery_version", version))
+				"device_discovery_version", version)
 			break
 		}
 		backoffDuration := time.Duration(backoff) * time.Second
 		d.logger.Info("device-discovery is not ready, trying again with backoff",
-			slog.String("backoff backoffDuration", backoffDuration.String()))
+			"backoff backoffDuration", backoffDuration.String())
 		time.Sleep(backoffDuration)
 	}
 
 	if readinessErr != nil {
-		d.logger.Error("device-discovery error on readiness", slog.Any("error", readinessErr))
+		d.logger.Error("device-discovery error on readiness", "error", readinessErr)
 		err := d.proc.Stop()
 		if err != nil {
-			d.logger.Error("proc.Stop error", slog.Any("error", err))
+			d.logger.Error("proc.Stop error", "error", err)
 		}
 		return readinessErr
 	}
@@ -276,14 +276,14 @@ func (d *deviceDiscoveryBackend) logDeviceDiscoveryOutput(line string, fallback 
 }
 
 func (d *deviceDiscoveryBackend) Stop(ctx context.Context) error {
-	d.logger.Info("routine call to stop device-discovery", slog.Any("routine", ctx.Value(config.ContextKey("routine"))))
+	d.logger.Info("routine call to stop device-discovery", "routine", ctx.Value(config.ContextKey("routine")))
 	defer d.cancelFunc()
 	err := d.proc.Stop()
 	finalStatus := <-d.statusChan
 	if err != nil {
-		d.logger.Error("device-discovery shutdown error", slog.Any("error", err))
+		d.logger.Error("device-discovery shutdown error", "error", err)
 	}
-	d.logger.Info("device-discovery process stopped", slog.Int("pid", finalStatus.PID), slog.Int("exit_code", finalStatus.Exit))
+	d.logger.Info("device-discovery process stopped", "pid", finalStatus.PID, "exit_code", finalStatus.Exit)
 	return nil
 }
 
@@ -291,7 +291,7 @@ func (d *deviceDiscoveryBackend) FullReset(ctx context.Context) error {
 	// force a stop, which stops scrape as well. if proc is dead, it no ops.
 	if state, _, _ := backend.GetRunningStatus(d.proc); state == backend.Running {
 		if err := d.Stop(ctx); err != nil {
-			d.logger.Error("failed to stop backend on restart procedure", slog.Any("error", err))
+			d.logger.Error("failed to stop backend on restart procedure", "error", err)
 			return err
 		}
 	}
@@ -299,7 +299,7 @@ func (d *deviceDiscoveryBackend) FullReset(ctx context.Context) error {
 	backendCtx, cancelFunc := context.WithCancel(context.WithValue(ctx, config.ContextKey("routine"), "device-discovery"))
 	// start it
 	if err := d.Start(backendCtx, cancelFunc); err != nil {
-		d.logger.Error("failed to start backend on restart procedure", slog.Any("error", err))
+		d.logger.Error("failed to start backend on restart procedure", "error", err)
 		return err
 	}
 	return nil
@@ -343,12 +343,12 @@ func (d *deviceDiscoveryBackend) ApplyPolicy(data policies.PolicyData, updatePol
 	if updatePolicy {
 		// To update a policy it's necessary first remove it and then apply a new version
 		if err := d.RemovePolicy(data); err != nil {
-			d.logger.Warn("policy failed to remove", slog.String("policy_id", data.ID),
-				slog.String("policy_name", data.Name), slog.Any("error", err))
+			d.logger.Warn("policy failed to remove", "policy_id", data.ID,
+				"policy_name", data.Name, "error", err)
 		}
 	}
 
-	d.logger.Debug("device-discovery policy apply", slog.String("policy_id", data.ID), slog.Any("data", data.Data))
+	d.logger.Debug("device-discovery policy apply", "policy_id", data.ID, "data", data.Data)
 
 	fullPolicy := map[string]any{
 		"policies": map[string]any{
@@ -358,7 +358,7 @@ func (d *deviceDiscoveryBackend) ApplyPolicy(data policies.PolicyData, updatePol
 
 	policyYaml, err := yaml.Marshal(fullPolicy)
 	if err != nil {
-		d.logger.Warn("policy yaml marshal failure", slog.String("policy_id", data.ID), slog.String("policy_name", data.Name))
+		d.logger.Warn("policy yaml marshal failure", "policy_id", data.ID, "policy_name", data.Name)
 		return err
 	}
 
@@ -367,7 +367,7 @@ func (d *deviceDiscoveryBackend) ApplyPolicy(data policies.PolicyData, updatePol
 	err = backend.CommonRequest("device-discovery", d.proc, d.logger, url, &resp, http.MethodPost,
 		bytes.NewBuffer(policyYaml), "application/x-yaml", applyPolicyTimeout, "detail")
 	if err != nil {
-		d.logger.Warn("policy application failure", slog.String("policy_id", data.ID), slog.String("policy_name", data.Name))
+		d.logger.Warn("policy application failure", "policy_id", data.ID, "policy_name", data.Name)
 		return err
 	}
 
@@ -375,7 +375,7 @@ func (d *deviceDiscoveryBackend) ApplyPolicy(data policies.PolicyData, updatePol
 }
 
 func (d *deviceDiscoveryBackend) RemovePolicy(data policies.PolicyData) error {
-	d.logger.Debug("device-discovery policy remove", slog.String("policy_id", data.ID))
+	d.logger.Debug("device-discovery policy remove", "policy_id", data.ID)
 	var resp any
 	var name string
 	// Since we use Name for removing policies not IDs, if there is a change, we need to remove the previous name of the policy

--- a/agent/backend/networkdiscovery/network_discovery.go
+++ b/agent/backend/networkdiscovery/network_discovery.go
@@ -73,7 +73,7 @@ func Register() bool {
 func (d *networkDiscoveryBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	config map[string]any, common config.BackendCommons,
 ) error {
-	d.logger = logger.With(slog.String("backend", "network_discovery"))
+	d.logger = logger.With("backend", "network_discovery")
 	d.policyRepo = repo
 
 	var prs bool
@@ -120,7 +120,7 @@ func (d *networkDiscoveryBackend) Configure(logger *slog.Logger, repo policies.P
 	if common.Otlp.Grpc != "" {
 		d.diodeOtelEndpoint = common.Otlp.Grpc
 		d.logger.Info("network-discovery using OTLP metrics endpoint",
-			slog.String("endpoint", d.diodeOtelEndpoint))
+			"endpoint", d.diodeOtelEndpoint)
 	}
 
 	return nil
@@ -163,16 +163,16 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 	if d.diodeLogLevel != "" {
 		pvOptions = append(pvOptions, "--log-level", d.diodeLogLevel)
 		d.logger.Info("network-discovery using log level",
-			slog.String("log_level", d.diodeLogLevel))
+			"log_level", d.diodeLogLevel)
 	}
 
 	if d.diodeOtelEndpoint != "" {
 		pvOptions = append(pvOptions, "--otel-endpoint", d.diodeOtelEndpoint)
 		d.logger.Info("network-discovery using OTLP metrics endpoint",
-			slog.String("endpoint", d.diodeOtelEndpoint))
+			"endpoint", d.diodeOtelEndpoint)
 	}
 
-	d.logger.Info("network-discovery startup", slog.Any("arguments", pvOptions))
+	d.logger.Info("network-discovery startup", "arguments", pvOptions)
 
 	if !d.diodeDryRun {
 		// Find and replace the masked client secret with the actual value
@@ -224,19 +224,19 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 	status := d.proc.Status()
 
 	if status.Error != nil {
-		d.logger.Error("network-discovery startup error", slog.Any("error", status.Error))
+		d.logger.Error("network-discovery startup error", "error", status.Error)
 		return status.Error
 	}
 
 	if status.Complete {
 		err := d.proc.Stop()
 		if err != nil {
-			d.logger.Error("proc.Stop error", slog.Any("error", err))
+			d.logger.Error("proc.Stop error", "error", err)
 		}
 		return errors.New("network-discovery startup error, check log")
 	}
 
-	d.logger.Info("network-discovery process started", slog.Int("pid", status.PID))
+	d.logger.Info("network-discovery process started", "pid", status.PID)
 
 	var version string
 	var readinessErr error
@@ -244,27 +244,27 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 		if status := d.proc.Status(); status.Complete {
 			err := d.proc.Stop()
 			if err != nil {
-				d.logger.Error("proc.Stop error", slog.Any("error", err))
+				d.logger.Error("proc.Stop error", "error", err)
 			}
 			return errors.New("network-discovery process ended unexpectedly, check log")
 		}
 		version, readinessErr = d.Version()
 		if readinessErr == nil {
 			d.logger.Info("network-discovery readiness ok, got version ",
-				slog.String("network_discovery_version", version))
+				"network_discovery_version", version)
 			break
 		}
 		backoffDuration := time.Duration(backoff) * time.Second
 		d.logger.Info("network-discovery is not ready, trying again with backoff",
-			slog.String("backoff backoffDuration", backoffDuration.String()))
+			"backoff backoffDuration", backoffDuration.String())
 		time.Sleep(backoffDuration)
 	}
 
 	if readinessErr != nil {
-		d.logger.Error("network-discovery error on readiness", slog.Any("error", readinessErr))
+		d.logger.Error("network-discovery error on readiness", "error", readinessErr)
 		err := d.proc.Stop()
 		if err != nil {
-			d.logger.Error("proc.Stop error", slog.Any("error", err))
+			d.logger.Error("proc.Stop error", "error", err)
 		}
 		return readinessErr
 	}
@@ -297,15 +297,15 @@ func (d *networkDiscoveryBackend) logNetworkDiscoveryOutput(line string, fallbac
 }
 
 func (d *networkDiscoveryBackend) Stop(ctx context.Context) error {
-	d.logger.Info("routine call to stop network-discovery", slog.Any("routine", ctx.Value(config.ContextKey("routine"))))
+	d.logger.Info("routine call to stop network-discovery", "routine", ctx.Value(config.ContextKey("routine")))
 	defer d.cancelFunc()
 	err := d.proc.Stop()
 	finalStatus := <-d.statusChan
 	if err != nil {
-		d.logger.Error("network-discovery shutdown error", slog.Any("error", err))
+		d.logger.Error("network-discovery shutdown error", "error", err)
 	}
-	d.logger.Info("network-discovery process stopped", slog.Int("pid", finalStatus.PID),
-		slog.Int("exit_code", finalStatus.Exit))
+	d.logger.Info("network-discovery process stopped", "pid", finalStatus.PID,
+		"exit_code", finalStatus.Exit)
 	return nil
 }
 
@@ -313,7 +313,7 @@ func (d *networkDiscoveryBackend) FullReset(ctx context.Context) error {
 	// force a stop, which stops scrape as well. if proc is dead, it no ops.
 	if state, _, _ := backend.GetRunningStatus(d.proc); state == backend.Running {
 		if err := d.Stop(ctx); err != nil {
-			d.logger.Error("failed to stop backend on restart procedure", slog.Any("error", err))
+			d.logger.Error("failed to stop backend on restart procedure", "error", err)
 			return err
 		}
 	}
@@ -321,7 +321,7 @@ func (d *networkDiscoveryBackend) FullReset(ctx context.Context) error {
 	backendCtx, cancelFunc := context.WithCancel(context.WithValue(ctx, config.ContextKey("routine"), "network-discovery"))
 	// start it
 	if err := d.Start(backendCtx, cancelFunc); err != nil {
-		d.logger.Error("failed to start backend on restart procedure", slog.Any("error", err))
+		d.logger.Error("failed to start backend on restart procedure", "error", err)
 		return err
 	}
 	return nil
@@ -365,12 +365,12 @@ func (d *networkDiscoveryBackend) ApplyPolicy(data policies.PolicyData, updatePo
 	if updatePolicy {
 		// To update a policy it's necessary first remove it and then apply a new version
 		if err := d.RemovePolicy(data); err != nil {
-			d.logger.Warn("policy failed to remove", slog.String("policy_id", data.ID),
-				slog.String("policy_name", data.Name), slog.Any("error", err))
+			d.logger.Warn("policy failed to remove", "policy_id", data.ID,
+				"policy_name", data.Name, "error", err)
 		}
 	}
 
-	d.logger.Debug("network-discovery policy apply", slog.String("policy_id", data.ID), slog.Any("data", data.Data))
+	d.logger.Debug("network-discovery policy apply", "policy_id", data.ID, "data", data.Data)
 
 	fullPolicy := map[string]any{
 		"policies": map[string]any{
@@ -380,7 +380,7 @@ func (d *networkDiscoveryBackend) ApplyPolicy(data policies.PolicyData, updatePo
 
 	policyYaml, err := yaml.Marshal(fullPolicy)
 	if err != nil {
-		d.logger.Warn("policy yaml marshal failure", slog.String("policy_id", data.ID), slog.String("policy_name", data.Name))
+		d.logger.Warn("policy yaml marshal failure", "policy_id", data.ID, "policy_name", data.Name)
 		return err
 	}
 
@@ -389,7 +389,7 @@ func (d *networkDiscoveryBackend) ApplyPolicy(data policies.PolicyData, updatePo
 	err = backend.CommonRequest("network-discovery", d.proc, d.logger, url, &resp, http.MethodPost,
 		bytes.NewBuffer(policyYaml), "application/x-yaml", applyPolicyTimeout, "detail")
 	if err != nil {
-		d.logger.Warn("policy application failure", slog.String("policy_id", data.ID), slog.String("policy_name", data.Name))
+		d.logger.Warn("policy application failure", "policy_id", data.ID, "policy_name", data.Name)
 		return err
 	}
 
@@ -397,7 +397,7 @@ func (d *networkDiscoveryBackend) ApplyPolicy(data policies.PolicyData, updatePo
 }
 
 func (d *networkDiscoveryBackend) RemovePolicy(data policies.PolicyData) error {
-	d.logger.Debug("network-discovery policy remove", slog.String("policy_id", data.ID))
+	d.logger.Debug("network-discovery policy remove", "policy_id", data.ID)
 	var resp any
 	name := data.Name
 	// Since we use Name for removing policies not IDs, if there is a change, we need to remove the previous name of the policy

--- a/agent/backend/opentelemetryinfinity/opentelemetry_infinity.go
+++ b/agent/backend/opentelemetryinfinity/opentelemetry_infinity.go
@@ -68,7 +68,7 @@ func Register() bool {
 func (o *openTelemetryBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	config map[string]any, common config.BackendCommons,
 ) error {
-	o.logger = logger.With(slog.String("backend", "opentelemetry_infinity"))
+	o.logger = logger.With("backend", "opentelemetry_infinity")
 	o.policyRepo = repo
 
 	var prs bool
@@ -112,7 +112,7 @@ func (o *openTelemetryBackend) Start(ctx context.Context, cancelFunc context.Can
 		"--log_timestamp=false",
 	}
 
-	o.logger.Info("opentelemetry infinity startup", slog.Any("arguments", pvOptions))
+	o.logger.Info("opentelemetry infinity startup", "arguments", pvOptions)
 
 	o.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,
@@ -154,19 +154,19 @@ func (o *openTelemetryBackend) Start(ctx context.Context, cancelFunc context.Can
 	status := o.proc.Status()
 
 	if status.Error != nil {
-		o.logger.Error("opentelemetry infinity startup error", slog.Any("error", status.Error))
+		o.logger.Error("opentelemetry infinity startup error", "error", status.Error)
 		return status.Error
 	}
 
 	if status.Complete {
 		err := o.proc.Stop()
 		if err != nil {
-			o.logger.Error("proc.Stop error", slog.Any("error", err))
+			o.logger.Error("proc.Stop error", "error", err)
 		}
 		return errors.New("opentelemetry infinity startup error, check log")
 	}
 
-	o.logger.Info("opentelemetry infinity process started", slog.Int("pid", status.PID))
+	o.logger.Info("opentelemetry infinity process started", "pid", status.PID)
 
 	var version string
 	var readinessErr error
@@ -174,27 +174,27 @@ func (o *openTelemetryBackend) Start(ctx context.Context, cancelFunc context.Can
 		if status := o.proc.Status(); status.Complete {
 			err := o.proc.Stop()
 			if err != nil {
-				o.logger.Error("proc.Stop error", slog.Any("error", err))
+				o.logger.Error("proc.Stop error", "error", err)
 			}
 			return errors.New("opentelemetry infinity process ended unexpectedly, check log")
 		}
 		version, readinessErr = o.Version()
 		if readinessErr == nil {
 			o.logger.Info("opentelemetry infinity readiness ok, got version ",
-				slog.String("opentelemetry_infinity_version", version))
+				"opentelemetry_infinity_version", version)
 			break
 		}
 		backoffDuration := time.Duration(backoff) * time.Second
 		o.logger.Info("opentelemetry infinity is not ready, trying again with backoff",
-			slog.String("backoff backoffDuration", backoffDuration.String()))
+			"backoff backoffDuration", backoffDuration.String())
 		time.Sleep(backoffDuration)
 	}
 
 	if readinessErr != nil {
-		o.logger.Error("opentelemetry infinity error on readiness", slog.Any("error", readinessErr))
+		o.logger.Error("opentelemetry infinity error on readiness", "error", readinessErr)
 		err := o.proc.Stop()
 		if err != nil {
-			o.logger.Error("proc.Stop error", slog.Any("error", err))
+			o.logger.Error("proc.Stop error", "error", err)
 		}
 		return readinessErr
 	}
@@ -204,15 +204,15 @@ func (o *openTelemetryBackend) Start(ctx context.Context, cancelFunc context.Can
 
 func (o *openTelemetryBackend) Stop(ctx context.Context) error {
 	o.logger.Info("routine call to stop opentelemetry infinity",
-		slog.Any("routine", ctx.Value(config.ContextKey("routine"))))
+		"routine", ctx.Value(config.ContextKey("routine")))
 	defer o.cancelFunc()
 	err := o.proc.Stop()
 	finalStatus := <-o.statusChan
 	if err != nil {
-		o.logger.Error("opentelemetry infinity shutdown error", slog.Any("error", err))
+		o.logger.Error("opentelemetry infinity shutdown error", "error", err)
 	}
-	o.logger.Info("opentelemetry infinity process stopped", slog.Int("pid", finalStatus.PID),
-		slog.Int("exit_code", finalStatus.Exit))
+	o.logger.Info("opentelemetry infinity process stopped", "pid", finalStatus.PID,
+		"exit_code", finalStatus.Exit)
 	return nil
 }
 
@@ -220,7 +220,7 @@ func (o *openTelemetryBackend) FullReset(ctx context.Context) error {
 	// force a stop, which stops scrape as well. if proc is dead, it no ops.
 	if state, _, _ := backend.GetRunningStatus(o.proc); state == backend.Running {
 		if err := o.Stop(ctx); err != nil {
-			o.logger.Error("failed to stop backend on restart procedure", slog.Any("error", err))
+			o.logger.Error("failed to stop backend on restart procedure", "error", err)
 			return err
 		}
 	}
@@ -228,7 +228,7 @@ func (o *openTelemetryBackend) FullReset(ctx context.Context) error {
 	backendCtx, cancelFunc := context.WithCancel(context.WithValue(ctx, config.ContextKey("routine"), "opentelemetry"))
 	// start it
 	if err := o.Start(backendCtx, cancelFunc); err != nil {
-		o.logger.Error("failed to start backend on restart procedure", slog.Any("error", err))
+		o.logger.Error("failed to start backend on restart procedure", "error", err)
 		return err
 	}
 	return nil
@@ -270,12 +270,12 @@ func (o *openTelemetryBackend) ApplyPolicy(data policies.PolicyData, updatePolic
 	if updatePolicy {
 		// To update a policy it's necessary first remove it and then apply a new version
 		if err := o.RemovePolicy(data); err != nil {
-			o.logger.Warn("policy failed to remove", slog.String("policy_id", data.ID),
-				slog.String("policy_name", data.Name), slog.Any("error", err))
+			o.logger.Warn("policy failed to remove", "policy_id", data.ID,
+				"policy_name", data.Name, "error", err)
 		}
 	}
 
-	o.logger.Debug("opentelemetry infinity policy apply", slog.String("policy_id", data.ID), slog.Any("data", data.Data))
+	o.logger.Debug("opentelemetry infinity policy apply", "policy_id", data.ID, "data", data.Data)
 
 	fullPolicy := map[string]any{
 		data.Name: data.Data,
@@ -283,7 +283,7 @@ func (o *openTelemetryBackend) ApplyPolicy(data policies.PolicyData, updatePolic
 
 	policyYaml, err := yaml.Marshal(fullPolicy)
 	if err != nil {
-		o.logger.Warn("policy yaml marshal failure", slog.String("policy_id", data.ID), slog.String("policy_name", data.Name))
+		o.logger.Warn("policy yaml marshal failure", "policy_id", data.ID, "policy_name", data.Name)
 		return err
 	}
 
@@ -292,7 +292,7 @@ func (o *openTelemetryBackend) ApplyPolicy(data policies.PolicyData, updatePolic
 	err = backend.CommonRequest("opentelemetry-infinity", o.proc, o.logger, url, &resp, http.MethodPost,
 		bytes.NewBuffer(policyYaml), "application/x-yaml", applyPolicyTimeout, "message")
 	if err != nil {
-		o.logger.Warn("policy application failure", slog.String("policy_id", data.ID), slog.String("policy_name", data.Name))
+		o.logger.Warn("policy application failure", "policy_id", data.ID, "policy_name", data.Name)
 		return err
 	}
 
@@ -300,7 +300,7 @@ func (o *openTelemetryBackend) ApplyPolicy(data policies.PolicyData, updatePolic
 }
 
 func (o *openTelemetryBackend) RemovePolicy(data policies.PolicyData) error {
-	o.logger.Debug("opentelemetry policy remove", slog.String("policy_id", data.ID))
+	o.logger.Debug("opentelemetry policy remove", "policy_id", data.ID)
 	var resp any
 	var name string
 	// Since we use Name for removing policies not IDs, if there is a change, we need to remove the previous name of the policy

--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -109,7 +109,7 @@ func (p *pktvisorBackend) Start(ctx context.Context, cancelFunc context.CancelFu
 
 	_, err := exec.LookPath(p.binary)
 	if err != nil {
-		p.logger.Error("pktvisor startup error: binary not found", slog.Any("error", err))
+		p.logger.Error("pktvisor startup error: binary not found", "error", err)
 		return err
 	}
 
@@ -135,7 +135,7 @@ func (p *pktvisorBackend) Start(ctx context.Context, cancelFunc context.CancelFu
 		pvOptions = append(pvOptions, "--cp-custom", ctx.Value("agent_id").(string))
 	}
 
-	p.logger.Info("pktvisor startup", slog.Any("arguments", pvOptions))
+	p.logger.Info("pktvisor startup", "arguments", pvOptions)
 
 	p.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,
@@ -177,26 +177,26 @@ func (p *pktvisorBackend) Start(ctx context.Context, cancelFunc context.CancelFu
 	status := p.proc.Status()
 
 	if status.Error != nil {
-		p.logger.Error("pktvisor startup error", slog.Any("error", status.Error))
+		p.logger.Error("pktvisor startup error", "error", status.Error)
 		return status.Error
 	}
 
 	if status.Complete {
 		err = p.proc.Stop()
 		if err != nil {
-			p.logger.Error("proc.Stop error", slog.Any("error", err))
+			p.logger.Error("proc.Stop error", "error", err)
 		}
 		return errors.New("pktvisor startup error, check log")
 	}
 
-	p.logger.Info("pktvisor process started", slog.Int("pid", status.PID))
+	p.logger.Info("pktvisor process started", "pid", status.PID)
 
 	var readinessError error
 	for backoff := range readinessBackoff {
 		if status := p.proc.Status(); status.Complete {
 			err := p.proc.Stop()
 			if err != nil {
-				p.logger.Error("proc.Stop error", slog.Any("error", err))
+				p.logger.Error("proc.Stop error", "error", err)
 			}
 			return errors.New("pktvisor process ended unexpectedly, check log")
 		}
@@ -206,20 +206,20 @@ func (p *pktvisorBackend) Start(ctx context.Context, cancelFunc context.CancelFu
 			http.NoBody, "application/json", readinessTimeout, "error")
 		if readinessError == nil {
 			p.logger.Info("pktvisor readiness ok, got version ",
-				slog.String("pktvisor_version", appMetrics.App.Version))
+				"pktvisor_version", appMetrics.App.Version)
 			break
 		}
 		backoffDuration := time.Duration(backoff) * time.Second
 		p.logger.Info("pktvisor is not ready, trying again with backoff",
-			slog.String("backoff backoffDuration", backoffDuration.String()))
+			"backoff backoffDuration", backoffDuration.String())
 		time.Sleep(backoffDuration)
 	}
 
 	if readinessError != nil {
-		p.logger.Error("pktvisor error on readiness", slog.Any("error", readinessError))
+		p.logger.Error("pktvisor error on readiness", "error", readinessError)
 		err = p.proc.Stop()
 		if err != nil {
-			p.logger.Error("proc.Stop error", slog.Any("error", err))
+			p.logger.Error("proc.Stop error", "error", err)
 		}
 		return readinessError
 	}
@@ -312,16 +312,16 @@ func parsePktvisorEntity(line string) (entity, name, rest string, ok bool) {
 }
 
 func (p *pktvisorBackend) Stop(ctx context.Context) error {
-	p.logger.Info("routine call to stop pktvisor", slog.Any("routine", ctx.Value(config.ContextKey("routine"))))
+	p.logger.Info("routine call to stop pktvisor", "routine", ctx.Value(config.ContextKey("routine")))
 	defer p.cancelFunc()
 	err := p.proc.Stop()
 	finalStatus := <-p.statusChan
 	if err != nil {
-		p.logger.Error("pktvisor shutdown error", slog.Any("error", err))
+		p.logger.Error("pktvisor shutdown error", "error", err)
 	}
 
-	p.logger.Info("pktvisor process stopped", slog.Int("pid", finalStatus.PID),
-		slog.Int("exit_code", finalStatus.Exit))
+	p.logger.Info("pktvisor process stopped", "pid", finalStatus.PID,
+		"exit_code", finalStatus.Exit)
 	return nil
 }
 
@@ -329,7 +329,7 @@ func (p *pktvisorBackend) Stop(ctx context.Context) error {
 func (p *pktvisorBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	config map[string]any, common config.BackendCommons,
 ) error {
-	p.logger = logger.With(slog.String("backend", "pktvisor"))
+	p.logger = logger.With("backend", "pktvisor")
 	p.policyRepo = repo
 
 	p.binary = defaultBinary
@@ -377,15 +377,15 @@ func (p *pktvisorBackend) Configure(logger *slog.Logger, repo policies.PolicyRep
 	yamlData, err := yaml.Marshal(fullConfig)
 	if err != nil {
 		if rerr := os.Remove(tmpFile.Name()); rerr != nil {
-			p.logger.Error("failed to remove temp config file", slog.String("file", tmpFile.Name()),
-				slog.Any("error", rerr))
+			p.logger.Error("failed to remove temp config file", "file", tmpFile.Name(),
+				"error", rerr)
 		}
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 	if err := os.WriteFile(tmpFile.Name(), yamlData, 0o644); err != nil {
 		if rerr := os.Remove(tmpFile.Name()); rerr != nil {
-			p.logger.Error("failed to remove temp config file", slog.String("file", tmpFile.Name()),
-				slog.Any("error", rerr))
+			p.logger.Error("failed to remove temp config file", "file", tmpFile.Name(),
+				"error", rerr)
 		}
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
@@ -403,8 +403,8 @@ func (p *pktvisorBackend) Configure(logger *slog.Logger, repo policies.PolicyRep
 			return fmt.Errorf("failed to parse otlp receiver port: %w", err)
 		}
 		p.otelReceiverPort = port
-		p.logger.Info("configured otlp receiver host", slog.String("host", p.otelReceiverHost),
-			slog.Int("port", p.otelReceiverPort))
+		p.logger.Info("configured otlp receiver host", "host", p.otelReceiverHost,
+			"port", p.otelReceiverPort)
 	}
 
 	return nil
@@ -427,7 +427,7 @@ func (p *pktvisorBackend) FullReset(ctx context.Context) error {
 	// force a stop, which stops scrape as well. if proc is dead, it no ops.
 	if state, _, _ := backend.GetRunningStatus(p.proc); state == backend.Running {
 		if err := p.Stop(ctx); err != nil {
-			p.logger.Error("failed to stop backend on restart procedure", slog.Any("error", err))
+			p.logger.Error("failed to stop backend on restart procedure", "error", err)
 			return err
 		}
 	}
@@ -437,7 +437,7 @@ func (p *pktvisorBackend) FullReset(ctx context.Context) error {
 
 	// start it
 	if err := p.Start(backendCtx, cancelFunc); err != nil {
-		p.logger.Error("failed to start backend on restart procedure", slog.Any("error", err))
+		p.logger.Error("failed to start backend on restart procedure", "error", err)
 		return err
 	}
 
@@ -456,12 +456,12 @@ func (p *pktvisorBackend) ApplyPolicy(data policies.PolicyData, updatePolicy boo
 	if updatePolicy {
 		// To update a policy it's necessary first remove it and then apply a new version
 		if err := p.RemovePolicy(data); err != nil {
-			p.logger.Warn("policy failed to remove", slog.String("policy_id", data.ID),
-				slog.String("policy_name", data.Name), slog.Any("error", err))
+			p.logger.Warn("policy failed to remove", "policy_id", data.ID,
+				"policy_name", data.Name, "error", err)
 		}
 	}
 
-	p.logger.Debug("pktvisor policy apply", slog.String("policy_id", data.ID), slog.Any("data", data.Data))
+	p.logger.Debug("pktvisor policy apply", "policy_id", data.ID, "data", data.Data)
 
 	fullPolicy := map[string]any{
 		"version": "1.0",
@@ -474,7 +474,7 @@ func (p *pktvisorBackend) ApplyPolicy(data policies.PolicyData, updatePolicy boo
 
 	policyYaml, err := yaml.Marshal(fullPolicy)
 	if err != nil {
-		p.logger.Warn("yaml policy marshal failure", slog.String("policy_id", data.ID), slog.String("policy_name", data.Name))
+		p.logger.Warn("yaml policy marshal failure", "policy_id", data.ID, "policy_name", data.Name)
 		return err
 	}
 
@@ -483,7 +483,7 @@ func (p *pktvisorBackend) ApplyPolicy(data policies.PolicyData, updatePolicy boo
 	err = backend.CommonRequest("pktvisor", p.proc, p.logger, url, &resp, http.MethodPost,
 		bytes.NewBuffer(policyYaml), "application/x-yaml", applyPolicyTimeout, "error")
 	if err != nil {
-		p.logger.Warn("yaml policy application failure", slog.String("policy_id", data.ID), slog.String("policy_name", data.Name))
+		p.logger.Warn("yaml policy application failure", "policy_id", data.ID, "policy_name", data.Name)
 		return err
 	}
 
@@ -491,7 +491,7 @@ func (p *pktvisorBackend) ApplyPolicy(data policies.PolicyData, updatePolicy boo
 }
 
 func (p *pktvisorBackend) RemovePolicy(data policies.PolicyData) error {
-	p.logger.Debug("pktvisor policy remove", slog.String("policy_id", data.ID))
+	p.logger.Debug("pktvisor policy remove", "policy_id", data.ID)
 	var resp any
 	var name string
 	// Since we use Name for removing policies not IDs, if there is a change, we need to remove the previous name of the policy

--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -73,7 +73,7 @@ func Register() bool {
 func (d *snmpDiscoveryBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	config map[string]any, common config.BackendCommons,
 ) error {
-	d.logger = logger.With(slog.String("backend", "snmp_discovery"))
+	d.logger = logger.With("backend", "snmp_discovery")
 	d.policyRepo = repo
 
 	var prs bool
@@ -120,7 +120,7 @@ func (d *snmpDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Poli
 	if common.Otlp.Grpc != "" {
 		d.diodeOtelEndpoint = common.Otlp.Grpc
 		d.logger.Info("snmp-discovery using OTLP metrics endpoint",
-			slog.String("endpoint", d.diodeOtelEndpoint))
+			"endpoint", d.diodeOtelEndpoint)
 	}
 
 	return nil
@@ -163,16 +163,16 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 	if d.diodeLogLevel != "" {
 		pvOptions = append(pvOptions, "--log-level", d.diodeLogLevel)
 		d.logger.Info("snmp-discovery using log level",
-			slog.String("log_level", d.diodeLogLevel))
+			"log_level", d.diodeLogLevel)
 	}
 
 	if d.diodeOtelEndpoint != "" {
 		pvOptions = append(pvOptions, "--otel-endpoint", d.diodeOtelEndpoint)
 		d.logger.Info("snmp-discovery using OTLP metrics endpoint",
-			slog.String("endpoint", d.diodeOtelEndpoint))
+			"endpoint", d.diodeOtelEndpoint)
 	}
 
-	d.logger.Info("snmp-discovery startup", slog.Any("arguments", pvOptions))
+	d.logger.Info("snmp-discovery startup", "arguments", pvOptions)
 
 	if !d.diodeDryRun && len(pvOptions) > 9 {
 		pvOptions[9] = d.diodeClientSecret
@@ -218,19 +218,19 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 	status := d.proc.Status()
 
 	if status.Error != nil {
-		d.logger.Error("snmp-discovery startup error", slog.Any("error", status.Error))
+		d.logger.Error("snmp-discovery startup error", "error", status.Error)
 		return status.Error
 	}
 
 	if status.Complete {
 		err := d.proc.Stop()
 		if err != nil {
-			d.logger.Error("proc.Stop error", slog.Any("error", err))
+			d.logger.Error("proc.Stop error", "error", err)
 		}
 		return errors.New("snmp-discovery startup error, check log")
 	}
 
-	d.logger.Info("snmp-discovery process started", slog.Int("pid", status.PID))
+	d.logger.Info("snmp-discovery process started", "pid", status.PID)
 
 	var version string
 	var readinessErr error
@@ -238,27 +238,27 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 		if status := d.proc.Status(); status.Complete {
 			err := d.proc.Stop()
 			if err != nil {
-				d.logger.Error("proc.Stop error", slog.Any("error", err))
+				d.logger.Error("proc.Stop error", "error", err)
 			}
 			return errors.New("snmp-discovery process ended unexpectedly, check log")
 		}
 		version, readinessErr = d.Version()
 		if readinessErr == nil {
 			d.logger.Info("snmp-discovery readiness ok, got version ",
-				slog.String("network_discovery_version", version))
+				"network_discovery_version", version)
 			break
 		}
 		backoffDuration := time.Duration(backoff) * time.Second
 		d.logger.Info("snmp-discovery is not ready, trying again with backoff",
-			slog.String("backoff backoffDuration", backoffDuration.String()))
+			"backoff backoffDuration", backoffDuration.String())
 		time.Sleep(backoffDuration)
 	}
 
 	if readinessErr != nil {
-		d.logger.Error("snmp-discovery error on readiness", slog.Any("error", readinessErr))
+		d.logger.Error("snmp-discovery error on readiness", "error", readinessErr)
 		err := d.proc.Stop()
 		if err != nil {
-			d.logger.Error("proc.Stop error", slog.Any("error", err))
+			d.logger.Error("proc.Stop error", "error", err)
 		}
 		return readinessErr
 	}
@@ -267,15 +267,15 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 }
 
 func (d *snmpDiscoveryBackend) Stop(ctx context.Context) error {
-	d.logger.Info("routine call to stop snmp-discovery", slog.Any("routine", ctx.Value(config.ContextKey("routine"))))
+	d.logger.Info("routine call to stop snmp-discovery", "routine", ctx.Value(config.ContextKey("routine")))
 	defer d.cancelFunc()
 	err := d.proc.Stop()
 	finalStatus := <-d.statusChan
 	if err != nil {
-		d.logger.Error("snmp-discovery shutdown error", slog.Any("error", err))
+		d.logger.Error("snmp-discovery shutdown error", "error", err)
 	}
-	d.logger.Info("snmp-discovery process stopped", slog.Int("pid", finalStatus.PID),
-		slog.Int("exit_code", finalStatus.Exit))
+	d.logger.Info("snmp-discovery process stopped", "pid", finalStatus.PID,
+		"exit_code", finalStatus.Exit)
 	return nil
 }
 
@@ -283,7 +283,7 @@ func (d *snmpDiscoveryBackend) FullReset(ctx context.Context) error {
 	// force a stop, which stops scrape as well. if proc is dead, it no ops.
 	if state, _, _ := backend.GetRunningStatus(d.proc); state == backend.Running {
 		if err := d.Stop(ctx); err != nil {
-			d.logger.Error("failed to stop backend on restart procedure", slog.Any("error", err))
+			d.logger.Error("failed to stop backend on restart procedure", "error", err)
 			return err
 		}
 	}
@@ -291,7 +291,7 @@ func (d *snmpDiscoveryBackend) FullReset(ctx context.Context) error {
 	backendCtx, cancelFunc := context.WithCancel(context.WithValue(ctx, config.ContextKey("routine"), "snmp-discovery"))
 	// start it
 	if err := d.Start(backendCtx, cancelFunc); err != nil {
-		d.logger.Error("failed to start backend on restart procedure", slog.Any("error", err))
+		d.logger.Error("failed to start backend on restart procedure", "error", err)
 		return err
 	}
 	return nil
@@ -335,12 +335,12 @@ func (d *snmpDiscoveryBackend) ApplyPolicy(data policies.PolicyData, updatePolic
 	if updatePolicy {
 		// To update a policy it's necessary first remove it and then apply a new version
 		if err := d.RemovePolicy(data); err != nil {
-			d.logger.Warn("policy failed to remove", slog.String("policy_id", data.ID),
-				slog.String("policy_name", data.Name), slog.Any("error", err))
+			d.logger.Warn("policy failed to remove", "policy_id", data.ID,
+				"policy_name", data.Name, "error", err)
 		}
 	}
 
-	d.logger.Debug("snmp-discovery policy apply", slog.String("policy_id", data.ID), slog.Any("data", data.Data))
+	d.logger.Debug("snmp-discovery policy apply", "policy_id", data.ID, "data", data.Data)
 
 	fullPolicy := map[string]any{
 		"policies": map[string]any{
@@ -350,7 +350,7 @@ func (d *snmpDiscoveryBackend) ApplyPolicy(data policies.PolicyData, updatePolic
 
 	policyYaml, err := yaml.Marshal(fullPolicy)
 	if err != nil {
-		d.logger.Warn("policy yaml marshal failure", slog.String("policy_id", data.ID), slog.String("policy_name", data.Name))
+		d.logger.Warn("policy yaml marshal failure", "policy_id", data.ID, "policy_name", data.Name)
 		return err
 	}
 
@@ -359,7 +359,7 @@ func (d *snmpDiscoveryBackend) ApplyPolicy(data policies.PolicyData, updatePolic
 	err = backend.CommonRequest("snmp-discovery", d.proc, d.logger, url, &resp, http.MethodPost,
 		bytes.NewBuffer(policyYaml), "application/x-yaml", applyPolicyTimeout, "detail")
 	if err != nil {
-		d.logger.Warn("policy application failure", slog.String("policy_id", data.ID), slog.String("policy_name", data.Name))
+		d.logger.Warn("policy application failure", "policy_id", data.ID, "policy_name", data.Name)
 		return err
 	}
 
@@ -549,7 +549,7 @@ func readSnmpUnquotedValue(runes []rune, start int) (string, int, bool) {
 }
 
 func (d *snmpDiscoveryBackend) RemovePolicy(data policies.PolicyData) error {
-	d.logger.Debug("snmp-discovery policy remove", slog.String("policy_id", data.ID))
+	d.logger.Debug("snmp-discovery policy remove", "policy_id", data.ID)
 	var resp any
 	name := data.Name
 	// Since we use Name for removing policies not IDs, if there is a change, we need to remove the previous name of the policy

--- a/agent/backend/utils.go
+++ b/agent/backend/utils.go
@@ -45,7 +45,7 @@ func CommonRequest(backendName string, proc Commander, logger *slog.Logger, url 
 	status, _, err := GetRunningStatus(proc)
 	if status != Running {
 		logger.Warn("skipping REST API request because process is not running or is unresponsive",
-			slog.String("backend", backendName), slog.String("url", url), slog.String("method", method), slog.Any("error", err))
+			"backend", backendName, "url", url, "method", method, "error", err)
 		return err
 	}
 
@@ -63,7 +63,7 @@ func CommonRequest(backendName string, proc Commander, logger *slog.Logger, url 
 
 	defer func() {
 		if err := res.Body.Close(); err != nil {
-			logger.Error("failed to close response body", slog.Any("error", err))
+			logger.Error("failed to close response body", "error", err)
 		}
 	}()
 

--- a/agent/backend/worker/worker.go
+++ b/agent/backend/worker/worker.go
@@ -71,7 +71,7 @@ func Register() bool {
 func (d *workerBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	config map[string]any, common config.BackendCommons,
 ) error {
-	d.logger = logger.With(slog.String("backend", "worker"))
+	d.logger = logger.With("backend", "worker")
 	d.policyRepo = repo
 
 	var prs bool
@@ -113,7 +113,7 @@ func (d *workerBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	if common.Otlp.Grpc != "" {
 		d.diodeOtelEndpoint = common.Otlp.Grpc
 		d.logger.Info("orb-worker using OTLP metrics endpoint",
-			slog.String("endpoint", d.diodeOtelEndpoint))
+			"endpoint", d.diodeOtelEndpoint)
 	}
 
 	return nil
@@ -157,7 +157,7 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 		pvOptions = append(pvOptions, "--otel-endpoint", d.diodeOtelEndpoint)
 	}
 
-	d.logger.Info("worker startup", slog.Any("arguments", pvOptions))
+	d.logger.Info("worker startup", "arguments", pvOptions)
 
 	if !d.diodeDryRun && len(pvOptions) > 9 {
 		pvOptions[9] = d.diodeClientSecret
@@ -203,19 +203,19 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 	status := d.proc.Status()
 
 	if status.Error != nil {
-		d.logger.Error("worker startup error", slog.Any("error", status.Error))
+		d.logger.Error("worker startup error", "error", status.Error)
 		return status.Error
 	}
 
 	if status.Complete {
 		err := d.proc.Stop()
 		if err != nil {
-			d.logger.Error("proc.Stop error", slog.Any("error", err))
+			d.logger.Error("proc.Stop error", "error", err)
 		}
 		return errors.New("worker startup error, check log")
 	}
 
-	d.logger.Info("worker process started", slog.Int("pid", status.PID))
+	d.logger.Info("worker process started", "pid", status.PID)
 
 	var version string
 	var readinessErr error
@@ -223,27 +223,27 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 		if status := d.proc.Status(); status.Complete {
 			err := d.proc.Stop()
 			if err != nil {
-				d.logger.Error("proc.Stop error", slog.Any("error", err))
+				d.logger.Error("proc.Stop error", "error", err)
 			}
 			return errors.New("worker process ended unexpectedly, check log")
 		}
 		version, readinessErr = d.Version()
 		if readinessErr == nil {
 			d.logger.Info("worker readiness ok, got version ",
-				slog.String("worker_version", version))
+				"worker_version", version)
 			break
 		}
 		backoffDuration := time.Duration(backoff) * time.Second
 		d.logger.Info("worker is not ready, trying again with backoff",
-			slog.String("backoff backoffDuration", backoffDuration.String()))
+			"backoff backoffDuration", backoffDuration.String())
 		time.Sleep(backoffDuration)
 	}
 
 	if readinessErr != nil {
-		d.logger.Error("worker error on readiness", slog.Any("error", readinessErr))
+		d.logger.Error("worker error on readiness", "error", readinessErr)
 		err := d.proc.Stop()
 		if err != nil {
-			d.logger.Error("proc.Stop error", slog.Any("error", err))
+			d.logger.Error("proc.Stop error", "error", err)
 		}
 		return readinessErr
 	}
@@ -252,15 +252,15 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 }
 
 func (d *workerBackend) Stop(ctx context.Context) error {
-	d.logger.Info("routine call to stop worker", slog.Any("routine", ctx.Value(config.ContextKey("routine"))))
+	d.logger.Info("routine call to stop worker", "routine", ctx.Value(config.ContextKey("routine")))
 	defer d.cancelFunc()
 	err := d.proc.Stop()
 	finalStatus := <-d.statusChan
 	if err != nil {
-		d.logger.Error("worker shutdown error", slog.Any("error", err))
+		d.logger.Error("worker shutdown error", "error", err)
 	}
-	d.logger.Info("worker process stopped", slog.Int("pid", finalStatus.PID),
-		slog.Int("exit_code", finalStatus.Exit))
+	d.logger.Info("worker process stopped", "pid", finalStatus.PID,
+		"exit_code", finalStatus.Exit)
 	return nil
 }
 
@@ -268,7 +268,7 @@ func (d *workerBackend) FullReset(ctx context.Context) error {
 	// force a stop, which stops scrape as well. if proc is dead, it no ops.
 	if state, _, _ := backend.GetRunningStatus(d.proc); state == backend.Running {
 		if err := d.Stop(ctx); err != nil {
-			d.logger.Error("failed to stop backend on restart procedure", slog.Any("error", err))
+			d.logger.Error("failed to stop backend on restart procedure", "error", err)
 			return err
 		}
 	}
@@ -276,7 +276,7 @@ func (d *workerBackend) FullReset(ctx context.Context) error {
 	backendCtx, cancelFunc := context.WithCancel(context.WithValue(ctx, config.ContextKey("routine"), "worker"))
 	// start it
 	if err := d.Start(backendCtx, cancelFunc); err != nil {
-		d.logger.Error("failed to start backend on restart procedure", slog.Any("error", err))
+		d.logger.Error("failed to start backend on restart procedure", "error", err)
 		return err
 	}
 	return nil
@@ -344,12 +344,12 @@ func (d *workerBackend) ApplyPolicy(data policies.PolicyData, updatePolicy bool)
 	if updatePolicy {
 		// To update a policy it's necessary first remove it and then apply a new version
 		if err := d.RemovePolicy(data); err != nil {
-			d.logger.Warn("policy failed to remove", slog.String("policy_id", data.ID),
-				slog.String("policy_name", data.Name), slog.Any("error", err))
+			d.logger.Warn("policy failed to remove", "policy_id", data.ID,
+				"policy_name", data.Name, "error", err)
 		}
 	}
 
-	d.logger.Debug("worker policy apply", slog.String("policy_id", data.ID), slog.Any("data", data.Data))
+	d.logger.Debug("worker policy apply", "policy_id", data.ID, "data", data.Data)
 
 	fullPolicy := map[string]any{
 		"policies": map[string]any{
@@ -359,7 +359,7 @@ func (d *workerBackend) ApplyPolicy(data policies.PolicyData, updatePolicy bool)
 
 	policyYaml, err := yaml.Marshal(fullPolicy)
 	if err != nil {
-		d.logger.Warn("policy yaml marshal failure", slog.String("policy_id", data.ID), slog.String("policy_name", data.Name))
+		d.logger.Warn("policy yaml marshal failure", "policy_id", data.ID, "policy_name", data.Name)
 		return err
 	}
 
@@ -368,7 +368,7 @@ func (d *workerBackend) ApplyPolicy(data policies.PolicyData, updatePolicy bool)
 	err = backend.CommonRequest("worker", d.proc, d.logger, url, &resp, http.MethodPost,
 		bytes.NewBuffer(policyYaml), "application/x-yaml", applyPolicyTimeout, "detail")
 	if err != nil {
-		d.logger.Warn("policy application failure", slog.String("policy_id", data.ID), slog.String("policy_name", data.Name))
+		d.logger.Warn("policy application failure", "policy_id", data.ID, "policy_name", data.Name)
 		return err
 	}
 
@@ -376,7 +376,7 @@ func (d *workerBackend) ApplyPolicy(data policies.PolicyData, updatePolicy bool)
 }
 
 func (d *workerBackend) RemovePolicy(data policies.PolicyData) error {
-	d.logger.Debug("worker policy remove", slog.String("policy_id", data.ID))
+	d.logger.Debug("worker policy remove", "policy_id", data.ID)
 	var resp any
 	var name string
 	// Since we use Name for removing policies not IDs, if there is a change, we need to remove the previous name of the policy

--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -64,7 +64,7 @@ func (gc *gitConfigManager) readPolicies(tree *object.Tree, matchingPolicies []s
 		}
 		defer func() {
 			if err := reader.Close(); err != nil {
-				gc.logger.Error("failed to close file", slog.Any("error", err))
+				gc.logger.Error("failed to close file", "error", err)
 			}
 		}()
 
@@ -108,7 +108,7 @@ func (gc *gitConfigManager) removePolicies(policiesByPath map[policyPath]policyD
 
 	appliedPolicies, err := gc.pMgr.GetRepo().GetAll()
 	if err != nil {
-		gc.logger.Error("failed to get applied policies", slog.Any("error", err))
+		gc.logger.Error("failed to get applied policies", "error", err)
 		return
 	}
 
@@ -117,7 +117,7 @@ func (gc *gitConfigManager) removePolicies(policiesByPath map[policyPath]policyD
 		key := policyKey{Backend: policy.Backend, Name: policy.Name}
 		if _, exists := definedPolicies[key]; !exists {
 			if err := gc.pMgr.RemovePolicy(policy.ID, policy.Name, policy.Backend); err != nil {
-				gc.logger.Error("failed to remove policy", slog.Any("error", err))
+				gc.logger.Error("failed to remove policy", "error", err)
 			}
 		}
 	}
@@ -154,7 +154,7 @@ func (gc *gitConfigManager) processSelector(file *object.File, cfg config.Config
 	}
 	defer func() {
 		if err := reader.Close(); err != nil {
-			gc.logger.Error("failed to close file", slog.Any("error", err))
+			gc.logger.Error("failed to close file", "error", err)
 		}
 	}()
 
@@ -187,14 +187,14 @@ func (gc *gitConfigManager) processSelector(file *object.File, cfg config.Config
 			}
 		}
 		if matches {
-			gc.logger.Info("Selector matched", slog.String("selector", selectorName))
+			gc.logger.Info("Selector matched", "selector", selectorName)
 			for pName, policy := range entry.Policies {
 				if policy.Enabled != nil && !*policy.Enabled {
 					continue
 				}
 				if _, exists := policyPathsSet[policy.Path]; exists {
-					gc.logger.Warn("Policy path already exists", slog.String("selector", selectorName),
-						slog.String("policy", pName), slog.String("path", policy.Path))
+					gc.logger.Warn("Policy path already exists", "selector", selectorName,
+						"policy", pName, "path", policy.Path)
 				}
 				policyPathsSet[policy.Path] = struct{}{}
 			}
@@ -219,14 +219,14 @@ func (gc *gitConfigManager) schedule(cfg config.Config, backends map[string]back
 		RefSpecs:        []gitconfig.RefSpec{"refs/heads/*:refs/heads/*"},
 	})
 	if err != nil && err != gitv5.NoErrAlreadyUpToDate {
-		gc.logger.Error("Failed to fetch latest changes", slog.Any("error", err))
+		gc.logger.Error("Failed to fetch latest changes", "error", err)
 		return
 	}
 
 	// Get the latest reference (HEAD)
 	ref, err := gc.repo.Reference(plumbing.ReferenceName("refs/heads/"+gc.config.Branch), true)
 	if err != nil {
-		gc.logger.Error("Failed to get latest branch reference", slog.Any("error", err))
+		gc.logger.Error("Failed to get latest branch reference", "error", err)
 		return
 	}
 
@@ -239,13 +239,13 @@ func (gc *gitConfigManager) schedule(cfg config.Config, backends map[string]back
 	// Get the latest commit
 	commit, err := gc.repo.CommitObject(ref.Hash())
 	if err != nil {
-		gc.logger.Error("Failed to get commit object", slog.Any("error", err))
+		gc.logger.Error("Failed to get commit object", "error", err)
 		return
 	}
 
 	tree, err := commit.Tree()
 	if err != nil {
-		gc.logger.Error("Failed to get commit tree", slog.Any("error", err))
+		gc.logger.Error("Failed to get commit tree", "error", err)
 		return
 	}
 
@@ -261,20 +261,20 @@ func (gc *gitConfigManager) schedule(cfg config.Config, backends map[string]back
 	// Get the last commit's tree
 	oldCommit, err := gc.repo.CommitObject(gc.lastRef)
 	if err != nil {
-		gc.logger.Error("Failed to get old commit object", slog.Any("error", err))
+		gc.logger.Error("Failed to get old commit object", "error", err)
 		return
 	}
 
 	oldTree, err := oldCommit.Tree()
 	if err != nil {
-		gc.logger.Error("Failed to get old commit tree", slog.Any("error", err))
+		gc.logger.Error("Failed to get old commit tree", "error", err)
 		return
 	}
 
 	// Check for file changes
 	changes, err := oldTree.Diff(tree)
 	if err != nil {
-		gc.logger.Error("Failed to get diff", slog.Any("error", err))
+		gc.logger.Error("Failed to get diff", "error", err)
 		return
 	}
 
@@ -283,7 +283,7 @@ func (gc *gitConfigManager) schedule(cfg config.Config, backends map[string]back
 
 	matchingPolicies, err := gc.processSelector(selectorFile, cfg)
 	if err != nil {
-		gc.logger.Error("Failed to process selector", slog.Any("error", err))
+		gc.logger.Error("Failed to process selector", "error", err)
 		return
 	}
 
@@ -302,7 +302,7 @@ func (gc *gitConfigManager) schedule(cfg config.Config, backends map[string]back
 
 	policiesByPath, err := gc.readPolicies(tree, matchingPolicies)
 	if err != nil {
-		gc.logger.Error("Failed to read policies", slog.Any("error", err))
+		gc.logger.Error("Failed to read policies", "error", err)
 		return
 	}
 
@@ -316,7 +316,7 @@ func (gc *gitConfigManager) schedule(cfg config.Config, backends map[string]back
 		}
 		policies := policiesByPath[policyPath(policy)]
 		if err = gc.applyPolicies(policies, backends); err != nil {
-			gc.logger.Error("failed to apply policies", slog.Any("error", err))
+			gc.logger.Error("failed to apply policies", "error", err)
 		}
 	}
 
@@ -328,7 +328,7 @@ func (gc *gitConfigManager) schedule(cfg config.Config, backends map[string]back
 		for path, policies := range policiesByPath {
 			if change.To.Name == string(path) {
 				if err = gc.applyPolicies(policies, backends); err != nil {
-					gc.logger.Error("Failed to apply policies", slog.Any("error", err))
+					gc.logger.Error("Failed to apply policies", "error", err)
 				}
 			}
 		}
@@ -412,7 +412,7 @@ func (gc *gitConfigManager) Start(cfg config.Config, backends map[string]backend
 		for _, ref := range refs {
 			if ref.Name().IsBranch() {
 				branchName = ref.Name().Short()
-				gc.logger.Info("detected default branch", slog.String("branch", branchName))
+				gc.logger.Info("detected default branch", "branch", branchName)
 				break
 			}
 		}
@@ -422,7 +422,7 @@ func (gc *gitConfigManager) Start(cfg config.Config, backends map[string]backend
 		}
 	}
 
-	gc.logger.Info("cloning repository", slog.String("url", gc.config.URL), slog.String("branch", branchName))
+	gc.logger.Info("cloning repository", "url", gc.config.URL, "branch", branchName)
 
 	// Now clone the repository with the determined branch
 	gc.repo, err = gitv5.Clone(memory.NewStorage(), nil, &gitv5.CloneOptions{

--- a/agent/policymgr/manager.go
+++ b/agent/policymgr/manager.go
@@ -53,12 +53,12 @@ func (a *policyManager) GetPolicyState() ([]policies.PolicyData, error) {
 
 func (a *policyManager) ManagePolicy(payload config.PolicyPayload) {
 	a.logger.Info("managing agent policy from core",
-		slog.String("action", payload.Action),
-		slog.String("name", payload.Name),
-		slog.String("dataset", payload.DatasetID),
-		slog.String("backend", payload.Backend),
-		slog.String("id", payload.ID),
-		slog.Int("version", int(payload.Version)))
+		"action", payload.Action,
+		"name", payload.Name,
+		"dataset", payload.DatasetID,
+		"backend", payload.Backend,
+		"id", payload.ID,
+		"version", int(payload.Version))
 
 	switch payload.Action {
 	case "manage":
@@ -78,28 +78,28 @@ func (a *policyManager) ManagePolicy(payload config.PolicyPayload) {
 			if payload.DatasetID != "" {
 				err := a.repo.EnsureDataset(payload.ID, payload.DatasetID)
 				if err != nil {
-					a.logger.Warn("policy failed to ensure dataset id", slog.String("policy_id", payload.ID),
-						slog.String("policy_name", payload.Name), slog.String("dataset_id", payload.DatasetID), slog.Any("error", err))
+					a.logger.Warn("policy failed to ensure dataset id", "policy_id", payload.ID,
+						"policy_name", payload.Name, "dataset_id", payload.DatasetID, "error", err)
 				}
 			}
 
 			if payload.AgentGroupID != "" {
 				err := a.repo.EnsureGroupID(payload.ID, payload.AgentGroupID)
 				if err != nil {
-					a.logger.Warn("policy failed to ensure agent group id", slog.String("policy_id", payload.ID),
-						slog.String("policy_name", payload.Name), slog.String("agent_group_id", payload.AgentGroupID), slog.Any("error", err))
+					a.logger.Warn("policy failed to ensure agent group id", "policy_id", payload.ID,
+						"policy_name", payload.Name, "agent_group_id", payload.AgentGroupID, "error", err)
 				}
 			}
 
 			// if policy already exist and has no version upgrade, has no need to apply it again
 			currentPolicy, err := a.repo.Get(payload.ID)
 			if err != nil {
-				a.logger.Error("failed to retrieve policy", slog.String("policy_id", payload.ID), slog.Any("error", err))
+				a.logger.Error("failed to retrieve policy", "policy_id", payload.ID, "error", err)
 				return
 			}
 			if currentPolicy.Backend == pd.Backend && currentPolicy.Version >= pd.Version && currentPolicy.State == policies.Running {
-				a.logger.Info("a better version of this policy has already been applied, skipping", slog.String("policy_id", pd.ID), slog.String("policy_name", pd.Name),
-					slog.String("attempted_version", fmt.Sprint(pd.Version)), slog.String("current_version", fmt.Sprint(currentPolicy.Version)))
+				a.logger.Info("a better version of this policy has already been applied, skipping", "policy_id", pd.ID, "policy_name", pd.Name,
+					"attempted_version", fmt.Sprint(pd.Version), "current_version", fmt.Sprint(currentPolicy.Version))
 				return
 			}
 			updatePolicy = true
@@ -112,7 +112,7 @@ func (a *policyManager) ManagePolicy(payload config.PolicyPayload) {
 			// new policy we have not seen before, associate with this dataset
 			// on first time we see policy, we *require* dataset
 			if payload.DatasetID == "" {
-				a.logger.Error("policy RPC for unseen policy did not include dataset ID, skipping", slog.String("policy_id", payload.ID), slog.String("policy_name", payload.Name))
+				a.logger.Error("policy RPC for unseen policy did not include dataset ID, skipping", "policy_id", payload.ID, "policy_name", payload.Name)
 				return
 			}
 			pd.Datasets = map[string]bool{payload.DatasetID: true}
@@ -123,7 +123,7 @@ func (a *policyManager) ManagePolicy(payload config.PolicyPayload) {
 
 		}
 		if !backend.HaveBackend(payload.Backend) {
-			a.logger.Warn("policy failed to apply because backend is not available", slog.String("policy_id", payload.ID), slog.String("policy_name", payload.Name))
+			a.logger.Warn("policy failed to apply because backend is not available", "policy_id", payload.ID, "policy_name", payload.Name)
 			pd.State = policies.FailedToApply
 			pd.BackendErr = "backend not available"
 		} else {
@@ -131,7 +131,7 @@ func (a *policyManager) ManagePolicy(payload config.PolicyPayload) {
 			be := backend.GetBackend(payload.Backend)
 			newPayload, err := a.secrets.SolvePolicySecrets(payload)
 			if err != nil {
-				a.logger.Error("failed to solve secrets", slog.String("policy_id", payload.ID), slog.String("policy_name", payload.Name), slog.Any("error", err))
+				a.logger.Error("failed to solve secrets", "policy_id", payload.ID, "policy_name", payload.Name, "error", err)
 				return
 			}
 			pd.Data = newPayload.Data
@@ -141,18 +141,18 @@ func (a *policyManager) ManagePolicy(payload config.PolicyPayload) {
 		// save policy (with latest status) to local policy db
 		err := a.repo.Update(pd)
 		if err != nil {
-			a.logger.Error("got error in update last status", slog.Any("error", err))
+			a.logger.Error("got error in update last status", "error", err)
 			return
 		}
 		return
 	case "remove":
 		err := a.RemovePolicy(payload.ID, payload.Name, payload.Backend)
 		if err != nil {
-			a.logger.Error("policy failed to be removed", slog.String("policy_id", payload.ID), slog.String("policy_name", payload.Name), slog.Any("error", err))
+			a.logger.Error("policy failed to be removed", "policy_id", payload.ID, "policy_name", payload.Name, "error", err)
 		}
 		return
 	default:
-		a.logger.Error("unknown policy action, ignored", slog.String("action", payload.Action))
+		a.logger.Error("unknown policy action, ignored", "action", payload.Action)
 	}
 }
 
@@ -167,7 +167,7 @@ func (a *policyManager) RemovePolicy(policyID string, policyName string, beName 
 	be := backend.GetBackend(beName)
 	err := be.RemovePolicy(pd)
 	if err != nil {
-		a.logger.Error("backend remove policy failed: will still remove from PolicyManager", slog.String("policy_id", policyID), slog.Any("error", err))
+		a.logger.Error("backend remove policy failed: will still remove from PolicyManager", "policy_id", policyID, "error", err)
 	}
 	// Remove policy from orb-agent local repo
 	err = a.repo.Remove(pd.ID)
@@ -180,24 +180,24 @@ func (a *policyManager) RemovePolicy(policyID string, policyName string, beName 
 func (a *policyManager) RemovePolicyDataset(policyID string, datasetID string, be backend.Backend) {
 	policyData, err := a.repo.Get(policyID)
 	if err != nil {
-		a.logger.Warn("failed to retrieve policy data", slog.String("policy_id", policyID), slog.String("policy_name", policyData.Name), slog.Any("error", err))
+		a.logger.Warn("failed to retrieve policy data", "policy_id", policyID, "policy_name", policyData.Name, "error", err)
 		return
 	}
 	removePolicy, err := a.repo.RemoveDataset(policyID, datasetID)
 	if err != nil {
-		a.logger.Warn("failed to remove policy dataset", slog.String("dataset_id", datasetID), slog.String("policy_name", policyData.Name), slog.Any("error", err))
+		a.logger.Warn("failed to remove policy dataset", "dataset_id", datasetID, "policy_name", policyData.Name, "error", err)
 		return
 	}
 	if removePolicy {
 		// Remove policy via http request
 		err := be.RemovePolicy(policyData)
 		if err != nil {
-			a.logger.Warn("policy failed to remove", slog.String("policy_id", policyID), slog.String("policy_name", policyData.Name), slog.Any("error", err))
+			a.logger.Warn("policy failed to remove", "policy_id", policyID, "policy_name", policyData.Name, "error", err)
 		}
 		// Remove policy from orb-agent local repo
 		err = a.repo.Remove(policyData.ID)
 		if err != nil {
-			a.logger.Warn("policy failed to remove local", slog.String("policy_id", policyData.ID), slog.String("policy_name", policyData.Name), slog.Any("error", err))
+			a.logger.Warn("policy failed to remove local", "policy_id", policyData.ID, "policy_name", policyData.Name, "error", err)
 		}
 	}
 }
@@ -205,13 +205,13 @@ func (a *policyManager) RemovePolicyDataset(policyID string, datasetID string, b
 func (a *policyManager) applyPolicy(payload config.PolicyPayload, be backend.Backend, pd *policies.PolicyData, updatePolicy bool) {
 	err := be.ApplyPolicy(*pd, updatePolicy)
 	if err != nil {
-		a.logger.Warn("policy failed to apply", slog.String("policy_id", payload.ID), slog.String("policy_name", payload.Name),
-			slog.String("backend", pd.Backend), slog.Any("error", err))
+		a.logger.Warn("policy failed to apply", "policy_id", payload.ID, "policy_name", payload.Name,
+			"backend", pd.Backend, "error", err)
 		pd.State = policies.FailedToApply
 		pd.BackendErr = err.Error()
 	} else {
-		a.logger.Info("policy applied successfully", slog.String("policy_id", payload.ID), slog.String("policy_name", payload.Name),
-			slog.String("backend", pd.Backend))
+		a.logger.Info("policy applied successfully", "policy_id", payload.ID, "policy_name", payload.Name,
+			"backend", pd.Backend)
 		pd.State = policies.Running
 		pd.BackendErr = ""
 	}
@@ -220,14 +220,14 @@ func (a *policyManager) applyPolicy(payload config.PolicyPayload, be backend.Bac
 func (a *policyManager) RemoveBackendPolicies(be backend.Backend, permanently bool) error {
 	plcies, err := a.repo.GetAll()
 	if err != nil {
-		a.logger.Error("failed to retrieve list of policies", slog.Any("error", err))
+		a.logger.Error("failed to retrieve list of policies", "error", err)
 		return err
 	}
 
 	for _, plcy := range plcies {
 		err := be.RemovePolicy(plcy)
 		if err != nil {
-			a.logger.Error("failed to remove policy from backend", slog.String("policy_id", plcy.ID), slog.String("policy_name", plcy.Name), slog.Any("error", err))
+			a.logger.Error("failed to remove policy from backend", "policy_id", plcy.ID, "policy_name", plcy.Name, "error", err)
 			// note we continue here: even if the backend failed to remove, we update our policy repo to remove it
 		}
 		if permanently {
@@ -249,18 +249,18 @@ func (a *policyManager) RemoveBackendPolicies(be backend.Backend, permanently bo
 func (a *policyManager) ApplyBackendPolicies(be backend.Backend) error {
 	plcies, err := a.repo.GetAll()
 	if err != nil {
-		a.logger.Error("failed to retrieve list of policies", slog.Any("error", err))
+		a.logger.Error("failed to retrieve list of policies", "error", err)
 		return err
 	}
 
 	for _, policy := range plcies {
 		err := be.ApplyPolicy(policy, false)
 		if err != nil {
-			a.logger.Warn("policy failed to apply", slog.String("policy_id", policy.ID), slog.String("policy_name", policy.Name), slog.Any("error", err))
+			a.logger.Warn("policy failed to apply", "policy_id", policy.ID, "policy_name", policy.Name, "error", err)
 			policy.State = policies.FailedToApply
 			policy.BackendErr = err.Error()
 		} else {
-			a.logger.Info("policy applied successfully", slog.String("policy_id", policy.ID), slog.String("policy_name", policy.Name))
+			a.logger.Info("policy applied successfully", "policy_id", policy.ID, "policy_name", policy.Name)
 			policy.State = policies.Running
 			policy.BackendErr = ""
 		}
@@ -276,17 +276,17 @@ func (a *policyManager) policiesChanged(policiesIDs map[string]bool) {
 	for id, valid := range policiesIDs {
 		policy, err := a.repo.Get(id)
 		if err != nil {
-			a.logger.Error("failed to get policy", slog.Any("error", err))
+			a.logger.Error("failed to get policy", "error", err)
 			continue
 		}
 		if !valid {
 			if err := a.RemovePolicy(policy.ID, policy.Name, policy.Backend); err != nil {
-				a.logger.Error("failed to remove policy", slog.Any("error", err))
+				a.logger.Error("failed to remove policy", "error", err)
 			}
 			continue
 		}
 		if !backend.HaveBackend(policy.Backend) {
-			a.logger.Warn("policy failed to apply because backend is not available", slog.String("policy_id", policy.ID), slog.String("policy_name", policy.Name))
+			a.logger.Warn("policy failed to apply because backend is not available", "policy_id", policy.ID, "policy_name", policy.Name)
 			policy.State = policies.FailedToApply
 			policy.BackendErr = "backend not available"
 		} else {
@@ -297,7 +297,7 @@ func (a *policyManager) policiesChanged(policiesIDs map[string]bool) {
 			}
 			newPayload, err := a.secrets.SolvePolicySecrets(payload)
 			if err != nil {
-				a.logger.Error("failed to solve secrets", slog.String("policy_id", policy.ID), slog.String("policy_name", policy.Name), slog.Any("error", err))
+				a.logger.Error("failed to solve secrets", "policy_id", policy.ID, "policy_name", policy.Name, "error", err)
 				continue
 			}
 			policy.Data = newPayload.Data
@@ -307,7 +307,7 @@ func (a *policyManager) policiesChanged(policiesIDs map[string]bool) {
 		}
 
 		if err = a.repo.Update(policy); err != nil {
-			a.logger.Error("got error in update last status", slog.Any("error", err))
+			a.logger.Error("got error in update last status", "error", err)
 		}
 	}
 }

--- a/agent/secretsmgr/vault.go
+++ b/agent/secretsmgr/vault.go
@@ -85,7 +85,7 @@ func (v *vaultManager) Start(ctx context.Context) error {
 			return fmt.Errorf("failed to create polling job: %w", err)
 		}
 
-		v.logger.Info("Starting vault secret polling", slog.String("cron interval", *v.config.Schedule))
+		v.logger.Info("Starting vault secret polling", "cron interval", *v.config.Schedule)
 		v.scheduler.Start()
 	}
 
@@ -121,14 +121,14 @@ func (v *vaultManager) pollSecrets() {
 		return
 	}
 
-	v.logger.Debug("Polling vault secrets for changes", slog.Int("secretCount", len(v.usedVars)))
+	v.logger.Debug("Polling vault secrets for changes", "secretCount", len(v.usedVars))
 	changedPolicyIDs := make(map[string]bool)
 
 	// Check each cached secret
 	for path, cachedSecret := range v.usedVars {
 		currentValue, err := v.getSecret(path)
 		if err != nil {
-			v.logger.Error("Failed to retrieve secret during polling", slog.String("path", path), slog.Any("error", err))
+			v.logger.Error("Failed to retrieve secret during polling", "path", path, "error", err)
 			for id := range cachedSecret.policyIDs {
 				changedPolicyIDs[id] = false
 			}
@@ -136,7 +136,7 @@ func (v *vaultManager) pollSecrets() {
 		}
 
 		if currentValue != cachedSecret.Value {
-			v.logger.Info("Detected changed secret", slog.String("path", path))
+			v.logger.Info("Detected changed secret", "path", path)
 			cachedSecret.Value = currentValue
 			v.usedVars[path] = cachedSecret
 			for id := range cachedSecret.policyIDs {
@@ -146,7 +146,7 @@ func (v *vaultManager) pollSecrets() {
 	}
 
 	if len(changedPolicyIDs) > 0 {
-		v.logger.Info("Calling update callback for changed secrets", slog.Int("policyCount", len(changedPolicyIDs)))
+		v.logger.Info("Calling update callback for changed secrets", "policyCount", len(changedPolicyIDs))
 		v.callback(changedPolicyIDs)
 	}
 }
@@ -237,10 +237,10 @@ func (v *vaultManager) addTokenLifecycleWatcher() error {
 
 			case err := <-lw.DoneCh():
 				if err != nil {
-					v.logger.Error("Token renewal failed", slog.Any("error", err))
+					v.logger.Error("Token renewal failed", "error", err)
 				}
 			case output := <-lw.RenewCh():
-				v.logger.Info("Token renewed", slog.Time("renewedAt", output.RenewedAt))
+				v.logger.Info("Token renewed", "renewedAt", output.RenewedAt)
 			}
 		}
 	}()

--- a/agent/telemetry/logs.go
+++ b/agent/telemetry/logs.go
@@ -236,8 +236,8 @@ func (r *resilientLogExporter) Export(ctx context.Context, records []sdklog.Reco
 		r.warnOnce.Do(func() {
 			if r.logger != nil {
 				r.logger.Error("OTLP gRPC log export failed",
-					slog.String("endpoint", r.endpoint),
-					slog.Any("error", err))
+					"endpoint", r.endpoint,
+					"error", err)
 			}
 		})
 		return err

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -92,12 +92,12 @@ func Run(_ *cobra.Command, _ []string) {
 		cobra.CheckErr(fmt.Errorf("no config file specified, use --config or -c flag to provide config files"))
 	}
 
-	logger.Info("backends loaded", slog.Any("backends", configData.OrbAgent.Backends))
+	logger.Info("backends loaded", "backends", configData.OrbAgent.Backends)
 
 	// new agent
 	a, err := agent.New(logger, configData)
 	if err != nil {
-		logger.Error("agent start up error", slog.Any("error", err))
+		logger.Error("agent start up error", "error", err)
 		os.Exit(1)
 	}
 
@@ -123,7 +123,7 @@ func Run(_ *cobra.Command, _ []string) {
 	// start agent
 	err = a.Start(rootCtx, cancelFunc)
 	if err != nil {
-		logger.Error("agent startup error", slog.Any("error", err))
+		logger.Error("agent startup error", "error", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
This pull request refactors logging calls throughout the agent and backend code to use a more idiomatic and consistent key-value format, replacing the previous use of `slog.String` and `slog.Any` wrappers. This change improves readability, aligns with recommended usage of the logging library, and simplifies future maintenance.

**Logging format modernization:**

* Replaced usages of `slog.String` and `slog.Any` with direct key-value pairs in all `Info`, `Error`, `Warn`, and `Debug` logging calls across `agent/agent.go`, `agent/backend/devicediscovery/device_discovery.go`, and `agent/backend/networkdiscovery/network_discovery.go`. This ensures a consistent and idiomatic approach to structured logging. [[1]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL59-R63) [[2]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL87-R87) [[3]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL104-R104) [[4]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL117-R117) [[5]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL145-R145) [[6]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL172-R191) [[7]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL214-R224) [[8]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL242-R242) [[9]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL254-R258) [[10]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL271-R271) [[11]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL282-R287) [[12]](diffhunk://#diff-6301055a8fa5f25637f457f26fa4d9556ff42cfe18d83199b773f78de9332819L108-R108) [[13]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L74-R74) [[14]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L116-R116) [[15]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L160-R160) [[16]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L206-R246) [[17]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L279-R302) [[18]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L346-R351) [[19]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L361-R361) [[20]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L370-R378) [[21]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L76-R76) [[22]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L123-R123) [[23]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L166-R175)

**Backend-specific improvements:**

* Updated backend startup, shutdown, and policy application log messages to use the new key-value format, improving clarity and consistency in logs for device and network discovery backends. [[1]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L160-R160) [[2]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L206-R246) [[3]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L279-R302) [[4]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L346-R351) [[5]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L361-R361) [[6]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L370-R378) [[7]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L166-R175)

**Agent lifecycle logging:**

* Refactored agent startup, backend configuration, restart, and shutdown log messages to use the new format, making operational logs easier to parse and understand. [[1]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL172-R191) [[2]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL214-R224) [[3]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL242-R242) [[4]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL254-R258) [[5]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL271-R271) [[6]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL282-R287)

**Policy management and error reporting:**

* Improved logging for policy application, removal, and error handling to use key-value pairs, aiding troubleshooting and log analysis. [[1]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L346-R351) [[2]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L361-R361) [[3]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L370-R378) [[4]](diffhunk://#diff-6301055a8fa5f25637f457f26fa4d9556ff42cfe18d83199b773f78de9332819L108-R108)

**Configuration and telemetry:**

* Updated configuration-related log messages in backend and agent initialization to use the new logging format, including OTLP telemetry endpoint reporting. [[1]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL117-R117) [[2]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L116-R116) [[3]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L123-R123)

These changes help standardize logging practices and improve overall code maintainability.