### PR TITLE
fix: try to apply policy to a backend that has not even configured

### DIFF
--- a/agent/policymgr/manager.go
+++ b/agent/policymgr/manager.go
@@ -203,7 +203,31 @@ func (a *policyManager) RemovePolicyDataset(policyID string, datasetID string, b
 }
 
 func (a *policyManager) applyPolicy(payload config.PolicyPayload, be backend.Backend, pd *policies.PolicyData, updatePolicy bool) {
-	err := be.ApplyPolicy(*pd, updatePolicy)
+	state, detail, err := be.GetRunningStatus()
+	if state != backend.Running || err != nil {
+		pd.State = policies.FailedToApply
+		switch {
+		case err != nil:
+			pd.BackendErr = err.Error()
+		case detail != "":
+			pd.BackendErr = detail
+		default:
+			pd.BackendErr = fmt.Sprintf("backend state: %s", state)
+		}
+
+		a.logger.Warn(
+			"backend is not ready to apply policy",
+			"backend", pd.Backend,
+			"policy_id", payload.ID,
+			"policy_name", payload.Name,
+			"backend_state", state.String(),
+			"detail", detail,
+			"error", err,
+		)
+		return
+	}
+
+	err = be.ApplyPolicy(*pd, updatePolicy)
 	if err != nil {
 		a.logger.Warn("policy failed to apply", "policy_id", payload.ID, "policy_name", payload.Name,
 			"backend", pd.Backend, "error", err)

--- a/agent/policymgr/manager_test.go
+++ b/agent/policymgr/manager_test.go
@@ -136,6 +136,7 @@ func TestManagePolicy_ManageAction_NewPolicy(t *testing.T) {
 
 	// Configure mock backend
 	mockBe := &mockBackend{name: "testbackend"}
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 	backend.Register("testbackend", mockBe)
 
 	mgr, err := policymgr.New(logger, secretsMgr, cfg)
@@ -197,6 +198,7 @@ func TestManagePolicy_ManageAction_UpdatePolicy(t *testing.T) {
 
 	// Configure mock backend
 	mockBe := &mockBackend{name: "testbackend"}
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 	backend.Register("testbackend", mockBe)
 
 	mgr, err := policymgr.New(logger, secretsMgr, cfg)
@@ -256,6 +258,43 @@ func TestManagePolicy_ManageAction_UpdatePolicy(t *testing.T) {
 	assert.Equal(t, "Test Policy", state[0].PreviousPolicyData.Name)
 }
 
+func TestManagePolicy_BackendNotRunning(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	cfg := config.Config{}
+
+	mockBe := &mockBackend{name: "testbackend"}
+	mockBe.On("GetRunningStatus").Return(backend.Unknown, "backend not running", nil)
+	backend.Register("testbackend", mockBe)
+
+	mgr, err := policymgr.New(logger, secretsMgr, cfg)
+	require.NoError(t, err)
+
+	payload := config.PolicyPayload{
+		Action:    "manage",
+		ID:        "policy1",
+		Name:      "Test Policy",
+		Backend:   "testbackend",
+		Version:   1,
+		Data:      map[string]any{"key": "value"},
+		DatasetID: "dataset1",
+	}
+
+	secretsMgr.On("SolvePolicySecrets", payload).Return(payload, nil)
+
+	mgr.ManagePolicy(payload)
+
+	mockBe.AssertExpectations(t)
+	mockBe.AssertNotCalled(t, "ApplyPolicy", mock.Anything, mock.Anything)
+	secretsMgr.AssertExpectations(t)
+
+	state, err := mgr.GetPolicyState()
+	require.NoError(t, err)
+	require.Len(t, state, 1)
+	assert.Equal(t, policies.FailedToApply, state[0].State)
+	assert.Equal(t, "backend not running", state[0].BackendErr)
+}
+
 func TestManagePolicy_ManageAction_BackendUnavailable(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	secretsMgr := new(mockSecretsManager)
@@ -294,6 +333,7 @@ func TestManagePolicy_RemoveAction(t *testing.T) {
 	cfg := config.Config{}
 
 	mockBe := &mockBackend{name: "testbackend"}
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 	backend.Register("testbackend", mockBe)
 
 	mgr, err := policymgr.New(logger, secretsMgr, cfg)
@@ -343,6 +383,7 @@ func TestRemovePolicy(t *testing.T) {
 	cfg := config.Config{}
 
 	mockBe := &mockBackend{name: "testbackend"}
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 	backend.Register("testbackend", mockBe)
 
 	mgr, err := policymgr.New(logger, secretsMgr, cfg)
@@ -383,6 +424,7 @@ func TestRemoveBackendPolicies(t *testing.T) {
 	cfg := config.Config{}
 
 	mockBe := &mockBackend{name: "testbackend"}
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 	backend.Register("testbackend", mockBe)
 
 	mgr, err := policymgr.New(logger, secretsMgr, cfg)
@@ -444,6 +486,7 @@ func TestApplyBackendPolicies(t *testing.T) {
 	cfg := config.Config{}
 
 	mockBe := &mockBackend{name: "testbackend"}
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 	backend.Register("testbackend", mockBe)
 
 	mgr, err := policymgr.New(logger, secretsMgr, cfg)
@@ -499,6 +542,7 @@ func TestApplyBackendPolicies(t *testing.T) {
 
 	// Make policy2 fail
 	mockBe.ExpectedCalls = nil
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 	mockBe.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool {
 		return pd.ID == "policy1" || pd.ID == "policy3"
 	}), false).Return(nil).Times(2)
@@ -532,6 +576,7 @@ func TestPoliciesChanged(t *testing.T) {
 	cfg := config.Config{}
 
 	mockBe := &mockBackend{name: "testbackend"}
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 	backend.Register("testbackend", mockBe)
 
 	mgr, err := policymgr.New(logger, secretsMgr, cfg)
@@ -616,6 +661,7 @@ func TestRemovePolicyDataset(t *testing.T) {
 	cfg := config.Config{}
 
 	mockBe := &mockBackend{name: "testbackend"}
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 	backend.Register("testbackend", mockBe)
 
 	mgr, err := policymgr.New(logger, secretsMgr, cfg)


### PR DESCRIPTION
This pull request improves the reliability of policy application in the policy manager by adding a check for backend readiness before attempting to apply a policy. It also enhances test coverage to verify this behavior, ensuring that policies are not applied when the backend is not running and that appropriate error handling occurs.

### Backend readiness check

* Updated `policyManager.applyPolicy` in `manager.go` to check backend running status via `GetRunningStatus` before applying a policy. If the backend is not running, the policy is marked as failed to apply and detailed error information is logged and stored.

### Test coverage improvements

* Added a new test `TestManagePolicy_BackendNotRunning` to verify that policies are not applied and are marked as failed when the backend is not running, including checking the error details.
* Updated all relevant tests in `manager_test.go` to mock `GetRunningStatus` and ensure the backend is reported as running for successful scenarios, improving test accuracy and coverage. [[1]](diffhunk://#diff-964787f061019790343c1b6f1194fdf870146ec6587d358e02eeed1a20dfcce6R139) [[2]](diffhunk://#diff-964787f061019790343c1b6f1194fdf870146ec6587d358e02eeed1a20dfcce6R201) [[3]](diffhunk://#diff-964787f061019790343c1b6f1194fdf870146ec6587d358e02eeed1a20dfcce6R336) [[4]](diffhunk://#diff-964787f061019790343c1b6f1194fdf870146ec6587d358e02eeed1a20dfcce6R386) [[5]](diffhunk://#diff-964787f061019790343c1b6f1194fdf870146ec6587d358e02eeed1a20dfcce6R427) [[6]](diffhunk://#diff-964787f061019790343c1b6f1194fdf870146ec6587d358e02eeed1a20dfcce6R489) [[7]](diffhunk://#diff-964787f061019790343c1b6f1194fdf870146ec6587d358e02eeed1a20dfcce6R545) [[8]](diffhunk://#diff-964787f061019790343c1b6f1194fdf870146ec6587d358e02eeed1a20dfcce6R579) [[9]](diffhunk://#diff-964787f061019790343c1b6f1194fdf870146ec6587d358e02eeed1a20dfcce6R664)