### PR TITLE
chore: exit if pip install fails

### DIFF
--- a/agent/docker/orb-agent-entry.sh
+++ b/agent/docker/orb-agent-entry.sh
@@ -16,15 +16,21 @@ agentstop2 () {
 }
 
 if [ "${INSTALL_DRIVERS_PATH}" != '' ]; then
-  cd $(dirname "$(realpath "$INSTALL_DRIVERS_PATH")")
+  cd "$(dirname "$(realpath "${INSTALL_DRIVERS_PATH}")")"
   echo "Installing additional drivers"
-  pip3 install -r ${INSTALL_DRIVERS_PATH}
+  pip3 install -r "${INSTALL_DRIVERS_PATH}" || {
+    echo "Failed to install additional drivers from ${INSTALL_DRIVERS_PATH}" >&2
+    exit 1
+  }
 fi
 
 if [ "${INSTALL_WORKERS_PATH}" != '' ]; then
-  cd $(dirname "$(realpath "$INSTALL_WORKERS_PATH")")
+  cd "$(dirname "$(realpath "${INSTALL_WORKERS_PATH}")")"
   echo "Installing custom orb workers"
-  pip3 install -r ${INSTALL_WORKERS_PATH}
+  pip3 install -r "${INSTALL_WORKERS_PATH}" || {
+    echo "Failed to install custom orb workers from ${INSTALL_WORKERS_PATH}" >&2
+    exit 1
+  }
 fi
 
 # check geodb folder and extract db


### PR DESCRIPTION
This pull request improves the robustness of the installation process for additional drivers and custom orb workers in the `agent/docker/orb-agent-entry.sh` script. The changes ensure that errors during installation are properly handled and that file paths are quoted to prevent issues with spaces or special characters.

Error handling and robustness improvements:

* Added error handling to the `pip3 install -r` commands for both drivers and workers, so the script exits with an error message if installation fails.
* Quoted all variable expansions in `cd` and `pip3 install` commands to prevent issues with paths containing spaces or special characters.