### PR TITLE
feat: do not exit if git scheduler is configured and no policy exists

### DIFF
--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -211,6 +211,8 @@ func (gc *gitConfigManager) processSelector(file *object.File, cfg config.Config
 }
 
 func (gc *gitConfigManager) schedule(cfg config.Config, backends map[string]backend.Backend) {
+	gc.logger.Debug("Running scheduled Git Config Manager task")
+
 	// Fetch latest updates from remote
 	err := gc.repo.Fetch(&gitv5.FetchOptions{
 		RemoteName:      "origin",
@@ -469,8 +471,10 @@ func (gc *gitConfigManager) Start(cfg config.Config, backends map[string]backend
 		return err
 	}
 	if matchingPolicies == nil {
-		gc.logger.Info("No matching selector found. No policies will be applied.")
-		return nil
+		if gc.config.Schedule == nil {
+			return errors.New("no policies match the selector; skipping policy application")
+		}
+		gc.logger.Info("No matching policies were found; scheduler will retry policy application", "schedule", *gc.config.Schedule)
 	}
 
 	// Read all policies

--- a/agent/configmgr/git_test.go
+++ b/agent/configmgr/git_test.go
@@ -118,3 +118,79 @@ backend1:
 	err = gc.Start(cfg, backends)
 	require.NoError(t, err)
 }
+
+// TestGitStartNoMatchingPolicies ensures Start returns an error when no selector entries match agent labels.
+func TestGitStartNoMatchingPolicies(t *testing.T) {
+	remoteDir, err := os.MkdirTemp("", "fake-remote-nomatch")
+	require.NoError(t, err)
+	defer func() {
+		if err := os.RemoveAll(remoteDir); err != nil {
+			require.NoError(t, err, "failed to remove temp dir")
+		}
+	}()
+
+	remoteRepo, err := gitv5.PlainInit(remoteDir, false)
+	require.NoError(t, err)
+
+	selectorContent := `
+test_selector:
+  selector:
+    env: prod
+  policies:
+    test_policy:
+      enabled: true
+      path: "policy.yaml"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(remoteDir, "selector.yaml"), []byte(selectorContent), 0o644))
+
+	policyContent := `
+backend1:
+  test_policy:
+    key: "value"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(remoteDir, "policy.yaml"), []byte(policyContent), 0o644))
+
+	worktree, err := remoteRepo.Worktree()
+	require.NoError(t, err)
+	_, err = worktree.Add("selector.yaml")
+	require.NoError(t, err)
+	_, err = worktree.Add("policy.yaml")
+	require.NoError(t, err)
+	_, err = worktree.Commit("initial commit", &gitv5.CommitOptions{
+		Author: &object.Signature{
+			Name:  "tester",
+			Email: "tester@example.com",
+			When:  time.Now(),
+		},
+	})
+	require.NoError(t, err)
+
+	repoURL := "file://" + remoteDir
+	pMgr := new(mockPolicyManager)
+	cfg := config.Config{
+		OrbAgent: config.OrbAgent{
+			Labels: map[string]string{"env": "dev"},
+			ConfigManager: config.ManagerConfig{
+				Active: "git",
+				Sources: config.Sources{
+					Git: config.GitManager{
+						URL:  repoURL,
+						Auth: "none",
+					},
+				},
+			},
+		},
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	gc := configmgr.New(logger, pMgr, cfg.OrbAgent.ConfigManager.Active, &mockBackendState{})
+
+	backends := map[string]backend.Backend{
+		"backend1": &mockBackend{name: "backend1"},
+	}
+
+	err = gc.Start(cfg, backends)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no policies match the selector")
+	pMgr.AssertNotCalled(t, "ManagePolicy", mock.Anything)
+}


### PR DESCRIPTION
This pull request improves error handling and logging in the `gitConfigManager` when no matching policies are found, and adds a new test to ensure this behavior is correctly implemented. The most important changes are grouped below:

**Error Handling and Logging Improvements**

* Updated the `Start` method in `gitConfigManager` to return an error when no policies match the selector and no schedule is configured, and to log a message when a schedule exists, indicating the scheduler will retry policy application.
* Added a debug log message to the `schedule` method to indicate when the scheduled task is running.

**Testing Enhancements**

* Added `TestGitStartNoMatchingPolicies` to verify that the `Start` method returns an error when no selector entries match the agent labels, and that no policy management actions are attempted in this scenario.