### PR TITLE
fix: configmgr tag should be fleet and not orb

### DIFF
--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -33,7 +33,7 @@ type GitManager struct {
 	SkipTLS    bool    `yaml:"skip_tls"`
 }
 
-// FleetManager represents the Orb ConfigManager configuration.
+// FleetManager represents the Fleet ConfigManager configuration.
 type FleetManager struct {
 	URL          string `yaml:"url"`
 	TokenURL     string `yaml:"token_url"`
@@ -47,7 +47,7 @@ type FleetManager struct {
 type Sources struct {
 	Local LocalManager `yaml:"local"`
 	Git   GitManager   `yaml:"git"`
-	Fleet FleetManager `yaml:"orb"`
+	Fleet FleetManager `yaml:"fleet"`
 }
 
 // ManagerConfig represents the configuration for the Config Manager

--- a/agent/docker/default_config.yaml
+++ b/agent/docker/default_config.yaml
@@ -2,7 +2,7 @@ orb:
   config_manager:
     active: fleet
     sources:
-      orb:
+      fleet:
         token_url: ${FLEET_AUTH_URL}
         client_id: ${FLEET_CLIENT_ID}
         client_secret: ${FLEET_CLIENT_SECRET}


### PR DESCRIPTION
This pull request updates the configuration to consistently use the term "fleet" instead of "orb" for the FleetManager throughout the codebase and configuration files. The changes help clarify naming and improve maintainability.

Configuration schema updates:

* Renamed the `FleetManager` struct comment to reference "Fleet ConfigManager" instead of "Orb ConfigManager" in `types.go`.
* Changed the field name in the `Sources` struct from `orb` to `fleet` in `types.go`, aligning with the new naming convention.

Configuration file updates:

* Updated the key from `orb` to `fleet` in the default configuration YAML to match the code changes and environment variable usage.