### PR TITLE
Update git.md - add policy name to selector.yaml example

### DIFF
--- a/docs/configs/git.md
+++ b/docs/configs/git.md
@@ -88,7 +88,8 @@ agent_selector_2:
 agent_selector_matches_all:
   selector:
   policies:
-    path: folder4/policy4.yaml
+    policy4:
+      path: folder4/policy4.yaml
 ```
 
 ### policy.yaml


### PR DESCRIPTION
The `selector.yaml` example file is missing the policy name, which results in an error when you try to run it