### PR TITLE
fix: backend log levels

### DIFF
--- a/agent/backend/networkdiscovery/network_discovery.go
+++ b/agent/backend/networkdiscovery/network_discovery.go
@@ -115,6 +115,8 @@ func (d *networkDiscoveryBackend) Configure(logger *slog.Logger, repo policies.P
 		d.diodeLogLevel = logLevel
 	} else if debug, prs := config["debug"].(bool); prs && debug {
 		d.diodeLogLevel = "debug"
+	} else if logger.Enabled(context.Background(), slog.LevelDebug) {
+		d.diodeLogLevel = "debug"
 	}
 
 	if common.Otlp.Grpc != "" {

--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -114,7 +114,9 @@ func (d *snmpDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Poli
 	if logLevel, prs := config["log_level"].(string); prs {
 		d.diodeLogLevel = logLevel
 	} else if debug, prs := config["debug"].(bool); prs && debug {
-		d.diodeLogLevel = "debug"
+		d.diodeLogLevel = "DEBUG"
+	} else if logger.Enabled(context.Background(), slog.LevelDebug) {
+		d.diodeLogLevel = "DEBUG"
 	}
 
 	if common.Otlp.Grpc != "" {

--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -114,9 +114,9 @@ func (d *snmpDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Poli
 	if logLevel, prs := config["log_level"].(string); prs {
 		d.diodeLogLevel = logLevel
 	} else if debug, prs := config["debug"].(bool); prs && debug {
-		d.diodeLogLevel = "DEBUG"
+		d.diodeLogLevel = "debug"
 	} else if logger.Enabled(context.Background(), slog.LevelDebug) {
-		d.diodeLogLevel = "DEBUG"
+		d.diodeLogLevel = "debug"
 	}
 
 	if common.Otlp.Grpc != "" {


### PR DESCRIPTION
This pull request updates the log level configuration logic in both the network discovery and SNMP discovery backends to better handle debug logging. The changes ensure that the log level is set to debug if either the configuration specifies it or if the logger is enabled for debug, and also standardize the log level string for SNMP discovery.

**Logging improvements:**

* In `network_discovery.go`, added a check to set `diodeLogLevel` to `"debug"` if the logger is enabled for debug level, improving flexibility in debug logging configuration.
* In `snmp_discovery.go`, standardized the debug log level string to `"DEBUG"` instead of `"debug"` and added a similar logger-enabled check to set the log level, ensuring consistency and improved configurability.