### PR TITLE
feat: allow otlp client

### DIFF
--- a/agent/backend/devicediscovery/device_discovery.go
+++ b/agent/backend/devicediscovery/device_discovery.go
@@ -28,6 +28,7 @@ const (
 	defaultExec         = "device-discovery"
 	defaultAPIHost      = "localhost"
 	defaultAPIPort      = "8072"
+	maskedSecret        = "********"
 )
 
 type deviceDiscoveryBackend struct {
@@ -44,6 +45,7 @@ type deviceDiscoveryBackend struct {
 	diodeClientSecret    string
 	diodeAppNamePrefix   string
 	diodeOtelEndpoint    string
+	diodeTargetFromOtel  bool
 	diodeDryRun          bool
 	diodeDryRunOutputDir string
 
@@ -73,6 +75,7 @@ func (d *deviceDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Po
 ) error {
 	d.logger = logger.With("backend", "device_discovery")
 	d.policyRepo = repo
+	d.diodeTargetFromOtel = false
 
 	var prs bool
 	if d.apiHost, prs = config["host"].(string); !prs {
@@ -115,6 +118,10 @@ func (d *deviceDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Po
 		d.logger.Info("device-discovery using OTLP metrics endpoint",
 			"endpoint", d.diodeOtelEndpoint)
 	}
+	if d.diodeTarget == "" && d.diodeOtelEndpoint != "" {
+		d.diodeTarget = d.diodeOtelEndpoint
+		d.diodeTargetFromOtel = true
+	}
 
 	return nil
 }
@@ -135,22 +142,25 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 	d.cancelFunc = cancelFunc
 	d.ctx = ctx
 
-	var pvOptions []string
+	pvOptions := []string{"--diode-app-name-prefix", d.diodeAppNamePrefix}
 	if d.diodeDryRun {
-		pvOptions = []string{
+		pvOptions = append([]string{
 			"--dry-run",
 			"--dry-run-output-dir", d.diodeDryRunOutputDir,
-			"--diode-app-name-prefix", d.diodeAppNamePrefix,
-		}
+		}, pvOptions...)
 	} else {
-		pvOptions = []string{
+		opts := []string{
 			"--host", d.apiHost,
 			"--port", d.apiPort,
 			"--diode-target", d.diodeTarget,
-			"--diode-client-id", d.diodeClientID,
-			"--diode-client-secret", "********",
-			"--diode-app-name-prefix", d.diodeAppNamePrefix,
 		}
+		if !d.diodeTargetFromOtel {
+			opts = append(opts,
+				"--diode-client-id", d.diodeClientID,
+				"--diode-client-secret", maskedSecret,
+			)
+		}
+		pvOptions = append(opts, pvOptions...)
 	}
 
 	if d.diodeOtelEndpoint != "" {
@@ -159,8 +169,13 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 
 	d.logger.Info("device-discovery startup", "arguments", pvOptions)
 
-	if !d.diodeDryRun && len(pvOptions) > 9 {
-		pvOptions[9] = d.diodeClientSecret
+	if !d.diodeDryRun {
+		for i, arg := range pvOptions {
+			if arg == maskedSecret {
+				pvOptions[i] = d.diodeClientSecret
+				break
+			}
+		}
 	}
 
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{

--- a/agent/backend/devicediscovery/device_discovery.go
+++ b/agent/backend/devicediscovery/device_discovery.go
@@ -115,7 +115,7 @@ func (d *deviceDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Po
 
 	if common.Otlp.Grpc != "" {
 		d.diodeOtelEndpoint = common.Otlp.Grpc
-		d.logger.Info("device-discovery using OTLP metrics endpoint",
+		d.logger.Info("device-discovery using OTLP endpoint",
 			"endpoint", d.diodeOtelEndpoint)
 	}
 	if d.diodeTarget == "" && d.diodeOtelEndpoint != "" {
@@ -142,12 +142,12 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 	d.cancelFunc = cancelFunc
 	d.ctx = ctx
 
-	pvOptions := []string{"--diode-app-name-prefix", d.diodeAppNamePrefix}
+	dOptions := []string{"--diode-app-name-prefix", d.diodeAppNamePrefix}
 	if d.diodeDryRun {
-		pvOptions = append([]string{
+		dOptions = append([]string{
 			"--dry-run",
 			"--dry-run-output-dir", d.diodeDryRunOutputDir,
-		}, pvOptions...)
+		}, dOptions...)
 	} else {
 		opts := []string{
 			"--host", d.apiHost,
@@ -160,19 +160,19 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 				"--diode-client-secret", maskedSecret,
 			)
 		}
-		pvOptions = append(opts, pvOptions...)
+		dOptions = append(opts, dOptions...)
 	}
 
 	if d.diodeOtelEndpoint != "" {
-		pvOptions = append(pvOptions, "--otel-endpoint", d.diodeOtelEndpoint)
+		dOptions = append(dOptions, "--otel-endpoint", d.diodeOtelEndpoint)
 	}
 
-	d.logger.Info("device-discovery startup", "arguments", pvOptions)
+	d.logger.Info("device-discovery startup", "arguments", dOptions)
 
 	if !d.diodeDryRun {
-		for i, arg := range pvOptions {
+		for i, arg := range dOptions {
 			if arg == maskedSecret {
-				pvOptions[i] = d.diodeClientSecret
+				dOptions[i] = d.diodeClientSecret
 				break
 			}
 		}
@@ -181,7 +181,7 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,
 		Streaming: true,
-	}, d.exec, pvOptions...)
+	}, d.exec, dOptions...)
 	d.statusChan = d.proc.Start()
 
 	// log STDOUT and STDERR lines streaming from Cmd

--- a/agent/backend/devicediscovery/device_discovery_test.go
+++ b/agent/backend/devicediscovery/device_discovery_test.go
@@ -161,6 +161,73 @@ func TestDeviceDiscoveryBackendStart(t *testing.T) {
 	mockCmd.AssertExpectations(t)
 }
 
+func TestDeviceDiscoveryUsesOtelTargetWithoutCredentials(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path == "/api/v1/status" {
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(StatusResponse{Version: "1.0.0"}))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	createExecutable(t, "device-discovery")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 4242)
+
+	otelEndpoint := "collector:4317"
+	overrideNewCmdOptions(t, mockCmd, func(_ backend.CmdOptions, name string, args []string) {
+		assert.Equal(t, "device-discovery", name)
+		assert.Contains(t, args, "--diode-target")
+		assert.Contains(t, args, otelEndpoint)
+		assert.NotContains(t, args, "--diode-client-id")
+		assert.NotContains(t, args, "--diode-client-secret")
+		assert.NotContains(t, args, "device-client")
+		assert.NotContains(t, args, "device-secret")
+		assert.NotContains(t, args, "********")
+	})
+
+	assert.True(t, devicediscovery.Register())
+	assert.True(t, backend.HaveBackend("device_discovery"))
+
+	be := backend.GetBackend("device_discovery")
+
+	commons := config.BackendCommons{}
+	commons.Otlp.Grpc = otelEndpoint
+	commons.Diode.ClientID = "default-client"
+	commons.Diode.ClientSecret = "default-secret"
+	commons.Diode.AgentName = "device-agent"
+
+	err = be.Configure(logger, repo, map[string]any{
+		"host":          serverURL.Hostname(),
+		"port":          serverURL.Port(),
+		"client_id":     "device-client",
+		"client_secret": "device-secret",
+		"agent_name":    "device-agent",
+	}, commons)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, be.Start(ctx, cancel))
+	require.NoError(t, be.Stop(ctx))
+
+	mockCmd.AssertExpectations(t)
+}
+
 func TestDeviceDiscoveryBackendCompleted(t *testing.T) {
 	mockCmd := &mocks.MockCmd{}
 	mocks.SetupCompletedProcess(mockCmd, 0, nil)

--- a/agent/backend/networkdiscovery/network_discovery.go
+++ b/agent/backend/networkdiscovery/network_discovery.go
@@ -122,7 +122,7 @@ func (d *networkDiscoveryBackend) Configure(logger *slog.Logger, repo policies.P
 
 	if common.Otlp.Grpc != "" {
 		d.diodeOtelEndpoint = common.Otlp.Grpc
-		d.logger.Info("network-discovery using OTLP metrics endpoint",
+		d.logger.Info("network-discovery using OTLP endpoint",
 			"endpoint", d.diodeOtelEndpoint)
 	}
 	if d.diodeTarget == "" && d.diodeOtelEndpoint != "" {
@@ -149,12 +149,12 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 	d.cancelFunc = cancelFunc
 	d.ctx = ctx
 
-	pvOptions := []string{"--diode-app-name-prefix", d.diodeAppNamePrefix}
+	dOptions := []string{"--diode-app-name-prefix", d.diodeAppNamePrefix}
 	if d.diodeDryRun {
-		pvOptions = append([]string{
+		dOptions = append([]string{
 			"--dry-run",
 			"--dry-run-output-dir", d.diodeDryRunOutputDir,
-		}, pvOptions...)
+		}, dOptions...)
 	} else {
 		opts := []string{
 			"--host", d.apiHost,
@@ -167,27 +167,27 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 				"--diode-client-secret", maskedSecret,
 			)
 		}
-		pvOptions = append(opts, pvOptions...)
+		dOptions = append(opts, dOptions...)
 	}
 
 	if d.diodeLogLevel != "" {
-		pvOptions = append(pvOptions, "--log-level", d.diodeLogLevel)
+		dOptions = append(dOptions, "--log-level", d.diodeLogLevel)
 		d.logger.Info("network-discovery using log level",
 			"log_level", d.diodeLogLevel)
 	}
 
 	if d.diodeOtelEndpoint != "" {
-		pvOptions = append(pvOptions, "--otel-endpoint", d.diodeOtelEndpoint)
+		dOptions = append(dOptions, "--otel-endpoint", d.diodeOtelEndpoint)
 		d.logger.Info("network-discovery using OTLP metrics endpoint",
 			"endpoint", d.diodeOtelEndpoint)
 	}
 
-	d.logger.Info("network-discovery startup", "arguments", pvOptions)
+	d.logger.Info("network-discovery startup", "arguments", dOptions)
 
 	if !d.diodeDryRun {
-		for i, arg := range pvOptions {
+		for i, arg := range dOptions {
 			if arg == maskedSecret {
-				pvOptions[i] = d.diodeClientSecret
+				dOptions[i] = d.diodeClientSecret
 				break
 			}
 		}
@@ -196,7 +196,7 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,
 		Streaming: true,
-	}, d.exec, pvOptions...)
+	}, d.exec, dOptions...)
 	d.statusChan = d.proc.Start()
 
 	// log STDOUT and STDERR lines streaming from Cmd

--- a/agent/backend/networkdiscovery/network_discovery.go
+++ b/agent/backend/networkdiscovery/network_discovery.go
@@ -29,6 +29,7 @@ const (
 	defaultExec         = "network-discovery"
 	defaultAPIHost      = "localhost"
 	defaultAPIPort      = "8073"
+	maskedSecret        = "********"
 )
 
 type networkDiscoveryBackend struct {
@@ -45,6 +46,7 @@ type networkDiscoveryBackend struct {
 	diodeClientSecret    string
 	diodeAppNamePrefix   string
 	diodeOtelEndpoint    string
+	diodeTargetFromOtel  bool
 	diodeDryRun          bool
 	diodeDryRunOutputDir string
 	diodeLogLevel        string
@@ -75,6 +77,7 @@ func (d *networkDiscoveryBackend) Configure(logger *slog.Logger, repo policies.P
 ) error {
 	d.logger = logger.With("backend", "network_discovery")
 	d.policyRepo = repo
+	d.diodeTargetFromOtel = false
 
 	var prs bool
 	if d.apiHost, prs = config["host"].(string); !prs {
@@ -122,6 +125,10 @@ func (d *networkDiscoveryBackend) Configure(logger *slog.Logger, repo policies.P
 		d.logger.Info("network-discovery using OTLP metrics endpoint",
 			"endpoint", d.diodeOtelEndpoint)
 	}
+	if d.diodeTarget == "" && d.diodeOtelEndpoint != "" {
+		d.diodeTarget = d.diodeOtelEndpoint
+		d.diodeTargetFromOtel = true
+	}
 
 	return nil
 }
@@ -142,22 +149,25 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 	d.cancelFunc = cancelFunc
 	d.ctx = ctx
 
-	var pvOptions []string
+	pvOptions := []string{"--diode-app-name-prefix", d.diodeAppNamePrefix}
 	if d.diodeDryRun {
-		pvOptions = []string{
+		pvOptions = append([]string{
 			"--dry-run",
 			"--dry-run-output-dir", d.diodeDryRunOutputDir,
-			"--diode-app-name-prefix", d.diodeAppNamePrefix,
-		}
+		}, pvOptions...)
 	} else {
-		pvOptions = []string{
+		opts := []string{
 			"--host", d.apiHost,
 			"--port", d.apiPort,
 			"--diode-target", d.diodeTarget,
-			"--diode-client-id", d.diodeClientID,
-			"--diode-client-secret", "********",
-			"--diode-app-name-prefix", d.diodeAppNamePrefix,
 		}
+		if !d.diodeTargetFromOtel {
+			opts = append(opts,
+				"--diode-client-id", d.diodeClientID,
+				"--diode-client-secret", maskedSecret,
+			)
+		}
+		pvOptions = append(opts, pvOptions...)
 	}
 
 	if d.diodeLogLevel != "" {
@@ -175,9 +185,8 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 	d.logger.Info("network-discovery startup", "arguments", pvOptions)
 
 	if !d.diodeDryRun {
-		// Find and replace the masked client secret with the actual value
 		for i, arg := range pvOptions {
-			if arg == "********" {
+			if arg == maskedSecret {
 				pvOptions[i] = d.diodeClientSecret
 				break
 			}

--- a/agent/backend/networkdiscovery/network_discovery_test.go
+++ b/agent/backend/networkdiscovery/network_discovery_test.go
@@ -164,6 +164,73 @@ func TestNetworkDiscoveryBackendStart(t *testing.T) {
 	mockCmd.AssertExpectations(t)
 }
 
+func TestNetworkDiscoveryUsesOtelTargetWithoutCredentials(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path == "/api/v1/status" {
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(StatusResponse{Version: "1.0.0"}))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	createExecutable(t, "network-discovery")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 4244)
+
+	otelEndpoint := "collector:4317"
+	overrideNewCmdOptions(t, mockCmd, func(_ backend.CmdOptions, name string, args []string) {
+		assert.Equal(t, "network-discovery", name)
+		assert.Contains(t, args, "--diode-target")
+		assert.Contains(t, args, otelEndpoint)
+		assert.NotContains(t, args, "--diode-client-id")
+		assert.NotContains(t, args, "--diode-client-secret")
+		assert.NotContains(t, args, "network-client")
+		assert.NotContains(t, args, "network-secret")
+		assert.NotContains(t, args, "********")
+	})
+
+	assert.True(t, networkdiscovery.Register())
+	assert.True(t, backend.HaveBackend("network_discovery"))
+
+	be := backend.GetBackend("network_discovery")
+
+	commons := config.BackendCommons{}
+	commons.Otlp.Grpc = otelEndpoint
+	commons.Diode.ClientID = "default-client"
+	commons.Diode.ClientSecret = "default-secret"
+	commons.Diode.AgentName = "network-agent"
+
+	err = be.Configure(logger, repo, map[string]any{
+		"host":          serverURL.Hostname(),
+		"port":          serverURL.Port(),
+		"client_id":     "network-client",
+		"client_secret": "network-secret",
+		"agent_name":    "network-agent",
+	}, commons)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, be.Start(ctx, cancel))
+	require.NoError(t, be.Stop(ctx))
+
+	mockCmd.AssertExpectations(t)
+}
+
 func TestNetworkDiscoveryBackendCompleted(t *testing.T) {
 	mockCmd := &mocks.MockCmd{}
 	mocks.SetupCompletedProcess(mockCmd, 0, nil)

--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -149,12 +149,12 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 	d.cancelFunc = cancelFunc
 	d.ctx = ctx
 
-	pvOptions := []string{"--diode-app-name-prefix", d.diodeAppNamePrefix}
+	dOptions := []string{"--diode-app-name-prefix", d.diodeAppNamePrefix}
 	if d.diodeDryRun {
-		pvOptions = append([]string{
+		dOptions = append([]string{
 			"--dry-run",
 			"--dry-run-output-dir", d.diodeDryRunOutputDir,
-		}, pvOptions...)
+		}, dOptions...)
 	} else {
 		opts := []string{
 			"--host", d.apiHost,
@@ -167,28 +167,28 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 				"--diode-client-secret", maskedSecret,
 			)
 		}
-		pvOptions = append(opts, pvOptions...)
+		dOptions = append(opts, dOptions...)
 	}
 
 	if d.diodeLogLevel != "" {
-		pvOptions = append(pvOptions, "--log-level", d.diodeLogLevel)
+		dOptions = append(dOptions, "--log-level", d.diodeLogLevel)
 		d.logger.Info("snmp-discovery using log level",
 			"log_level", d.diodeLogLevel)
 	}
 
 	if d.diodeOtelEndpoint != "" {
-		pvOptions = append(pvOptions, "--otel-endpoint", d.diodeOtelEndpoint)
-		d.logger.Info("snmp-discovery using OTLP metrics endpoint",
+		dOptions = append(dOptions, "--otel-endpoint", d.diodeOtelEndpoint)
+		d.logger.Info("snmp-discovery using OTLP endpoint",
 			"endpoint", d.diodeOtelEndpoint)
 	}
 
-	d.logger.Info("snmp-discovery startup", "arguments", pvOptions)
+	d.logger.Info("snmp-discovery startup", "arguments", dOptions)
 
 	if !d.diodeDryRun {
 		// Swap the masked secret used for logging with the real value before execution
-		for i, arg := range pvOptions {
+		for i, arg := range dOptions {
 			if arg == maskedSecret {
-				pvOptions[i] = d.diodeClientSecret
+				dOptions[i] = d.diodeClientSecret
 				break
 			}
 		}
@@ -197,7 +197,7 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,
 		Streaming: true,
-	}, d.exec, pvOptions...)
+	}, d.exec, dOptions...)
 	d.statusChan = d.proc.Start()
 
 	// log STDOUT and STDERR lines streaming from Cmd

--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -29,6 +29,7 @@ const (
 	defaultExec         = "snmp-discovery"
 	defaultAPIHost      = "localhost"
 	defaultAPIPort      = "8070"
+	maskedSecret        = "********"
 )
 
 type snmpDiscoveryBackend struct {
@@ -45,6 +46,7 @@ type snmpDiscoveryBackend struct {
 	diodeClientSecret    string
 	diodeAppNamePrefix   string
 	diodeOtelEndpoint    string
+	diodeTargetFromOtel  bool
 	diodeDryRun          bool
 	diodeDryRunOutputDir string
 	diodeLogLevel        string
@@ -75,6 +77,7 @@ func (d *snmpDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Poli
 ) error {
 	d.logger = logger.With("backend", "snmp_discovery")
 	d.policyRepo = repo
+	d.diodeTargetFromOtel = false
 
 	var prs bool
 	if d.apiHost, prs = config["host"].(string); !prs {
@@ -122,6 +125,10 @@ func (d *snmpDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Poli
 		d.logger.Info("snmp-discovery using OTLP metrics endpoint",
 			"endpoint", d.diodeOtelEndpoint)
 	}
+	if d.diodeTarget == "" && d.diodeOtelEndpoint != "" {
+		d.diodeTarget = d.diodeOtelEndpoint
+		d.diodeTargetFromOtel = true
+	}
 
 	return nil
 }
@@ -142,22 +149,25 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 	d.cancelFunc = cancelFunc
 	d.ctx = ctx
 
-	var pvOptions []string
+	pvOptions := []string{"--diode-app-name-prefix", d.diodeAppNamePrefix}
 	if d.diodeDryRun {
-		pvOptions = []string{
+		pvOptions = append([]string{
 			"--dry-run",
 			"--dry-run-output-dir", d.diodeDryRunOutputDir,
-			"--diode-app-name-prefix", d.diodeAppNamePrefix,
-		}
+		}, pvOptions...)
 	} else {
-		pvOptions = []string{
+		opts := []string{
 			"--host", d.apiHost,
 			"--port", d.apiPort,
 			"--diode-target", d.diodeTarget,
-			"--diode-client-id", d.diodeClientID,
-			"--diode-client-secret", "********",
-			"--diode-app-name-prefix", d.diodeAppNamePrefix,
 		}
+		if !d.diodeTargetFromOtel {
+			opts = append(opts,
+				"--diode-client-id", d.diodeClientID,
+				"--diode-client-secret", maskedSecret,
+			)
+		}
+		pvOptions = append(opts, pvOptions...)
 	}
 
 	if d.diodeLogLevel != "" {
@@ -174,8 +184,14 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 
 	d.logger.Info("snmp-discovery startup", "arguments", pvOptions)
 
-	if !d.diodeDryRun && len(pvOptions) > 9 {
-		pvOptions[9] = d.diodeClientSecret
+	if !d.diodeDryRun {
+		// Swap the masked secret used for logging with the real value before execution
+		for i, arg := range pvOptions {
+			if arg == maskedSecret {
+				pvOptions[i] = d.diodeClientSecret
+				break
+			}
+		}
 	}
 
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{

--- a/agent/backend/snmpdiscovery/snmp_discovery_test.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery_test.go
@@ -164,6 +164,73 @@ func TestSnmpDiscoveryBackendStart(t *testing.T) {
 	mockCmd.AssertExpectations(t)
 }
 
+func TestSnmpDiscoveryUsesOtelTargetWithoutCredentials(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path == "/api/v1/status" {
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(StatusResponse{Version: "1.0.0"}))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	createExecutable(t, "snmp-discovery")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 4245)
+
+	otelEndpoint := "collector:4317"
+	overrideNewCmdOptions(t, mockCmd, func(_ backend.CmdOptions, name string, args []string) {
+		assert.Equal(t, "snmp-discovery", name)
+		assert.Contains(t, args, "--diode-target")
+		assert.Contains(t, args, otelEndpoint)
+		assert.NotContains(t, args, "--diode-client-id")
+		assert.NotContains(t, args, "--diode-client-secret")
+		assert.NotContains(t, args, "snmp-client")
+		assert.NotContains(t, args, "snmp-secret")
+		assert.NotContains(t, args, "********")
+	})
+
+	assert.True(t, snmpdiscovery.Register())
+	assert.True(t, backend.HaveBackend("snmp_discovery"))
+
+	be := backend.GetBackend("snmp_discovery")
+
+	commons := config.BackendCommons{}
+	commons.Otlp.Grpc = otelEndpoint
+	commons.Diode.ClientID = "default-client"
+	commons.Diode.ClientSecret = "default-secret"
+	commons.Diode.AgentName = "snmp-agent"
+
+	err = be.Configure(logger, repo, map[string]any{
+		"host":          serverURL.Hostname(),
+		"port":          serverURL.Port(),
+		"client_id":     "snmp-client",
+		"client_secret": "snmp-secret",
+		"agent_name":    "snmp-agent",
+	}, commons)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, be.Start(ctx, cancel))
+	require.NoError(t, be.Stop(ctx))
+
+	mockCmd.AssertExpectations(t)
+}
+
 func TestSnmpDiscoveryBackendCompleted(t *testing.T) {
 	mockCmd := &mocks.MockCmd{}
 	mocks.SetupCompletedProcess(mockCmd, 0, nil)

--- a/agent/backend/worker/worker.go
+++ b/agent/backend/worker/worker.go
@@ -115,7 +115,7 @@ func (d *workerBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 
 	if common.Otlp.Grpc != "" {
 		d.diodeOtelEndpoint = common.Otlp.Grpc
-		d.logger.Info("orb-worker using OTLP metrics endpoint",
+		d.logger.Info("orb-worker using OTLP endpoint",
 			"endpoint", d.diodeOtelEndpoint)
 	}
 	if d.diodeTarget == "" && d.diodeOtelEndpoint != "" {
@@ -142,12 +142,12 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 	d.cancelFunc = cancelFunc
 	d.ctx = ctx
 
-	pvOptions := []string{"--diode-app-name-prefix", d.diodeAppNamePrefix}
+	dOptions := []string{"--diode-app-name-prefix", d.diodeAppNamePrefix}
 	if d.diodeDryRun {
-		pvOptions = append([]string{
+		dOptions = append([]string{
 			"--dry-run",
 			"--dry-run-output-dir", d.diodeDryRunOutputDir,
-		}, pvOptions...)
+		}, dOptions...)
 	} else {
 		opts := []string{
 			"--host", d.apiHost,
@@ -160,20 +160,20 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 				"--diode-client-secret", maskedSecret,
 			)
 		}
-		pvOptions = append(opts, pvOptions...)
+		dOptions = append(opts, dOptions...)
 	}
 
 	if d.diodeOtelEndpoint != "" {
-		pvOptions = append(pvOptions, "--otel-endpoint", d.diodeOtelEndpoint)
+		dOptions = append(dOptions, "--otel-endpoint", d.diodeOtelEndpoint)
 	}
 
-	d.logger.Info("worker startup", "arguments", pvOptions)
+	d.logger.Info("worker startup", "arguments", dOptions)
 
 	if !d.diodeDryRun {
 		// Swap the masked secret used for logging with the real value before execution
-		for i, arg := range pvOptions {
+		for i, arg := range dOptions {
 			if arg == maskedSecret {
-				pvOptions[i] = d.diodeClientSecret
+				dOptions[i] = d.diodeClientSecret
 				break
 			}
 		}
@@ -182,7 +182,7 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,
 		Streaming: true,
-	}, d.exec, pvOptions...)
+	}, d.exec, dOptions...)
 	d.statusChan = d.proc.Start()
 
 	// log STDOUT and STDERR lines streaming from Cmd

--- a/agent/backend/worker/worker.go
+++ b/agent/backend/worker/worker.go
@@ -28,6 +28,7 @@ const (
 	defaultExec         = "orb-worker"
 	defaultAPIHost      = "localhost"
 	defaultAPIPort      = "8071"
+	maskedSecret        = "********"
 )
 
 type workerBackend struct {
@@ -44,6 +45,7 @@ type workerBackend struct {
 	diodeClientSecret    string
 	diodeAppNamePrefix   string
 	diodeOtelEndpoint    string
+	diodeTargetFromOtel  bool
 	diodeDryRun          bool
 	diodeDryRunOutputDir string
 
@@ -73,6 +75,7 @@ func (d *workerBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 ) error {
 	d.logger = logger.With("backend", "worker")
 	d.policyRepo = repo
+	d.diodeTargetFromOtel = false
 
 	var prs bool
 	if d.apiHost, prs = config["host"].(string); !prs {
@@ -115,6 +118,10 @@ func (d *workerBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 		d.logger.Info("orb-worker using OTLP metrics endpoint",
 			"endpoint", d.diodeOtelEndpoint)
 	}
+	if d.diodeTarget == "" && d.diodeOtelEndpoint != "" {
+		d.diodeTarget = d.diodeOtelEndpoint
+		d.diodeTargetFromOtel = true
+	}
 
 	return nil
 }
@@ -135,22 +142,25 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 	d.cancelFunc = cancelFunc
 	d.ctx = ctx
 
-	var pvOptions []string
+	pvOptions := []string{"--diode-app-name-prefix", d.diodeAppNamePrefix}
 	if d.diodeDryRun {
-		pvOptions = []string{
+		pvOptions = append([]string{
 			"--dry-run",
 			"--dry-run-output-dir", d.diodeDryRunOutputDir,
-			"--diode-app-name-prefix", d.diodeAppNamePrefix,
-		}
+		}, pvOptions...)
 	} else {
-		pvOptions = []string{
+		opts := []string{
 			"--host", d.apiHost,
 			"--port", d.apiPort,
 			"--diode-target", d.diodeTarget,
-			"--diode-client-id", d.diodeClientID,
-			"--diode-client-secret", "********",
-			"--diode-app-name-prefix", d.diodeAppNamePrefix,
 		}
+		if !d.diodeTargetFromOtel {
+			opts = append(opts,
+				"--diode-client-id", d.diodeClientID,
+				"--diode-client-secret", maskedSecret,
+			)
+		}
+		pvOptions = append(opts, pvOptions...)
 	}
 
 	if d.diodeOtelEndpoint != "" {
@@ -159,8 +169,14 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 
 	d.logger.Info("worker startup", "arguments", pvOptions)
 
-	if !d.diodeDryRun && len(pvOptions) > 9 {
-		pvOptions[9] = d.diodeClientSecret
+	if !d.diodeDryRun {
+		// Swap the masked secret used for logging with the real value before execution
+		for i, arg := range pvOptions {
+			if arg == maskedSecret {
+				pvOptions[i] = d.diodeClientSecret
+				break
+			}
+		}
 	}
 
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{

--- a/agent/backend/worker/worker_test.go
+++ b/agent/backend/worker/worker_test.go
@@ -155,6 +155,73 @@ func TestWorkerBackendStart(t *testing.T) {
 	mockCmd.AssertExpectations(t)
 }
 
+func TestWorkerUsesOtelTargetWithoutCredentials(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path == "/api/v1/status" {
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"version": "1.0.0"}))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	createExecutable(t, "orb-worker")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 4243)
+
+	otelEndpoint := "collector:4317"
+	overrideNewCmdOptions(t, mockCmd, func(_ backend.CmdOptions, name string, args []string) {
+		assert.Equal(t, "orb-worker", name)
+		assert.Contains(t, args, "--diode-target")
+		assert.Contains(t, args, otelEndpoint)
+		assert.NotContains(t, args, "--diode-client-id")
+		assert.NotContains(t, args, "--diode-client-secret")
+		assert.NotContains(t, args, "worker-client")
+		assert.NotContains(t, args, "worker-secret")
+		assert.NotContains(t, args, "********")
+	})
+
+	assert.True(t, worker.Register())
+	assert.True(t, backend.HaveBackend("worker"))
+
+	be := backend.GetBackend("worker")
+
+	commons := config.BackendCommons{}
+	commons.Otlp.Grpc = otelEndpoint
+	commons.Diode.ClientID = "default-client"
+	commons.Diode.ClientSecret = "default-secret"
+	commons.Diode.AgentName = "worker-agent"
+
+	err = be.Configure(logger, repo, map[string]any{
+		"host":          serverURL.Hostname(),
+		"port":          serverURL.Port(),
+		"client_id":     "worker-client",
+		"client_secret": "worker-secret",
+		"agent_name":    "worker-agent",
+	}, commons)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, be.Start(ctx, cancel))
+	require.NoError(t, be.Stop(ctx))
+
+	mockCmd.AssertExpectations(t)
+}
+
 func TestWorkerGetRunningStatusAPIFailure(t *testing.T) {
 	var statusCalls atomic.Int32
 


### PR DESCRIPTION
This pull request improves how device, network, SNMP, and worker discovery backends handle the configuration and startup of their Diode client connections, especially when an OTLP (OpenTelemetry) metrics endpoint is provided. The main change is that when an OTLP endpoint is specified and no explicit Diode target is set, the backends use the OTLP endpoint as the Diode target and omit Diode client credentials from the startup arguments. This prevents unnecessary exposure of secrets and ensures correct behavior when using telemetry endpoints. The PR also refactors argument construction for clarity and safety, and adds corresponding tests to verify that credentials are omitted when expected.

**Backend configuration and startup logic:**

* Added logic to use the OTLP endpoint as the Diode target if no explicit target is set, and to indicate when this is the case via the `diodeTargetFromOtel` flag in all discovery and worker backends (`device_discovery.go`, `network_discovery.go`, `snmp_discovery.go`, `worker.go`). [[1]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02R48) [[2]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854R49) [[3]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91R49) [[4]](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcR48)
* Refactored argument construction for backend startup commands to always mask the Diode client secret in logs and only substitute the real secret immediately before execution, unless the target is from OTLP, in which case credentials are omitted (`device_discovery.go`, `network_discovery.go`, `snmp_discovery.go`, `worker.go`). [[1]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L138-R163) [[2]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L145-R170) [[3]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91L145-R170) [[4]](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcL138-R163)
* Updated backend configuration methods to set `diodeTargetFromOtel` and use OTLP endpoint as Diode target when appropriate (`device_discovery.go`, `network_discovery.go`, `snmp_discovery.go`, `worker.go`). [[1]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02R121-R124) [[2]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854R128-R131) [[3]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91R128-R131) [[4]](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcR121-R124)

**Testing improvements:**

* Added new tests for each backend to verify that when an OTLP endpoint is used as the Diode target, Diode client credentials are not included in the startup arguments (`device_discovery_test.go`, `network_discovery_test.go`, `snmp_discovery_test.go`). [[1]](diffhunk://#diff-d8cd58f53782228d6e966e2617d17185d5c43c3e13354103f356c6ceeb179132R164-R230) [[2]](diffhunk://#diff-6b6bc95e89f599a44ce52ca0b65600c07498fdec88d42c6e72a6b56a49e9967aR167-R233) [[3]](diffhunk://#diff-d6f915c486f108a406be6c96e380a0aaa3a8d322203567fcf7bfc8f1d592af7cR167-R233)

These changes ensure more secure handling of secrets and correct configuration when using telemetry endpoints, while also improving code clarity and test coverage.