### PR TITLE
fix: set backend ports from config

### DIFF
--- a/agent/backend/devicediscovery/device_discovery.go
+++ b/agent/backend/devicediscovery/device_discovery.go
@@ -142,7 +142,11 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 	d.cancelFunc = cancelFunc
 	d.ctx = ctx
 
-	dOptions := []string{"--diode-app-name-prefix", d.diodeAppNamePrefix}
+	dOptions := []string{
+		"--diode-app-name-prefix", d.diodeAppNamePrefix,
+		"--host", d.apiHost,
+		"--port", d.apiPort,
+	}
 	if d.diodeDryRun {
 		dOptions = append([]string{
 			"--dry-run",
@@ -150,8 +154,6 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 		}, dOptions...)
 	} else {
 		opts := []string{
-			"--host", d.apiHost,
-			"--port", d.apiPort,
 			"--diode-target", d.diodeTarget,
 		}
 		if !d.diodeTargetFromOtel {

--- a/agent/backend/devicediscovery/device_discovery_test.go
+++ b/agent/backend/devicediscovery/device_discovery_test.go
@@ -252,6 +252,74 @@ func TestDeviceDiscoveryBackendCompleted(t *testing.T) {
 	mockCmd.AssertExpectations(t)
 }
 
+func TestDeviceDiscoveryBackendStartWithDryRunIncludesHostAndPort(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/status" {
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(StatusResponse{Version: "1.0.0"}))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	createExecutable(t, "device-discovery")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 12348)
+
+	overrideNewCmdOptions(t, mockCmd, func(options backend.CmdOptions, name string, args []string) {
+		assert.Equal(t, "device-discovery", name, "Expected command name to be device-discovery")
+		assert.Contains(t, args, "--dry-run", "Expected args to contain dry-run flag")
+		assert.Contains(t, args, "--dry-run-output-dir", "Expected args to contain dry-run-output-dir flag")
+		assert.Contains(t, args, "/tmp/device-dry-run", "Expected args to contain dry-run-output-dir value")
+		assert.Contains(t, args, "--host", "Expected args to contain host flag even in dry-run mode")
+		assert.Contains(t, args, serverURL.Hostname(), "Expected args to contain host value even in dry-run mode")
+		assert.Contains(t, args, "--port", "Expected args to contain port flag even in dry-run mode")
+		assert.Contains(t, args, serverURL.Port(), "Expected args to contain port value even in dry-run mode")
+		assert.Contains(t, args, "--diode-app-name-prefix", "Expected args to contain diode app name prefix flag")
+		assert.Contains(t, args, "device-agent", "Expected args to contain diode app name prefix value")
+		assert.NotContains(t, args, "--diode-target", "Expected args to NOT contain diode target flag in dry-run mode")
+		assert.NotContains(t, args, "--diode-client-id", "Expected args to NOT contain diode client id flag in dry-run mode")
+		assert.NotContains(t, args, "--diode-client-secret", "Expected args to NOT contain diode client secret flag in dry-run mode")
+	})
+
+	assert.True(t, devicediscovery.Register(), "Failed to register DeviceDiscovery backend")
+	assert.True(t, backend.HaveBackend("device_discovery"), "Failed to get DeviceDiscovery backend")
+
+	be := backend.GetBackend("device_discovery")
+
+	commons := config.BackendCommons{}
+	commons.Diode.AgentName = "device-agent"
+	commons.Diode.DryRunOutputDir = "/tmp/device-dry-run"
+
+	err = be.Configure(logger, repo, map[string]any{
+		"host":               serverURL.Hostname(),
+		"port":               serverURL.Port(),
+		"agent_name":         "device-agent",
+		"dry_run":            true,
+		"dry_run_output_dir": "/tmp/device-dry-run",
+	}, commons)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, be.Start(ctx, cancel))
+	require.NoError(t, be.Stop(ctx))
+
+	mockCmd.AssertExpectations(t)
+}
+
 func createExecutable(t *testing.T, name string) {
 	t.Helper()
 

--- a/agent/backend/devicediscovery/device_discovery_test.go
+++ b/agent/backend/devicediscovery/device_discovery_test.go
@@ -277,7 +277,7 @@ func TestDeviceDiscoveryBackendStartWithDryRunIncludesHostAndPort(t *testing.T) 
 	mockCmd := &mocks.MockCmd{}
 	mocks.SetupSuccessfulProcess(mockCmd, 12348)
 
-	overrideNewCmdOptions(t, mockCmd, func(options backend.CmdOptions, name string, args []string) {
+	overrideNewCmdOptions(t, mockCmd, func(_ backend.CmdOptions, name string, args []string) {
 		assert.Equal(t, "device-discovery", name, "Expected command name to be device-discovery")
 		assert.Contains(t, args, "--dry-run", "Expected args to contain dry-run flag")
 		assert.Contains(t, args, "--dry-run-output-dir", "Expected args to contain dry-run-output-dir flag")

--- a/agent/backend/networkdiscovery/network_discovery.go
+++ b/agent/backend/networkdiscovery/network_discovery.go
@@ -151,7 +151,11 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 	d.cancelFunc = cancelFunc
 	d.ctx = ctx
 
-	dOptions := []string{"--diode-app-name-prefix", d.diodeAppNamePrefix}
+	dOptions := []string{
+		"--diode-app-name-prefix", d.diodeAppNamePrefix,
+		"--host", d.apiHost,
+		"--port", d.apiPort,
+	}
 	if d.diodeDryRun {
 		dOptions = append([]string{
 			"--dry-run",
@@ -159,8 +163,6 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 		}, dOptions...)
 	} else {
 		opts := []string{
-			"--host", d.apiHost,
-			"--port", d.apiPort,
 			"--diode-target", d.diodeTarget,
 		}
 		if !d.diodeTargetFromOtel {

--- a/agent/backend/networkdiscovery/network_discovery_test.go
+++ b/agent/backend/networkdiscovery/network_discovery_test.go
@@ -280,7 +280,7 @@ func TestNetworkDiscoveryBackendStartWithDryRunIncludesHostAndPort(t *testing.T)
 	mockCmd := &mocks.MockCmd{}
 	mocks.SetupSuccessfulProcess(mockCmd, 12349)
 
-	overrideNewCmdOptions(t, mockCmd, func(options backend.CmdOptions, name string, args []string) {
+	overrideNewCmdOptions(t, mockCmd, func(_ backend.CmdOptions, name string, args []string) {
 		assert.Equal(t, "network-discovery", name, "Expected command name to be network-discovery")
 		assert.Contains(t, args, "--dry-run", "Expected args to contain dry-run flag")
 		assert.Contains(t, args, "--dry-run-output-dir", "Expected args to contain dry-run-output-dir flag")

--- a/agent/backend/networkdiscovery/network_discovery_test.go
+++ b/agent/backend/networkdiscovery/network_discovery_test.go
@@ -255,6 +255,74 @@ func TestNetworkDiscoveryBackendCompleted(t *testing.T) {
 	mockCmd.AssertExpectations(t)
 }
 
+func TestNetworkDiscoveryBackendStartWithDryRunIncludesHostAndPort(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/status" {
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(StatusResponse{Version: "1.0.0"}))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	createExecutable(t, "network-discovery")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 12349)
+
+	overrideNewCmdOptions(t, mockCmd, func(options backend.CmdOptions, name string, args []string) {
+		assert.Equal(t, "network-discovery", name, "Expected command name to be network-discovery")
+		assert.Contains(t, args, "--dry-run", "Expected args to contain dry-run flag")
+		assert.Contains(t, args, "--dry-run-output-dir", "Expected args to contain dry-run-output-dir flag")
+		assert.Contains(t, args, "/tmp/network-dry-run", "Expected args to contain dry-run-output-dir value")
+		assert.Contains(t, args, "--host", "Expected args to contain host flag even in dry-run mode")
+		assert.Contains(t, args, serverURL.Hostname(), "Expected args to contain host value even in dry-run mode")
+		assert.Contains(t, args, "--port", "Expected args to contain port flag even in dry-run mode")
+		assert.Contains(t, args, serverURL.Port(), "Expected args to contain port value even in dry-run mode")
+		assert.Contains(t, args, "--diode-app-name-prefix", "Expected args to contain diode app name prefix flag")
+		assert.Contains(t, args, "network-agent", "Expected args to contain diode app name prefix value")
+		assert.NotContains(t, args, "--diode-target", "Expected args to NOT contain diode target flag in dry-run mode")
+		assert.NotContains(t, args, "--diode-client-id", "Expected args to NOT contain diode client id flag in dry-run mode")
+		assert.NotContains(t, args, "--diode-client-secret", "Expected args to NOT contain diode client secret flag in dry-run mode")
+	})
+
+	assert.True(t, networkdiscovery.Register(), "Failed to register NetworkDiscovery backend")
+	assert.True(t, backend.HaveBackend("network_discovery"), "Failed to get NetworkDiscovery backend")
+
+	be := backend.GetBackend("network_discovery")
+
+	commons := config.BackendCommons{}
+	commons.Diode.AgentName = "network-agent"
+	commons.Diode.DryRunOutputDir = "/tmp/network-dry-run"
+
+	err = be.Configure(logger, repo, map[string]any{
+		"host":               serverURL.Hostname(),
+		"port":               serverURL.Port(),
+		"agent_name":         "network-agent",
+		"dry_run":            true,
+		"dry_run_output_dir": "/tmp/network-dry-run",
+	}, commons)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, be.Start(ctx, cancel))
+	require.NoError(t, be.Stop(ctx))
+
+	mockCmd.AssertExpectations(t)
+}
+
 func createExecutable(t *testing.T, name string) {
 	t.Helper()
 

--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -151,7 +151,11 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 	d.cancelFunc = cancelFunc
 	d.ctx = ctx
 
-	dOptions := []string{"--diode-app-name-prefix", d.diodeAppNamePrefix}
+	dOptions := []string{
+		"--diode-app-name-prefix", d.diodeAppNamePrefix,
+		"--host", d.apiHost,
+		"--port", d.apiPort,
+	}
 	if d.diodeDryRun {
 		dOptions = append([]string{
 			"--dry-run",
@@ -159,8 +163,6 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 		}, dOptions...)
 	} else {
 		opts := []string{
-			"--host", d.apiHost,
-			"--port", d.apiPort,
 			"--diode-target", d.diodeTarget,
 		}
 		if !d.diodeTargetFromOtel {

--- a/agent/backend/snmpdiscovery/snmp_discovery_test.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery_test.go
@@ -280,7 +280,7 @@ func TestSnmpDiscoveryBackendStartWithDryRunIncludesHostAndPort(t *testing.T) {
 	mockCmd := &mocks.MockCmd{}
 	mocks.SetupSuccessfulProcess(mockCmd, 12347)
 
-	overrideNewCmdOptions(t, mockCmd, func(options backend.CmdOptions, name string, args []string) {
+	overrideNewCmdOptions(t, mockCmd, func(_ backend.CmdOptions, name string, args []string) {
 		assert.Equal(t, "snmp-discovery", name, "Expected command name to be snmp-discovery")
 		assert.Contains(t, args, "--dry-run", "Expected args to contain dry-run flag")
 		assert.Contains(t, args, "--dry-run-output-dir", "Expected args to contain dry-run-output-dir flag")

--- a/agent/backend/snmpdiscovery/snmp_discovery_test.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery_test.go
@@ -255,6 +255,74 @@ func TestSnmpDiscoveryBackendCompleted(t *testing.T) {
 	mockCmd.AssertExpectations(t)
 }
 
+func TestSnmpDiscoveryBackendStartWithDryRunIncludesHostAndPort(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/status" {
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(StatusResponse{Version: "1.0.0"}))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	createExecutable(t, "snmp-discovery")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 12347)
+
+	overrideNewCmdOptions(t, mockCmd, func(options backend.CmdOptions, name string, args []string) {
+		assert.Equal(t, "snmp-discovery", name, "Expected command name to be snmp-discovery")
+		assert.Contains(t, args, "--dry-run", "Expected args to contain dry-run flag")
+		assert.Contains(t, args, "--dry-run-output-dir", "Expected args to contain dry-run-output-dir flag")
+		assert.Contains(t, args, "/tmp/snmp-dry-run", "Expected args to contain dry-run-output-dir value")
+		assert.Contains(t, args, "--host", "Expected args to contain host flag even in dry-run mode")
+		assert.Contains(t, args, serverURL.Hostname(), "Expected args to contain host value even in dry-run mode")
+		assert.Contains(t, args, "--port", "Expected args to contain port flag even in dry-run mode")
+		assert.Contains(t, args, serverURL.Port(), "Expected args to contain port value even in dry-run mode")
+		assert.Contains(t, args, "--diode-app-name-prefix", "Expected args to contain diode app name prefix flag")
+		assert.Contains(t, args, "snmp-agent", "Expected args to contain diode app name prefix value")
+		assert.NotContains(t, args, "--diode-target", "Expected args to NOT contain diode target flag in dry-run mode")
+		assert.NotContains(t, args, "--diode-client-id", "Expected args to NOT contain diode client id flag in dry-run mode")
+		assert.NotContains(t, args, "--diode-client-secret", "Expected args to NOT contain diode client secret flag in dry-run mode")
+	})
+
+	assert.True(t, snmpdiscovery.Register(), "Failed to register SnmpDiscovery backend")
+	assert.True(t, backend.HaveBackend("snmp_discovery"), "Failed to get SnmpDiscovery backend")
+
+	be := backend.GetBackend("snmp_discovery")
+
+	commons := config.BackendCommons{}
+	commons.Diode.AgentName = "snmp-agent"
+	commons.Diode.DryRunOutputDir = "/tmp/snmp-dry-run"
+
+	err = be.Configure(logger, repo, map[string]any{
+		"host":               serverURL.Hostname(),
+		"port":               serverURL.Port(),
+		"agent_name":         "snmp-agent",
+		"dry_run":            true,
+		"dry_run_output_dir": "/tmp/snmp-dry-run",
+	}, commons)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, be.Start(ctx, cancel))
+	require.NoError(t, be.Stop(ctx))
+
+	mockCmd.AssertExpectations(t)
+}
+
 func createExecutable(t *testing.T, name string) {
 	t.Helper()
 

--- a/agent/backend/worker/worker.go
+++ b/agent/backend/worker/worker.go
@@ -142,7 +142,11 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 	d.cancelFunc = cancelFunc
 	d.ctx = ctx
 
-	dOptions := []string{"--diode-app-name-prefix", d.diodeAppNamePrefix}
+	dOptions := []string{
+		"--diode-app-name-prefix", d.diodeAppNamePrefix,
+		"--host", d.apiHost,
+		"--port", d.apiPort,
+	}
 	if d.diodeDryRun {
 		dOptions = append([]string{
 			"--dry-run",
@@ -150,8 +154,6 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 		}, dOptions...)
 	} else {
 		opts := []string{
-			"--host", d.apiHost,
-			"--port", d.apiPort,
 			"--diode-target", d.diodeTarget,
 		}
 		if !d.diodeTargetFromOtel {

--- a/agent/backend/worker/worker_test.go
+++ b/agent/backend/worker/worker_test.go
@@ -320,6 +320,74 @@ func TestWorkerBackendCompleted(t *testing.T) {
 	mockCmd.AssertExpectations(t)
 }
 
+func TestWorkerBackendStartWithDryRunIncludesHostAndPort(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/status" {
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"version": "1.0.0"}))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	createExecutable(t, "orb-worker")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 12346)
+
+	overrideNewCmdOptions(t, mockCmd, func(options backend.CmdOptions, name string, args []string) {
+		assert.Equal(t, "orb-worker", name, "Expected command name to be orb-worker")
+		assert.Contains(t, args, "--dry-run", "Expected args to contain dry-run flag")
+		assert.Contains(t, args, "--dry-run-output-dir", "Expected args to contain dry-run-output-dir flag")
+		assert.Contains(t, args, "/tmp/worker-dry-run", "Expected args to contain dry-run-output-dir value")
+		assert.Contains(t, args, "--host", "Expected args to contain host flag even in dry-run mode")
+		assert.Contains(t, args, serverURL.Hostname(), "Expected args to contain host value even in dry-run mode")
+		assert.Contains(t, args, "--port", "Expected args to contain port flag even in dry-run mode")
+		assert.Contains(t, args, serverURL.Port(), "Expected args to contain port value even in dry-run mode")
+		assert.Contains(t, args, "--diode-app-name-prefix", "Expected args to contain diode app name prefix flag")
+		assert.Contains(t, args, "worker-agent", "Expected args to contain diode app name prefix value")
+		assert.NotContains(t, args, "--diode-target", "Expected args to NOT contain diode target flag in dry-run mode")
+		assert.NotContains(t, args, "--diode-client-id", "Expected args to NOT contain diode client id flag in dry-run mode")
+		assert.NotContains(t, args, "--diode-client-secret", "Expected args to NOT contain diode client secret flag in dry-run mode")
+	})
+
+	assert.True(t, worker.Register(), "Failed to register Worker backend")
+	assert.True(t, backend.HaveBackend("worker"), "Failed to get Worker backend")
+
+	be := backend.GetBackend("worker")
+
+	commons := config.BackendCommons{}
+	commons.Diode.AgentName = "worker-agent"
+	commons.Diode.DryRunOutputDir = "/tmp/worker-dry-run"
+
+	err = be.Configure(logger, repo, map[string]any{
+		"host":               serverURL.Hostname(),
+		"port":               serverURL.Port(),
+		"agent_name":         "worker-agent",
+		"dry_run":            true,
+		"dry_run_output_dir": "/tmp/worker-dry-run",
+	}, commons)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, be.Start(ctx, cancel))
+	require.NoError(t, be.Stop(ctx))
+
+	mockCmd.AssertExpectations(t)
+}
+
 func createExecutable(t *testing.T, name string) {
 	t.Helper()
 

--- a/agent/backend/worker/worker_test.go
+++ b/agent/backend/worker/worker_test.go
@@ -345,7 +345,7 @@ func TestWorkerBackendStartWithDryRunIncludesHostAndPort(t *testing.T) {
 	mockCmd := &mocks.MockCmd{}
 	mocks.SetupSuccessfulProcess(mockCmd, 12346)
 
-	overrideNewCmdOptions(t, mockCmd, func(options backend.CmdOptions, name string, args []string) {
+	overrideNewCmdOptions(t, mockCmd, func(_ backend.CmdOptions, name string, args []string) {
 		assert.Equal(t, "orb-worker", name, "Expected command name to be orb-worker")
 		assert.Contains(t, args, "--dry-run", "Expected args to contain dry-run flag")
 		assert.Contains(t, args, "--dry-run-output-dir", "Expected args to contain dry-run-output-dir flag")


### PR DESCRIPTION
This pull request updates the initialization of command-line options in the `Start` methods for several backend services. The main change is that the `--host` and `--port` options are now included earlier in the `dOptions` slice, ensuring these options are consistently set regardless of whether the service is running in dry-run mode or not.

Consistent option initialization:

* Updated the `Start` methods in `deviceDiscoveryBackend`, `networkDiscoveryBackend`, `snmpDiscoveryBackend`, and `workerBackend` to include `--host` and `--port` in the initial `dOptions` slice, rather than conditionally adding them later. This change ensures that these options are always present and simplifies the logic for building command-line arguments. (`agent/backend/devicediscovery/device_discovery.go` [[1]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L145-L154) `agent/backend/networkdiscovery/network_discovery.go` [[2]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L154-L163) `agent/backend/snmpdiscovery/snmp_discovery.go` [[3]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91L154-L163) `agent/backend/worker/worker.go` [[4]](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcL145-L154)