### PR TITLE
fix: improve handling of port in use errors

### DIFF
--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -140,6 +140,25 @@ func (fleetManager *fleetConfigManager) Start(cfg config.Config, backends map[st
 	fleetManager.configYaml = string(configYaml)
 	fleetManager.connectionDetails = connectionDetails
 
+	// Start OTLP bridge server early, before MQTT connection
+	// This ensures port binding errors are detected immediately and propagate to fail the agent startup
+	grpcPort := 4317
+	if cfg.OrbAgent.ConfigManager.Sources.Fleet.OTLPBridgeGRPCPort != nil {
+		grpcPort = *cfg.OrbAgent.ConfigManager.Sources.Fleet.OTLPBridgeGRPCPort
+	}
+	bridgeConfig := otlpbridge.BridgeConfig{
+		ListenAddr: fmt.Sprintf(":%d", grpcPort),
+		Encoding:   "json",
+	}
+	fleetManager.otlpBridge, err = otlpbridge.NewBridgeServer(bridgeConfig, fleetManager.policyManager.GetRepo(), fleetManager.logger)
+	if err != nil {
+		return fmt.Errorf("failed to create OTLP bridge: %w", err)
+	}
+	if err := fleetManager.otlpBridge.Start(context.Background()); err != nil {
+		return fmt.Errorf("failed to start OTLP bridge on port %d: %w", grpcPort, err)
+	}
+	fleetManager.logger.Info("OTLP bridge server started", slog.Int("grpc_port", grpcPort))
+
 	err = fleetManager.connection.Connect(ctx, connectionDetails, backends, cfg.OrbAgent.Labels, string(configYaml))
 	if err != nil {
 		return err
@@ -167,32 +186,12 @@ func (fleetManager *fleetConfigManager) Start(cfg config.Config, backends map[st
 		}
 	}()
 
-	// Register MQTTOnReadyHook to initialize the OTLP bridge
+	// Register MQTTOnReadyHook to bind publisher and topics to the OTLP bridge
+	// The bridge server is already started earlier in Start(), so we only need to bind MQTT here
 	fleetManager.connection.AddOnReadyHook(func(cm *autopaho.ConnectionManager, topics fleet.TokenResponseTopics) {
 		if fleetManager.otlpBridge == nil {
-			fleetManager.logger.Info("MQTT connection ready, initializing OTLP bridge")
-			// Get gRPC port from config, defaulting to 4317 if not specified
-			grpcPort := 4317
-			if fleetManager.config.OrbAgent.ConfigManager.Sources.Fleet.OTLPBridgeGRPCPort != nil {
-				grpcPort = *fleetManager.config.OrbAgent.ConfigManager.Sources.Fleet.OTLPBridgeGRPCPort
-			}
-			bridgeConfig := otlpbridge.BridgeConfig{
-				ListenAddr: fmt.Sprintf(":%d", grpcPort),
-				Encoding:   "json",
-			}
-			var err error
-			fleetManager.otlpBridge, err = otlpbridge.NewBridgeServer(bridgeConfig, fleetManager.policyManager.GetRepo(), fleetManager.logger)
-			if err != nil {
-				fleetManager.logger.Error("failed to create OTLP bridge", slog.Any("error", err))
-				return
-			}
-			if err := fleetManager.otlpBridge.Start(context.Background()); err != nil {
-				fleetManager.logger.Error("failed to start OTLP bridge", slog.Any("error", err))
-				return
-			}
-			fleetManager.logger.Info("OTLP bridge server started", slog.Int("grpc_port", grpcPort))
-		} else {
-			fleetManager.logger.Info("OTLP bridge already initialized, skipping initialization")
+			fleetManager.logger.Error("OTLP bridge not initialized, cannot bind to MQTT")
+			return
 		}
 
 		// Create publisher adapter and bind to bridge

--- a/agent/configmgr/fleet_test.go
+++ b/agent/configmgr/fleet_test.go
@@ -1027,7 +1027,9 @@ func TestFleetConfigManager_Start_OTLPBridgePortInUse(t *testing.T) {
 	testPort := 54321
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", testPort))
 	require.NoError(t, err, "failed to create test listener")
-	defer listener.Close()
+	defer func() {
+		_ = listener.Close()
+	}()
 
 	// Create mock HTTP server for token endpoint
 	validJWT := fleet.RawJWTWithClaims(map[string]any{

--- a/agent/configmgr/fleet_test.go
+++ b/agent/configmgr/fleet_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -78,6 +79,7 @@ func TestFleetConfigManager_Start_TokenError(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
+	mockPMgr.On("GetRepo").Return(nil)
 	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{})
 
 	// Create config with invalid token URL
@@ -108,6 +110,7 @@ func TestFleetConfigManager_Start_ConnectError(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
+	mockPMgr.On("GetRepo").Return(nil)
 
 	// Create mock MQTT connection that returns a connection error immediately
 	mockConn := &fleet.MockMQTTConnection{
@@ -203,6 +206,7 @@ func TestFleetConfigManager_Start_WithJWTTopicGeneration(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	mockPMgr := &mockPolicyManagerForFleet{}
+	mockPMgr.On("GetRepo").Return(nil)
 
 	// Create mock MQTT connection that returns a connection error
 	mockConn := &fleet.MockMQTTConnection{
@@ -223,16 +227,18 @@ func TestFleetConfigManager_Start_WithJWTTopicGeneration(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// Create test config
+	// Create test config with ephemeral port (0) to avoid port conflicts
+	ephemeralPort := 0
 	cfg := config.Config{
 		OrbAgent: config.OrbAgent{
 			ConfigManager: config.ManagerConfig{
 				Sources: config.Sources{
 					Fleet: config.FleetManager{
-						TokenURL:     server.URL,
-						SkipTLS:      true,
-						ClientID:     "test_client_id",
-						ClientSecret: "test_client_secret",
+						TokenURL:           server.URL,
+						SkipTLS:            true,
+						ClientID:           "test_client_id",
+						ClientSecret:       "test_client_secret",
+						OTLPBridgeGRPCPort: &ephemeralPort,
 					},
 				},
 			},
@@ -1004,6 +1010,146 @@ func TestFleetConfigManager_OnReadyHook_UsesDefaultGRPCPort(t *testing.T) {
 
 	// Verify bridge was initialized (should use default port 4317)
 	require.NotNil(t, fleetManager.otlpBridge, "bridge should be initialized with default port")
+
+	// Cleanup
+	if fleetManager.otlpBridge != nil {
+		_ = fleetManager.otlpBridge.Stop(context.Background())
+	}
+}
+
+func TestFleetConfigManager_Start_OTLPBridgePortInUse(t *testing.T) {
+	// Test that Start() fails with a clear error when the OTLP bridge port is already in use
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mockPMgr := &mockPolicyManagerForFleet{}
+	mockPMgr.On("GetRepo").Return(nil)
+
+	// Pre-occupy a port with a test listener
+	testPort := 54321
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", testPort))
+	require.NoError(t, err, "failed to create test listener")
+	defer listener.Close()
+
+	// Create mock HTTP server for token endpoint
+	validJWT := fleet.RawJWTWithClaims(map[string]any{
+		"orb:org_id":   "test-org",
+		"orb:zone":     "default",
+		"orb:agent_id": "test-agent",
+		"client_id":    "test-client",
+		"iat":          1516239022,
+		"ext": map[string]any{
+			"orb:mqtt_url": "mqtt://test.example.com:1883",
+		},
+	})
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		response := fleet.TokenResponse{
+			AccessToken: validJWT,
+			MQTTURL:     "mqtt://test.example.com:1883",
+			ExpiresIn:   3600,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	// Create config with the pre-occupied port
+	cfg := config.Config{
+		OrbAgent: config.OrbAgent{
+			ConfigManager: config.ManagerConfig{
+				Sources: config.Sources{
+					Fleet: config.FleetManager{
+						TokenURL:           server.URL,
+						SkipTLS:            true,
+						ClientID:           "test_client",
+						ClientSecret:       "test_secret",
+						OTLPBridgeGRPCPort: &testPort,
+					},
+				},
+			},
+		},
+	}
+
+	backends := make(map[string]backend.Backend)
+	// Use mock connection so we don't try to actually connect to MQTT
+	mockConn := &fleet.MockMQTTConnection{
+		ConnectError: fmt.Errorf("mqtt connection failed"),
+	}
+	fleetManager := newFleetConfigManagerWithConnection(logger, mockPMgr, &mockBackendState{}, mockConn)
+
+	// Act
+	err = fleetManager.Start(cfg, backends)
+
+	// Assert
+	require.Error(t, err, "Start() should fail when port is in use")
+	assert.Contains(t, err.Error(), "failed to start OTLP bridge", "error should mention OTLP bridge failure")
+	assert.Contains(t, err.Error(), fmt.Sprintf("%d", testPort), "error should mention the port number")
+}
+
+func TestFleetConfigManager_Start_OTLPBridgeStartsBeforeMQTT(t *testing.T) {
+	// Test that OTLP bridge starts before MQTT connection attempt
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mockPMgr := &mockPolicyManagerForFleet{}
+	mockPMgr.On("GetRepo").Return(nil)
+
+	// Create a mock MQTT connection that tracks when Connect() is called
+	mockConn := &fleet.MockMQTTConnection{
+		ConnectError: fmt.Errorf("mqtt connection failed"),
+	}
+	fleetManager := newFleetConfigManagerWithConnection(logger, mockPMgr, &mockBackendState{}, mockConn)
+
+	// Create mock HTTP server for token endpoint
+	validJWT := fleet.RawJWTWithClaims(map[string]any{
+		"orb:org_id":   "test-org",
+		"orb:zone":     "default",
+		"orb:agent_id": "test-agent",
+		"client_id":    "test-client",
+		"iat":          1516239022,
+		"ext": map[string]any{
+			"orb:mqtt_url": "mqtt://test.example.com:1883",
+		},
+	})
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		response := fleet.TokenResponse{
+			AccessToken: validJWT,
+			MQTTURL:     "mqtt://test.example.com:1883",
+			ExpiresIn:   3600,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	// Use ephemeral port (0) to avoid port conflicts with other tests
+	ephemeralPort := 0
+	cfg := config.Config{
+		OrbAgent: config.OrbAgent{
+			ConfigManager: config.ManagerConfig{
+				Sources: config.Sources{
+					Fleet: config.FleetManager{
+						TokenURL:           server.URL,
+						SkipTLS:            true,
+						ClientID:           "test_client",
+						ClientSecret:       "test_secret",
+						OTLPBridgeGRPCPort: &ephemeralPort,
+					},
+				},
+			},
+		},
+	}
+
+	backends := make(map[string]backend.Backend)
+
+	// Act
+	err := fleetManager.Start(cfg, backends)
+
+	// Assert
+	// Even though MQTT connection fails, we should verify that:
+	// 1. OTLP bridge was started (it should exist)
+	// 2. Connect() was called (indicating we got past bridge startup)
+	require.Error(t, err, "Start() should fail due to MQTT connection error")
+	assert.True(t, mockConn.ConnectCalled, "MQTT Connect() should have been called")
+	// The bridge should have been created and started before Connect() was called
+	// Since Connect() was called, the bridge must have started successfully
+	assert.NotNil(t, fleetManager.otlpBridge, "OTLP bridge should be initialized before MQTT connection")
 
 	// Cleanup
 	if fleetManager.otlpBridge != nil {

--- a/agent/otlpbridge/server.go
+++ b/agent/otlpbridge/server.go
@@ -107,7 +107,7 @@ func (s *BridgeServer) GetPolicyRepo() policies.PolicyRepo {
 func (s *BridgeServer) Start(_ context.Context) error {
 	lis, err := net.Listen("tcp", s.cfg.ListenAddr)
 	if err != nil {
-		return fmt.Errorf("failed to listen on %s: %w", s.cfg.ListenAddr, err)
+		return fmt.Errorf("failed to listen on %s (port may be in use by another service): %w", s.cfg.ListenAddr, err)
 	}
 	s.listener = lis
 

--- a/agent/otlpbridge/server_test.go
+++ b/agent/otlpbridge/server_test.go
@@ -1,0 +1,100 @@
+package otlpbridge
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBridgeServer_Start_PortInUse(t *testing.T) {
+	// Test that Start() returns a clear error when the port is already in use
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// Pre-occupy a port with a test listener
+	testPort := 54322
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", testPort))
+	require.NoError(t, err, "failed to create test listener")
+	defer listener.Close()
+
+	// Create bridge server with the pre-occupied port
+	bridgeConfig := BridgeConfig{
+		ListenAddr: fmt.Sprintf(":%d", testPort),
+		Encoding:   "json",
+	}
+
+	bridge, err := NewBridgeServer(bridgeConfig, nil, logger)
+	require.NoError(t, err, "failed to create bridge server")
+
+	// Act
+	err = bridge.Start(context.Background())
+
+	// Assert
+	require.Error(t, err, "Start() should fail when port is in use")
+	assert.Contains(t, err.Error(), "failed to listen", "error should mention listening failure")
+	assert.Contains(t, err.Error(), fmt.Sprintf(":%d", testPort), "error should mention the port")
+	assert.Contains(t, err.Error(), "port may be in use", "error should mention port may be in use")
+}
+
+func TestBridgeServer_Start_Success(t *testing.T) {
+	// Test that Start() succeeds when port is available
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// Use port 0 to let the OS assign an available port
+	bridgeConfig := BridgeConfig{
+		ListenAddr: ":0",
+		Encoding:   "json",
+	}
+
+	bridge, err := NewBridgeServer(bridgeConfig, nil, logger)
+	require.NoError(t, err, "failed to create bridge server")
+
+	// Act
+	err = bridge.Start(context.Background())
+
+	// Assert
+	require.NoError(t, err, "Start() should succeed when port is available")
+
+	// Cleanup
+	if bridge != nil {
+		_ = bridge.Stop(context.Background())
+	}
+}
+
+func TestBridgeServer_Start_ErrorMessageFormat(t *testing.T) {
+	// Test that the error message format is helpful
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	// Pre-occupy a port
+	testPort := 54323
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", testPort))
+	require.NoError(t, err, "failed to create test listener")
+	defer listener.Close()
+
+	bridgeConfig := BridgeConfig{
+		ListenAddr: fmt.Sprintf(":%d", testPort),
+		Encoding:   "json",
+	}
+
+	bridge, err := NewBridgeServer(bridgeConfig, nil, logger)
+	require.NoError(t, err)
+
+	err = bridge.Start(context.Background())
+
+	// Verify error message contains helpful information
+	require.Error(t, err)
+	errorMsg := strings.ToLower(err.Error())
+	assert.True(t,
+		strings.Contains(errorMsg, "port") || strings.Contains(errorMsg, "listen"),
+		"error message should mention port or listen: %s", err.Error())
+	assert.True(t,
+		strings.Contains(errorMsg, "use") || strings.Contains(errorMsg, "bind"),
+		"error message should mention port in use or bind failure: %s", err.Error())
+}
+

--- a/agent/otlpbridge/server_test.go
+++ b/agent/otlpbridge/server_test.go
@@ -21,7 +21,9 @@ func TestBridgeServer_Start_PortInUse(t *testing.T) {
 	testPort := 54322
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", testPort))
 	require.NoError(t, err, "failed to create test listener")
-	defer listener.Close()
+	defer func() {
+		_ = listener.Close()
+	}()
 
 	// Create bridge server with the pre-occupied port
 	bridgeConfig := BridgeConfig{
@@ -75,7 +77,9 @@ func TestBridgeServer_Start_ErrorMessageFormat(t *testing.T) {
 	testPort := 54323
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", testPort))
 	require.NoError(t, err, "failed to create test listener")
-	defer listener.Close()
+	defer func() {
+		_ = listener.Close()
+	}()
 
 	bridgeConfig := BridgeConfig{
 		ListenAddr: fmt.Sprintf(":%d", testPort),
@@ -97,4 +101,3 @@ func TestBridgeServer_Start_ErrorMessageFormat(t *testing.T) {
 		strings.Contains(errorMsg, "use") || strings.Contains(errorMsg, "bind"),
 		"error message should mention port in use or bind failure: %s", err.Error())
 }
-


### PR DESCRIPTION
This pull request refactors the startup sequence for the OTLP bridge server in the Fleet config manager to ensure that port binding errors are detected early, improving agent reliability and error reporting. It also adds comprehensive unit tests for OTLP bridge startup error scenarios and enhances error messages for port binding failures. The changes are grouped below by theme:

**Startup Sequence and Error Handling Improvements:**

* The OTLP bridge server is now started before the MQTT connection is attempted in `fleetConfigManager.Start()`, so port binding errors fail the agent startup immediately rather than later in the process.
* The MQTT `OnReadyHook` is updated to only bind MQTT publisher and topics to the already-started OTLP bridge, rather than initializing the bridge server at this point.

**Enhanced Error Messages:**

* The error message returned when the OTLP bridge server fails to bind to a port is improved to clearly indicate that the port may be in use by another service.

**Unit Test Additions and Improvements:**

* New tests are added to verify OTLP bridge server startup error handling, including port-in-use scenarios and helpful error message formatting (`agent/otlpbridge/server_test.go`).
* Fleet config manager tests are updated to cover cases where the OTLP bridge port is already in use and to ensure the bridge starts before MQTT connection attempts (`agent/configmgr/fleet_test.go`). [[1]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eR1019-R1158) [[2]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL226-R231) [[3]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eR241)
* Existing fleet config manager tests are updated to mock the policy manager's `GetRepo` method for correct initialization. [[1]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eR82) [[2]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eR113) [[3]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eR209)

**Test Infrastructure Improvements:**

* Test configs use ephemeral ports (`0`) to avoid port conflicts and ensure reliable test execution. [[1]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL226-R231) [[2]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eR241)
* The Go `net` package is imported to facilitate port binding tests.