### PR TITLE
chore: device discovery tenant group support

### DIFF
--- a/docs/backends/device_discovery.md
+++ b/docs/backends/device_discovery.md
@@ -63,7 +63,7 @@ Current supported defaults:
 | role  | str  | Device role (e.g., switch) (defaults to 'undefined' if not specified) |
 | if_type | str | Interface Type (defaults to 'other' if not specified) |
 | location | str | Device location |
-| tenant | str | Device tenant |
+| tenant | str/map | Device tenant |
 | description | str  | General description   |
 | comments   | str  | General comments       |
 | tags       | list | List of tags           |
@@ -79,6 +79,11 @@ Current supported defaults:
 | ├─ description | str  | Device description           |
 | ├─ comments   | str  | Device comments               |
 | ├─ tags       | list | Device tags                   |
+| tenant | map | Tenant-specific defaults              |
+| ├─ name | str | Tenant name                          |
+| ├─ group | str | Tenant group                        |
+| ├─ description | str  | Tenant description           |
+| ├─ tags       | list | Tenant tags                   |
 | interface    | map  | Interface-specific defaults    |
 | ├─ description | str  | Interface description        |
 | ├─ tags       | list | Interface tags               |


### PR DESCRIPTION
This pull request updates the documentation for device discovery to clarify and expand how tenant information is represented in the supported defaults. The main focus is on improving the description of the `tenant` field, indicating it can be either a string or a map, and providing more detail on the structure of tenant-specific defaults.

Documentation improvements:

* Updated the `tenant` field in the supported defaults table to indicate it can now be either a string or a map, reflecting more flexible tenant data representation.
* Added a breakdown of tenant-specific defaults, detailing possible fields such as `name`, `group`, `description`, and `tags` within the `tenant` map.