### PR TITLE
fix: rename jobs to runs

### DIFF
--- a/agent/backend/backend.go
+++ b/agent/backend/backend.go
@@ -10,8 +10,8 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/policies"
 )
 
-// PolicyStatusJob represents a job in the backend status response
-type PolicyStatusJob struct {
+// PolicyStatusRun represents a run in the backend status response
+type PolicyStatusRun struct {
 	ID          string    `json:"id"`
 	Status      string    `json:"status"`
 	Reason      string    `json:"reason"`
@@ -24,7 +24,7 @@ type PolicyStatusJob struct {
 type PolicyStatus struct {
 	Name   string            `json:"name"`
 	Status string            `json:"status"`
-	Jobs   []PolicyStatusJob `json:"jobs"`
+	Runs   []PolicyStatusRun `json:"runs"`
 }
 
 // StatusResponse represents the full status response from backend

--- a/agent/backend/backend_state.go
+++ b/agent/backend/backend_state.go
@@ -111,9 +111,9 @@ func (manager *stateManager) StartBackendMonitor(name string, be Backend) {
 					manager.logger.Debug("failed to get policy status", "backend", name, "error", err)
 				} else {
 					for _, ps := range statuses {
-						jobs := convertToJobData(ps.Jobs)
-						if err := manager.policyRepo.UpdateJobs(ps.Name, jobs); err != nil {
-							manager.logger.Debug("failed to update jobs for policy", "policy", ps.Name, "error", err)
+						runs := convertToRunData(ps.Runs)
+						if err := manager.policyRepo.UpdateRuns(ps.Name, runs); err != nil {
+							manager.logger.Debug("failed to update runs for policy", "policy", ps.Name, "error", err)
 						}
 					}
 				}
@@ -158,18 +158,18 @@ func (manager *stateManager) Get() map[string]*State {
 	return result
 }
 
-// convertToJobData converts backend PolicyStatusJob to policies.JobData
-func convertToJobData(statusJobs []PolicyStatusJob) []policies.JobData {
-	jobs := make([]policies.JobData, len(statusJobs))
-	for i, sj := range statusJobs {
-		jobs[i] = policies.JobData{
-			ID:          sj.ID,
-			Status:      sj.Status,
-			Reason:      sj.Reason,
-			EntityCount: sj.EntityCount,
-			CreatedAt:   sj.CreatedAt,
-			UpdatedAt:   sj.UpdatedAt,
+// convertToRunData converts backend PolicyStatusRun to policies.RunData
+func convertToRunData(statusRuns []PolicyStatusRun) []policies.RunData {
+	runs := make([]policies.RunData, len(statusRuns))
+	for i, sr := range statusRuns {
+		runs[i] = policies.RunData{
+			ID:          sr.ID,
+			Status:      sr.Status,
+			Reason:      sr.Reason,
+			EntityCount: sr.EntityCount,
+			CreatedAt:   sr.CreatedAt,
+			UpdatedAt:   sr.UpdatedAt,
 		}
 	}
-	return jobs
+	return runs
 }

--- a/agent/backend/backend_state_test.go
+++ b/agent/backend/backend_state_test.go
@@ -526,9 +526,9 @@ func TestBackendStateManager_PolicyStatusPolling(t *testing.T) {
 		{
 			Name:   "test-policy",
 			Status: "completed",
-			Jobs: []backend.PolicyStatusJob{
+			Runs: []backend.PolicyStatusRun{
 				{
-					ID:        "job-1",
+					ID:        "run-1",
 					Status:    "completed",
 					CreatedAt: testTime,
 					UpdatedAt: testTime.Add(5 * time.Minute),
@@ -547,16 +547,16 @@ func TestBackendStateManager_PolicyStatusPolling(t *testing.T) {
 	// Add a small buffer to ensure the ticker has fired and the update has completed
 	time.Sleep(backend.BackendMonitorInterval + 200*time.Millisecond)
 
-	// Assert - Verify jobs were updated in the policy repo
+	// Assert - Verify runs were updated in the policy repo
 	// Wait a bit more to ensure the goroutine has finished updating the repo
 	// (policyMemRepo is not thread-safe, so we need to avoid concurrent access)
 	time.Sleep(50 * time.Millisecond)
 
 	retrievedPolicy, err2 := repo.Get("policy-1")
 	require.NoError(t, err2)
-	require.Len(t, retrievedPolicy.Jobs, 1, "Expected jobs to be updated after ticker fires")
-	assert.Equal(t, "job-1", retrievedPolicy.Jobs[0].ID)
-	assert.Equal(t, "completed", retrievedPolicy.Jobs[0].Status)
+	require.Len(t, retrievedPolicy.Runs, 1, "Expected runs to be updated after ticker fires")
+	assert.Equal(t, "run-1", retrievedPolicy.Runs[0].ID)
+	assert.Equal(t, "completed", retrievedPolicy.Runs[0].Status)
 
 	mockBe.AssertExpectations(t)
 }
@@ -596,9 +596,9 @@ func TestBackendStateManager_PolicyStatusPolling_WithEntityCount(t *testing.T) {
 		{
 			Name:   "test-policy",
 			Status: "completed",
-			Jobs: []backend.PolicyStatusJob{
+			Runs: []backend.PolicyStatusRun{
 				{
-					ID:          "job-1",
+					ID:          "run-1",
 					Status:      "completed",
 					EntityCount: &entityCount,
 					CreatedAt:   testTime,
@@ -621,11 +621,11 @@ func TestBackendStateManager_PolicyStatusPolling_WithEntityCount(t *testing.T) {
 	// Assert - Verify entity_count was stored
 	retrievedPolicy, err2 := repo.Get("policy-1")
 	require.NoError(t, err2)
-	require.Len(t, retrievedPolicy.Jobs, 1, "Expected jobs to be updated after ticker fires")
-	assert.Equal(t, "job-1", retrievedPolicy.Jobs[0].ID)
-	assert.Equal(t, "completed", retrievedPolicy.Jobs[0].Status)
-	require.NotNil(t, retrievedPolicy.Jobs[0].EntityCount, "Expected entity_count to be stored")
-	assert.Equal(t, int64(42), *retrievedPolicy.Jobs[0].EntityCount)
+	require.Len(t, retrievedPolicy.Runs, 1, "Expected runs to be updated after ticker fires")
+	assert.Equal(t, "run-1", retrievedPolicy.Runs[0].ID)
+	assert.Equal(t, "completed", retrievedPolicy.Runs[0].Status)
+	require.NotNil(t, retrievedPolicy.Runs[0].EntityCount, "Expected entity_count to be stored")
+	assert.Equal(t, int64(42), *retrievedPolicy.Runs[0].EntityCount)
 
 	mockBe.AssertExpectations(t)
 }
@@ -665,9 +665,9 @@ func TestBackendStateManager_PolicyStatusPolling_WithoutEntityCount(t *testing.T
 		{
 			Name:   "test-policy",
 			Status: "completed",
-			Jobs: []backend.PolicyStatusJob{
+			Runs: []backend.PolicyStatusRun{
 				{
-					ID:          "job-1",
+					ID:          "run-1",
 					Status:      "completed",
 					EntityCount: nil, // Explicitly nil
 					CreatedAt:   testTime,
@@ -690,10 +690,10 @@ func TestBackendStateManager_PolicyStatusPolling_WithoutEntityCount(t *testing.T
 	// Assert - Verify entity_count is nil when not provided
 	retrievedPolicy, err2 := repo.Get("policy-1")
 	require.NoError(t, err2)
-	require.Len(t, retrievedPolicy.Jobs, 1, "Expected jobs to be updated after ticker fires")
-	assert.Equal(t, "job-1", retrievedPolicy.Jobs[0].ID)
-	assert.Equal(t, "completed", retrievedPolicy.Jobs[0].Status)
-	assert.Nil(t, retrievedPolicy.Jobs[0].EntityCount, "Expected entity_count to be nil when not provided")
+	require.Len(t, retrievedPolicy.Runs, 1, "Expected runs to be updated after ticker fires")
+	assert.Equal(t, "run-1", retrievedPolicy.Runs[0].ID)
+	assert.Equal(t, "completed", retrievedPolicy.Runs[0].Status)
+	assert.Nil(t, retrievedPolicy.Runs[0].EntityCount, "Expected entity_count to be nil when not provided")
 
 	mockBe.AssertExpectations(t)
 }

--- a/agent/configmgr/fleet/from_rpc_test.go
+++ b/agent/configmgr/fleet/from_rpc_test.go
@@ -107,8 +107,8 @@ func (m *mockPolicyRepo) EnsureGroupID(policyID string, agentGroupID string) err
 	return args.Error(0)
 }
 
-func (m *mockPolicyRepo) UpdateJobs(policyName string, jobs []policies.JobData) error {
-	args := m.Called(policyName, jobs)
+func (m *mockPolicyRepo) UpdateRuns(policyName string, runs []policies.RunData) error {
+	args := m.Called(policyName, runs)
 	return args.Error(0)
 }
 

--- a/agent/configmgr/fleet/heartbeats.go
+++ b/agent/configmgr/fleet/heartbeats.go
@@ -98,29 +98,29 @@ func (hb *heartbeater) getPolicyState() map[string]messages.PolicyStateInfo {
 			Error:    policyState.BackendErr,
 			Version:  policyState.Version,
 			Backend:  policyState.Backend,
-			Jobs:     convertJobsToStateInfo(policyState.Jobs),
+			Runs:     convertRunsToStateInfo(policyState.Runs),
 		}
 	}
 	return ps
 }
 
-// convertJobsToStateInfo converts policies.JobData to messages.JobStateInfo
-func convertJobsToStateInfo(jobs []policies.JobData) []messages.JobStateInfo {
-	if len(jobs) == 0 {
+// convertRunsToStateInfo converts policies.RunData to messages.RunStateInfo
+func convertRunsToStateInfo(runs []policies.RunData) []messages.RunStateInfo {
+	if len(runs) == 0 {
 		return nil
 	}
-	jobInfos := make([]messages.JobStateInfo, len(jobs))
-	for i, job := range jobs {
-		jobInfos[i] = messages.JobStateInfo{
-			ID:          job.ID,
-			Status:      job.Status,
-			Reason:      job.Reason,
-			EntityCount: job.EntityCount,
-			CreatedAt:   job.CreatedAt,
-			UpdatedAt:   job.UpdatedAt,
+	runInfos := make([]messages.RunStateInfo, len(runs))
+	for i, run := range runs {
+		runInfos[i] = messages.RunStateInfo{
+			ID:          run.ID,
+			Status:      run.Status,
+			Reason:      run.Reason,
+			EntityCount: run.EntityCount,
+			CreatedAt:   run.CreatedAt,
+			UpdatedAt:   run.UpdatedAt,
 		}
 	}
-	return jobInfos
+	return runInfos
 }
 
 func (hb *heartbeater) getGroupState() map[string]messages.GroupStateInfo {

--- a/agent/configmgr/fleet/heartbeats_test.go
+++ b/agent/configmgr/fleet/heartbeats_test.go
@@ -1407,7 +1407,7 @@ func TestNewHeartbeater_WithGroupManager(t *testing.T) {
 	hb.hbTicker.Stop()
 }
 
-func TestHeartbeater_GetPolicyState_WithJobs(t *testing.T) {
+func TestHeartbeater_GetPolicyState_WithRuns(t *testing.T) {
 	// Arrange
 	testTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	mockPMgr := &mockPolicyManagerForHeartbeat{}
@@ -1420,15 +1420,15 @@ func TestHeartbeater_GetPolicyState_WithJobs(t *testing.T) {
 			State:      policies.Running,
 			BackendErr: "",
 			Datasets:   map[string]bool{"dataset-1": true},
-			Jobs: []policies.JobData{
+			Runs: []policies.RunData{
 				{
-					ID:        "job-1",
+					ID:        "run-1",
 					Status:    "completed",
 					CreatedAt: testTime,
 					UpdatedAt: testTime.Add(5 * time.Minute),
 				},
 				{
-					ID:        "job-2",
+					ID:        "run-2",
 					Status:    "running",
 					CreatedAt: testTime.Add(10 * time.Minute),
 					UpdatedAt: testTime.Add(12 * time.Minute),
@@ -1443,7 +1443,7 @@ func TestHeartbeater_GetPolicyState_WithJobs(t *testing.T) {
 			State:      policies.Running,
 			BackendErr: "",
 			Datasets:   map[string]bool{"dataset-2": true},
-			Jobs:       []policies.JobData{}, // Empty jobs
+			Runs:       []policies.RunData{}, // Empty runs
 		},
 	}, nil)
 
@@ -1456,25 +1456,25 @@ func TestHeartbeater_GetPolicyState_WithJobs(t *testing.T) {
 	// Assert
 	assert.Len(t, policyState, 2)
 
-	// Verify policy-1 has jobs
+	// Verify policy-1 has runs
 	policy1, ok := policyState["policy-1"]
 	assert.True(t, ok)
-	assert.Len(t, policy1.Jobs, 2)
-	assert.Equal(t, "job-1", policy1.Jobs[0].ID)
-	assert.Equal(t, "completed", policy1.Jobs[0].Status)
-	assert.Equal(t, testTime, policy1.Jobs[0].CreatedAt)
-	assert.Equal(t, "job-2", policy1.Jobs[1].ID)
-	assert.Equal(t, "running", policy1.Jobs[1].Status)
+	assert.Len(t, policy1.Runs, 2)
+	assert.Equal(t, "run-1", policy1.Runs[0].ID)
+	assert.Equal(t, "completed", policy1.Runs[0].Status)
+	assert.Equal(t, testTime, policy1.Runs[0].CreatedAt)
+	assert.Equal(t, "run-2", policy1.Runs[1].ID)
+	assert.Equal(t, "running", policy1.Runs[1].Status)
 
-	// Verify policy-2 has no jobs (nil or empty)
+	// Verify policy-2 has no runs (nil or empty)
 	policy2, ok := policyState["policy-2"]
 	assert.True(t, ok)
-	assert.Nil(t, policy2.Jobs)
+	assert.Nil(t, policy2.Runs)
 
 	mockPMgr.AssertExpectations(t)
 }
 
-func TestHeartbeater_SendSingleHeartbeat_WithJobs(t *testing.T) {
+func TestHeartbeater_SendSingleHeartbeat_WithRuns(t *testing.T) {
 	// Arrange
 	testTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 	mockPMgr := &mockPolicyManagerForHeartbeat{}
@@ -1486,9 +1486,9 @@ func TestHeartbeater_SendSingleHeartbeat_WithJobs(t *testing.T) {
 			Version:  1,
 			State:    policies.Running,
 			Datasets: map[string]bool{"dataset-1": true},
-			Jobs: []policies.JobData{
+			Runs: []policies.RunData{
 				{
-					ID:        "job-1",
+					ID:        "run-1",
 					Status:    "completed",
 					CreatedAt: testTime,
 					UpdatedAt: testTime.Add(5 * time.Minute),
@@ -1519,16 +1519,16 @@ func TestHeartbeater_SendSingleHeartbeat_WithJobs(t *testing.T) {
 	err := json.Unmarshal(capturedPayload, &heartbeat)
 	require.NoError(t, err)
 
-	// Verify policy state includes jobs
+	// Verify policy state includes runs
 	assert.NotNil(t, heartbeat.PolicyState)
 	assert.Len(t, heartbeat.PolicyState, 1)
 
 	policy, ok := heartbeat.PolicyState["policy-1"]
 	assert.True(t, ok)
-	assert.Len(t, policy.Jobs, 1)
-	assert.Equal(t, "job-1", policy.Jobs[0].ID)
-	assert.Equal(t, "completed", policy.Jobs[0].Status)
-	assert.Equal(t, testTime, policy.Jobs[0].CreatedAt)
+	assert.Len(t, policy.Runs, 1)
+	assert.Equal(t, "run-1", policy.Runs[0].ID)
+	assert.Equal(t, "completed", policy.Runs[0].Status)
+	assert.Equal(t, testTime, policy.Runs[0].CreatedAt)
 
 	mockPMgr.AssertExpectations(t)
 }
@@ -1546,9 +1546,9 @@ func TestHeartbeater_SendSingleHeartbeat_WithEntityCount(t *testing.T) {
 			Version:  1,
 			State:    policies.Running,
 			Datasets: map[string]bool{"dataset-1": true},
-			Jobs: []policies.JobData{
+			Runs: []policies.RunData{
 				{
-					ID:          "job-1",
+					ID:          "run-1",
 					Status:      "completed",
 					EntityCount: &entityCount,
 					CreatedAt:   testTime,
@@ -1580,18 +1580,18 @@ func TestHeartbeater_SendSingleHeartbeat_WithEntityCount(t *testing.T) {
 	err := json.Unmarshal(capturedPayload, &heartbeat)
 	require.NoError(t, err)
 
-	// Verify policy state includes jobs with entity_count
+	// Verify policy state includes runs with entity_count
 	assert.NotNil(t, heartbeat.PolicyState)
 	assert.Len(t, heartbeat.PolicyState, 1)
 
 	policy, ok := heartbeat.PolicyState["policy-1"]
 	assert.True(t, ok)
-	assert.Len(t, policy.Jobs, 1)
-	assert.Equal(t, "job-1", policy.Jobs[0].ID)
-	assert.Equal(t, "completed", policy.Jobs[0].Status)
-	assert.Equal(t, testTime, policy.Jobs[0].CreatedAt)
-	require.NotNil(t, policy.Jobs[0].EntityCount, "Expected entity_count to be included in heartbeat")
-	assert.Equal(t, int64(100), *policy.Jobs[0].EntityCount)
+	assert.Len(t, policy.Runs, 1)
+	assert.Equal(t, "run-1", policy.Runs[0].ID)
+	assert.Equal(t, "completed", policy.Runs[0].Status)
+	assert.Equal(t, testTime, policy.Runs[0].CreatedAt)
+	require.NotNil(t, policy.Runs[0].EntityCount, "Expected entity_count to be included in heartbeat")
+	assert.Equal(t, int64(100), *policy.Runs[0].EntityCount)
 
 	mockPMgr.AssertExpectations(t)
 }
@@ -1609,9 +1609,9 @@ func TestHeartbeater_SendSingleHeartbeat_WithoutEntityCount(t *testing.T) {
 			Version:  1,
 			State:    policies.Running,
 			Datasets: map[string]bool{"dataset-1": true},
-			Jobs: []policies.JobData{
+			Runs: []policies.RunData{
 				{
-					ID:          "job-1",
+					ID:          "run-1",
 					Status:      "completed",
 					EntityCount: nil, // Explicitly nil
 					CreatedAt:   testTime,
@@ -1643,17 +1643,17 @@ func TestHeartbeater_SendSingleHeartbeat_WithoutEntityCount(t *testing.T) {
 	err := json.Unmarshal(capturedPayload, &heartbeat)
 	require.NoError(t, err)
 
-	// Verify policy state includes jobs without entity_count
+	// Verify policy state includes runs without entity_count
 	assert.NotNil(t, heartbeat.PolicyState)
 	assert.Len(t, heartbeat.PolicyState, 1)
 
 	policy, ok := heartbeat.PolicyState["policy-1"]
 	assert.True(t, ok)
-	assert.Len(t, policy.Jobs, 1)
-	assert.Equal(t, "job-1", policy.Jobs[0].ID)
-	assert.Equal(t, "completed", policy.Jobs[0].Status)
-	assert.Equal(t, testTime, policy.Jobs[0].CreatedAt)
-	assert.Nil(t, policy.Jobs[0].EntityCount, "Expected entity_count to be nil when not provided")
+	assert.Len(t, policy.Runs, 1)
+	assert.Equal(t, "run-1", policy.Runs[0].ID)
+	assert.Equal(t, "completed", policy.Runs[0].Status)
+	assert.Equal(t, testTime, policy.Runs[0].CreatedAt)
+	assert.Nil(t, policy.Runs[0].EntityCount, "Expected entity_count to be nil when not provided")
 
 	mockPMgr.AssertExpectations(t)
 }

--- a/agent/configmgr/fleet/messages/fleet_messages.go
+++ b/agent/configmgr/fleet/messages/fleet_messages.go
@@ -30,8 +30,8 @@ type BackendStateInfo struct {
 	LastRestartReason string    `json:"last_restart_reason,omitempty"`
 }
 
-// JobStateInfo contains state information for a job
-type JobStateInfo struct {
+// RunStateInfo contains state information for a run
+type RunStateInfo struct {
 	ID          string    `json:"id"`
 	Status      string    `json:"status"`
 	Reason      string    `json:"reason,omitempty"`
@@ -48,7 +48,7 @@ type PolicyStateInfo struct {
 	Error    string         `json:"error,omitempty"`
 	Version  int32          `json:"version,omitempty"`
 	Backend  string         `json:"backend,omitempty"`
-	Jobs     []JobStateInfo `json:"jobs,omitempty"`
+	Runs     []RunStateInfo `json:"runs,omitempty"`
 }
 
 // GroupStateInfo contains state information for a group

--- a/agent/policies/repo.go
+++ b/agent/policies/repo.go
@@ -16,7 +16,7 @@ type PolicyRepo interface {
 	EnsureDataset(policyID string, datasetID string) error
 	RemoveDataset(policyID string, datasetID string) (bool, error)
 	EnsureGroupID(policyID string, agentGroupID string) error
-	UpdateJobs(policyName string, jobs []JobData) error
+	UpdateRuns(policyName string, runs []RunData) error
 }
 
 type policyMemRepo struct {
@@ -144,7 +144,7 @@ func (p *policyMemRepo) EnsureGroupID(policyID string, agentGroupID string) erro
 	return nil
 }
 
-func (p *policyMemRepo) UpdateJobs(policyName string, jobs []JobData) error {
+func (p *policyMemRepo) UpdateRuns(policyName string, runs []RunData) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	policyID, ok := p.nameMap[policyName]
@@ -155,7 +155,7 @@ func (p *policyMemRepo) UpdateJobs(policyName string, jobs []JobData) error {
 	if !ok {
 		return errors.New("unknown policy ID")
 	}
-	policy.Jobs = jobs
+	policy.Runs = runs
 	p.db[policyID] = policy
 	return nil
 }

--- a/agent/policies/repo_test.go
+++ b/agent/policies/repo_test.go
@@ -396,7 +396,7 @@ func TestUpdateRenamingPolicy(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestUpdateJobs(t *testing.T) {
+func TestUpdateRuns(t *testing.T) {
 	repo, err := policies.NewMemRepo()
 	require.NoError(t, err)
 
@@ -415,59 +415,59 @@ func TestUpdateJobs(t *testing.T) {
 	err = repo.Update(pd)
 	require.NoError(t, err)
 
-	// Update jobs for the policy
-	jobs := []policies.JobData{
+	// Update runs for the policy
+	runs := []policies.RunData{
 		{
-			ID:        "job-1",
+			ID:        "run-1",
 			Status:    "completed",
 			CreatedAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
 			UpdatedAt: time.Date(2024, 1, 1, 0, 5, 0, 0, time.UTC),
 		},
 		{
-			ID:        "job-2",
+			ID:        "run-2",
 			Status:    "running",
 			CreatedAt: time.Date(2024, 1, 1, 0, 10, 0, 0, time.UTC),
 			UpdatedAt: time.Date(2024, 1, 1, 0, 12, 0, 0, time.UTC),
 		},
 	}
 
-	err = repo.UpdateJobs("test-policy", jobs)
+	err = repo.UpdateRuns("test-policy", runs)
 	require.NoError(t, err)
 
-	// Verify jobs are updated
+	// Verify runs are updated
 	retrievedPD, err := repo.Get("test-id")
 	require.NoError(t, err)
-	assert.Len(t, retrievedPD.Jobs, 2)
-	assert.Equal(t, "job-1", retrievedPD.Jobs[0].ID)
-	assert.Equal(t, "completed", retrievedPD.Jobs[0].Status)
-	assert.Equal(t, "job-2", retrievedPD.Jobs[1].ID)
-	assert.Equal(t, "running", retrievedPD.Jobs[1].Status)
+	assert.Len(t, retrievedPD.Runs, 2)
+	assert.Equal(t, "run-1", retrievedPD.Runs[0].ID)
+	assert.Equal(t, "completed", retrievedPD.Runs[0].Status)
+	assert.Equal(t, "run-2", retrievedPD.Runs[1].ID)
+	assert.Equal(t, "running", retrievedPD.Runs[1].Status)
 
-	// Verify jobs are also returned via GetByName
+	// Verify runs are also returned via GetByName
 	retrievedPDByName, err := repo.GetByName("test-policy")
 	require.NoError(t, err)
-	assert.Len(t, retrievedPDByName.Jobs, 2)
+	assert.Len(t, retrievedPDByName.Runs, 2)
 }
 
-func TestUpdateJobs_NonExistentPolicy(t *testing.T) {
+func TestUpdateRuns_NonExistentPolicy(t *testing.T) {
 	repo, err := policies.NewMemRepo()
 	require.NoError(t, err)
 
-	jobs := []policies.JobData{
+	runs := []policies.RunData{
 		{
-			ID:        "job-1",
+			ID:        "run-1",
 			Status:    "completed",
 			CreatedAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
 			UpdatedAt: time.Date(2024, 1, 1, 0, 5, 0, 0, time.UTC),
 		},
 	}
 
-	err = repo.UpdateJobs("non-existent-policy", jobs)
+	err = repo.UpdateRuns("non-existent-policy", runs)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "policy name not found")
 }
 
-func TestUpdateJobs_GetAllIncludesJobs(t *testing.T) {
+func TestUpdateRuns_GetAllIncludesRuns(t *testing.T) {
 	repo, err := policies.NewMemRepo()
 	require.NoError(t, err)
 
@@ -499,40 +499,40 @@ func TestUpdateJobs_GetAllIncludesJobs(t *testing.T) {
 	err = repo.Update(pd2)
 	require.NoError(t, err)
 
-	// Update jobs for policy 1
-	jobs1 := []policies.JobData{
+	// Update runs for policy 1
+	runs1 := []policies.RunData{
 		{
-			ID:        "job-1",
+			ID:        "run-1",
 			Status:    "completed",
 			CreatedAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
 			UpdatedAt: time.Date(2024, 1, 1, 0, 5, 0, 0, time.UTC),
 		},
 	}
-	err = repo.UpdateJobs("test-policy-1", jobs1)
+	err = repo.UpdateRuns("test-policy-1", runs1)
 	require.NoError(t, err)
 
 	// Get all policies
 	allPolicies, err := repo.GetAll()
 	require.NoError(t, err)
 
-	// Find policy 1 and verify jobs
+	// Find policy 1 and verify runs
 	var foundPolicy1 bool
 	for _, p := range allPolicies {
 		if p.ID == "test-id-1" {
 			foundPolicy1 = true
-			assert.Len(t, p.Jobs, 1)
-			assert.Equal(t, "job-1", p.Jobs[0].ID)
+			assert.Len(t, p.Runs, 1)
+			assert.Equal(t, "run-1", p.Runs[0].ID)
 			break
 		}
 	}
 	assert.True(t, foundPolicy1, "Policy 1 should be found in GetAll()")
 
-	// Verify policy 2 has no jobs
+	// Verify policy 2 has no runs
 	var foundPolicy2 bool
 	for _, p := range allPolicies {
 		if p.ID == "test-id-2" {
 			foundPolicy2 = true
-			assert.Empty(t, p.Jobs)
+			assert.Empty(t, p.Runs)
 			break
 		}
 	}

--- a/agent/policies/types.go
+++ b/agent/policies/types.go
@@ -5,8 +5,8 @@ import (
 	"time"
 )
 
-// JobData represents job information for a policy
-type JobData struct {
+// RunData represents run information for a policy
+type RunData struct {
 	ID          string    `json:"id"`
 	Status      string    `json:"status"`
 	Reason      string    `json:"reason,omitempty"`
@@ -27,7 +27,7 @@ type PolicyData struct {
 	State              PolicyState
 	BackendErr         string
 	PreviousPolicyData *PolicyData
-	Jobs               []JobData
+	Runs               []RunData
 }
 
 // GetDatasetIDs returns the dataset IDs


### PR DESCRIPTION
This pull request performs a comprehensive terminology update throughout the backend, agent, and tests, renaming "Job" to "Run" in all relevant data structures, methods, and test cases. This aligns the codebase with updated domain language and improves clarity and consistency. The changes also update related conversion functions, repository interfaces, and test assertions to use the new naming.

Key changes include:

**Backend and Data Structures:**
- Renamed `PolicyStatusJob` to `PolicyStatusRun` and the associated field in `PolicyStatus` from `Jobs` to `Runs` in `agent/backend/backend.go`. [[1]](diffhunk://#diff-921d949ef1a9a60cb730ef2954ba18a735285f256c914f724ec42e152b5d8415L13-R14) [[2]](diffhunk://#diff-921d949ef1a9a60cb730ef2954ba18a735285f256c914f724ec42e152b5d8415L27-R27)
- Updated the conversion function from `convertToJobData` to `convertToRunData` and changed all usages to reflect the new "Run" terminology in `agent/backend/backend_state.go`. [[1]](diffhunk://#diff-6301055a8fa5f25637f457f26fa4d9556ff42cfe18d83199b773f78de9332819L114-R116) [[2]](diffhunk://#diff-6301055a8fa5f25637f457f26fa4d9556ff42cfe18d83199b773f78de9332819L161-R174)

**Repository and Interfaces:**
- Changed the `PolicyRepo` interface and its in-memory implementation to use `UpdateRuns` with `RunData` instead of `UpdateJobs` with `JobData` in `agent/policies/repo.go`. [[1]](diffhunk://#diff-eb4a205c4c49cd98ecadf3087734a365441d47285f8a6f07e0498cd52eb7668fL19-R19) [[2]](diffhunk://#diff-eb4a205c4c49cd98ecadf3087734a365441d47285f8a6f07e0498cd52eb7668fL147-R147)
- Updated mocks and method calls in tests to use `UpdateRuns` and `RunData` in `agent/configmgr/fleet/from_rpc_test.go`.

**Messaging and State Information:**
- Replaced `JobStateInfo` with `RunStateInfo` and updated the `PolicyStateInfo` struct to use a `Runs` field in `agent/configmgr/fleet/messages/fleet_messages.go`. [[1]](diffhunk://#diff-593a16290809c4abe2c77d31d9f8c4517d5f81da75110e1e7b8acf2f8ee5eaa2L33-R34) [[2]](diffhunk://#diff-593a16290809c4abe2c77d31d9f8c4517d5f81da75110e1e7b8acf2f8ee5eaa2L51-R51)
- Changed conversion functions and usages in the heartbeater logic to use "Run" instead of "Job" in `agent/configmgr/fleet/heartbeats.go`.

**Tests:**
- Refactored all test cases to use the new "Run" terminology, including renaming test functions, variables, and assertions throughout `agent/backend/backend_state_test.go` and `agent/configmgr/fleet/heartbeats_test.go`. [[1]](diffhunk://#diff-16d75b20cc8e0e0bca240ef496681c6908cf3023b660ec78a226743b86361de0L529-R531) [[2]](diffhunk://#diff-16d75b20cc8e0e0bca240ef496681c6908cf3023b660ec78a226743b86361de0L550-R559) [[3]](diffhunk://#diff-16d75b20cc8e0e0bca240ef496681c6908cf3023b660ec78a226743b86361de0L599-R601) [[4]](diffhunk://#diff-16d75b20cc8e0e0bca240ef496681c6908cf3023b660ec78a226743b86361de0L624-R628) [[5]](diffhunk://#diff-16d75b20cc8e0e0bca240ef496681c6908cf3023b660ec78a226743b86361de0L668-R670) [[6]](diffhunk://#diff-16d75b20cc8e0e0bca240ef496681c6908cf3023b660ec78a226743b86361de0L693-R696) [[7]](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72L1410-R1410) [[8]](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72L1423-R1431) [[9]](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72L1446-R1446) [[10]](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72L1459-R1477) [[11]](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72L1489-R1491) [[12]](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72L1522-R1531) [[13]](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72L1549-R1551) [[14]](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72L1583-R1594) [[15]](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72L1612-R1614) [[16]](diffhunk://#diff-61bcdb2570d98db360b12b22aede9c54e0c453085acd5e60d5902c8f92380e72L1646-R1656)

These updates ensure the codebase consistently uses the term "Run" instead of "Job" for policy execution units, improving maintainability and domain alignment.