### PR TITLE
feat: adds policy id to runs

### DIFF
--- a/agent/configmgr/fleet/heartbeats.go
+++ b/agent/configmgr/fleet/heartbeats.go
@@ -113,6 +113,7 @@ func convertRunsToStateInfo(runs []policies.RunData) []messages.RunStateInfo {
 	for i, run := range runs {
 		runInfos[i] = messages.RunStateInfo{
 			ID:          run.ID,
+			PolicyID:    run.PolicyID,
 			Status:      run.Status,
 			Reason:      run.Reason,
 			EntityCount: run.EntityCount,

--- a/agent/configmgr/fleet/messages/fleet_messages.go
+++ b/agent/configmgr/fleet/messages/fleet_messages.go
@@ -33,6 +33,7 @@ type BackendStateInfo struct {
 // RunStateInfo contains state information for a run
 type RunStateInfo struct {
 	ID          string    `json:"id"`
+	PolicyID    string    `json:"policy_id"`
 	Status      string    `json:"status"`
 	Reason      string    `json:"reason,omitempty"`
 	EntityCount *int64    `json:"entity_count,omitempty"`

--- a/agent/policies/types.go
+++ b/agent/policies/types.go
@@ -8,6 +8,7 @@ import (
 // RunData represents run information for a policy
 type RunData struct {
 	ID          string    `json:"id"`
+	PolicyID    string    `json:"policy_id"`
 	Status      string    `json:"status"`
 	Reason      string    `json:"reason,omitempty"`
 	EntityCount *int64    `json:"entity_count,omitempty"`


### PR DESCRIPTION
This pull request adds the `PolicyID` field to the `RunData` and `RunStateInfo` types and ensures it is included when converting run data to state info. This change improves traceability by allowing each run to be associated with its corresponding policy throughout the codebase.

Data model updates:

* Added a `PolicyID` field to the `RunData` struct in `agent/policies/types.go` to store the policy identifier for each run.
* Added a `PolicyID` field to the `RunStateInfo` struct in `agent/configmgr/fleet/messages/fleet_messages.go` to include the policy identifier in run state information.

Conversion logic update:

* Updated the `convertRunsToStateInfo` function in `agent/configmgr/fleet/heartbeats.go` to populate the new `PolicyID` field when converting `RunData` to `RunStateInfo`.