### PR TITLE
feat: dynamic scan support

### DIFF
--- a/docs/backends/device_discovery.md
+++ b/docs/backends/device_discovery.md
@@ -53,7 +53,7 @@ Current supported options:
 |  Key  | Type |  Description  |
 |:-----:|:----:|:-------------:|
 | platform_omit_version  | bool | If True, only the driver name will be used as the NetBox platform name (defaults to 'False' if not specified) |
-| port_scan_ports | list | TCP ports to probe before discovery if hostname is a IP Range or a Subnet (defaults to  [22,23,80,443,830,57400]) |
+| port_scan_ports | list | TCP ports to probe before discovery if hostname is a IP Range or a Subnet (defaults to [22,23,80,443,830,57400]) |
 | port_scan_timeout | float | TCP port probe timeout in seconds (defaults to 0.5) |
 
 #### Defaults

--- a/docs/backends/device_discovery.md
+++ b/docs/backends/device_discovery.md
@@ -53,6 +53,8 @@ Current supported options:
 |  Key  | Type |  Description  |
 |:-----:|:----:|:-------------:|
 | platform_omit_version  | bool | If True, only the driver name will be used as the NetBox platform name (defaults to 'False' if not specified) |
+| port_scan_ports | list | TCP ports to probe before discovery if hostname is a IP Range or a Subnet (defaults to  [22,23,80,443,830,57400]) |
+| port_scan_timeout | float | TCP port probe timeout in seconds (defaults to 0.5) |
 
 #### Defaults
 Current supported defaults:
@@ -114,7 +116,7 @@ The scope defines a list of devices that can be accessed and pulled data.
 
 | Parameter | Type | Required | Description |
 |:---------:|:----:|:--------:|:-----------:|
-| hostname | string | yes  | Device hostname |
+| hostname | string | yes  | Device hostname. It also supports subnets (e.g. 192.168.1.0/28) and IP ranges in the format 192.168.0.1-192.168.0.10 or 192.168.0.1-10.  |
 | username | string | yes  | Device username  |
 | password | string | yes  | Device username's password |
 | driver | string | no  |  If defined, try to connect to device using the specified NAPALM driver. If not, it will try all the current installed drivers |

--- a/docs/backends/snmp_discovery.md
+++ b/docs/backends/snmp_discovery.md
@@ -30,14 +30,14 @@ orb:
 ## Policy
 SNMP discovery policies are broken down into two subsections: `config` and `scope`.
 
-### Configuration Parameters
 
-#### Config Section
+### Config Section
 | Parameter | Type | Required | Description |
 |:---------:|:----:|:--------:|:-----------:|
 | schedule | cron format | no | Cron expression for scheduling (e.g., "*/5 * * * *") |
 | timeout | integer | no | Timeout for whole policy in seconds (defaults to 120) |
 | snmp_timeout | integer | no | Timeout for SNMP operations in seconds for SNMP operations (defaults to 5) |
+| snmp_probe_timeout | integer | no | Timeout for SNMP probe operations in seconds (defaults to 1) |
 | retries | integer | no | Number of retries for SNMP operations (defaults to 0) |
 | lookup_extensions_dir | string | no | Directory containing device model lookup files |
 | defaults | map | no | Default values for entities (description, comments, tags, etc.) |
@@ -49,34 +49,24 @@ SNMP discovery policies are broken down into two subsections: `config` and `scop
 | site | string | no | Default site name for discovered devices |
 | location | string | no | Default location for discovered devices |
 | role | string | no | Default role for discovered devices |
-| ip_address | map | no | Default values for discovered IP addresses |
-| interface | map | no | Default values for discovered interfaces |
-| device | map | no | Default values for discovered devices |
 
-#### IP Address Defaults Parameters
+##### Nested Defaults
+| device      | map  | Device-specific defaults        |
+| ├─ description | string  | Device description           |
+| ├─ comments   | string  | Device comments               |
+| interface    | map  | Interface-specific defaults    |
+| ├─ description | string  | Interface description        |
+| ├─ if_type       | string | Interface type (e.g. "ethernet", "virtual")  |
+| ipaddress    | map  | IP address-specific defaults  |
+| ├─ role   | string  | IP address role                  |
+| ├─ vrf   | string  | IP address vrf                    |
+| ├─ tenant   | string  | IP address tenant              |
+| ├─ description | string  | IP address description      |
+
+### Scope Section
 | Parameter | Type | Required | Description |
 |:---------:|:----:|:--------:|:-----------:|
-| description | string | no | Description for discovered IP addresses |
-| role | string | no | Role for discovered IP addresses (e.g. "management") |
-| tenant | string | no | Tenant name for discovered IP addresses |
-| vrf | string | no | VRF name for discovered IP addresses |
-
-#### Interface Defaults Parameters
-| Parameter | Type | Required | Description |
-|:---------:|:----:|:--------:|:-----------:|
-| description | string | no | Description for discovered interfaces |
-| if_type | string | no | Interface type (e.g. "ethernet", "virtual") |
-
-#### Device Defaults Parameters
-| Parameter | Type | Required | Description |
-|:---------:|:----:|:--------:|:-----------:|
-| description | string | no | Description for discovered devices |
-| comments | string | no | Comments for discovered devices |
-
-#### Scope Section
-| Parameter | Type | Required | Description |
-|:---------:|:----:|:--------:|:-----------:|
-| targets | list | yes | List of SNMP targets to discover |
+| targets | list | yes | List of SNMP targets to discover. It also supports subnets (e.g. 192.168.1.0/28) and IP ranges in the format 192.168.0.1-192.168.0.10 or 192.168.0.1-10. |
 | authentication | map | yes | SNMP authentication settings |
 
 #### Authentication Parameters
@@ -121,8 +111,8 @@ config:
   lookup_extensions_dir: "/opt/orb/snmp-extensions" # Specifies a directory containing device data yaml files (see below)
 scope:
   targets:
-    - host: "192.168.1.1"
-    - host: "192.168.1.254"
+    - host: "192.168.1.1/24" # subnet support
+    - host: "192.168.2.2-10" #range support
     - host: "10.0.0.1"
       port: 162  # Non-standard SNMP port
   authentication:


### PR DESCRIPTION
This pull request updates the documentation for device and SNMP discovery backends, focusing on clarifying and expanding the configuration options and improving the structure of defaults. The changes highlight new options for port scanning, subnet and IP range support, and a more organized approach to specifying default values for discovered entities.

**Device Discovery Documentation Improvements:**

* Added new configuration options: `port_scan_ports` (list of TCP ports to probe) and `port_scan_timeout` (probe timeout in seconds) to the supported options table.
* Clarified that the `hostname` parameter in the device discovery scope supports subnets and IP ranges, with examples of accepted formats.

**SNMP Discovery Documentation Improvements:**

* Added `snmp_probe_timeout` configuration parameter for SNMP probe operations.
* Reorganized the defaults section to use a nested table structure, grouping device, interface, and IP address defaults for clarity and maintainability.
* Clarified that the `targets` parameter in the SNMP discovery scope supports subnets and IP ranges, and updated the example configuration to demonstrate this. [[1]](diffhunk://#diff-b6159b73743d6ed59c85c2de680c7153976499a8c848216fd59e5c9823ae9dc2L52-R69) [[2]](diffhunk://#diff-b6159b73743d6ed59c85c2de680c7153976499a8c848216fd59e5c9823ae9dc2L124-R115)