### PR TITLE
fix: typo in snmp version

### DIFF
--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -266,7 +266,7 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 		version, readinessErr = d.Version()
 		if readinessErr == nil {
 			d.logger.Info("snmp-discovery readiness ok, got version ",
-				"network_discovery_version", version)
+				"snmp_discovery_version", version)
 			break
 		}
 		backoffDuration := time.Duration(backoff) * time.Second


### PR DESCRIPTION
This pull request makes a minor logging improvement to the `snmpDiscoveryBackend` in the SNMP discovery backend. The change corrects the log field name for the version information to improve clarity and consistency.

- Logging improvement:
  * In `snmp_discovery.go`, updated the log field from `"network_discovery_version"` to `"snmp_discovery_version"` in the readiness log message.