### PR TITLE
feat: fleet secrets manager

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -191,6 +191,17 @@ func (a *orbAgent) Start(ctx context.Context, cancelFunc context.CancelFunc) err
 		return err
 	}
 
+	// Bind fleet secrets manager to fleet config manager if both are fleet-based
+	// This needs to happen before SolveConfigSecrets so secrets can be resolved
+	if a.config.OrbAgent.ConfigManager.Active == "fleet" && a.config.OrbAgent.SecretsManager.Active == "fleet" {
+		if fleetCM, ok := a.configManager.(*configmgr.FleetConfigManager); ok {
+			if err := fleetCM.BindSecretsManager(a.secretsManager); err != nil {
+				a.logger.Error("error binding fleet secrets manager", "error", err)
+				return err
+			}
+		}
+	}
+
 	var err error
 	if a.config.OrbAgent.Backends,
 		a.config.OrbAgent.ConfigManager,

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -69,9 +69,15 @@ type VaultManager struct {
 	Schedule  *string        `yaml:"schedule,omitempty"`
 }
 
-// SecretsSources represents the configuration for manager sources, including vault.
+// FleetSecretsManager represents the configuration for the Fleet secrets manager
+type FleetSecretsManager struct {
+	Timeout *int `yaml:"timeout,omitempty"` // Request timeout in seconds
+}
+
+// SecretsSources represents the configuration for manager sources, including vault and fleet.
 type SecretsSources struct {
-	Vault VaultManager `yaml:"vault"`
+	Vault VaultManager        `yaml:"vault"`
+	Fleet FleetSecretsManager `yaml:"fleet"`
 }
 
 // ManagerSecrets represents the configuration for the Secrets Manager

--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -15,12 +15,14 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/otlpbridge"
 	"github.com/netboxlabs/orb-agent/agent/policymgr"
 	"github.com/netboxlabs/orb-agent/agent/redact"
+	"github.com/netboxlabs/orb-agent/agent/secretsmgr"
 )
 
-// Compile-time check to ensure fleetConfigManager implements Manager interface
-var _ Manager = (*fleetConfigManager)(nil)
+// Compile-time check to ensure FleetConfigManager implements Manager interface
+var _ Manager = (*FleetConfigManager)(nil)
 
-type fleetConfigManager struct {
+// FleetConfigManager implements the Manager interface for Fleet-based configuration
+type FleetConfigManager struct {
 	logger            *slog.Logger
 	connection        fleet.MQTTConnector
 	authTokenManager  *fleet.AuthTokenManager
@@ -38,10 +40,10 @@ type fleetConfigManager struct {
 	monitorCancel     context.CancelFunc
 }
 
-func newFleetConfigManager(logger *slog.Logger, pMgr policymgr.PolicyManager, backendState backend.StateRetriever) *fleetConfigManager {
+func newFleetConfigManager(logger *slog.Logger, pMgr policymgr.PolicyManager, backendState backend.StateRetriever) *FleetConfigManager {
 	resetChan := make(chan struct{}, 1)
 	reconnectChan := make(chan struct{}, 1)
-	return &fleetConfigManager{
+	return &FleetConfigManager{
 		logger:           logger,
 		connection:       fleet.NewMQTTConnection(logger, pMgr, resetChan, reconnectChan, backendState),
 		authTokenManager: fleet.NewAuthTokenManager(logger),
@@ -52,11 +54,11 @@ func newFleetConfigManager(logger *slog.Logger, pMgr policymgr.PolicyManager, ba
 	}
 }
 
-// newFleetConfigManagerWithConnection creates a fleetConfigManager with a custom connection (for testing)
-func newFleetConfigManagerWithConnection(logger *slog.Logger, pMgr policymgr.PolicyManager, backendState backend.StateRetriever, conn fleet.MQTTConnector) *fleetConfigManager {
+// newFleetConfigManagerWithConnection creates a FleetConfigManager with a custom connection (for testing)
+func newFleetConfigManagerWithConnection(logger *slog.Logger, pMgr policymgr.PolicyManager, backendState backend.StateRetriever, conn fleet.MQTTConnector) *FleetConfigManager {
 	resetChan := make(chan struct{}, 1)
 	reconnectChan := make(chan struct{}, 1)
-	return &fleetConfigManager{
+	return &FleetConfigManager{
 		logger:           logger,
 		connection:       conn, // Use provided connection instead of creating new one
 		authTokenManager: fleet.NewAuthTokenManager(logger),
@@ -67,7 +69,8 @@ func newFleetConfigManagerWithConnection(logger *slog.Logger, pMgr policymgr.Pol
 	}
 }
 
-func (fleetManager *fleetConfigManager) Start(cfg config.Config, backends map[string]backend.Backend) error {
+// Start initializes and starts the Fleet configuration manager
+func (fleetManager *FleetConfigManager) Start(cfg config.Config, backends map[string]backend.Backend) error {
 	ctx := context.Background()
 
 	var err error
@@ -222,8 +225,48 @@ func (fleetManager *fleetConfigManager) Start(cfg config.Config, backends map[st
 	return nil
 }
 
+// BindSecretsManager binds a fleet secrets manager to the MQTT connection
+func (fleetManager *FleetConfigManager) BindSecretsManager(sm secretsmgr.Manager) error {
+	// Check if it's a fleet secrets manager by type assertion
+	fleetSM, ok := sm.(*secretsmgr.FleetSecretsManager)
+	if !ok {
+		// Try to get the underlying fleet secrets manager
+		// This handles the case where the manager is wrapped
+		return nil // Not a fleet secrets manager, nothing to bind
+	}
+
+	// Register OnReadyHook to bind secrets manager when MQTT connection is ready
+	fleetManager.connection.AddOnReadyHook(func(cm *autopaho.ConnectionManager, topics fleet.TokenResponseTopics) {
+		// Create publisher and subscriber adapters
+		pub := secretsmgr.NewCMAdapterPublisher(cm)
+		sub := secretsmgr.NewCMAdapterSubscriber(cm)
+
+		// Bind the secrets manager to MQTT
+		if err := fleetSM.BindMQTT(pub, sub, topics.SecretsRequest, topics.SecretsResponse, topics.SecretsUpdated); err != nil {
+			fleetManager.logger.Error("failed to bind fleet secrets manager to MQTT", "error", err)
+			return
+		}
+
+		// Register topic handlers for secrets topics
+		// Note: These handlers will be called from OnPublishReceived in connection.go
+		fleetManager.connection.RegisterTopicHandler(topics.SecretsResponse, func(topic string, payload []byte) error {
+			return fleetSM.HandleMessage(topic, payload)
+		})
+		fleetManager.connection.RegisterTopicHandler(topics.SecretsUpdated, func(topic string, payload []byte) error {
+			return fleetSM.HandleMessage(topic, payload)
+		})
+
+		fleetManager.logger.Info("Fleet secrets manager bound to MQTT",
+			slog.String("request_topic", topics.SecretsRequest),
+			slog.String("response_topic", topics.SecretsResponse),
+			slog.String("updated_topic", topics.SecretsUpdated))
+	})
+
+	return nil
+}
+
 // refreshAndReconnect refreshes the JWT token and reconnects to MQTT
-func (fleetManager *fleetConfigManager) refreshAndReconnect(ctx context.Context, timeout time.Duration) error {
+func (fleetManager *FleetConfigManager) refreshAndReconnect(ctx context.Context, timeout time.Duration) error {
 	// Refresh JWT token
 	token, err := fleetManager.authTokenManager.RefreshToken(ctx)
 	if err != nil {
@@ -271,7 +314,7 @@ func (fleetManager *fleetConfigManager) refreshAndReconnect(ctx context.Context,
 	return nil
 }
 
-func (fleetManager *fleetConfigManager) configToSafeString(cfg config.Config) (string, error) {
+func (fleetManager *FleetConfigManager) configToSafeString(cfg config.Config) (string, error) {
 	redacted := redact.SensitiveData(cfg)
 	configYaml, err := yaml.Marshal(redacted)
 	if err != nil {
@@ -280,13 +323,14 @@ func (fleetManager *fleetConfigManager) configToSafeString(cfg config.Config) (s
 	return string(configYaml), nil
 }
 
-func (fleetManager *fleetConfigManager) GetContext(ctx context.Context) context.Context {
+// GetContext returns the context for the Fleet configuration manager
+func (fleetManager *FleetConfigManager) GetContext(ctx context.Context) context.Context {
 	// Empty implementation for now - just return the context as-is
 	return ctx
 }
 
 // monitorTokenExpiry periodically checks token expiry and triggers reconnection before token expires
-func (fleetManager *fleetConfigManager) monitorTokenExpiry() {
+func (fleetManager *FleetConfigManager) monitorTokenExpiry() {
 	// Check interval: default 30 seconds, configurable via config
 	checkInterval := 30 * time.Second
 	if fleetManager.config.OrbAgent.ConfigManager.Sources.Fleet.TokenExpiryCheckInterval != nil && *fleetManager.config.OrbAgent.ConfigManager.Sources.Fleet.TokenExpiryCheckInterval > 0 {
@@ -346,7 +390,7 @@ func (fleetManager *fleetConfigManager) monitorTokenExpiry() {
 }
 
 // Stop gracefully shuts down the OTLP bridge and token expiry monitor.
-func (fleetManager *fleetConfigManager) Stop(ctx context.Context) error {
+func (fleetManager *FleetConfigManager) Stop(ctx context.Context) error {
 	// Stop token expiry monitor
 	if fleetManager.monitorCancel != nil {
 		fleetManager.monitorCancel()

--- a/agent/configmgr/fleet/connection.go
+++ b/agent/configmgr/fleet/connection.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/eclipse/paho.golang/autopaho"
@@ -40,6 +41,7 @@ type MQTTConnection struct {
 	reconnectChan            chan struct{}
 	dispatchQueue            chan dispatchJob
 	dispatchWorkerDone       chan struct{}
+	shuttingDown             atomic.Bool
 	capabilitiesFailCount    int
 	groupMembershipFailCount int
 	heartbeatFailCount       int
@@ -290,16 +292,23 @@ func (connection *MQTTConnection) Connect(ctx context.Context, details Connectio
 						return true, nil
 					}
 
-					// Enqueue the job for sequential processing by the dispatch worker
-					// This preserves message ordering and prevents race conditions
-					parts := strings.Split(pr.Packet.Topic, "/")
-					if len(parts) < 2 {
-						connection.logger.Error("received MQTT message with malformed topic; cannot extract orgID", "topic", pr.Packet.Topic)
-						return true, nil
-					}
-					orgID := parts[1]
-					select {
-					case connection.dispatchQueue <- dispatchJob{
+				// Enqueue the job for sequential processing by the dispatch worker
+				// This preserves message ordering and prevents race conditions
+				parts := strings.Split(pr.Packet.Topic, "/")
+				if len(parts) < 2 {
+					connection.logger.Error("received MQTT message with malformed topic; cannot extract orgID", "topic", pr.Packet.Topic)
+					return true, nil
+				}
+				orgID := parts[1]
+
+				// Check if we're shutting down to avoid sending to a closed channel
+				if connection.shuttingDown.Load() {
+					connection.logger.Debug("ignoring message during shutdown", "topic", pr.Packet.Topic)
+					return true, nil
+				}
+
+				select {
+				case connection.dispatchQueue <- dispatchJob{
 						payload: pr.Packet.Payload,
 						orgID:   orgID,
 						agentID: details.AgentID,
@@ -372,19 +381,23 @@ func (connection *MQTTConnection) Reconnect(ctx context.Context, details Connect
 
 	// Disconnect the existing connection
 	if connection.connectionManager != nil {
+		// Set shutdown flag first to prevent new messages from being enqueued
+		connection.shuttingDown.Store(true)
+
 		disconnectCtx, cancel := context.WithTimeout(ctx, timeout)
 		connection.heartbeater.stop(details.Topics.Heartbeat, connection.publishToTopic)
-		// Stop the dispatch worker before disconnecting
-		connection.stopDispatchWorker()
 		err := connection.connectionManager.Disconnect(disconnectCtx)
 		cancel()
 		if err != nil {
 			connection.logger.Error("failed to disconnect during reconnect", "error", err)
 			// Continue anyway to try to establish new connection
 		}
-		// Create new channels for the next connection
+		connection.stopDispatchWorker()
+
+		// Create new channels for the next connection and reset shutdown flag
 		connection.dispatchQueue = make(chan dispatchJob, 100)
 		connection.dispatchWorkerDone = make(chan struct{})
+		connection.shuttingDown.Store(false)
 	}
 
 	// Reset failure counters
@@ -404,9 +417,14 @@ func (connection *MQTTConnection) Reconnect(ctx context.Context, details Connect
 
 // Disconnect disconnects from the MQTT broker
 func (connection *MQTTConnection) Disconnect(ctx context.Context, heartbeatTopic string) error {
+	// Set shutdown flag first to prevent new messages from being enqueued
+	connection.shuttingDown.Store(true)
+
 	connection.heartbeater.stop(heartbeatTopic, connection.publishToTopic)
+	// Disconnect first to stop receiving new messages, then stop the worker
+	err := connection.connectionManager.Disconnect(ctx)
 	connection.stopDispatchWorker()
-	return connection.connectionManager.Disconnect(ctx)
+	return err
 }
 
 func (connection *MQTTConnection) subscribeToTopic(topic string) error {

--- a/agent/configmgr/fleet/connection.go
+++ b/agent/configmgr/fleet/connection.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/eclipse/paho.golang/autopaho"
@@ -15,6 +16,9 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/policymgr"
 )
 
+// TopicMessageHandler handles messages for a specific topic
+type TopicMessageHandler func(topic string, payload []byte) error
+
 // MQTTConnection manages the MQTT connection
 type MQTTConnection struct {
 	logger                   *slog.Logger
@@ -23,11 +27,13 @@ type MQTTConnection struct {
 	messaging                *Messaging
 	resetChan                chan struct{}
 	onReadyHooks             []func(cm *autopaho.ConnectionManager, topics TokenResponseTopics)
+	topicHandlers            map[string]TopicMessageHandler
 	connectionTopics         TokenResponseTopics
 	reconnectChan            chan struct{}
 	capabilitiesFailCount    int
 	groupMembershipFailCount int
 	heartbeatFailCount       int
+	mu                       sync.Mutex
 }
 
 // NewMQTTConnection creates a new MQTTConnection
@@ -40,6 +46,7 @@ func NewMQTTConnection(logger *slog.Logger, pMgr policymgr.PolicyManager, resetC
 		messaging:         NewMessaging(logger, pMgr, resetChan, &groupManager),
 		resetChan:         resetChan,
 		onReadyHooks:      make([]func(cm *autopaho.ConnectionManager, topics TokenResponseTopics), 0),
+		topicHandlers:     make(map[string]TopicMessageHandler),
 		reconnectChan:     reconnectChan,
 	}
 }
@@ -47,6 +54,13 @@ func NewMQTTConnection(logger *slog.Logger, pMgr policymgr.PolicyManager, resetC
 // AddOnReadyHook registers a callback to be invoked when MQTT connection is ready.
 func (connection *MQTTConnection) AddOnReadyHook(fn func(cm *autopaho.ConnectionManager, topics TokenResponseTopics)) {
 	connection.onReadyHooks = append(connection.onReadyHooks, fn)
+}
+
+// RegisterTopicHandler registers a handler for a specific topic
+func (connection *MQTTConnection) RegisterTopicHandler(topic string, handler TopicMessageHandler) {
+	connection.mu.Lock()
+	defer connection.mu.Unlock()
+	connection.topicHandlers[topic] = handler
 }
 
 // TopicActions are the actions to take on a topic
@@ -72,6 +86,7 @@ type MQTTConnector interface {
 	Disconnect(ctx context.Context, heartbeatTopic string) error
 	Reconnect(ctx context.Context, details ConnectionDetails, backends map[string]backend.Backend, labels map[string]string, configFile string, timeout time.Duration) error
 	AddOnReadyHook(fn func(cm *autopaho.ConnectionManager, topics TokenResponseTopics))
+	RegisterTopicHandler(topic string, handler TopicMessageHandler)
 }
 
 // Connect connects to the MQTT broker
@@ -211,6 +226,18 @@ func (connection *MQTTConnection) Connect(ctx context.Context, details Connectio
 				func(pr paho.PublishReceived) (bool, error) {
 					// Log any published messages to subscribed topics
 					connection.logger.Info("received MQTT message", "topic", pr.Packet.Topic)
+
+					// Check if there's a topic-specific handler
+					connection.mu.Lock()
+					handler, hasHandler := connection.topicHandlers[pr.Packet.Topic]
+					connection.mu.Unlock()
+
+					if hasHandler {
+						if err := handler(pr.Packet.Topic, pr.Packet.Payload); err != nil {
+							connection.logger.Error("topic handler failed", "topic", pr.Packet.Topic, "error", err)
+						}
+						return true, nil
+					}
 
 					orgID := strings.Split(pr.Packet.Topic, "/")[1]
 

--- a/agent/configmgr/fleet/connection.go
+++ b/agent/configmgr/fleet/connection.go
@@ -122,6 +122,14 @@ func (connection *MQTTConnection) startDispatchWorker() {
 
 // stopDispatchWorker stops the dispatch worker and waits for it to finish
 func (connection *MQTTConnection) stopDispatchWorker() {
+	// If the worker is already done (dispatchWorkerDone is closed), do nothing.
+	select {
+	case <-connection.dispatchWorkerDone:
+		return
+	default:
+	}
+
+	// First time stopping: close the queue to signal the worker to exit, then wait for it.
 	close(connection.dispatchQueue)
 	<-connection.dispatchWorkerDone
 }
@@ -284,7 +292,12 @@ func (connection *MQTTConnection) Connect(ctx context.Context, details Connectio
 
 					// Enqueue the job for sequential processing by the dispatch worker
 					// This preserves message ordering and prevents race conditions
-					orgID := strings.Split(pr.Packet.Topic, "/")[1]
+					parts := strings.Split(pr.Packet.Topic, "/")
+					if len(parts) < 2 {
+						connection.logger.Error("received MQTT message with malformed topic; cannot extract orgID", "topic", pr.Packet.Topic)
+						return true, nil
+					}
+					orgID := parts[1]
 					select {
 					case connection.dispatchQueue <- dispatchJob{
 						payload: pr.Packet.Payload,

--- a/agent/configmgr/fleet/connection.go
+++ b/agent/configmgr/fleet/connection.go
@@ -19,6 +19,14 @@ import (
 // TopicMessageHandler handles messages for a specific topic
 type TopicMessageHandler func(topic string, payload []byte) error
 
+// dispatchJob represents a message to be processed by the dispatch worker
+type dispatchJob struct {
+	payload      []byte
+	orgID        string
+	agentID      string
+	topicActions TopicActions
+}
+
 // MQTTConnection manages the MQTT connection
 type MQTTConnection struct {
 	logger                   *slog.Logger
@@ -30,6 +38,8 @@ type MQTTConnection struct {
 	topicHandlers            map[string]TopicMessageHandler
 	connectionTopics         TokenResponseTopics
 	reconnectChan            chan struct{}
+	dispatchQueue            chan dispatchJob
+	dispatchWorkerDone       chan struct{}
 	capabilitiesFailCount    int
 	groupMembershipFailCount int
 	heartbeatFailCount       int
@@ -40,14 +50,16 @@ type MQTTConnection struct {
 func NewMQTTConnection(logger *slog.Logger, pMgr policymgr.PolicyManager, resetChan chan struct{}, reconnectChan chan struct{}, backendState backend.StateRetriever) *MQTTConnection {
 	groupManager := newGroupManager()
 	return &MQTTConnection{
-		connectionManager: nil,
-		logger:            logger,
-		heartbeater:       newHeartbeater(logger, backendState, pMgr, &groupManager),
-		messaging:         NewMessaging(logger, pMgr, resetChan, &groupManager),
-		resetChan:         resetChan,
-		onReadyHooks:      make([]func(cm *autopaho.ConnectionManager, topics TokenResponseTopics), 0),
-		topicHandlers:     make(map[string]TopicMessageHandler),
-		reconnectChan:     reconnectChan,
+		connectionManager:  nil,
+		logger:             logger,
+		heartbeater:        newHeartbeater(logger, backendState, pMgr, &groupManager),
+		messaging:          NewMessaging(logger, pMgr, resetChan, &groupManager),
+		resetChan:          resetChan,
+		onReadyHooks:       make([]func(cm *autopaho.ConnectionManager, topics TokenResponseTopics), 0),
+		topicHandlers:      make(map[string]TopicMessageHandler),
+		reconnectChan:      reconnectChan,
+		dispatchQueue:      make(chan dispatchJob, 100), // Buffered channel to prevent blocking MQTT acks
+		dispatchWorkerDone: make(chan struct{}),
 	}
 }
 
@@ -89,6 +101,31 @@ type MQTTConnector interface {
 	RegisterTopicHandler(topic string, handler TopicMessageHandler)
 }
 
+// startDispatchWorker starts the worker goroutine that processes dispatch jobs sequentially
+func (connection *MQTTConnection) startDispatchWorker() {
+	go func() {
+		defer close(connection.dispatchWorkerDone)
+		for job := range connection.dispatchQueue {
+			err := connection.messaging.DispatchToHandlers(
+				context.Background(),
+				job.payload,
+				job.orgID,
+				job.agentID,
+				job.topicActions,
+			)
+			if err != nil {
+				connection.logger.Error("failed to dispatch to handlers", "error", err)
+			}
+		}
+	}()
+}
+
+// stopDispatchWorker stops the dispatch worker and waits for it to finish
+func (connection *MQTTConnection) stopDispatchWorker() {
+	close(connection.dispatchQueue)
+	<-connection.dispatchWorkerDone
+}
+
 // Connect connects to the MQTT broker
 func (connection *MQTTConnection) Connect(ctx context.Context, details ConnectionDetails, backends map[string]backend.Backend, labels map[string]string, configFile string) error {
 	// Parse the ORB URL
@@ -100,6 +137,9 @@ func (connection *MQTTConnection) Connect(ctx context.Context, details Connectio
 
 	// Store topics for hook callbacks
 	connection.connectionTopics = details.Topics
+
+	// Start the dispatch worker to process incoming messages sequentially
+	connection.startDispatchWorker()
 
 	cfg := autopaho.ClientConfig{
 		ServerUrls:                    []*url.URL{serverURL},
@@ -242,12 +282,24 @@ func (connection *MQTTConnection) Connect(ctx context.Context, details Connectio
 						return true, nil
 					}
 
-					// Process in goroutine to avoid blocking message acknowledgment
-					go func() {
-						orgID := strings.Split(pr.Packet.Topic, "/")[1]
-
-						// Use a fresh context for async message handling, not the Connect() context
-						// which may be canceled or have a short timeout
+					// Enqueue the job for sequential processing by the dispatch worker
+					// This preserves message ordering and prevents race conditions
+					orgID := strings.Split(pr.Packet.Topic, "/")[1]
+					select {
+					case connection.dispatchQueue <- dispatchJob{
+						payload: pr.Packet.Payload,
+						orgID:   orgID,
+						agentID: details.AgentID,
+						topicActions: TopicActions{
+							Subscribe:   connection.subscribeToTopic,
+							Publish:     connection.publishToTopic,
+							Unsubscribe: connection.unsubscribeFromTopic,
+						},
+					}:
+						// Job enqueued successfully
+					default:
+						// Queue is full - log warning and process synchronously as fallback
+						connection.logger.Warn("dispatch queue full, processing synchronously", "topic", pr.Packet.Topic)
 						err := connection.messaging.DispatchToHandlers(
 							context.Background(),
 							pr.Packet.Payload,
@@ -262,7 +314,7 @@ func (connection *MQTTConnection) Connect(ctx context.Context, details Connectio
 						if err != nil {
 							connection.logger.Error("failed to dispatch to handlers", "error", err)
 						}
-					}()
+					}
 
 					return true, nil
 				},
@@ -281,6 +333,7 @@ func (connection *MQTTConnection) Connect(ctx context.Context, details Connectio
 	connection.connectionManager, err = autopaho.NewConnection(ctx, cfg)
 	if err != nil {
 		connection.logger.Error("failed to create MQTT connection", "error", err)
+		connection.stopDispatchWorker()
 		return err
 	}
 
@@ -292,6 +345,7 @@ func (connection *MQTTConnection) Connect(ctx context.Context, details Connectio
 	err = connection.connectionManager.AwaitConnection(waitCtx)
 	if err != nil {
 		connection.logger.Error("failed to establish initial MQTT connection", "error", err)
+		connection.stopDispatchWorker()
 		return err
 	}
 
@@ -307,12 +361,17 @@ func (connection *MQTTConnection) Reconnect(ctx context.Context, details Connect
 	if connection.connectionManager != nil {
 		disconnectCtx, cancel := context.WithTimeout(ctx, timeout)
 		connection.heartbeater.stop(details.Topics.Heartbeat, connection.publishToTopic)
+		// Stop the dispatch worker before disconnecting
+		connection.stopDispatchWorker()
 		err := connection.connectionManager.Disconnect(disconnectCtx)
 		cancel()
 		if err != nil {
 			connection.logger.Error("failed to disconnect during reconnect", "error", err)
 			// Continue anyway to try to establish new connection
 		}
+		// Create new channels for the next connection
+		connection.dispatchQueue = make(chan dispatchJob, 100)
+		connection.dispatchWorkerDone = make(chan struct{})
 	}
 
 	// Reset failure counters
@@ -333,6 +392,7 @@ func (connection *MQTTConnection) Reconnect(ctx context.Context, details Connect
 // Disconnect disconnects from the MQTT broker
 func (connection *MQTTConnection) Disconnect(ctx context.Context, heartbeatTopic string) error {
 	connection.heartbeater.stop(heartbeatTopic, connection.publishToTopic)
+	connection.stopDispatchWorker()
 	return connection.connectionManager.Disconnect(ctx)
 }
 

--- a/agent/configmgr/fleet/connection.go
+++ b/agent/configmgr/fleet/connection.go
@@ -233,30 +233,36 @@ func (connection *MQTTConnection) Connect(ctx context.Context, details Connectio
 					connection.mu.Unlock()
 
 					if hasHandler {
-						if err := handler(pr.Packet.Topic, pr.Packet.Payload); err != nil {
-							connection.logger.Error("topic handler failed", "topic", pr.Packet.Topic, "error", err)
-						}
+						// Process in goroutine to avoid blocking message acknowledgment
+						go func() {
+							if err := handler(pr.Packet.Topic, pr.Packet.Payload); err != nil {
+								connection.logger.Error("topic handler failed", "topic", pr.Packet.Topic, "error", err)
+							}
+						}()
 						return true, nil
 					}
 
-					orgID := strings.Split(pr.Packet.Topic, "/")[1]
+					// Process in goroutine to avoid blocking message acknowledgment
+					go func() {
+						orgID := strings.Split(pr.Packet.Topic, "/")[1]
 
-					// Use a fresh context for async message handling, not the Connect() context
-					// which may be canceled or have a short timeout
-					err = connection.messaging.DispatchToHandlers(
-						context.Background(),
-						pr.Packet.Payload,
-						orgID,
-						details.AgentID,
-						TopicActions{
-							Subscribe:   connection.subscribeToTopic,
-							Publish:     connection.publishToTopic,
-							Unsubscribe: connection.unsubscribeFromTopic,
-						},
-					)
-					if err != nil {
-						connection.logger.Error("failed to dispatch to handlers", "error", err)
-					}
+						// Use a fresh context for async message handling, not the Connect() context
+						// which may be canceled or have a short timeout
+						err := connection.messaging.DispatchToHandlers(
+							context.Background(),
+							pr.Packet.Payload,
+							orgID,
+							details.AgentID,
+							TopicActions{
+								Subscribe:   connection.subscribeToTopic,
+								Publish:     connection.publishToTopic,
+								Unsubscribe: connection.unsubscribeFromTopic,
+							},
+						)
+						if err != nil {
+							connection.logger.Error("failed to dispatch to handlers", "error", err)
+						}
+					}()
 
 					return true, nil
 				},

--- a/agent/configmgr/fleet/connection.go
+++ b/agent/configmgr/fleet/connection.go
@@ -292,23 +292,23 @@ func (connection *MQTTConnection) Connect(ctx context.Context, details Connectio
 						return true, nil
 					}
 
-				// Enqueue the job for sequential processing by the dispatch worker
-				// This preserves message ordering and prevents race conditions
-				parts := strings.Split(pr.Packet.Topic, "/")
-				if len(parts) < 2 {
-					connection.logger.Error("received MQTT message with malformed topic; cannot extract orgID", "topic", pr.Packet.Topic)
-					return true, nil
-				}
-				orgID := parts[1]
+					// Enqueue the job for sequential processing by the dispatch worker
+					// This preserves message ordering and prevents race conditions
+					parts := strings.Split(pr.Packet.Topic, "/")
+					if len(parts) < 2 {
+						connection.logger.Error("received MQTT message with malformed topic; cannot extract orgID", "topic", pr.Packet.Topic)
+						return true, nil
+					}
+					orgID := parts[1]
 
-				// Check if we're shutting down to avoid sending to a closed channel
-				if connection.shuttingDown.Load() {
-					connection.logger.Debug("ignoring message during shutdown", "topic", pr.Packet.Topic)
-					return true, nil
-				}
+					// Check if we're shutting down to avoid sending to a closed channel
+					if connection.shuttingDown.Load() {
+						connection.logger.Debug("ignoring message during shutdown", "topic", pr.Packet.Topic)
+						return true, nil
+					}
 
-				select {
-				case connection.dispatchQueue <- dispatchJob{
+					select {
+					case connection.dispatchQueue <- dispatchJob{
 						payload: pr.Packet.Payload,
 						orgID:   orgID,
 						agentID: details.AgentID,

--- a/agent/configmgr/fleet/connection_test.go
+++ b/agent/configmgr/fleet/connection_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -121,4 +122,96 @@ func TestFleetConfigManager_Connect_ValidURL(t *testing.T) {
 			strings.Contains(err.Error(), "no such host") ||
 			strings.Contains(err.Error(), "server denied connect"),
 		"Expected connection-related error, got: %v", err)
+}
+
+func TestDispatchQueue_ProcessesJobsSequentially(t *testing.T) {
+	// Arrange
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mockPMgr := &mockPolicyManagerForFleet{}
+	resetChan := make(chan struct{}, 1)
+	reconnectChan := make(chan struct{}, 1)
+	connection := NewMQTTConnection(logger, mockPMgr, resetChan, reconnectChan, &mockBackendState{})
+
+	// Track the order of job processing using a channel
+	processedOrder := make([]int, 0, 10)
+	var mu sync.Mutex
+	jobProcessed := make(chan struct{}, 10)
+
+	// Create a custom messaging handler that tracks processing order
+	numJobs := 10
+
+	// Start the dispatch worker
+	connection.startDispatchWorker()
+
+	// Enqueue multiple jobs rapidly
+	for i := 0; i < numJobs; i++ {
+		jobIndex := i
+		// Create a group_membership RPC payload that will trigger Subscribe
+		payload := []byte(`{"schema_version":"1.0","func":"group_membership","payload":{"full_list":false,"groups":[{"group_id":"test-group","name":"Test"}]}}`)
+		connection.dispatchQueue <- dispatchJob{
+			payload: payload,
+			orgID:   "test-org",
+			agentID: "test-agent",
+			topicActions: TopicActions{
+				Subscribe: func(_ string) error {
+					mu.Lock()
+					processedOrder = append(processedOrder, jobIndex)
+					mu.Unlock()
+					jobProcessed <- struct{}{}
+					return nil
+				},
+				Publish:     func(_ context.Context, _ string, _ []byte) error { return nil },
+				Unsubscribe: func(_ string) error { return nil },
+			},
+		}
+	}
+
+	// Wait for all jobs to be processed
+	for i := 0; i < numJobs; i++ {
+		select {
+		case <-jobProcessed:
+			// Job processed
+		case <-time.After(5 * time.Second):
+			t.Fatal("timeout waiting for jobs to be processed")
+		}
+	}
+
+	// Stop the worker
+	connection.stopDispatchWorker()
+
+	// Assert - all jobs were processed in order (since they're processed sequentially)
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Len(t, processedOrder, numJobs)
+	for i := 0; i < numJobs; i++ {
+		assert.Equal(t, i, processedOrder[i], "Jobs should be processed in order")
+	}
+}
+
+func TestDispatchQueue_HandlesQueueFull(t *testing.T) {
+	// Arrange
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mockPMgr := &mockPolicyManagerForFleet{}
+	resetChan := make(chan struct{}, 1)
+	reconnectChan := make(chan struct{}, 1)
+	connection := NewMQTTConnection(logger, mockPMgr, resetChan, reconnectChan, &mockBackendState{})
+
+	// Don't start the worker so the queue fills up
+	// Just verify we can enqueue up to the buffer size
+	for i := 0; i < 100; i++ {
+		select {
+		case connection.dispatchQueue <- dispatchJob{}:
+			// Successfully enqueued
+		default:
+			t.Fatal("Queue should have capacity for 100 items")
+		}
+	}
+
+	// The 101st item should not block (select with default)
+	select {
+	case connection.dispatchQueue <- dispatchJob{}:
+		t.Fatal("Queue should be full")
+	default:
+		// Expected - queue is full
+	}
 }

--- a/agent/configmgr/fleet/groups.go
+++ b/agent/configmgr/fleet/groups.go
@@ -1,6 +1,10 @@
 package fleet
 
-import "github.com/netboxlabs/orb-agent/agent/configmgr/fleet/messages"
+import (
+	"sync"
+
+	"github.com/netboxlabs/orb-agent/agent/configmgr/fleet/messages"
+)
 
 // GroupRetriever provides read-only access to group memberships
 type GroupRetriever interface {
@@ -9,6 +13,7 @@ type GroupRetriever interface {
 
 // GroupManager manages the agent's group memberships
 type GroupManager struct {
+	mu     sync.RWMutex
 	groups []messages.GroupMembershipData
 }
 
@@ -20,16 +25,22 @@ func newGroupManager() GroupManager {
 
 // Add adds a group to the manager
 func (gm *GroupManager) Add(group messages.GroupMembershipData) {
+	gm.mu.Lock()
+	defer gm.mu.Unlock()
 	gm.groups = append(gm.groups, group)
 }
 
 // RemoveAll removes all groups from the manager
 func (gm *GroupManager) RemoveAll() {
+	gm.mu.Lock()
+	defer gm.mu.Unlock()
 	gm.groups = []messages.GroupMembershipData{}
 }
 
 // Remove removes a specific group by ID from the manager
 func (gm *GroupManager) Remove(groupID string) {
+	gm.mu.Lock()
+	defer gm.mu.Unlock()
 	for i, group := range gm.groups {
 		if group.GroupID == groupID {
 			gm.groups = append(gm.groups[:i], gm.groups[i+1:]...)
@@ -39,6 +50,11 @@ func (gm *GroupManager) Remove(groupID string) {
 }
 
 // GetAll returns all groups managed by the manager
+// Returns a copy to prevent external mutation
 func (gm *GroupManager) GetAll() []messages.GroupMembershipData {
-	return gm.groups
+	gm.mu.RLock()
+	defer gm.mu.RUnlock()
+	result := make([]messages.GroupMembershipData, len(gm.groups))
+	copy(result, gm.groups)
+	return result
 }

--- a/agent/configmgr/fleet/groups_test.go
+++ b/agent/configmgr/fleet/groups_test.go
@@ -1,6 +1,7 @@
 package fleet
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -191,4 +192,62 @@ func TestGroupManager_GroupRetrieverInterface(t *testing.T) {
 	require.Len(t, groups, 2)
 	assert.Equal(t, "group-1", groups[0].GroupID)
 	assert.Equal(t, "group-2", groups[1].GroupID)
+}
+
+func TestGroupManager_ConcurrentAccess(t *testing.T) {
+	// Arrange
+	gm := newGroupManager()
+	numGoroutines := 100
+	var wg sync.WaitGroup
+
+	// Act - Concurrent adds, removes, and reads
+	wg.Add(numGoroutines * 3)
+
+	// Concurrent adds
+	for i := 0; i < numGoroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			gm.Add(messages.GroupMembershipData{
+				GroupID: "group-" + string(rune('A'+id%26)),
+				Name:    "Test Group",
+			})
+		}(i)
+	}
+
+	// Concurrent reads
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			_ = gm.GetAll()
+		}()
+	}
+
+	// Concurrent removes
+	for i := 0; i < numGoroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			gm.Remove("group-" + string(rune('A'+id%26)))
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Assert - No panics occurred and state is consistent
+	groups := gm.GetAll()
+	assert.NotNil(t, groups)
+}
+
+func TestGroupManager_GetAll_ReturnsCopy(t *testing.T) {
+	// Arrange
+	gm := newGroupManager()
+	gm.Add(messages.GroupMembershipData{GroupID: "group-1", Name: "Test Group 1"})
+	gm.Add(messages.GroupMembershipData{GroupID: "group-2", Name: "Test Group 2"})
+
+	// Act - Get groups and modify the returned slice
+	groups := gm.GetAll()
+	groups[0].GroupID = "modified"
+
+	// Assert - Original should be unchanged
+	originalGroups := gm.GetAll()
+	assert.Equal(t, "group-1", originalGroups[0].GroupID)
 }

--- a/agent/configmgr/fleet/messages/secrets_messages.go
+++ b/agent/configmgr/fleet/messages/secrets_messages.go
@@ -1,0 +1,71 @@
+package messages
+
+import (
+	"time"
+)
+
+// CurrentSecretsSchemaVersion defines the current version of the secrets schema
+const CurrentSecretsSchemaVersion = "1.0"
+
+// Error codes for secret operations
+const (
+	ErrorCodeNotFound      = "NOT_FOUND"
+	ErrorCodeForbidden     = "FORBIDDEN"
+	ErrorCodeInvalidPath   = "INVALID_PATH"
+	ErrorCodeTimeout       = "TIMEOUT"
+	ErrorCodeInternalError = "INTERNAL_ERROR"
+	ErrorCodeRateLimited   = "RATE_LIMITED"
+)
+
+// SecretRequest represents a single secret request in a SecretRequestMsg
+type SecretRequest struct {
+	Path    string `json:"path"`    // The path to the secret in the control plane's secret store
+	Context string `json:"context"` // The context where the secret is used (policy ID, "config", or "backend")
+}
+
+// SecretRequestMsg represents a request for secrets
+type SecretRequestMsg struct {
+	SchemaVersion string          `json:"schema_version"`
+	RequestID     string          `json:"request_id"` // UUID v4
+	Timestamp     time.Time       `json:"timestamp"`
+	Secrets       []SecretRequest `json:"secrets"`
+}
+
+// SecretValue represents a successfully retrieved secret
+type SecretValue struct {
+	Path     string            `json:"path"`
+	Value    string            `json:"value"`
+	Version  int               `json:"version"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// SecretError represents an error for a failed secret retrieval
+type SecretError struct {
+	Path  string `json:"path"`
+	Error string `json:"error"` // Human-readable error message
+	Code  string `json:"code"`  // Machine-readable error code
+}
+
+// SecretResponseMsg represents a response to a secret request
+type SecretResponseMsg struct {
+	SchemaVersion string        `json:"schema_version"`
+	RequestID     string        `json:"request_id"` // Matches the request_id from the original request
+	Timestamp     time.Time     `json:"timestamp"`
+	Status        string        `json:"status"`            // "success", "partial", "error"
+	Secrets       []SecretValue `json:"secrets,omitempty"` // Omitted if status is "error"
+	Errors        []SecretError `json:"errors,omitempty"`  // Omitted if status is "success"
+}
+
+// SecretUpdate represents a single secret update notification
+type SecretUpdate struct {
+	Path     string   `json:"path"`
+	Version  int      `json:"version"`
+	Contexts []string `json:"contexts"` // List of contexts (policy IDs) that use this secret
+}
+
+// SecretUpdateNotificationMsg represents a push notification for updated secrets
+type SecretUpdateNotificationMsg struct {
+	SchemaVersion string         `json:"schema_version"`
+	Timestamp     time.Time      `json:"timestamp"`
+	Updates       []SecretUpdate `json:"updates"`
+}

--- a/agent/configmgr/fleet/mocks.go
+++ b/agent/configmgr/fleet/mocks.go
@@ -118,6 +118,11 @@ func (m *MockMQTTConnection) AddOnReadyHook(fn func(cm *autopaho.ConnectionManag
 	m.hooks = append(m.hooks, fn)
 }
 
+// RegisterTopicHandler registers a handler for a specific topic (mock implementation)
+func (m *MockMQTTConnection) RegisterTopicHandler(_ string, _ TopicMessageHandler) {
+	// No-op for mock
+}
+
 // TriggerOnReadyHook triggers all registered onReady hooks (for testing)
 func (m *MockMQTTConnection) TriggerOnReadyHook(cm *autopaho.ConnectionManager, topics TokenResponseTopics) {
 	for _, hook := range m.hooks {

--- a/agent/configmgr/fleet/topics.go
+++ b/agent/configmgr/fleet/topics.go
@@ -13,35 +13,44 @@ func fillTopicTemplate(template string, claims *JWTClaims) string {
 }
 
 const (
-	heartbeatTemplate    = "orgs/{org_id}/agents/{agent_id}/heartbeats"
-	capabilitiesTemplate = "orgs/{org_id}/agents/{agent_id}/capabilities"
-	inboxTemplate        = "orgs/{org_id}/agents/{agent_id}/inbox"
-	outboxTemplate       = "orgs/{org_id}/agents/{agent_id}/outbox"
-	ingestTemplate       = "orgs/{org_id}/agents/{agent_id}/ingest"
-	telemetryTemplate    = "orgs/{org_id}/agents/{agent_id}/telemetry"
+	heartbeatTemplate       = "orgs/{org_id}/agents/{agent_id}/heartbeats"
+	capabilitiesTemplate    = "orgs/{org_id}/agents/{agent_id}/capabilities"
+	inboxTemplate           = "orgs/{org_id}/agents/{agent_id}/inbox"
+	outboxTemplate          = "orgs/{org_id}/agents/{agent_id}/outbox"
+	ingestTemplate          = "orgs/{org_id}/agents/{agent_id}/ingest"
+	telemetryTemplate       = "orgs/{org_id}/agents/{agent_id}/telemetry"
+	secretsRequestTemplate  = "orgs/{org_id}/agents/{agent_id}/secrets/request"
+	secretsResponseTemplate = "orgs/{org_id}/agents/{agent_id}/secrets/response"
+	secretsUpdatedTemplate  = "orgs/{org_id}/agents/{agent_id}/secrets/updated"
 
 	groupsTemplate = "orgs/{org_id}/groups/{group_id}"
 )
 
 // TokenResponseTopics are the topics extracted from the JWT claims
 type TokenResponseTopics struct {
-	Heartbeat    string `json:"heartbeat"`
-	Capabilities string `json:"capabilities"`
-	Inbox        string `json:"inbox"`
-	Outbox       string `json:"outbox"`
-	Ingest       string `json:"ingest"`
-	Telemetry    string `json:"telemetry"`
+	Heartbeat       string `json:"heartbeat"`
+	Capabilities    string `json:"capabilities"`
+	Inbox           string `json:"inbox"`
+	Outbox          string `json:"outbox"`
+	Ingest          string `json:"ingest"`
+	Telemetry       string `json:"telemetry"`
+	SecretsRequest  string `json:"secrets_request"`
+	SecretsResponse string `json:"secrets_response"`
+	SecretsUpdated  string `json:"secrets_updated"`
 }
 
 // GenerateTopicsFromTemplate creates actual topic names from templates using JWT claims and config agent_id
 func GenerateTopicsFromTemplate(jwtClaims *JWTClaims) (*TokenResponseTopics, error) {
 	return &TokenResponseTopics{
-		Heartbeat:    fillTopicTemplate(heartbeatTemplate, jwtClaims),
-		Capabilities: fillTopicTemplate(capabilitiesTemplate, jwtClaims),
-		Inbox:        fillTopicTemplate(inboxTemplate, jwtClaims),
-		Outbox:       fillTopicTemplate(outboxTemplate, jwtClaims),
-		Ingest:       fillTopicTemplate(ingestTemplate, jwtClaims),
-		Telemetry:    fillTopicTemplate(telemetryTemplate, jwtClaims),
+		Heartbeat:       fillTopicTemplate(heartbeatTemplate, jwtClaims),
+		Capabilities:    fillTopicTemplate(capabilitiesTemplate, jwtClaims),
+		Inbox:           fillTopicTemplate(inboxTemplate, jwtClaims),
+		Outbox:          fillTopicTemplate(outboxTemplate, jwtClaims),
+		Ingest:          fillTopicTemplate(ingestTemplate, jwtClaims),
+		Telemetry:       fillTopicTemplate(telemetryTemplate, jwtClaims),
+		SecretsRequest:  fillTopicTemplate(secretsRequestTemplate, jwtClaims),
+		SecretsResponse: fillTopicTemplate(secretsResponseTemplate, jwtClaims),
+		SecretsUpdated:  fillTopicTemplate(secretsUpdatedTemplate, jwtClaims),
 	}, nil
 }
 

--- a/agent/configmgr/fleet_test.go
+++ b/agent/configmgr/fleet_test.go
@@ -75,6 +75,18 @@ func (m *mockBackendState) Get() map[string]*backend.State {
 	return m.Called().Get(0).(map[string]*backend.State)
 }
 
+// findAvailablePort finds an available port by listening on port 0 and returning the assigned port
+func findAvailablePort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", ":0")
+	require.NoError(t, err, "failed to find available port")
+	defer func() {
+		_ = listener.Close()
+	}()
+	addr := listener.Addr().(*net.TCPAddr)
+	return addr.Port
+}
+
 func TestFleetConfigManager_Start_TokenError(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
@@ -1024,7 +1036,7 @@ func TestFleetConfigManager_Start_OTLPBridgePortInUse(t *testing.T) {
 	mockPMgr.On("GetRepo").Return(nil)
 
 	// Pre-occupy a port with a test listener
-	testPort := 54321
+	testPort := findAvailablePort(t)
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", testPort))
 	require.NoError(t, err, "failed to create test listener")
 	defer func() {

--- a/agent/docker/default_config.yaml
+++ b/agent/docker/default_config.yaml
@@ -7,6 +7,11 @@ orb:
         client_id: ${FLEET_CLIENT_ID}
         client_secret: ${FLEET_CLIENT_SECRET}
         otlp_bridge_grpc_port: 4337
+  secrets_manager:
+    active: fleet
+    sources:
+      fleet:
+        timeout: 30
   backends:
     network_discovery:
     device_discovery:

--- a/agent/otlpbridge/server_test.go
+++ b/agent/otlpbridge/server_test.go
@@ -13,12 +13,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// findAvailablePort finds an available port by listening on port 0 and returning the assigned port
+func findAvailablePort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", ":0")
+	require.NoError(t, err, "failed to find available port")
+	defer func() {
+		_ = listener.Close()
+	}()
+	addr := listener.Addr().(*net.TCPAddr)
+	return addr.Port
+}
+
 func TestBridgeServer_Start_PortInUse(t *testing.T) {
 	// Test that Start() returns a clear error when the port is already in use
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
 	// Pre-occupy a port with a test listener
-	testPort := 54322
+	testPort := findAvailablePort(t)
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", testPort))
 	require.NoError(t, err, "failed to create test listener")
 	defer func() {
@@ -74,7 +86,7 @@ func TestBridgeServer_Start_ErrorMessageFormat(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
 	// Pre-occupy a port
-	testPort := 54323
+	testPort := findAvailablePort(t)
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", testPort))
 	require.NoError(t, err, "failed to create test listener")
 	defer func() {

--- a/agent/secretsmgr/fleet.go
+++ b/agent/secretsmgr/fleet.go
@@ -80,7 +80,11 @@ func (f *FleetSecretsManager) BindMQTT(publisher Publisher, subscriber Subscribe
 	f.updatedTopic = updatedTopic
 
 	// Subscribe to response and updated topics
-	ctx := context.Background()
+	// Use the manager's context if available, otherwise use background context
+	ctx := f.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if err := f.subscriber.Subscribe(ctx, &paho.Subscribe{
 		Subscriptions: []paho.SubscribeOptions{
 			{Topic: responseTopic, QoS: 1},
@@ -164,7 +168,10 @@ func (f *FleetSecretsManager) handleUpdateNotification(payload []byte) error {
 				"new_version", update.Version)
 
 			// Request updated secret
-			ctx := context.Background()
+			ctx := f.ctx
+			if ctx == nil {
+				ctx = context.Background()
+			}
 			secret, err := f.requestSecret(ctx, update.Path, cached.policyIDs)
 			if err != nil {
 				f.logger.Error("failed to request updated secret", "path", update.Path, "error", err)
@@ -301,7 +308,10 @@ func (f *FleetSecretsManager) processString(s string, id string) (string, error)
 	}
 
 	// Request secret from control plane
-	ctx := context.Background()
+	ctx := f.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	policyIDs := map[string]bool{id: true}
 	secret, err := f.requestSecret(ctx, fleetPath, policyIDs)
 	if err != nil {
@@ -373,13 +383,18 @@ func (f *FleetSecretsManager) requestSecret(ctx context.Context, path string, po
 		return nil, fmt.Errorf("failed to marshal secret request: %w", err)
 	}
 
-	// Create response channel
+	// Create response channel with buffer size 1 to prevent blocking handleResponse
 	responseCh := make(chan *messages.SecretResponseMsg, 1)
 	f.mu.Lock()
 	f.pendingReqs[requestID] = responseCh
 	f.mu.Unlock()
 
 	// Cleanup pending request on exit
+	// Note: The channel is intentionally not closed here to avoid a race condition where
+	// handleResponse might already have a reference to the channel and attempt to send after
+	// it's closed (which would panic). By removing the channel from pendingReqs, we ensure
+	// no new sends will be attempted, and the buffered channel prevents blocking. The channel
+	// will be garbage collected once this function returns and any in-flight sends complete.
 	defer func() {
 		f.mu.Lock()
 		delete(f.pendingReqs, requestID)

--- a/agent/secretsmgr/fleet.go
+++ b/agent/secretsmgr/fleet.go
@@ -19,6 +19,11 @@ import (
 
 var _ Manager = (*FleetSecretsManager)(nil)
 
+// fleetRefRegex matches fleet secret references in the format ${fleet://path}
+var fleetRefRegex = regexp.MustCompile(`\${fleet://([^}]+)}`)
+
+const defaultSecretRequestTimeout = 30 * time.Second
+
 // Publisher interface for MQTT publishing
 type Publisher interface {
 	Publish(ctx context.Context, topic string, payload []byte) error
@@ -54,7 +59,7 @@ type fleetCachedSecret struct {
 
 // NewFleetSecretsManager creates a new Fleet secrets manager
 func NewFleetSecretsManager(logger *slog.Logger, cfg config.FleetSecretsManager) *FleetSecretsManager {
-	timeout := 120 * time.Second
+	timeout := defaultSecretRequestTimeout
 	if cfg.Timeout != nil && *cfg.Timeout > 0 {
 		timeout = time.Duration(*cfg.Timeout) * time.Second
 	}
@@ -149,49 +154,80 @@ func (f *FleetSecretsManager) handleUpdateNotification(payload []byte) error {
 		return err
 	}
 
-	f.mu.Lock()
-	defer f.mu.Unlock()
-
 	changedPolicyIDs := make(map[string]bool)
 
 	for _, update := range notification.Updates {
+		// Copy data needed for the request while holding the lock
+		f.mu.Lock()
 		cached, exists := f.usedVars[update.Path]
 		if !exists {
+			f.mu.Unlock()
 			continue
 		}
 
 		// Check if version changed
-		if update.Version > cached.Version {
-			f.logger.Info("secret version changed, requesting update",
-				"path", update.Path,
-				"old_version", cached.Version,
-				"new_version", update.Version)
-
-			// Request updated secret
-			ctx := f.ctx
-			if ctx == nil {
-				ctx = context.Background()
-			}
-			secret, err := f.requestSecret(ctx, update.Path, cached.policyIDs)
-			if err != nil {
-				f.logger.Error("failed to request updated secret", "path", update.Path, "error", err)
-				// Mark policies as needing update but with error
-				for id := range cached.policyIDs {
-					changedPolicyIDs[id] = false
-				}
-				continue
-			}
-
-			// Update cache
-			cached.Value = secret.Value
-			cached.Version = secret.Version
-			f.usedVars[update.Path] = cached
-
-			// Mark policies as needing update
-			for id := range cached.policyIDs {
-				changedPolicyIDs[id] = true
-			}
+		if update.Version <= cached.Version {
+			f.mu.Unlock()
+			continue
 		}
+
+		f.logger.Info("secret version changed, requesting update",
+			"path", update.Path,
+			"old_version", cached.Version,
+			"new_version", update.Version)
+
+		// Deep-copy policy IDs so they can be safely used while the lock is released
+		policyIDsCopy := make(map[string]bool, len(cached.policyIDs))
+		for id := range cached.policyIDs {
+			policyIDsCopy[id] = true
+		}
+		path := update.Path
+
+		// Release the lock before performing the potentially long-running network request
+		f.mu.Unlock()
+
+		// Request updated secret
+		ctx := f.ctx
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		secret, err := f.requestSecret(ctx, path, policyIDsCopy)
+
+		// Re-acquire the lock before accessing or mutating shared state
+		f.mu.Lock()
+		if err != nil {
+			f.logger.Error("failed to request updated secret", "path", path, "error", err)
+			// Mark policies as needing update but with error
+			for id := range policyIDsCopy {
+				changedPolicyIDs[id] = false
+			}
+			f.mu.Unlock()
+			continue
+		}
+
+		// Re-fetch the cached entry in case it changed while the lock was released
+		cached, exists = f.usedVars[path]
+		if !exists {
+			// The secret was removed while we were requesting it; skip updating.
+			f.mu.Unlock()
+			continue
+		}
+		// If the version is already up-to-date or newer, skip overwriting.
+		if cached.Version >= secret.Version {
+			f.mu.Unlock()
+			continue
+		}
+
+		// Update cache
+		cached.Value = secret.Value
+		cached.Version = secret.Version
+		f.usedVars[path] = cached
+
+		// Mark policies as needing update
+		for id := range cached.policyIDs {
+			changedPolicyIDs[id] = true
+		}
+		f.mu.Unlock()
 	}
 
 	// Call callback if secrets changed
@@ -283,29 +319,31 @@ func (f *FleetSecretsManager) processValue(value any, id string) (any, error) {
 
 // processString processes a string and replaces fleet secret references
 func (f *FleetSecretsManager) processString(s string, id string) (string, error) {
-	re := regexp.MustCompile(`\${fleet://([^}]+)}`)
-	if !re.MatchString(s) {
+	if !fleetRefRegex.MatchString(s) {
 		return s, nil
 	}
 
-	match := re.FindStringSubmatchIndex(s)
+	match := fleetRefRegex.FindStringSubmatchIndex(s)
 	if len(match) < 4 {
 		return "", fmt.Errorf("failed to find fleet secret reference in string: %s", s)
 	}
 
 	fleetPath := s[match[2]:match[3]]
 
-	f.mu.RLock()
+	// Check if secret exists in cache and update policy tracking
+	f.mu.Lock()
 	cached, exists := f.usedVars[fleetPath]
-	f.mu.RUnlock()
-
 	if exists {
-		f.mu.Lock()
+		if cached.policyIDs == nil {
+			cached.policyIDs = make(map[string]bool)
+		}
 		cached.policyIDs[id] = true
 		f.usedVars[fleetPath] = cached
+		value := cached.Value
 		f.mu.Unlock()
-		return cached.Value, nil
+		return value, nil
 	}
+	f.mu.Unlock()
 
 	// Request secret from control plane
 	ctx := f.ctx
@@ -419,6 +457,16 @@ func (f *FleetSecretsManager) requestSecret(ctx context.Context, path string, po
 
 		if len(response.Secrets) == 0 {
 			return nil, fmt.Errorf("no secrets in response")
+		}
+
+		// Log warning for partial responses (some secrets succeeded, some failed)
+		if response.Status == "partial" && len(response.Errors) > 0 {
+			for _, secretErr := range response.Errors {
+				f.logger.Warn("partial secret response: some secrets failed",
+					"path", secretErr.Path,
+					"error", secretErr.Error,
+					"code", secretErr.Code)
+			}
 		}
 
 		return &response.Secrets[0], nil

--- a/agent/secretsmgr/fleet.go
+++ b/agent/secretsmgr/fleet.go
@@ -54,7 +54,7 @@ type fleetCachedSecret struct {
 
 // NewFleetSecretsManager creates a new Fleet secrets manager
 func NewFleetSecretsManager(logger *slog.Logger, cfg config.FleetSecretsManager) *FleetSecretsManager {
-	timeout := 30 * time.Second
+	timeout := 120 * time.Second
 	if cfg.Timeout != nil && *cfg.Timeout > 0 {
 		timeout = time.Duration(*cfg.Timeout) * time.Second
 	}
@@ -105,6 +105,9 @@ func (f *FleetSecretsManager) HandleMessage(topic string, payload []byte) error 
 		return f.handleResponse(payload)
 	case f.updatedTopic:
 		return f.handleUpdateNotification(payload)
+	default:
+		f.logger.Info("received unknown message on topic", "topic", topic)
+		return nil
 	}
 	return nil
 }
@@ -115,6 +118,7 @@ func (f *FleetSecretsManager) handleResponse(payload []byte) error {
 		f.logger.Error("failed to unmarshal secret response", "error", err)
 		return err
 	}
+	f.logger.Debug("handling secret response", "request_id", response.RequestID, "status", response.Status, "secrets", len(response.Secrets))
 
 	f.mu.Lock()
 	ch, exists := f.pendingReqs[response.RequestID]
@@ -211,6 +215,7 @@ func (f *FleetSecretsManager) SolvePolicySecrets(payload config.PolicyPayload) (
 	newPayload := payload
 
 	// Process the Data field
+	// TODO: currently this will solve secrets sequentially - we should find all the secrets and then request them all at once
 	processedData, err := f.processValue(payload.Data, payload.ID)
 	if err != nil {
 		return payload, err
@@ -304,6 +309,8 @@ func (f *FleetSecretsManager) processString(s string, id string) (string, error)
 		return "", fmt.Errorf("failed to get secret %s: %w", fleetPath, err)
 	}
 
+	f.logger.Info("got secret", "secret_path", fleetPath)
+
 	// Cache the secret
 	f.mu.Lock()
 	f.usedVars[fleetPath] = fleetCachedSecret{
@@ -344,6 +351,7 @@ func (f *FleetSecretsManager) processSlice(s []any, id string) ([]any, error) {
 
 // requestSecret requests a secret from the control plane via MQTT
 func (f *FleetSecretsManager) requestSecret(ctx context.Context, path string, policyIDs map[string]bool) (*messages.SecretValue, error) {
+	f.logger.Info("requesting secret", "path", path, "policy_ids", policyIDs)
 	if f.publisher == nil {
 		return nil, fmt.Errorf("MQTT publisher not bound")
 	}
@@ -404,7 +412,7 @@ func (f *FleetSecretsManager) requestSecret(ctx context.Context, path string, po
 	case <-ctx.Done():
 		return nil, fmt.Errorf("context canceled while waiting for secret response")
 	case <-time.After(f.timeout):
-		return nil, fmt.Errorf("timeout waiting for secret response")
+		return nil, fmt.Errorf("timeout waiting for secret response after %s", f.timeout)
 	}
 }
 

--- a/agent/secretsmgr/fleet.go
+++ b/agent/secretsmgr/fleet.go
@@ -109,7 +109,6 @@ func (f *FleetSecretsManager) HandleMessage(topic string, payload []byte) error 
 		f.logger.Info("received unknown message on topic", "topic", topic)
 		return nil
 	}
-	return nil
 }
 
 func (f *FleetSecretsManager) handleResponse(payload []byte) error {

--- a/agent/secretsmgr/fleet.go
+++ b/agent/secretsmgr/fleet.go
@@ -1,0 +1,457 @@
+package secretsmgr
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/eclipse/paho.golang/autopaho"
+	"github.com/eclipse/paho.golang/paho"
+	"github.com/google/uuid"
+
+	"github.com/netboxlabs/orb-agent/agent/config"
+	"github.com/netboxlabs/orb-agent/agent/configmgr/fleet/messages"
+)
+
+var _ Manager = (*FleetSecretsManager)(nil)
+
+// Publisher interface for MQTT publishing
+type Publisher interface {
+	Publish(ctx context.Context, topic string, payload []byte) error
+}
+
+// Subscriber interface for MQTT subscribing
+type Subscriber interface {
+	Subscribe(ctx context.Context, subscribe *paho.Subscribe) error
+}
+
+// FleetSecretsManager implements the Manager interface for Fleet-based secrets
+type FleetSecretsManager struct {
+	logger        *slog.Logger
+	config        config.FleetSecretsManager
+	ctx           context.Context
+	usedVars      map[string]fleetCachedSecret
+	callback      func(map[string]bool)
+	publisher     Publisher
+	subscriber    Subscriber
+	requestTopic  string
+	responseTopic string
+	updatedTopic  string
+	mu            sync.RWMutex
+	pendingReqs   map[string]chan *messages.SecretResponseMsg
+	timeout       time.Duration
+}
+
+type fleetCachedSecret struct {
+	Value     string          // The actual secret value
+	Version   int             // Version number from control plane
+	policyIDs map[string]bool // The IDs of policies that have used this secret
+}
+
+// NewFleetSecretsManager creates a new Fleet secrets manager
+func NewFleetSecretsManager(logger *slog.Logger, cfg config.FleetSecretsManager) *FleetSecretsManager {
+	timeout := 30 * time.Second
+	if cfg.Timeout != nil && *cfg.Timeout > 0 {
+		timeout = time.Duration(*cfg.Timeout) * time.Second
+	}
+
+	return &FleetSecretsManager{
+		logger:      logger,
+		config:      cfg,
+		usedVars:    make(map[string]fleetCachedSecret),
+		pendingReqs: make(map[string]chan *messages.SecretResponseMsg),
+		timeout:     timeout,
+	}
+}
+
+// BindMQTT binds the secrets manager to MQTT connection and topics
+func (f *FleetSecretsManager) BindMQTT(publisher Publisher, subscriber Subscriber, requestTopic, responseTopic, updatedTopic string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.publisher = publisher
+	f.subscriber = subscriber
+	f.requestTopic = requestTopic
+	f.responseTopic = responseTopic
+	f.updatedTopic = updatedTopic
+
+	// Subscribe to response and updated topics
+	ctx := context.Background()
+	if err := f.subscriber.Subscribe(ctx, &paho.Subscribe{
+		Subscriptions: []paho.SubscribeOptions{
+			{Topic: responseTopic, QoS: 1},
+			{Topic: updatedTopic, QoS: 1},
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to subscribe to secrets topics: %w", err)
+	}
+
+	f.logger.Info("Fleet secrets manager bound to MQTT",
+		"request_topic", requestTopic,
+		"response_topic", responseTopic,
+		"updated_topic", updatedTopic)
+
+	return nil
+}
+
+// HandleMessage handles incoming MQTT messages on secrets topics
+func (f *FleetSecretsManager) HandleMessage(topic string, payload []byte) error {
+	switch topic {
+	case f.responseTopic:
+		return f.handleResponse(payload)
+	case f.updatedTopic:
+		return f.handleUpdateNotification(payload)
+	}
+	return nil
+}
+
+func (f *FleetSecretsManager) handleResponse(payload []byte) error {
+	var response messages.SecretResponseMsg
+	if err := json.Unmarshal(payload, &response); err != nil {
+		f.logger.Error("failed to unmarshal secret response", "error", err)
+		return err
+	}
+
+	f.mu.Lock()
+	ch, exists := f.pendingReqs[response.RequestID]
+	f.mu.Unlock()
+
+	if !exists {
+		f.logger.Warn("received response for unknown request", "request_id", response.RequestID)
+		return nil
+	}
+
+	// Send response to waiting goroutine
+	select {
+	case ch <- &response:
+	default:
+		f.logger.Warn("response channel full, dropping response", "request_id", response.RequestID)
+	}
+
+	return nil
+}
+
+func (f *FleetSecretsManager) handleUpdateNotification(payload []byte) error {
+	var notification messages.SecretUpdateNotificationMsg
+	if err := json.Unmarshal(payload, &notification); err != nil {
+		f.logger.Error("failed to unmarshal secret update notification", "error", err)
+		return err
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	changedPolicyIDs := make(map[string]bool)
+
+	for _, update := range notification.Updates {
+		cached, exists := f.usedVars[update.Path]
+		if !exists {
+			continue
+		}
+
+		// Check if version changed
+		if update.Version > cached.Version {
+			f.logger.Info("secret version changed, requesting update",
+				"path", update.Path,
+				"old_version", cached.Version,
+				"new_version", update.Version)
+
+			// Request updated secret
+			ctx := context.Background()
+			secret, err := f.requestSecret(ctx, update.Path, cached.policyIDs)
+			if err != nil {
+				f.logger.Error("failed to request updated secret", "path", update.Path, "error", err)
+				// Mark policies as needing update but with error
+				for id := range cached.policyIDs {
+					changedPolicyIDs[id] = false
+				}
+				continue
+			}
+
+			// Update cache
+			cached.Value = secret.Value
+			cached.Version = secret.Version
+			f.usedVars[update.Path] = cached
+
+			// Mark policies as needing update
+			for id := range cached.policyIDs {
+				changedPolicyIDs[id] = true
+			}
+		}
+	}
+
+	// Call callback if secrets changed
+	if len(changedPolicyIDs) > 0 && f.callback != nil {
+		f.logger.Info("calling update callback for changed secrets", "policy_count", len(changedPolicyIDs))
+		f.callback(changedPolicyIDs)
+	}
+
+	return nil
+}
+
+// Start initializes the Fleet secrets manager
+func (f *FleetSecretsManager) Start(ctx context.Context) error {
+	f.ctx = ctx
+	f.usedVars = make(map[string]fleetCachedSecret)
+	return nil
+}
+
+// RegisterUpdatePoliciesCallback registers a callback for policy updates when secrets change
+func (f *FleetSecretsManager) RegisterUpdatePoliciesCallback(callback func(map[string]bool)) {
+	f.callback = callback
+}
+
+// SolvePolicySecrets resolves fleet secret references in a policy payload
+func (f *FleetSecretsManager) SolvePolicySecrets(payload config.PolicyPayload) (config.PolicyPayload, error) {
+	// Create a copy of the payload
+	newPayload := payload
+
+	// Process the Data field
+	processedData, err := f.processValue(payload.Data, payload.ID)
+	if err != nil {
+		return payload, err
+	}
+
+	newPayload.Data = processedData
+	return newPayload, nil
+}
+
+// SolveConfigSecrets resolves fleet secret references in backend and config manager configurations
+func (f *FleetSecretsManager) SolveConfigSecrets(backends map[string]any, configManager config.ManagerConfig) (map[string]any, config.ManagerConfig, error) {
+	// Create a copy of the backends
+	newBackends := backends
+	processedBackends, err := f.processValue(newBackends, "_backends")
+	if err != nil {
+		return backends, configManager, fmt.Errorf("failed to process backends: %w", err)
+	}
+	newBackends, ok := processedBackends.(map[string]any)
+	if !ok {
+		return backends, configManager, fmt.Errorf("failed to cast processed backends to map[string]any")
+	}
+
+	// Convert configManager to map[string]any
+	configManagerMap, err := structToMap(configManager)
+	if err != nil {
+		return backends, configManager, fmt.Errorf("failed to convert config manager to map: %w", err)
+	}
+	// Process the config manager map
+	processedConfigManagerMap, err := f.processValue(configManagerMap, "_config_manager")
+	if err != nil {
+		return backends, configManager, fmt.Errorf("failed to process config manager: %w", err)
+	}
+	newConfigManager, err := mapToStruct[config.ManagerConfig](processedConfigManagerMap)
+	if err != nil {
+		return backends, configManager, fmt.Errorf("failed to convert processed map to config manager: %w", err)
+	}
+
+	// Do not track updates on config vars for now
+	f.mu.Lock()
+	f.usedVars = make(map[string]fleetCachedSecret)
+	f.mu.Unlock()
+
+	// Process the backends and config manager
+	return newBackends, newConfigManager, nil
+}
+
+func (f *FleetSecretsManager) processValue(value any, id string) (any, error) {
+	switch val := value.(type) {
+	case string:
+		return f.processString(val, id)
+	case map[string]any:
+		return f.processMap(val, id)
+	case []any:
+		return f.processSlice(val, id)
+	default:
+		return val, nil
+	}
+}
+
+// processString processes a string and replaces fleet secret references
+func (f *FleetSecretsManager) processString(s string, id string) (string, error) {
+	re := regexp.MustCompile(`\${fleet://([^}]+)}`)
+	if !re.MatchString(s) {
+		return s, nil
+	}
+
+	match := re.FindStringSubmatchIndex(s)
+	if len(match) < 4 {
+		return "", fmt.Errorf("failed to find fleet secret reference in string: %s", s)
+	}
+
+	fleetPath := s[match[2]:match[3]]
+
+	f.mu.RLock()
+	cached, exists := f.usedVars[fleetPath]
+	f.mu.RUnlock()
+
+	if exists {
+		f.mu.Lock()
+		cached.policyIDs[id] = true
+		f.usedVars[fleetPath] = cached
+		f.mu.Unlock()
+		return cached.Value, nil
+	}
+
+	// Request secret from control plane
+	ctx := context.Background()
+	policyIDs := map[string]bool{id: true}
+	secret, err := f.requestSecret(ctx, fleetPath, policyIDs)
+	if err != nil {
+		return "", fmt.Errorf("failed to get secret %s: %w", fleetPath, err)
+	}
+
+	// Cache the secret
+	f.mu.Lock()
+	f.usedVars[fleetPath] = fleetCachedSecret{
+		Value:     secret.Value,
+		Version:   secret.Version,
+		policyIDs: policyIDs,
+	}
+	f.mu.Unlock()
+
+	return secret.Value, nil
+}
+
+// processMap processes a map recursively and replaces fleet secret references in its values
+func (f *FleetSecretsManager) processMap(m map[string]any, id string) (map[string]any, error) {
+	result := make(map[string]any)
+	for key, val := range m {
+		processedVal, err := f.processValue(val, id)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process value for key %s: %w", key, err)
+		}
+		result[key] = processedVal
+	}
+	return result, nil
+}
+
+// processSlice processes a slice recursively and replaces fleet secret references in its elements
+func (f *FleetSecretsManager) processSlice(s []any, id string) ([]any, error) {
+	result := make([]any, len(s))
+	for i, val := range s {
+		processedVal, err := f.processValue(val, id)
+		if err != nil {
+			return nil, fmt.Errorf("failed to process value at index %d: %w", i, err)
+		}
+		result[i] = processedVal
+	}
+	return result, nil
+}
+
+// requestSecret requests a secret from the control plane via MQTT
+func (f *FleetSecretsManager) requestSecret(ctx context.Context, path string, policyIDs map[string]bool) (*messages.SecretValue, error) {
+	if f.publisher == nil {
+		return nil, fmt.Errorf("MQTT publisher not bound")
+	}
+
+	requestID := uuid.New().String()
+	request := messages.SecretRequestMsg{
+		SchemaVersion: messages.CurrentSecretsSchemaVersion,
+		RequestID:     requestID,
+		Timestamp:     time.Now(),
+		Secrets: []messages.SecretRequest{
+			{
+				Path:    path,
+				Context: getContextFromPolicyIDs(policyIDs),
+			},
+		},
+	}
+
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal secret request: %w", err)
+	}
+
+	// Create response channel
+	responseCh := make(chan *messages.SecretResponseMsg, 1)
+	f.mu.Lock()
+	f.pendingReqs[requestID] = responseCh
+	f.mu.Unlock()
+
+	// Cleanup pending request on exit
+	defer func() {
+		f.mu.Lock()
+		delete(f.pendingReqs, requestID)
+		f.mu.Unlock()
+	}()
+
+	// Publish request
+	if err := f.publisher.Publish(ctx, f.requestTopic, payload); err != nil {
+		return nil, fmt.Errorf("failed to publish secret request: %w", err)
+	}
+
+	// Wait for response with timeout
+	select {
+	case response := <-responseCh:
+		if response.Status == "error" {
+			if len(response.Errors) > 0 {
+				err := response.Errors[0]
+				return nil, fmt.Errorf("secret request failed: %s (code: %s)", err.Error, err.Code)
+			}
+			return nil, fmt.Errorf("secret request failed with status: %s", response.Status)
+		}
+
+		if len(response.Secrets) == 0 {
+			return nil, fmt.Errorf("no secrets in response")
+		}
+
+		return &response.Secrets[0], nil
+
+	case <-ctx.Done():
+		return nil, fmt.Errorf("context canceled while waiting for secret response")
+	case <-time.After(f.timeout):
+		return nil, fmt.Errorf("timeout waiting for secret response")
+	}
+}
+
+// getContextFromPolicyIDs extracts a context string from policy IDs
+// For now, we use the first policy ID or "config" if it's a config secret
+func getContextFromPolicyIDs(policyIDs map[string]bool) string {
+	for id := range policyIDs {
+		if id != "_backends" && id != "_config_manager" {
+			return id
+		}
+	}
+	return "config"
+}
+
+// CMAdapterPublisher adapts autopaho.ConnectionManager to implement Publisher
+type CMAdapterPublisher struct {
+	cm *autopaho.ConnectionManager
+}
+
+// NewCMAdapterPublisher creates a new adapter for an autopaho connection manager
+func NewCMAdapterPublisher(cm *autopaho.ConnectionManager) *CMAdapterPublisher {
+	return &CMAdapterPublisher{cm: cm}
+}
+
+// Publish sends the payload to the topic with QoS 0
+func (p *CMAdapterPublisher) Publish(ctx context.Context, topic string, payload []byte) error {
+	_, err := p.cm.Publish(ctx, &paho.Publish{
+		Topic:   topic,
+		Payload: payload,
+		QoS:     0,
+		Retain:  false,
+	})
+	return err
+}
+
+// CMAdapterSubscriber adapts autopaho.ConnectionManager to implement Subscriber
+type CMAdapterSubscriber struct {
+	cm *autopaho.ConnectionManager
+}
+
+// NewCMAdapterSubscriber creates a new adapter for an autopaho connection manager
+func NewCMAdapterSubscriber(cm *autopaho.ConnectionManager) *CMAdapterSubscriber {
+	return &CMAdapterSubscriber{cm: cm}
+}
+
+// Subscribe subscribes to topics
+func (s *CMAdapterSubscriber) Subscribe(ctx context.Context, subscribe *paho.Subscribe) error {
+	_, err := s.cm.Subscribe(ctx, subscribe)
+	return err
+}

--- a/agent/secretsmgr/fleet_test.go
+++ b/agent/secretsmgr/fleet_test.go
@@ -1,0 +1,261 @@
+package secretsmgr
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/eclipse/paho.golang/paho"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/config"
+	"github.com/netboxlabs/orb-agent/agent/configmgr/fleet/messages"
+)
+
+func TestFleetSecretsManager_processString(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	t.Run("no fleet reference", func(t *testing.T) {
+		fm := NewFleetSecretsManager(logger, config.FleetSecretsManager{Timeout: intPtr(1)})
+		fm.ctx = ctx
+
+		result, err := fm.processString("plain text", "policy1")
+		assert.NoError(t, err)
+		assert.Equal(t, "plain text", result)
+	})
+
+	t.Run("valid fleet reference", func(t *testing.T) {
+		fm := NewFleetSecretsManager(logger, config.FleetSecretsManager{Timeout: intPtr(5)})
+		fm.ctx = ctx
+		fm.requestTopic = "test/request"
+		fm.responseTopic = "test/response"
+		fm.updatedTopic = "test/updated"
+
+		// Create a mock publisher that simulates async responses
+		mockPub := &asyncMockPublisher{
+			fm: fm,
+			responseSecrets: []messages.SecretValue{
+				{
+					Path:    "orb/agents/database/password",
+					Value:   "secretvalue",
+					Version: 1,
+				},
+			},
+		}
+		fm.publisher = mockPub
+		fm.subscriber = &mockSubscriber{}
+
+		result, err := fm.processString("${fleet://orb/agents/database/password}", "policy1")
+		assert.NoError(t, err)
+		assert.Equal(t, "secretvalue", result)
+	})
+
+	t.Run("cached secret", func(t *testing.T) {
+		fm := NewFleetSecretsManager(logger, config.FleetSecretsManager{Timeout: intPtr(1)})
+		fm.ctx = ctx
+		// Pre-cache a secret
+		fm.usedVars["orb/agents/cached/secret"] = fleetCachedSecret{
+			Value:     "cachedvalue",
+			Version:   1,
+			policyIDs: map[string]bool{"policy1": true},
+		}
+
+		result, err := fm.processString("${fleet://orb/agents/cached/secret}", "policy1")
+		assert.NoError(t, err)
+		assert.Equal(t, "cachedvalue", result)
+	})
+
+	t.Run("malformed reference", func(t *testing.T) {
+		fm := NewFleetSecretsManager(logger, config.FleetSecretsManager{Timeout: intPtr(1)})
+		fm.ctx = ctx
+
+		result, err := fm.processString("${fleet:/malformed}", "policy1")
+		assert.NoError(t, err)
+		assert.Equal(t, "${fleet:/malformed}", result)
+	})
+}
+
+func TestFleetSecretsManager_handleResponse(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	fm := NewFleetSecretsManager(logger, config.FleetSecretsManager{})
+	fm.pendingReqs = make(map[string]chan *messages.SecretResponseMsg)
+
+	requestID := uuid.New().String()
+	responseCh := make(chan *messages.SecretResponseMsg, 1)
+	fm.pendingReqs[requestID] = responseCh
+
+	response := messages.SecretResponseMsg{
+		SchemaVersion: messages.CurrentSecretsSchemaVersion,
+		RequestID:     requestID,
+		Timestamp:     time.Now(),
+		Status:        "success",
+		Secrets: []messages.SecretValue{
+			{
+				Path:    "test/path",
+				Value:   "testvalue",
+				Version: 1,
+			},
+		},
+	}
+
+	payload, err := json.Marshal(response)
+	require.NoError(t, err)
+
+	err = fm.handleResponse(payload)
+	assert.NoError(t, err)
+
+	// Check that response was sent to channel
+	select {
+	case received := <-responseCh:
+		assert.Equal(t, requestID, received.RequestID)
+		assert.Equal(t, "success", received.Status)
+		assert.Len(t, received.Secrets, 1)
+		assert.Equal(t, "testvalue", received.Secrets[0].Value)
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout waiting for response")
+	}
+}
+
+func TestFleetSecretsManager_handleUpdateNotification(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	fm := NewFleetSecretsManager(logger, config.FleetSecretsManager{})
+	fm.usedVars = make(map[string]fleetCachedSecret)
+	fm.usedVars["test/path"] = fleetCachedSecret{
+		Value:     "oldvalue",
+		Version:   1,
+		policyIDs: map[string]bool{"policy1": true},
+	}
+
+	var callbackCalled bool
+	var callbackPolicyIDs map[string]bool
+	fm.callback = func(policyIDs map[string]bool) {
+		callbackCalled = true
+		callbackPolicyIDs = policyIDs
+	}
+
+	notification := messages.SecretUpdateNotificationMsg{
+		SchemaVersion: messages.CurrentSecretsSchemaVersion,
+		Timestamp:     time.Now(),
+		Updates: []messages.SecretUpdate{
+			{
+				Path:     "test/path",
+				Version:  2,
+				Contexts: []string{"policy1"},
+			},
+		},
+	}
+
+	payload, err := json.Marshal(notification)
+	require.NoError(t, err)
+
+	// Note: This test doesn't fully test the update flow since requestSecret
+	// requires a real MQTT connection. But we can test the notification parsing.
+	// handleUpdateNotification logs errors from requestSecret but returns nil
+	err = fm.handleUpdateNotification(payload)
+	assert.NoError(t, err) // Function returns nil even when requestSecret fails (it logs the error)
+
+	// Verify the callback was called with the policy marked as failed (false)
+	assert.True(t, callbackCalled)
+	assert.Contains(t, callbackPolicyIDs, "policy1")
+	assert.False(t, callbackPolicyIDs["policy1"]) // false because requestSecret failed
+}
+
+func TestNewFleetSecretsManager(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	tests := []struct {
+		name         string
+		config       config.FleetSecretsManager
+		expectedType string
+	}{
+		{
+			name: "with timeout",
+			config: config.FleetSecretsManager{
+				Timeout: intPtr(60),
+			},
+			expectedType: "*secretsmgr.FleetSecretsManager",
+		},
+		{
+			name:         "without timeout",
+			config:       config.FleetSecretsManager{},
+			expectedType: "*secretsmgr.FleetSecretsManager",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := NewFleetSecretsManager(logger, tt.config)
+			assert.NotNil(t, manager)
+			assert.Equal(t, tt.expectedType, fmt.Sprintf("%T", manager))
+		})
+	}
+}
+
+func TestFleetSecretsManager_RegisterUpdatePoliciesCallback(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	fm := NewFleetSecretsManager(logger, config.FleetSecretsManager{})
+
+	called := false
+	callback := func(_ map[string]bool) {
+		called = true
+	}
+
+	fm.RegisterUpdatePoliciesCallback(callback)
+	assert.NotNil(t, fm.callback)
+
+	// Manually call the callback to verify it works
+	fm.callback(map[string]bool{"policy1": true})
+	assert.True(t, called)
+}
+
+// Helper functions and mocks
+
+// asyncMockPublisher simulates async MQTT responses for testing
+type asyncMockPublisher struct {
+	fm              *FleetSecretsManager
+	responseSecrets []messages.SecretValue
+}
+
+func (m *asyncMockPublisher) Publish(_ context.Context, _ string, payload []byte) error {
+	// Parse the request to get the request ID
+	var req messages.SecretRequestMsg
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return err
+	}
+
+	// Simulate async response in a goroutine
+	go func() {
+		time.Sleep(10 * time.Millisecond) // Small delay to simulate network
+
+		response := messages.SecretResponseMsg{
+			SchemaVersion: messages.CurrentSecretsSchemaVersion,
+			RequestID:     req.RequestID,
+			Timestamp:     time.Now(),
+			Status:        "success",
+			Secrets:       m.responseSecrets,
+		}
+
+		responsePayload, _ := json.Marshal(response)
+		_ = m.fm.handleResponse(responsePayload)
+	}()
+
+	return nil
+}
+
+type mockSubscriber struct{}
+
+func (m *mockSubscriber) Subscribe(_ context.Context, _ *paho.Subscribe) error {
+	return nil
+}
+
+func intPtr(i int) *int {
+	return &i
+}

--- a/agent/secretsmgr/manager.go
+++ b/agent/secretsmgr/manager.go
@@ -20,6 +20,8 @@ func New(logger *slog.Logger, c config.ManagerSecrets) Manager {
 	switch c.Active {
 	case "vault":
 		return &vaultManager{logger: logger, config: c.Sources.Vault}
+	case "fleet":
+		return NewFleetSecretsManager(logger, c.Sources.Fleet)
 	default:
 		logger.Info("no secrets manager specified or invalid type, skipping")
 		return &dummyManager{}

--- a/agent/secretsmgr/vault_auth_test.go
+++ b/agent/secretsmgr/vault_auth_test.go
@@ -52,6 +52,7 @@ func TestNewAuthentication(t *testing.T) {
 
 func TestTokenAuth_Authenticate(t *testing.T) {
 	// Use shared test vault server
+	// If setup failed (e.g., Docker port binding), createTestVault will skip via getTestVaultClient
 	_, client := createTestVault(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
This pull request introduces support for integrating the Fleet-based secrets manager with the Fleet configuration manager, enabling secure secrets distribution over MQTT. It adds new types and message schemas for secrets management, updates the Fleet configuration manager to bind and handle secrets, and refactors several types and methods for consistency and extensibility. The changes also include improvements to topic handling in the MQTT connection and add necessary configuration fields for secrets management.

### Fleet secrets manager integration

* Added logic in `agent/agent.go` to bind the Fleet secrets manager to the Fleet configuration manager when both are active, ensuring secrets can be resolved during configuration.
* Implemented `BindSecretsManager` in `FleetConfigManager` to register MQTT topic handlers and bind the secrets manager for secure communication.

### Secrets message schema and configuration

* Introduced new message types and error codes for secrets operations in `agent/configmgr/fleet/messages/secrets_messages.go`, defining request, response, and update notification structures.
* Added `FleetSecretsManager` type and related configuration fields to support Fleet secrets manager options in `agent/config/types.go`.

### MQTT connection enhancements

* Added topic handler registration and dispatching to `MQTTConnection`, allowing dynamic handling of secrets-related MQTT topics. [[1]](diffhunk://#diff-1783db06b73b72c164682aec902cffc352ef29c1eee8cd92929e7637e72f8047R19-R21) [[2]](diffhunk://#diff-1783db06b73b72c164682aec902cffc352ef29c1eee8cd92929e7637e72f8047R30-R36) [[3]](diffhunk://#diff-1783db06b73b72c164682aec902cffc352ef29c1eee8cd92929e7637e72f8047R59-R65) [[4]](diffhunk://#diff-1783db06b73b72c164682aec902cffc352ef29c1eee8cd92929e7637e72f8047R89) [[5]](diffhunk://#diff-1783db06b73b72c164682aec902cffc352ef29c1eee8cd92929e7637e72f8047R230-R241)
* Updated topic templates and `TokenResponseTopics` to include secrets request, response, and update topics for proper routing. [[1]](diffhunk://#diff-17fd95244aee0b364f9b0cb6a5a0129b9f6b8a908b897cf375a6498dadc162a6R22-R24) [[2]](diffhunk://#diff-17fd95244aee0b364f9b0cb6a5a0129b9f6b8a908b897cf375a6498dadc162a6R37-R39) [[3]](diffhunk://#diff-17fd95244aee0b364f9b0cb6a5a0129b9f6b8a908b897cf375a6498dadc162a6R51-R53)

### Refactoring and consistency

* Renamed `fleetConfigManager` to `FleetConfigManager` and updated related constructors and methods for clarity and adherence to Go naming conventions. [[1]](diffhunk://#diff-b0dddd7590e09bc17b468db04b48a21f0d508a17eca4c086eb98c87325e5ba98R17-R24) [[2]](diffhunk://#diff-b0dddd7590e09bc17b468db04b48a21f0d508a17eca4c086eb98c87325e5ba98L40-R45) [[3]](diffhunk://#diff-b0dddd7590e09bc17b468db04b48a21f0d508a17eca4c086eb98c87325e5ba98L54-R60) [[4]](diffhunk://#diff-b0dddd7590e09bc17b468db04b48a21f0d508a17eca4c086eb98c87325e5ba98L69-R72) [[5]](diffhunk://#diff-b0dddd7590e09bc17b468db04b48a21f0d508a17eca4c086eb98c87325e5ba98L273-R316) [[6]](diffhunk://#diff-b0dddd7590e09bc17b468db04b48a21f0d508a17eca4c086eb98c87325e5ba98L285-R335) [[7]](diffhunk://#diff-b0dddd7590e09bc17b468db04b48a21f0d508a17eca4c086eb98c87325e5ba98L351-R395)
* Updated test utilities to dynamically find available ports for more robust testing in `agent/configmgr/fleet_test.go`. [[1]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eR78-R89) [[2]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL1027-R1039)