### PR TITLE
chore: update snmp docs

### DIFF
--- a/docs/backends/snmp_discovery.md
+++ b/docs/backends/snmp_discovery.md
@@ -69,8 +69,17 @@ SNMP discovery policies are broken down into two subsections: `config` and `scop
 ### Scope Section
 | Parameter | Type | Required | Description |
 |:---------:|:----:|:--------:|:-----------:|
-| targets | list | yes | List of SNMP targets to discover. It also supports subnets (e.g. 192.168.1.0/28) and IP ranges in the format 192.168.0.1-192.168.0.10 or 192.168.0.1-10. |
-| authentication | map | yes | SNMP authentication settings |
+| targets | list | yes | List of SNMP targets to discover. Supports subnets (e.g. 192.168.1.0/28), IP ranges (192.168.0.1-192.168.0.10 or 192.168.0.1-10), and per-target authentication. |
+| authentication | map | conditional | Policy-level SNMP authentication settings (required unless all targets have their own authentication) |
+
+#### Target Parameters
+Each target in the `targets` list can include:
+
+| Parameter | Type | Required | Description |
+|:---------:|:----:|:--------:|:-----------:|
+| host | string | yes | Target hostname or IP address |
+| port | integer | no | SNMP port (defaults to 161) |
+| authentication | map | no | Target-specific authentication (overrides policy-level authentication) |
 
 #### Authentication Parameters
 | Parameter | Type | Required | Description |
@@ -85,6 +94,8 @@ SNMP discovery policies are broken down into two subsections: `config` and `scop
 | priv_passphrase | string | no | SNMPv3 privacy passphrase |
 
 *Required for SNMPv1/v2c, optional for SNMPv3
+
+**Note:** Authentication can be specified at the policy level (under `scope.authentication`) as a fallback, or per-target (under each target's `authentication` field). Targets without authentication use the policy-level authentication. Environment variables are supported using `${VAR}` syntax for `community`, `username`, `auth_passphrase`, and `priv_passphrase` fields.
 
 ### Sample
 A sample policy including all parameters supported by the SNMP discovery backend.
@@ -120,10 +131,20 @@ config:
 scope:
   targets:
     - host: "192.168.1.1/24" # subnet support
-    - host: "192.168.2.2-10" #range support
+    - host: "192.168.2.2-10" # range support
     - host: "10.0.0.1"
       port: 162  # Non-standard SNMP port
-  authentication:
+    - host: "10.0.0.10"
+      port: 161
+      authentication:  # Per-target authentication (optional)
+        protocol_version: "SNMPv3"
+        security_level: "authPriv"
+        username: "admin"
+        auth_protocol: "SHA"
+        auth_passphrase: "${SNMP_AUTH_PASS}"
+        priv_protocol: "AES"
+        priv_passphrase: "${SNMP_PRIV_PASS}"
+  authentication:  # Policy-level authentication (fallback)
     protocol_version: "SNMPv2c"
     community: "public"
 ```

--- a/docs/backends/snmp_discovery.md
+++ b/docs/backends/snmp_discovery.md
@@ -49,11 +49,11 @@ SNMP discovery policies are broken down into two subsections: `config` and `scop
 | site | string | no | Default site name for discovered devices |
 | location | string | no | Default location for discovered devices |
 | role | string | no | Default role for discovered devices |
-| interface_patterns | list | User-defined interface type patterns (see [Interface Type Matching](./snmp_discovery_interface.md)) |
+| interface_patterns | list  | no | User-defined interface type patterns (see [Interface Type Matching](./snmp_discovery_interface.md)) |
 
 ##### Nested Defaults
 | Parameter | Type | Description |
-|:---------:|:----:|:-----------:|
+|---------|----|-----------|
 | device      | map  | Device-specific defaults        |
 | ├─ description | string  | Device description           |
 | ├─ comments   | string  | Device comments               |
@@ -77,9 +77,10 @@ Each target in the `targets` list can include:
 
 | Parameter | Type | Required | Description |
 |:---------:|:----:|:--------:|:-----------:|
-| host | string | yes | Target hostname or IP address |
+| host | string | yes | Target hostname,  IP address, subnets or IP ranges |
 | port | integer | no | SNMP port (defaults to 161) |
 | authentication | map | no | Target-specific authentication (overrides policy-level authentication) |
+| override_defaults | map | no | Allows overriding of any defaults for a specific target in the scope |
 
 #### Authentication Parameters
 | Parameter | Type | Required | Description |
@@ -134,6 +135,9 @@ scope:
     - host: "192.168.2.2-10" # range support
     - host: "10.0.0.1"
       port: 162  # Non-standard SNMP port
+      override_defaults:
+        role: "switch"
+        tags: ["custom"]
     - host: "10.0.0.10"
       port: 161
       authentication:  # Per-target authentication (optional)


### PR DESCRIPTION
This pull request updates the SNMP discovery backend documentation to clarify how authentication and target-specific overrides work in discovery policies. The changes improve the explanation of per-target and policy-level authentication, add documentation for target-specific overrides, and provide a more comprehensive sample configuration.

**Documentation improvements:**

* Clarified that each target in the `targets` list can specify its own `authentication` settings, which override the policy-level authentication, and added a new `override_defaults` field for per-target customization. [[1]](diffhunk://#diff-b6159b73743d6ed59c85c2de680c7153976499a8c848216fd59e5c9823ae9dc2L72-R83) [[2]](diffhunk://#diff-b6159b73743d6ed59c85c2de680c7153976499a8c848216fd59e5c9823ae9dc2L126-R151)
* Updated the description of the `authentication` parameter to indicate that it is now conditional, required only if not all targets have their own authentication.
* Added a note explaining the fallback behavior for authentication and support for environment variables in authentication fields.

**Formatting and clarity:**

* Fixed formatting in the parameters table for consistency and clarity.
* Expanded the sample policy to demonstrate per-target authentication and the use of `override_defaults`.