### PR TITLE
chore: add redact package to not print sensitive data

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -14,6 +14,7 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/configmgr"
 	"github.com/netboxlabs/orb-agent/agent/policymgr"
+	"github.com/netboxlabs/orb-agent/agent/redact"
 	"github.com/netboxlabs/orb-agent/agent/secretsmgr"
 	"github.com/netboxlabs/orb-agent/agent/telemetry"
 	"github.com/netboxlabs/orb-agent/agent/version"
@@ -183,7 +184,7 @@ func (a *orbAgent) Start(ctx context.Context, cancelFunc context.CancelFunc) err
 	agentCtx := context.WithValue(ctx, routineKey, "agentRoutine")
 	a.cancelFunction = cancelFunc
 	a.logger.Info("agent started", "version", version.GetBuildVersion(), "routine", agentCtx.Value(routineKey))
-	a.logger.Info("requested backends", "values", a.config.OrbAgent.Backends)
+	a.logger.Info("requested backends", "values", redact.SensitiveData(a.config.OrbAgent.Backends))
 
 	if err := a.secretsManager.Start(ctx); err != nil {
 		a.logger.Error("error during start secrets manager", "error", err)

--- a/agent/backend/devicediscovery/device_discovery.go
+++ b/agent/backend/devicediscovery/device_discovery.go
@@ -15,6 +15,7 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/policies"
+	"github.com/netboxlabs/orb-agent/agent/redact"
 )
 
 var _ backend.Backend = (*deviceDiscoveryBackend)(nil)
@@ -29,7 +30,6 @@ const (
 	defaultExec         = "device-discovery"
 	defaultAPIHost      = "localhost"
 	defaultAPIPort      = "8072"
-	maskedSecret        = "********"
 )
 
 type deviceDiscoveryBackend struct {
@@ -160,7 +160,7 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 		if !d.diodeTargetFromOtel {
 			opts = append(opts,
 				"--diode-client-id", d.diodeClientID,
-				"--diode-client-secret", maskedSecret,
+				"--diode-client-secret", d.diodeClientSecret,
 			)
 		}
 		dOptions = append(opts, dOptions...)
@@ -170,16 +170,7 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 		dOptions = append(dOptions, "--otel-endpoint", d.diodeOtelEndpoint)
 	}
 
-	d.logger.Info("device-discovery startup", "arguments", dOptions)
-
-	if !d.diodeDryRun {
-		for i, arg := range dOptions {
-			if arg == maskedSecret {
-				dOptions[i] = d.diodeClientSecret
-				break
-			}
-		}
-	}
+	d.logger.Info("device-discovery startup", "arguments", redact.Args(dOptions))
 
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,

--- a/agent/backend/networkdiscovery/network_discovery.go
+++ b/agent/backend/networkdiscovery/network_discovery.go
@@ -16,6 +16,7 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/policies"
+	"github.com/netboxlabs/orb-agent/agent/redact"
 )
 
 var _ backend.Backend = (*networkDiscoveryBackend)(nil)
@@ -30,7 +31,6 @@ const (
 	defaultExec         = "network-discovery"
 	defaultAPIHost      = "localhost"
 	defaultAPIPort      = "8073"
-	maskedSecret        = "********"
 )
 
 type networkDiscoveryBackend struct {
@@ -169,7 +169,7 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 		if !d.diodeTargetFromOtel {
 			opts = append(opts,
 				"--diode-client-id", d.diodeClientID,
-				"--diode-client-secret", maskedSecret,
+				"--diode-client-secret", d.diodeClientSecret,
 			)
 		}
 		dOptions = append(opts, dOptions...)
@@ -187,16 +187,7 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 			"endpoint", d.diodeOtelEndpoint)
 	}
 
-	d.logger.Info("network-discovery startup", "arguments", dOptions)
-
-	if !d.diodeDryRun {
-		for i, arg := range dOptions {
-			if arg == maskedSecret {
-				dOptions[i] = d.diodeClientSecret
-				break
-			}
-		}
-	}
+	d.logger.Info("network-discovery startup", "arguments", redact.Args(dOptions))
 
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,

--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -16,6 +16,7 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/policies"
+	"github.com/netboxlabs/orb-agent/agent/redact"
 )
 
 var _ backend.Backend = (*snmpDiscoveryBackend)(nil)
@@ -30,7 +31,6 @@ const (
 	defaultExec         = "snmp-discovery"
 	defaultAPIHost      = "localhost"
 	defaultAPIPort      = "8070"
-	maskedSecret        = "********"
 )
 
 type snmpDiscoveryBackend struct {
@@ -169,7 +169,7 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 		if !d.diodeTargetFromOtel {
 			opts = append(opts,
 				"--diode-client-id", d.diodeClientID,
-				"--diode-client-secret", maskedSecret,
+				"--diode-client-secret", d.diodeClientSecret,
 			)
 		}
 		dOptions = append(opts, dOptions...)
@@ -187,17 +187,7 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 			"endpoint", d.diodeOtelEndpoint)
 	}
 
-	d.logger.Info("snmp-discovery startup", "arguments", dOptions)
-
-	if !d.diodeDryRun {
-		// Swap the masked secret used for logging with the real value before execution
-		for i, arg := range dOptions {
-			if arg == maskedSecret {
-				dOptions[i] = d.diodeClientSecret
-				break
-			}
-		}
-	}
+	d.logger.Info("snmp-discovery startup", "arguments", redact.Args(dOptions))
 
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,

--- a/agent/backend/worker/worker.go
+++ b/agent/backend/worker/worker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/policies"
+	"github.com/netboxlabs/orb-agent/agent/redact"
 )
 
 var _ backend.Backend = (*workerBackend)(nil)
@@ -29,7 +30,6 @@ const (
 	defaultExec         = "orb-worker"
 	defaultAPIHost      = "localhost"
 	defaultAPIPort      = "8071"
-	maskedSecret        = "********"
 )
 
 type workerBackend struct {
@@ -160,7 +160,7 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 		if !d.diodeTargetFromOtel {
 			opts = append(opts,
 				"--diode-client-id", d.diodeClientID,
-				"--diode-client-secret", maskedSecret,
+				"--diode-client-secret", d.diodeClientSecret,
 			)
 		}
 		dOptions = append(opts, dOptions...)
@@ -170,17 +170,7 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 		dOptions = append(dOptions, "--otel-endpoint", d.diodeOtelEndpoint)
 	}
 
-	d.logger.Info("worker startup", "arguments", dOptions)
-
-	if !d.diodeDryRun {
-		// Swap the masked secret used for logging with the real value before execution
-		for i, arg := range dOptions {
-			if arg == maskedSecret {
-				dOptions[i] = d.diodeClientSecret
-				break
-			}
-		}
-	}
+	d.logger.Info("worker startup", "arguments", redact.Args(dOptions))
 
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{
 		Buffered:  false,

--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -14,6 +14,7 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/configmgr/fleet"
 	"github.com/netboxlabs/orb-agent/agent/otlpbridge"
 	"github.com/netboxlabs/orb-agent/agent/policymgr"
+	"github.com/netboxlabs/orb-agent/agent/redact"
 )
 
 // Compile-time check to ensure fleetConfigManager implements Manager interface
@@ -271,11 +272,8 @@ func (fleetManager *fleetConfigManager) refreshAndReconnect(ctx context.Context,
 }
 
 func (fleetManager *fleetConfigManager) configToSafeString(cfg config.Config) (string, error) {
-	if cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientSecret != "" {
-		cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientSecret = "******"
-	}
-
-	configYaml, err := yaml.Marshal(cfg)
+	redacted := redact.SensitiveData(cfg)
+	configYaml, err := yaml.Marshal(redacted)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal agent config: %w", err)
 	}

--- a/agent/configmgr/fleet/auth.go
+++ b/agent/configmgr/fleet/auth.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
+
+	"github.com/netboxlabs/orb-agent/agent/redact"
 )
 
 // AuthTokenManager manages auth tokens
@@ -92,7 +94,7 @@ func (fleetManager *AuthTokenManager) GetToken(ctx context.Context, tokenURL str
 		},
 	}
 
-	fleetManager.logger.Debug("sending token request", "url", tokenURL, "data", data, "client_id", clientID)
+	fleetManager.logger.Debug("sending token request", "url", tokenURL, "data", redact.SensitiveData(data), "client_id", clientID)
 
 	resp, err := httpClient.Do(req.WithContext(ctx))
 	if err != nil {

--- a/agent/configmgr/fleet_test.go
+++ b/agent/configmgr/fleet_test.go
@@ -279,7 +279,7 @@ func TestFleetConfigManager_configToSafeString(t *testing.T) {
 		{
 			name:         "sanitizes non-empty client secret",
 			clientSecret: "my-super-secret-password",
-			wantSecret:   "******",
+			wantSecret:   "********",
 			wantErr:      false,
 			checkInYAML:  true,
 		},
@@ -334,9 +334,9 @@ func TestFleetConfigManager_configToSafeString(t *testing.T) {
 				assert.Contains(t, result, tt.wantSecret, "sanitized secret should be in output")
 				// YAML can use either single or double quotes, so check for either
 				assert.True(t,
-					strings.Contains(result, "client_secret: '******'") ||
-						strings.Contains(result, "client_secret: \"******\"") ||
-						strings.Contains(result, "client_secret: ******"),
+					strings.Contains(result, "client_secret: '********'") ||
+						strings.Contains(result, "client_secret: \"********\"") ||
+						strings.Contains(result, "client_secret: ********"),
 					"client_secret should be masked in YAML output")
 			}
 		})

--- a/agent/redact/redact.go
+++ b/agent/redact/redact.go
@@ -100,9 +100,12 @@ func redactValue(val reflect.Value, fieldName string) any {
 
 	// Check if this field should be redacted
 	if fieldName != "" && isSensitiveField(fieldName) {
-		// Redact string values
+		// Redact non-empty string values (preserve empty strings for debugging)
 		if val.Kind() == reflect.String {
-			return MaskedSecret
+			if val.String() != "" {
+				return MaskedSecret
+			}
+			return "" // Preserve empty strings
 		}
 		// Redact slices/arrays of strings (e.g., url.Values which is map[string][]string)
 		if val.Kind() == reflect.Slice || val.Kind() == reflect.Array {

--- a/agent/redact/redact.go
+++ b/agent/redact/redact.go
@@ -288,8 +288,8 @@ func Args(args []string) []string {
 	// Scan for sensitive flags and mask the following value
 	for i := 0; i < len(result); i++ {
 		if isSensitiveArg(result[i]) {
-			// Mask the next argument if it exists and isn't another flag
-			if i+1 < len(result) && !strings.HasPrefix(result[i+1], "-") {
+			// Mask the next argument if it exists
+			if i+1 < len(result) {
 				result[i+1] = MaskedSecret
 				i++ // Skip the next iteration since we just processed it
 			}

--- a/agent/redact/redact.go
+++ b/agent/redact/redact.go
@@ -1,6 +1,7 @@
 package redact
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 )
@@ -8,7 +9,7 @@ import (
 // MaskedSecret is the value used to replace sensitive information in logs
 const MaskedSecret = "********"
 
-// sensitiveFieldPatterns contains lowercase patterns that identify sensitive fields
+// sensitiveFieldPatterns contains lowercase exact field names that identify sensitive fields
 var sensitiveFieldPatterns = []string{
 	"client_secret",
 	"clientsecret",
@@ -17,14 +18,24 @@ var sensitiveFieldPatterns = []string{
 	"privatekey",
 	"access_token",
 	"accesstoken",
-	"token",
-	"secret",
 	"api_key",
 	"apikey",
 	"auth_token",
 	"authtoken",
 	"bearer",
 	"jwt",
+	"secret", // Exact match only
+	"token",  // Exact match only
+}
+
+// sensitiveFieldSuffixes contains lowercase suffixes that indicate sensitive fields
+var sensitiveFieldSuffixes = []string{
+	"_secret",
+	"_password",
+	"_token",
+	"_private_key",
+	"_api_key",
+	"_auth_key",
 }
 
 // sensitiveFlagPatterns contains patterns for sensitive CLI flags
@@ -45,7 +56,9 @@ var sensitiveFlagSuffixes = []string{
 	"-secret",
 	"-password",
 	"-token",
-	"-key",
+	"-private-key",
+	"-api-key",
+	"-auth-key",
 }
 
 // SensitiveData creates a deep copy of the input data and masks sensitive fields.
@@ -87,9 +100,13 @@ func redactValue(val reflect.Value, fieldName string) any {
 
 	// Check if this field should be redacted
 	if fieldName != "" && isSensitiveField(fieldName) {
-		// Only redact string values
+		// Redact string values
 		if val.Kind() == reflect.String {
 			return MaskedSecret
+		}
+		// Redact slices/arrays of strings (e.g., url.Values which is map[string][]string)
+		if val.Kind() == reflect.Slice || val.Kind() == reflect.Array {
+			return redactSliceSensitive(val)
 		}
 		// For non-string sensitive fields, return as-is (e.g., port numbers)
 	}
@@ -133,11 +150,19 @@ func redactMap(val reflect.Value) any {
 		value := iter.Value()
 
 		// Get the key as a string
-		keyStr := ""
+		var keyStr string
 		if key.Kind() == reflect.String {
 			keyStr = key.String()
 		} else if key.CanInterface() {
-			keyStr = key.Interface().(string)
+			// Safely convert non-string keys using fmt.Sprintf
+			if str, ok := key.Interface().(string); ok {
+				keyStr = str
+			} else {
+				keyStr = fmt.Sprintf("%v", key.Interface())
+			}
+		} else {
+			// Fallback for unexported keys
+			keyStr = fmt.Sprintf("%v", key)
 		}
 
 		// Redact the value, passing the field name for sensitive field detection
@@ -184,6 +209,29 @@ func redactStruct(val reflect.Value) any {
 	return result
 }
 
+// redactSliceSensitive handles redaction of slice/array values for sensitive fields
+// It masks all string elements since the field itself is sensitive (e.g., url.Values)
+func redactSliceSensitive(val reflect.Value) any {
+	if val.Kind() == reflect.Slice && val.IsNil() {
+		return nil
+	}
+
+	length := val.Len()
+	result := make([]any, length)
+
+	for i := 0; i < length; i++ {
+		elem := val.Index(i)
+		// Mask string elements in sensitive slices
+		if elem.Kind() == reflect.String {
+			result[i] = MaskedSecret
+		} else {
+			result[i] = redactValue(elem, "")
+		}
+	}
+
+	return result
+}
+
 // redactSlice handles redaction of slice and array types
 func redactSlice(val reflect.Value) any {
 	if val.Kind() == reflect.Slice && val.IsNil() {
@@ -204,11 +252,21 @@ func redactSlice(val reflect.Value) any {
 // isSensitiveField checks if a field name matches sensitive patterns
 func isSensitiveField(fieldName string) bool {
 	lower := strings.ToLower(fieldName)
+
+	// Check exact matches first (to avoid false positives like "token_url")
 	for _, pattern := range sensitiveFieldPatterns {
-		if strings.Contains(lower, pattern) {
+		if lower == pattern {
 			return true
 		}
 	}
+
+	// Check suffixes (e.g., "my_custom_secret" matches "_secret")
+	for _, suffix := range sensitiveFieldSuffixes {
+		if strings.HasSuffix(lower, suffix) {
+			return true
+		}
+	}
+
 	return false
 }
 

--- a/agent/redact/redact.go
+++ b/agent/redact/redact.go
@@ -1,0 +1,260 @@
+package redact
+
+import (
+	"reflect"
+	"strings"
+)
+
+// MaskedSecret is the value used to replace sensitive information in logs
+const MaskedSecret = "********"
+
+// sensitiveFieldPatterns contains lowercase patterns that identify sensitive fields
+var sensitiveFieldPatterns = []string{
+	"client_secret",
+	"clientsecret",
+	"password",
+	"private_key",
+	"privatekey",
+	"access_token",
+	"accesstoken",
+	"token",
+	"secret",
+	"api_key",
+	"apikey",
+	"auth_token",
+	"authtoken",
+	"bearer",
+	"jwt",
+}
+
+// sensitiveFlagPatterns contains patterns for sensitive CLI flags
+var sensitiveFlagPatterns = []string{
+	"--diode-client-secret",
+	"--client-secret",
+	"--password",
+	"--token",
+	"--api-key",
+	"--auth-token",
+	"--private-key",
+	"--bearer",
+	"--jwt",
+}
+
+// sensitiveFlagSuffixes contains suffixes that indicate a sensitive flag
+var sensitiveFlagSuffixes = []string{
+	"-secret",
+	"-password",
+	"-token",
+	"-key",
+}
+
+// SensitiveData creates a deep copy of the input data and masks sensitive fields.
+// It handles maps, structs, slices, and primitive types recursively.
+// Returns the redacted copy suitable for logging - original data is never modified.
+func SensitiveData(data any) any {
+	if data == nil {
+		return nil
+	}
+
+	val := reflect.ValueOf(data)
+	return redactValue(val, "")
+}
+
+// redactValue recursively redacts values based on their type
+func redactValue(val reflect.Value, fieldName string) any {
+	if !val.IsValid() {
+		return nil
+	}
+
+	// Handle pointers
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil
+		}
+		elem := val.Elem()
+		redacted := redactValue(elem, fieldName)
+		// Return the redacted value directly, not wrapped in pointer
+		return redacted
+	}
+
+	// Handle interfaces
+	if val.Kind() == reflect.Interface {
+		if val.IsNil() {
+			return nil
+		}
+		return redactValue(val.Elem(), fieldName)
+	}
+
+	// Check if this field should be redacted
+	if fieldName != "" && isSensitiveField(fieldName) {
+		// Only redact string values
+		if val.Kind() == reflect.String {
+			return MaskedSecret
+		}
+		// For non-string sensitive fields, return as-is (e.g., port numbers)
+	}
+
+	switch val.Kind() {
+	case reflect.Map:
+		return redactMap(val)
+	case reflect.Struct:
+		return redactStruct(val)
+	case reflect.Slice, reflect.Array:
+		return redactSlice(val)
+	case reflect.String:
+		return val.String()
+	case reflect.Bool:
+		return val.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return val.Int()
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return val.Uint()
+	case reflect.Float32, reflect.Float64:
+		return val.Float()
+	default:
+		// For unknown types, try to return the interface value
+		if val.CanInterface() {
+			return val.Interface()
+		}
+		return nil
+	}
+}
+
+// redactMap handles redaction of map types
+func redactMap(val reflect.Value) any {
+	if val.IsNil() {
+		return nil
+	}
+
+	result := make(map[string]any, val.Len())
+	iter := val.MapRange()
+	for iter.Next() {
+		key := iter.Key()
+		value := iter.Value()
+
+		// Get the key as a string
+		keyStr := ""
+		if key.Kind() == reflect.String {
+			keyStr = key.String()
+		} else if key.CanInterface() {
+			keyStr = key.Interface().(string)
+		}
+
+		// Redact the value, passing the field name for sensitive field detection
+		result[keyStr] = redactValue(value, keyStr)
+	}
+
+	return result
+}
+
+// redactStruct handles redaction of struct types
+func redactStruct(val reflect.Value) any {
+	typ := val.Type()
+	result := make(map[string]any, val.NumField())
+
+	for i := 0; i < val.NumField(); i++ {
+		field := typ.Field(i)
+		fieldValue := val.Field(i)
+
+		// Skip unexported fields
+		if !field.IsExported() {
+			continue
+		}
+
+		// Get the field name from tags or use the struct field name
+		fieldName := field.Name
+		if jsonTag := field.Tag.Get("json"); jsonTag != "" && jsonTag != "-" {
+			// Parse json tag (handle "name,omitempty" format)
+			parts := strings.Split(jsonTag, ",")
+			if parts[0] != "" {
+				fieldName = parts[0]
+			}
+		} else if yamlTag := field.Tag.Get("yaml"); yamlTag != "" && yamlTag != "-" {
+			// Parse yaml tag
+			parts := strings.Split(yamlTag, ",")
+			if parts[0] != "" {
+				fieldName = parts[0]
+			}
+		}
+
+		// Redact the field value
+		result[fieldName] = redactValue(fieldValue, fieldName)
+	}
+
+	return result
+}
+
+// redactSlice handles redaction of slice and array types
+func redactSlice(val reflect.Value) any {
+	if val.Kind() == reflect.Slice && val.IsNil() {
+		return nil
+	}
+
+	length := val.Len()
+	result := make([]any, length)
+
+	for i := 0; i < length; i++ {
+		elem := val.Index(i)
+		result[i] = redactValue(elem, "")
+	}
+
+	return result
+}
+
+// isSensitiveField checks if a field name matches sensitive patterns
+func isSensitiveField(fieldName string) bool {
+	lower := strings.ToLower(fieldName)
+	for _, pattern := range sensitiveFieldPatterns {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// Args creates a copy of command-line arguments with sensitive values masked.
+// It detects sensitive flags (like --client-secret) and masks their values.
+// Returns a new slice - the original is never modified.
+func Args(args []string) []string {
+	if args == nil {
+		return nil
+	}
+
+	// Create a copy of the slice
+	result := make([]string, len(args))
+	copy(result, args)
+
+	// Scan for sensitive flags and mask the following value
+	for i := 0; i < len(result); i++ {
+		if isSensitiveArg(result[i]) {
+			// Mask the next argument if it exists and isn't another flag
+			if i+1 < len(result) && !strings.HasPrefix(result[i+1], "-") {
+				result[i+1] = MaskedSecret
+				i++ // Skip the next iteration since we just processed it
+			}
+		}
+	}
+
+	return result
+}
+
+// isSensitiveArg checks if a CLI argument is a sensitive flag
+func isSensitiveArg(arg string) bool {
+	lower := strings.ToLower(arg)
+
+	// Check exact matches
+	for _, pattern := range sensitiveFlagPatterns {
+		if lower == pattern {
+			return true
+		}
+	}
+
+	// Check suffixes
+	for _, suffix := range sensitiveFlagSuffixes {
+		if strings.HasSuffix(lower, suffix) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/agent/redact/redact_test.go
+++ b/agent/redact/redact_test.go
@@ -1,0 +1,466 @@
+package redact
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/netboxlabs/orb-agent/agent/config"
+)
+
+// TestSensitiveData_SimpleMap tests basic map redaction
+func TestSensitiveData_SimpleMap(t *testing.T) {
+	original := map[string]any{
+		"client_secret": "my-secret-123",
+		"password":      "my-password",
+		"client_id":     "my-client-id",
+		"url":           "https://example.com",
+	}
+
+	redacted := SensitiveData(original)
+
+	redactedMap, ok := redacted.(map[string]any)
+	if !ok {
+		t.Fatalf("Expected map[string]any, got %T", redacted)
+	}
+
+	// Verify sensitive fields are masked
+	if redactedMap["client_secret"] != MaskedSecret {
+		t.Errorf("Expected client_secret to be %s, got %v", MaskedSecret, redactedMap["client_secret"])
+	}
+	if redactedMap["password"] != MaskedSecret {
+		t.Errorf("Expected password to be %s, got %v", MaskedSecret, redactedMap["password"])
+	}
+
+	// Verify non-sensitive fields are preserved
+	if redactedMap["client_id"] != "my-client-id" {
+		t.Errorf("Expected client_id to be preserved, got %v", redactedMap["client_id"])
+	}
+	if redactedMap["url"] != "https://example.com" {
+		t.Errorf("Expected url to be preserved, got %v", redactedMap["url"])
+	}
+
+	// Verify original is NOT mutated
+	if original["client_secret"] != "my-secret-123" {
+		t.Error("Original map was mutated!")
+	}
+}
+
+// TestSensitiveData_NestedMap tests nested structure redaction
+func TestSensitiveData_NestedMap(t *testing.T) {
+	original := map[string]any{
+		"backend": map[string]any{
+			"client_secret": "nested-secret",
+			"target":        "https://api.example.com",
+		},
+		"public_key": "public-value",
+	}
+
+	redacted := SensitiveData(original)
+
+	redactedMap := redacted.(map[string]any)
+	backend := redactedMap["backend"].(map[string]any)
+
+	if backend["client_secret"] != MaskedSecret {
+		t.Errorf("Expected nested client_secret to be masked, got %v", backend["client_secret"])
+	}
+	if backend["target"] != "https://api.example.com" {
+		t.Errorf("Expected nested target to be preserved, got %v", backend["target"])
+	}
+}
+
+// TestSensitiveData_FleetManager tests real config type
+func TestSensitiveData_FleetManager(t *testing.T) {
+	original := config.FleetManager{
+		URL:          "https://fleet.example.com",
+		ClientID:     "my-client-id",
+		ClientSecret: "my-client-secret",
+		TokenURL:     "https://auth.example.com",
+	}
+
+	redacted := SensitiveData(original)
+
+	redactedMap, ok := redacted.(map[string]any)
+	if !ok {
+		t.Fatalf("Expected map[string]any, got %T", redacted)
+	}
+
+	// Verify sensitive field is masked (using yaml tag name)
+	if redactedMap["client_secret"] != MaskedSecret {
+		t.Errorf("Expected client_secret to be masked, got %v", redactedMap["client_secret"])
+	}
+
+	// Verify non-sensitive fields are preserved (using yaml tag names)
+	if redactedMap["url"] != "https://fleet.example.com" {
+		t.Errorf("Expected url to be preserved, got %v", redactedMap["url"])
+	}
+	if redactedMap["client_id"] != "my-client-id" {
+		t.Errorf("Expected client_id to be preserved, got %v", redactedMap["client_id"])
+	}
+
+	// Verify original struct is NOT mutated
+	if original.ClientSecret != "my-client-secret" {
+		t.Error("Original struct was mutated!")
+	}
+}
+
+// TestSensitiveData_GitManager tests GitManager with multiple secrets
+func TestSensitiveData_GitManager(t *testing.T) {
+	original := config.GitManager{
+		URL:        "https://git.example.com",
+		Username:   "gituser",
+		Password:   "gitpass123",
+		PrivateKey: "-----BEGIN RSA PRIVATE KEY-----",
+	}
+
+	redacted := SensitiveData(original)
+
+	redactedMap := redacted.(map[string]any)
+
+	// Verify both sensitive fields are masked (using yaml tag names)
+	if redactedMap["password"] != MaskedSecret {
+		t.Errorf("Expected password to be masked, got %v", redactedMap["password"])
+	}
+	if redactedMap["private_key"] != MaskedSecret {
+		t.Errorf("Expected private_key to be masked, got %v", redactedMap["private_key"])
+	}
+
+	// Verify non-sensitive fields are preserved (using yaml tag names)
+	if redactedMap["username"] != "gituser" {
+		t.Errorf("Expected username to be preserved, got %v", redactedMap["username"])
+	}
+}
+
+// TestSensitiveData_BackendCommons tests BackendCommons with Diode config
+func TestSensitiveData_BackendCommons(t *testing.T) {
+	original := config.BackendCommons{}
+	original.Diode.Target = "https://diode.example.com"
+	original.Diode.ClientID = "diode-client"
+	original.Diode.ClientSecret = "diode-secret-123"
+	original.Diode.AgentName = "test-agent"
+
+	redacted := SensitiveData(original)
+
+	redactedMap := redacted.(map[string]any)
+	diode := redactedMap["Diode"].(map[string]any)
+
+	// Verify sensitive field is masked (using yaml tag names)
+	if diode["client_secret"] != MaskedSecret {
+		t.Errorf("Expected Diode.client_secret to be masked, got %v", diode["client_secret"])
+	}
+
+	// Verify non-sensitive fields are preserved (using yaml tag names)
+	if diode["target"] != "https://diode.example.com" {
+		t.Errorf("Expected Diode.target to be preserved, got %v", diode["target"])
+	}
+	if diode["client_id"] != "diode-client" {
+		t.Errorf("Expected Diode.client_id to be preserved, got %v", diode["client_id"])
+	}
+}
+
+// TestSensitiveData_Slice tests slice redaction
+func TestSensitiveData_Slice(t *testing.T) {
+	original := []map[string]any{
+		{"client_secret": "secret1", "name": "backend1"},
+		{"client_secret": "secret2", "name": "backend2"},
+	}
+
+	redacted := SensitiveData(original)
+
+	redactedSlice, ok := redacted.([]any)
+	if !ok {
+		t.Fatalf("Expected []any, got %T", redacted)
+	}
+
+	// Verify each item is redacted
+	for i, item := range redactedSlice {
+		itemMap := item.(map[string]any)
+		if itemMap["client_secret"] != MaskedSecret {
+			t.Errorf("Expected item %d client_secret to be masked, got %v", i, itemMap["client_secret"])
+		}
+		if itemMap["name"] == "" {
+			t.Errorf("Expected item %d name to be preserved", i)
+		}
+	}
+
+	// Verify original is NOT mutated
+	if original[0]["client_secret"] != "secret1" {
+		t.Error("Original slice was mutated!")
+	}
+}
+
+// TestSensitiveData_NilValues tests handling of nil values
+func TestSensitiveData_NilValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		input any
+		want  any
+	}{
+		{"nil input", nil, nil},
+		{"nil map", map[string]any(nil), nil},
+		{"nil slice", []string(nil), nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SensitiveData(tt.input)
+			if result != tt.want {
+				t.Errorf("Expected %v, got %v", tt.want, result)
+			}
+		})
+	}
+}
+
+// TestSensitiveData_EmptyStrings tests that empty strings are preserved
+func TestSensitiveData_EmptyStrings(t *testing.T) {
+	original := map[string]any{
+		"client_secret": "",
+		"password":      "",
+	}
+
+	redacted := SensitiveData(original)
+
+	redactedMap := redacted.(map[string]any)
+
+	// Empty sensitive fields should be masked
+	if redactedMap["client_secret"] != MaskedSecret {
+		t.Errorf("Expected empty client_secret to be masked, got %v", redactedMap["client_secret"])
+	}
+}
+
+// TestSensitiveData_CaseVariations tests case-insensitive matching
+func TestSensitiveData_CaseVariations(t *testing.T) {
+	original := map[string]any{
+		"CLIENT_SECRET": "secret1",
+		"ClientSecret":  "secret2",
+		"client_secret": "secret3",
+		"Password":      "pass1",
+		"PASSWORD":      "pass2",
+	}
+
+	redacted := SensitiveData(original)
+
+	redactedMap := redacted.(map[string]any)
+
+	// All case variations should be masked
+	for key, value := range redactedMap {
+		if value != MaskedSecret {
+			t.Errorf("Expected %s to be masked, got %v", key, value)
+		}
+	}
+}
+
+// TestSensitiveData_NonStringValues tests non-string sensitive fields
+func TestSensitiveData_NonStringValues(t *testing.T) {
+	original := map[string]any{
+		"token_port":  8080,
+		"secret_flag": true,
+	}
+
+	redacted := SensitiveData(original)
+
+	redactedMap := redacted.(map[string]any)
+
+	// Non-string sensitive fields should be preserved (not masked)
+	// Note: reflection returns int64 for int types, not uint64
+	if redactedMap["token_port"] != int64(8080) {
+		t.Errorf("Expected token_port to be preserved, got %v (type %T)", redactedMap["token_port"], redactedMap["token_port"])
+	}
+	if redactedMap["secret_flag"] != true {
+		t.Errorf("Expected secret_flag to be preserved, got %v", redactedMap["secret_flag"])
+	}
+}
+
+// TestIsSensitiveField tests the field name pattern matching
+func TestIsSensitiveField(t *testing.T) {
+	tests := []struct {
+		fieldName string
+		want      bool
+	}{
+		{"client_secret", true},
+		{"clientSecret", true},
+		{"CLIENT_SECRET", true},
+		{"password", true},
+		{"Password", true},
+		{"private_key", true},
+		{"privateKey", true},
+		{"access_token", true},
+		{"accessToken", true},
+		{"token", true},
+		{"Token", true},
+		{"api_key", true},
+		{"apiKey", true},
+		{"secret", true},
+		{"bearer", true},
+		{"jwt", true},
+		{"client_id", false},
+		{"username", false},
+		{"url", false},
+		{"target", false},
+		{"token_url", true},   // Contains "token"
+		{"secret_name", true}, // Contains "secret"
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.fieldName, func(t *testing.T) {
+			result := isSensitiveField(tt.fieldName)
+			if result != tt.want {
+				t.Errorf("isSensitiveField(%q) = %v, want %v", tt.fieldName, result, tt.want)
+			}
+		})
+	}
+}
+
+// TestArgs tests command-line argument redaction
+func TestArgs(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  []string
+	}{
+		{
+			name:  "basic client secret",
+			input: []string{"--diode-client-secret", "secret123", "--host", "localhost"},
+			want:  []string{"--diode-client-secret", MaskedSecret, "--host", "localhost"},
+		},
+		{
+			name:  "multiple sensitive flags",
+			input: []string{"--client-id", "id123", "--client-secret", "secret123", "--password", "pass123"},
+			want:  []string{"--client-id", "id123", "--client-secret", MaskedSecret, "--password", MaskedSecret},
+		},
+		{
+			name:  "no sensitive flags",
+			input: []string{"--host", "localhost", "--port", "8080"},
+			want:  []string{"--host", "localhost", "--port", "8080"},
+		},
+		{
+			name:  "sensitive flag at end without value",
+			input: []string{"--host", "localhost", "--client-secret"},
+			want:  []string{"--host", "localhost", "--client-secret"},
+		},
+		{
+			name:  "sensitive flag followed by another flag",
+			input: []string{"--client-secret", "--host", "localhost"},
+			want:  []string{"--client-secret", "--host", "localhost"},
+		},
+		{
+			name:  "empty args",
+			input: []string{},
+			want:  []string{},
+		},
+		{
+			name:  "nil args",
+			input: nil,
+			want:  nil,
+		},
+		{
+			name:  "token flag",
+			input: []string{"--token", "mytoken123", "--url", "https://example.com"},
+			want:  []string{"--token", MaskedSecret, "--url", "https://example.com"},
+		},
+		{
+			name:  "api-key flag",
+			input: []string{"--api-key", "key123"},
+			want:  []string{"--api-key", MaskedSecret},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Store original for mutation check
+			var originalCopy []string
+			if tt.input != nil {
+				originalCopy = make([]string, len(tt.input))
+				copy(originalCopy, tt.input)
+			}
+
+			result := Args(tt.input)
+
+			if !reflect.DeepEqual(result, tt.want) {
+				t.Errorf("Args() = %v, want %v", result, tt.want)
+			}
+
+			// Verify original is NOT mutated
+			if tt.input != nil && !reflect.DeepEqual(tt.input, originalCopy) {
+				t.Error("Original args slice was mutated!")
+			}
+		})
+	}
+}
+
+// TestArgs_RealBackendExamples tests real backend argument patterns
+func TestArgs_RealBackendExamples(t *testing.T) {
+	// Simulate snmp-discovery backend args
+	snmpArgs := []string{
+		"--dry-run",
+		"--dry-run-output-dir", "/tmp/output",
+		"--diode-app-name-prefix", "test-agent",
+		"--host", "localhost",
+		"--port", "8070",
+	}
+	result := Args(snmpArgs)
+	// No sensitive data, should be unchanged
+	if !reflect.DeepEqual(result, snmpArgs) {
+		t.Error("Non-sensitive snmp args were modified")
+	}
+
+	// Simulate with diode credentials
+	diodeArgs := []string{
+		"--diode-target", "https://diode.example.com",
+		"--diode-client-id", "client123",
+		"--diode-client-secret", "secret123",
+		"--diode-app-name-prefix", "test-agent",
+		"--host", "localhost",
+		"--port", "8070",
+	}
+	result = Args(diodeArgs)
+	expected := []string{
+		"--diode-target", "https://diode.example.com",
+		"--diode-client-id", "client123",
+		"--diode-client-secret", MaskedSecret,
+		"--diode-app-name-prefix", "test-agent",
+		"--host", "localhost",
+		"--port", "8070",
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Diode args redaction failed.\nGot:  %v\nWant: %v", result, expected)
+	}
+}
+
+// TestIsSensitiveArg tests CLI flag pattern matching
+func TestIsSensitiveArg(t *testing.T) {
+	tests := []struct {
+		arg  string
+		want bool
+	}{
+		{"--diode-client-secret", true},
+		{"--client-secret", true},
+		{"--CLIENT-SECRET", true},
+		{"--password", true},
+		{"--Password", true},
+		{"--token", true},
+		{"--api-key", true},
+		{"--auth-token", true},
+		{"--private-key", true},
+		{"--bearer", true},
+		{"--jwt", true},
+		{"--my-custom-secret", true},
+		{"--my-custom-password", true},
+		{"--my-custom-token", true},
+		{"--my-custom-key", true},
+		{"--host", false},
+		{"--port", false},
+		{"--client-id", false},
+		{"--url", false},
+		{"--target", false},
+		{"--dry-run", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.arg, func(t *testing.T) {
+			result := isSensitiveArg(tt.arg)
+			if result != tt.want {
+				t.Errorf("isSensitiveArg(%q) = %v, want %v", tt.arg, result, tt.want)
+			}
+		})
+	}
+}

--- a/agent/redact/redact_test.go
+++ b/agent/redact/redact_test.go
@@ -398,9 +398,9 @@ func TestArgs(t *testing.T) {
 			want:  []string{"--host", "localhost", "--client-secret"},
 		},
 		{
-			name:  "sensitive flag followed by another flag",
+			name:  "sensitive flag followed by another flag (security: mask anyway)",
 			input: []string{"--client-secret", "--host", "localhost"},
-			want:  []string{"--client-secret", "--host", "localhost"},
+			want:  []string{"--client-secret", MaskedSecret, "localhost"},
 		},
 		{
 			name:  "empty args",
@@ -421,6 +421,26 @@ func TestArgs(t *testing.T) {
 			name:  "api-key flag",
 			input: []string{"--api-key", "key123"},
 			want:  []string{"--api-key", MaskedSecret},
+		},
+		{
+			name:  "private key with PEM format (starts with dashes)",
+			input: []string{"--private-key", "-----BEGIN RSA PRIVATE KEY-----\nMIIE...", "--host", "localhost"},
+			want:  []string{"--private-key", MaskedSecret, "--host", "localhost"},
+		},
+		{
+			name:  "password that starts with dash",
+			input: []string{"--password", "-myWeirdPassword123"},
+			want:  []string{"--password", MaskedSecret},
+		},
+		{
+			name:  "token that starts with double dash",
+			input: []string{"--token", "--someTokenValue"},
+			want:  []string{"--token", MaskedSecret},
+		},
+		{
+			name:  "client secret followed by flag-like value",
+			input: []string{"--client-secret", "-x-custom-header-value", "--url", "https://example.com"},
+			want:  []string{"--client-secret", MaskedSecret, "--url", "https://example.com"},
 		},
 	}
 

--- a/agent/redact/redact_test.go
+++ b/agent/redact/redact_test.go
@@ -215,15 +215,25 @@ func TestSensitiveData_EmptyStrings(t *testing.T) {
 	original := map[string]any{
 		"client_secret": "",
 		"password":      "",
+		"client_id":     "",
 	}
 
 	redacted := SensitiveData(original)
 
 	redactedMap := redacted.(map[string]any)
 
-	// Empty sensitive fields should be masked
-	if redactedMap["client_secret"] != MaskedSecret {
-		t.Errorf("Expected empty client_secret to be masked, got %v", redactedMap["client_secret"])
+	// Empty sensitive fields should remain empty (not masked)
+	// This allows distinguishing "no secret configured" from "secret configured (redacted)"
+	if redactedMap["client_secret"] != "" {
+		t.Errorf("Expected empty client_secret to remain empty, got %v", redactedMap["client_secret"])
+	}
+	if redactedMap["password"] != "" {
+		t.Errorf("Expected empty password to remain empty, got %v", redactedMap["password"])
+	}
+
+	// Non-sensitive empty fields should also remain empty
+	if redactedMap["client_id"] != "" {
+		t.Errorf("Expected empty client_id to remain empty, got %v", redactedMap["client_id"])
 	}
 }
 

--- a/agent/redact/redact_test.go
+++ b/agent/redact/redact_test.go
@@ -270,6 +270,49 @@ func TestSensitiveData_NonStringValues(t *testing.T) {
 	}
 }
 
+// TestSensitiveData_URLValues tests url.Values redaction (map[string][]string)
+func TestSensitiveData_URLValues(t *testing.T) {
+	// Simulate url.Values structure: map[string][]string
+	original := map[string]any{
+		"client_id":     []string{"my-client-id"},
+		"client_secret": []string{"my-secret-123"},
+		"grant_type":    []string{"client_credentials"},
+		"scope":         []string{"read write"},
+	}
+
+	redacted := SensitiveData(original)
+
+	redactedMap := redacted.(map[string]any)
+
+	// Verify sensitive field (slice) is masked
+	clientSecretSlice, ok := redactedMap["client_secret"].([]any)
+	if !ok {
+		t.Fatalf("Expected client_secret to be []any, got %T", redactedMap["client_secret"])
+	}
+	if len(clientSecretSlice) != 1 {
+		t.Fatalf("Expected client_secret slice to have 1 element, got %d", len(clientSecretSlice))
+	}
+	if clientSecretSlice[0] != MaskedSecret {
+		t.Errorf("Expected client_secret[0] to be %s, got %v", MaskedSecret, clientSecretSlice[0])
+	}
+
+	// Verify non-sensitive fields are preserved
+	clientIDSlice := redactedMap["client_id"].([]any)
+	if clientIDSlice[0] != "my-client-id" {
+		t.Errorf("Expected client_id to be preserved, got %v", clientIDSlice[0])
+	}
+
+	grantTypeSlice := redactedMap["grant_type"].([]any)
+	if grantTypeSlice[0] != "client_credentials" {
+		t.Errorf("Expected grant_type to be preserved, got %v", grantTypeSlice[0])
+	}
+
+	// Verify original is NOT mutated
+	if original["client_secret"].([]string)[0] != "my-secret-123" {
+		t.Error("Original map was mutated!")
+	}
+}
+
 // TestIsSensitiveField tests the field name pattern matching
 func TestIsSensitiveField(t *testing.T) {
 	tests := []struct {
@@ -296,8 +339,15 @@ func TestIsSensitiveField(t *testing.T) {
 		{"username", false},
 		{"url", false},
 		{"target", false},
-		{"token_url", true},   // Contains "token"
-		{"secret_name", true}, // Contains "secret"
+		{"token_url", false},         // Should NOT match - not exact "token"
+		{"secret_name", false},       // Should NOT match - not exact "secret"
+		{"my_custom_secret", true},   // Should match - ends with "_secret"
+		{"my_custom_token", true},    // Should match - ends with "_token"
+		{"my_custom_password", true}, // Should match - ends with "_password"
+		{"oauth_private_key", true},  // Should match - ends with "_private_key"
+		{"oauth_api_key", true},      // Should match - ends with "_api_key"
+		{"partition_key", false},     // Should NOT match - not a sensitive key type
+		{"sort_key", false},          // Should NOT match - not a sensitive key type
 	}
 
 	for _, tt := range tests {
@@ -446,7 +496,10 @@ func TestIsSensitiveArg(t *testing.T) {
 		{"--my-custom-secret", true},
 		{"--my-custom-password", true},
 		{"--my-custom-token", true},
-		{"--my-custom-key", true},
+		{"--my-custom-api-key", true},
+		{"--my-custom-private-key", true},
+		{"--sort-key", false},      // Should not match - not a sensitive key type
+		{"--partition-key", false}, // Should not match - not a sensitive key type
 		{"--host", false},
 		{"--port", false},
 		{"--client-id", false},

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/backend/snmpdiscovery"
 	"github.com/netboxlabs/orb-agent/agent/backend/worker"
 	"github.com/netboxlabs/orb-agent/agent/config"
+	"github.com/netboxlabs/orb-agent/agent/redact"
 	"github.com/netboxlabs/orb-agent/agent/version"
 )
 
@@ -92,7 +93,7 @@ func Run(_ *cobra.Command, _ []string) {
 		cobra.CheckErr(fmt.Errorf("no config file specified, use --config or -c flag to provide config files"))
 	}
 
-	logger.Info("backends loaded", "backends", configData.OrbAgent.Backends)
+	logger.Info("backends loaded", "backends", redact.SensitiveData(configData.OrbAgent.Backends))
 
 	// new agent
 	a, err := agent.New(logger, configData)


### PR DESCRIPTION
This pull request introduces a new `redact` package and refactors logging throughout the agent to ensure sensitive information (such as secrets, tokens, and passwords) is properly masked in logs. The changes replace previous ad-hoc secret masking with a consistent, reusable approach for redacting sensitive data in both structured data and command-line arguments. This improves security and maintainability.

Key changes:

**Sensitive Data Redaction (core implementation):**
- Added a new `agent/redact/redact.go` package, providing `SensitiveData` and `Args` functions to recursively mask sensitive fields in structs, maps, and CLI arguments. The package defines patterns and suffixes for identifying sensitive data and ensures all redacted output uses a consistent mask.

**Agent and Backend Logging Updates:**
- Refactored logging in `agent.go` and all backend `Start` methods (`device_discovery.go`, `network_discovery.go`, `snmp_discovery.go`, `worker.go`) to use `redact.SensitiveData` and `redact.Args` for masking secrets in configuration and CLI arguments, replacing previous manual masking and in-place value swapping. [[1]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bR17) [[2]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL186-R187) [[3]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02R18) [[4]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L163-R163) [[5]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L173-R173) [[6]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854R19) [[7]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L172-R172) [[8]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L190-R190) [[9]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91R19) [[10]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91L172-R172) [[11]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91L190-R190) [[12]](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcR18) [[13]](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcL163-R163) [[14]](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcL173-R173)

**Configuration Management Improvements:**
- Updated the `fleetConfigManager` in `configmgr/fleet.go` to use `redact.SensitiveData` for masking sensitive fields (like `client_secret`) in configuration logs, replacing the previous manual masking logic. [[1]](diffhunk://#diff-b0dddd7590e09bc17b468db04b48a21f0d508a17eca4c086eb98c87325e5ba98R17) [[2]](diffhunk://#diff-b0dddd7590e09bc17b468db04b48a21f0d508a17eca4c086eb98c87325e5ba98L274-R276)
- Adjusted the `AuthTokenManager` in `configmgr/fleet/auth.go` to mask sensitive data in debug logs for token requests. [[1]](diffhunk://#diff-3f4b071389adebdb2da068eaca7a2472120f9fba9b42241209878e8ac006e966R18-R19) [[2]](diffhunk://#diff-3f4b071389adebdb2da068eaca7a2472120f9fba9b42241209878e8ac006e966L95-R97)

**Testing Adjustments:**
- Updated tests in `fleet_test.go` to expect the new masked secret value (`********`) in YAML output, matching the new redaction standard. [[1]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL282-R282) [[2]](diffhunk://#diff-ffd2e1a25e0d7ade7e270cdffecf1f765962ee97e5883fa8a1cd39efe5c03e7eL337-R339)

**Code Clean-up:**
- Removed now-unnecessary `maskedSecret` constants from backend files, since masking is handled centrally by the new redaction package. [[1]](diffhunk://#diff-505a477cb920fb0c965f380b21405025cc178218dc6ba5c776c35773b6115a02L32) [[2]](diffhunk://#diff-7ab20e53dfab35342bc29810e861330f9c930fe37a665ae39ad655ea88dc0854L33) [[3]](diffhunk://#diff-68c29dcbe942d3640109d72d27766532f50809378a7bb2cf1db7d15693a4ce91L33) [[4]](diffhunk://#diff-0e7af3467457b49680c3aa4545187843724a87ef9d92620097827237881400bcL32)

These changes provide a robust and consistent way to prevent sensitive information from leaking into logs, improving the overall security posture of the agent.