### PR TITLE
chore: improve logging version for each backend

### DIFF
--- a/agent/backend/devicediscovery/device_discovery.go
+++ b/agent/backend/devicediscovery/device_discovery.go
@@ -238,8 +238,7 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 		}
 		version, readinessErr = d.Version()
 		if readinessErr == nil {
-			d.logger.Info("device-discovery readiness ok, got version ",
-				"device_discovery_version", version)
+			d.logger.Info("device-discovery readiness ok, got version", "version", version)
 			break
 		}
 		backoffDuration := time.Duration(backoff) * time.Second

--- a/agent/backend/networkdiscovery/network_discovery.go
+++ b/agent/backend/networkdiscovery/network_discovery.go
@@ -255,8 +255,7 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 		}
 		version, readinessErr = d.Version()
 		if readinessErr == nil {
-			d.logger.Info("network-discovery readiness ok, got version ",
-				"network_discovery_version", version)
+			d.logger.Info("network-discovery readiness ok, got version", "version", version)
 			break
 		}
 		backoffDuration := time.Duration(backoff) * time.Second

--- a/agent/backend/opentelemetryinfinity/opentelemetry_infinity.go
+++ b/agent/backend/opentelemetryinfinity/opentelemetry_infinity.go
@@ -181,8 +181,7 @@ func (o *openTelemetryBackend) Start(ctx context.Context, cancelFunc context.Can
 		}
 		version, readinessErr = o.Version()
 		if readinessErr == nil {
-			o.logger.Info("opentelemetry infinity readiness ok, got version ",
-				"opentelemetry_infinity_version", version)
+			o.logger.Info("opentelemetry infinity readiness ok, got version", "version", version)
 			break
 		}
 		backoffDuration := time.Duration(backoff) * time.Second

--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -205,8 +205,7 @@ func (p *pktvisorBackend) Start(ctx context.Context, cancelFunc context.CancelFu
 		readinessError = backend.CommonRequest("pktvisor", p.proc, p.logger, url, &appMetrics, http.MethodGet,
 			http.NoBody, "application/json", readinessTimeout, "error")
 		if readinessError == nil {
-			p.logger.Info("pktvisor readiness ok, got version ",
-				"pktvisor_version", appMetrics.App.Version)
+			p.logger.Info("pktvisor readiness ok, got version", "version", appMetrics.App.Version)
 			break
 		}
 		backoffDuration := time.Duration(backoff) * time.Second

--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -255,8 +255,7 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 		}
 		version, readinessErr = d.Version()
 		if readinessErr == nil {
-			d.logger.Info("snmp-discovery readiness ok, got version ",
-				"snmp_discovery_version", version)
+			d.logger.Info("snmp-discovery readiness ok, got version", "version", version)
 			break
 		}
 		backoffDuration := time.Duration(backoff) * time.Second

--- a/agent/backend/worker/worker.go
+++ b/agent/backend/worker/worker.go
@@ -238,8 +238,7 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 		}
 		version, readinessErr = d.Version()
 		if readinessErr == nil {
-			d.logger.Info("worker readiness ok, got version ",
-				"worker_version", version)
+			d.logger.Info("worker readiness ok, got version", "version", version)
 			break
 		}
 		backoffDuration := time.Duration(backoff) * time.Second


### PR DESCRIPTION
This pull request standardizes the logging of readiness messages across several backend components by unifying the log message format and the key used for version information. Instead of using different keys for each backend (e.g., `worker_version`, `snmp_discovery_version`), all readiness logs now use the key `version`. This makes log parsing and monitoring more consistent and easier to maintain.

**Logging consistency improvements:**

* Standardized the readiness log message in `device_discovery.go` to use `"version"` as the key instead of `"device_discovery_version"`.
* Standardized the readiness log message in `network_discovery.go` to use `"version"` as the key instead of `"network_discovery_version"`.
* Standardized the readiness log message in `opentelemetry_infinity.go` to use `"version"` as the key instead of `"opentelemetry_infinity_version"`.
* Standardized the readiness log message in `pktvisor.go` to use `"version"` as the key instead of `"pktvisor_version"`.
* Standardized the readiness log message in `snmp_discovery.go` to use `"version"` as the key instead of `"snmp_discovery_version"`.
* Standardized the readiness log message in `worker.go` to use `"version"` as the key instead of `"worker_version"`.