### PR TITLE
feat: propogate debug flag to worker backend.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/
 .vscode/
 
 docs/.cursor
+
+CLAUDE.md

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -38,6 +38,7 @@ type orbAgent struct {
 	config         config.Config
 	backends       map[string]backend.Backend
 	backendsCommon config.BackendCommons
+	debug          bool
 	ctx            context.Context
 	cancelFunction context.CancelFunc
 	otlpShutdown   func(context.Context) error
@@ -52,7 +53,7 @@ type orbAgent struct {
 var _ Agent = (*orbAgent)(nil)
 
 // New creates a new agent
-func New(logger *slog.Logger, c config.Config) (Agent, error) {
+func New(logger *slog.Logger, c config.Config, debug bool) (Agent, error) {
 	sm := secretsmgr.New(logger, c.OrbAgent.SecretsManager)
 	pm, err := policymgr.New(logger, sm, c)
 	if err != nil {
@@ -75,6 +76,7 @@ func New(logger *slog.Logger, c config.Config) (Agent, error) {
 	return &orbAgent{
 		logger:              logger,
 		config:              c,
+		debug:               debug,
 		policyManager:       pm,
 		configManager:       cm,
 		secretsManager:      sm,
@@ -105,6 +107,7 @@ func (a *orbAgent) startBackends(agentCtx context.Context, cfgBackends map[strin
 		commonConfig = config.BackendCommons{}
 	}
 	commonConfig.Otlp.AgentLabels = labels
+	commonConfig.Debug = a.debug
 	a.backendsCommon = commonConfig
 	delete(cfgBackends, "common")
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -108,7 +108,7 @@ func TestStart_FleetConfig_OverridesExistingOTLPGrpcURL(t *testing.T) {
 		},
 	}
 
-	agent, err := New(logger, cfg)
+	agent, err := New(logger, cfg, false)
 	require.NoError(t, err)
 
 	orbAgent := agent.(*orbAgent)
@@ -151,7 +151,7 @@ func TestStart_FleetConfig_CreatesOTLPSectionWhenMissing(t *testing.T) {
 		},
 	}
 
-	agent, err := New(logger, cfg)
+	agent, err := New(logger, cfg, false)
 	require.NoError(t, err)
 
 	orbAgent := agent.(*orbAgent)
@@ -187,7 +187,7 @@ func TestStart_FleetConfig_CreatesCommonBackendWhenMissing(t *testing.T) {
 		},
 	}
 
-	agent, err := New(logger, cfg)
+	agent, err := New(logger, cfg, false)
 	require.NoError(t, err)
 
 	orbAgent := agent.(*orbAgent)
@@ -230,7 +230,7 @@ func TestStart_NonFleetConfig_DoesNotModifyConfig(t *testing.T) {
 		},
 	}
 
-	agent, err := New(logger, cfg)
+	agent, err := New(logger, cfg, false)
 	require.NoError(t, err)
 
 	orbAgent := agent.(*orbAgent)
@@ -271,7 +271,7 @@ func TestStart_FleetConfig_UsesConfiguredGRPCPort(t *testing.T) {
 		},
 	}
 
-	agent, err := New(logger, cfg)
+	agent, err := New(logger, cfg, false)
 	require.NoError(t, err)
 
 	orbAgent := agent.(*orbAgent)

--- a/agent/backend/worker/worker.go
+++ b/agent/backend/worker/worker.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -49,6 +50,7 @@ type workerBackend struct {
 	diodeTargetFromOtel  bool
 	diodeDryRun          bool
 	diodeDryRunOutputDir string
+	debug                bool // Debug flag from CLI
 
 	startTime  time.Time
 	proc       backend.Commander
@@ -71,12 +73,34 @@ func Register() bool {
 	return true
 }
 
+// checkWorkerSupportsDebug checks if the orb-worker binary supports --debug flag
+func (d *workerBackend) checkWorkerSupportsDebug() bool {
+	cmd := exec.Command(d.exec, "--help")
+	output, err := cmd.Output()
+	if err != nil {
+		d.logger.Warn("unable to check orb-worker help, skipping --debug flag",
+			"error", err)
+		return false
+	}
+
+	supportsDebug := strings.Contains(string(output), "--debug")
+
+	if !supportsDebug {
+		d.logger.Info("orb-worker does not support --debug flag, skipping")
+	} else {
+		d.logger.Debug("orb-worker supports --debug flag")
+	}
+
+	return supportsDebug
+}
+
 func (d *workerBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	config map[string]any, common config.BackendCommons,
 ) error {
 	d.logger = logger.With("backend", "worker")
 	d.policyRepo = repo
 	d.diodeTargetFromOtel = false
+	d.debug = common.Debug
 
 	var prs bool
 	if d.apiHost, prs = config["host"].(string); !prs {
@@ -148,6 +172,12 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 		"--host", d.apiHost,
 		"--port", d.apiPort,
 	}
+
+	// Add debug flag if enabled and worker supports it
+	if d.debug {
+		dOptions = append(dOptions, "--debug")
+	}
+
 	if d.diodeDryRun {
 		dOptions = append([]string{
 			"--dry-run",

--- a/agent/backend/worker/worker.go
+++ b/agent/backend/worker/worker.go
@@ -73,7 +73,6 @@ func Register() bool {
 	return true
 }
 
-// checkWorkerSupportsDebug checks if the orb-worker binary supports --debug flag
 func (d *workerBackend) checkWorkerSupportsDebug() bool {
 	cmd := exec.Command(d.exec, "--help")
 	output, err := cmd.Output()
@@ -86,7 +85,7 @@ func (d *workerBackend) checkWorkerSupportsDebug() bool {
 	supportsDebug := strings.Contains(string(output), "--debug")
 
 	if !supportsDebug {
-		d.logger.Info("orb-worker does not support --debug flag, skipping")
+		d.logger.Debug("orb-worker does not support --debug flag")
 	} else {
 		d.logger.Debug("orb-worker supports --debug flag")
 	}
@@ -174,8 +173,10 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 	}
 
 	// Add debug flag if enabled and worker supports it
-	if d.debug {
+	if d.debug && d.checkWorkerSupportsDebug() {
 		dOptions = append(dOptions, "--debug")
+	} else if d.debug {
+		d.logger.Warn("Debug flag requested but not supported by orb-worker, skipping --debug flag")
 	}
 
 	if d.diodeDryRun {

--- a/agent/backend/worker/worker_debug_test.go
+++ b/agent/backend/worker/worker_debug_test.go
@@ -1,0 +1,59 @@
+package worker
+
+import (
+	"log/slog"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckWorkerSupportsDebug_Supported(t *testing.T) {
+	execPath := createHelpScript(t, `Usage: orb-worker [OPTIONS]
+
+Options:
+  --host         Server host
+  --port         Server port
+  --debug        Enable debug logging
+  --help         Show this message
+`)
+
+	backend := &workerBackend{
+		exec:   execPath,
+		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	assert.True(t, backend.checkWorkerSupportsDebug())
+}
+
+func TestCheckWorkerSupportsDebug_NotSupported(t *testing.T) {
+	execPath := createHelpScript(t, `Usage: orb-worker [OPTIONS]
+
+Options:
+  --host         Server host
+  --port         Server port
+  --help         Show this message
+`)
+
+	backend := &workerBackend{
+		exec:   execPath,
+		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	assert.False(t, backend.checkWorkerSupportsDebug())
+}
+
+func createHelpScript(t *testing.T, helpOutput string) string {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	scriptPath := path.Join(tempDir, "orb-worker")
+
+	script := "#!/bin/sh\necho '" + helpOutput + "'\n"
+	err := os.WriteFile(scriptPath, []byte(script), 0o755)
+	require.NoError(t, err)
+
+	return scriptPath
+}

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -95,6 +95,7 @@ type BackendCommons struct {
 		DryRun          bool   `yaml:"dry_run"`
 		DryRunOutputDir string `yaml:"dry_run_output_dir"`
 	}
+	Debug bool // Debug flag from CLI (not from YAML config)
 }
 
 // OrbAgent represents the configuration for the Orb agent

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -95,7 +95,7 @@ func Run(_ *cobra.Command, _ []string) {
 	logger.Info("backends loaded", "backends", configData.OrbAgent.Backends)
 
 	// new agent
-	a, err := agent.New(logger, configData)
+	a, err := agent.New(logger, configData, debug)
 	if err != nil {
 		logger.Error("agent start up error", "error", err)
 		os.Exit(1)


### PR DESCRIPTION
## Description
This PR introduces support for a debug flag that propagates from the CLI to the agent and down to the worker backend, enabling the orb-worker process to be started with the [--debug](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) flag if supported. The changes include:

- Adding a [debug](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) field to the agent and backend configuration structures.
- Passing the debug flag from the CLI ([main.go](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)) to the agent and worker backend.
- **Implementing logic in the worker backend to check if the orb-worker binary supports the [--debug](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) flag before appending it to the command-line arguments.**
- Updating the agent’s constructor and backend configuration to handle the debug flag.
- Adding unit tests for the worker backend to verify detection of [--debug](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) support.
- Updating [.gitignore](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to include [CLAUDE.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

## Testing
### Unit Tests
- Added [worker_debug_test.go](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to test the detection of [--debug](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) support in the orb-worker binary.
- Updated existing agent tests to use the new agent constructor signature with the debug flag.
- All existing and new tests pass, confirming that the debug flag is correctly handled and that the agent and worker backend behave as expected.Description

### Dev Test
Tested locally against with local aci integration against live cisco-aci lab environment.
- built orb-agent locally
- installed cisco-aci into local python env 
- installed orb-discover worker with [#269 changes](https://github.com/netboxlabs/orb-discovery/pull/269) into local python env
- run orb-agent with debug parameter
```
(venv) ~/local$>DIODE_CLIENT_ID=diode-ingest DIODE_CLIENT_SECRET="***" ./orb-agent run --debug -c orb/agent.yaml
{"time":"2026-02-05T11:25:03.41716-05:00","level":"INFO","msg":"backends loaded","backends":{"common":{"diode":{"agent_name":"agent02","client_id":"${DIODE_CLIENT_ID}","client_secret":"${DIODE_CLIENT_SECRET}","target":"grpc://localhost:8080/diode"}},"worker":{"port":8897}}}
{"time":"2026-02-05T11:25:03.418631-05:00","level":"INFO","msg":"no secrets manager specified or invalid type, skipping"}
{"time":"2026-02-05T11:25:03.418856-05:00","level":"INFO","msg":"agent started","version":"1.0.0","routine":"agentRoutine"}
{"time":"2026-02-05T11:25:03.41886-05:00","level":"INFO","msg":"requested backends","values":{"common":{"diode":{"agent_name":"agent02","client_id":"${DIODE_CLIENT_ID}","client_secret":"${DIODE_CLIENT_SECRET}","target":"grpc://localhost:8080/diode"}},"worker":{"port":8897}}}
{"time":"2026-02-05T11:25:03.419047-05:00","level":"INFO","msg":"registered backends","values":["device_discovery","network_discovery","opentelemetry_infinity","snmp_discovery","pktvisor","worker"]}
{"time":"2026-02-05T11:25:03.419444-05:00","level":"INFO","msg":"worker startup","backend":"worker","arguments":["--diode-target","grpc://localhost:8080/diode","--diode-client-id","${DIODE_CLIENT_ID}","--diode-client-secret","********","--diode-app-name-prefix","agent02","--host","localhost","--port","8897","--debug"]}
{"time":"2026-02-05T11:25:04.127735-05:00","level":"DEBUG","msg":"Debug logging enabled","backend":"worker","module":"worker.main"}
{
...
{"time":"2026-02-05T11:25:05.483668-05:00","level":"DEBUG","msg":"Added site: ACI Fabric","backend":"worker","module":"nbl_cisco_aci.builders.sites"}
{
...
{"time":"2026-02-05T11:25:05.485555-05:00","level":"DEBUG","msg":"Policy custom_policy: Backend execution completed in 0.004 seconds","backend":"worker","module":"worker.policy.runner"}
{
```