### PR TITLE
fix: only updated a run if it's updated

### DIFF
--- a/agent/backend/backend_state.go
+++ b/agent/backend/backend_state.go
@@ -111,7 +111,10 @@ func (manager *stateManager) StartBackendMonitor(name string, be Backend) {
 					manager.logger.Debug("failed to get policy status", "backend", name, "error", err)
 				} else {
 					for _, ps := range statuses {
-						existingRuns := getExistingRuns(manager.policyRepo, ps.Name)
+						existingRuns, err := getExistingRuns(manager.policyRepo, ps.Name)
+						if err != nil {
+							manager.logger.Debug("failed to get existing runs for policy", "policy", ps.Name, "error", err)
+						}
 						runs := convertToRunData(ps.Runs, existingRuns)
 						if err := manager.policyRepo.UpdateRuns(ps.Name, runs); err != nil {
 							manager.logger.Debug("failed to update runs for policy", "policy", ps.Name, "error", err)
@@ -159,13 +162,14 @@ func (manager *stateManager) Get() map[string]*State {
 	return result
 }
 
-// getExistingRuns returns the existing runs for a policy by name, or nil if not found
-func getExistingRuns(repo policies.PolicyRepo, policyName string) []policies.RunData {
+// getExistingRuns returns the existing runs for a policy by name.
+// Returns nil runs and an error if the policy lookup fails.
+func getExistingRuns(repo policies.PolicyRepo, policyName string) ([]policies.RunData, error) {
 	policy, err := repo.GetByName(policyName)
 	if err != nil {
-		return nil
+		return nil, err
 	}
-	return policy.Runs
+	return policy.Runs, nil
 }
 
 // entityCountEqual compares two entity count pointers for equality

--- a/agent/backend/backend_state.go
+++ b/agent/backend/backend_state.go
@@ -111,7 +111,8 @@ func (manager *stateManager) StartBackendMonitor(name string, be Backend) {
 					manager.logger.Debug("failed to get policy status", "backend", name, "error", err)
 				} else {
 					for _, ps := range statuses {
-						runs := convertToRunData(ps.Runs)
+						existingRuns := getExistingRuns(manager.policyRepo, ps.Name)
+						runs := convertToRunData(ps.Runs, existingRuns)
 						if err := manager.policyRepo.UpdateRuns(ps.Name, runs); err != nil {
 							manager.logger.Debug("failed to update runs for policy", "policy", ps.Name, "error", err)
 						}
@@ -158,17 +159,52 @@ func (manager *stateManager) Get() map[string]*State {
 	return result
 }
 
-// convertToRunData converts backend PolicyStatusRun to policies.RunData
-func convertToRunData(statusRuns []PolicyStatusRun) []policies.RunData {
+// getExistingRuns returns the existing runs for a policy by name, or nil if not found
+func getExistingRuns(repo policies.PolicyRepo, policyName string) []policies.RunData {
+	policy, err := repo.GetByName(policyName)
+	if err != nil {
+		return nil
+	}
+	return policy.Runs
+}
+
+// entityCountEqual compares two entity count pointers for equality
+func entityCountEqual(a, b *int64) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+// convertToRunData converts backend PolicyStatusRun to policies.RunData.
+// UpdatedAt is only updated when status, reason, or entity count have changed.
+func convertToRunData(statusRuns []PolicyStatusRun, existingRuns []policies.RunData) []policies.RunData {
+	existingByID := make(map[string]policies.RunData)
+	for _, r := range existingRuns {
+		existingByID[r.ID] = r
+	}
+
 	runs := make([]policies.RunData, len(statusRuns))
 	for i, sr := range statusRuns {
+		updatedAt := sr.UpdatedAt
+		if existing, ok := existingByID[sr.ID]; ok {
+			if sr.Status == existing.Status &&
+				sr.Reason == existing.Reason &&
+				entityCountEqual(sr.EntityCount, existing.EntityCount) {
+				updatedAt = existing.UpdatedAt
+			}
+		}
+
 		runs[i] = policies.RunData{
 			ID:          sr.ID,
 			Status:      sr.Status,
 			Reason:      sr.Reason,
 			EntityCount: sr.EntityCount,
 			CreatedAt:   sr.CreatedAt,
-			UpdatedAt:   sr.UpdatedAt,
+			UpdatedAt:   updatedAt,
 		}
 	}
 	return runs

--- a/agent/backend/backend_state.go
+++ b/agent/backend/backend_state.go
@@ -111,17 +111,17 @@ func (manager *stateManager) StartBackendMonitor(name string, be Backend) {
 				if err != nil {
 					manager.logger.Debug("failed to get policy status", "backend", name, "error", err)
 				} else {
-				for _, ps := range statuses {
-					existingRuns, err := getExistingRuns(manager.policyRepo, ps.Name)
-					if err != nil && !errors.Is(err, policies.ErrPolicyNotFound) {
-						manager.logger.Warn("unexpected error looking up policy runs", "policy", ps.Name, "error", err)
-						continue
+					for _, ps := range statuses {
+						existingRuns, err := getExistingRuns(manager.policyRepo, ps.Name)
+						if err != nil && !errors.Is(err, policies.ErrPolicyNotFound) {
+							manager.logger.Warn("unexpected error looking up policy runs", "policy", ps.Name, "error", err)
+							continue
+						}
+						runs := convertToRunData(ps.Runs, existingRuns)
+						if err := manager.policyRepo.UpdateRuns(ps.Name, runs); err != nil {
+							manager.logger.Debug("failed to update runs for policy", "policy", ps.Name, "error", err)
+						}
 					}
-					runs := convertToRunData(ps.Runs, existingRuns)
-					if err := manager.policyRepo.UpdateRuns(ps.Name, runs); err != nil {
-						manager.logger.Debug("failed to update runs for policy", "policy", ps.Name, "error", err)
-					}
-				}
 				}
 			}
 		}

--- a/agent/backend/backend_state.go
+++ b/agent/backend/backend_state.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -110,16 +111,17 @@ func (manager *stateManager) StartBackendMonitor(name string, be Backend) {
 				if err != nil {
 					manager.logger.Debug("failed to get policy status", "backend", name, "error", err)
 				} else {
-					for _, ps := range statuses {
-						existingRuns, err := getExistingRuns(manager.policyRepo, ps.Name)
-						if err != nil {
-							manager.logger.Debug("failed to get existing runs for policy", "policy", ps.Name, "error", err)
-						}
-						runs := convertToRunData(ps.Runs, existingRuns)
-						if err := manager.policyRepo.UpdateRuns(ps.Name, runs); err != nil {
-							manager.logger.Debug("failed to update runs for policy", "policy", ps.Name, "error", err)
-						}
+				for _, ps := range statuses {
+					existingRuns, err := getExistingRuns(manager.policyRepo, ps.Name)
+					if err != nil && !errors.Is(err, policies.ErrPolicyNotFound) {
+						manager.logger.Warn("unexpected error looking up policy runs", "policy", ps.Name, "error", err)
+						continue
 					}
+					runs := convertToRunData(ps.Runs, existingRuns)
+					if err := manager.policyRepo.UpdateRuns(ps.Name, runs); err != nil {
+						manager.logger.Debug("failed to update runs for policy", "policy", ps.Name, "error", err)
+					}
+				}
 				}
 			}
 		}

--- a/agent/backend/convert_to_run_data_test.go
+++ b/agent/backend/convert_to_run_data_test.go
@@ -1,0 +1,246 @@
+package backend
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/policies"
+)
+
+func TestConvertToRunData_UpdatedAtPreservedWhenUnchanged(t *testing.T) {
+	// When status, reason, and entity count are unchanged, UpdatedAt should be preserved
+	existingUpdatedAt := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	backendUpdatedAt := time.Date(2024, 1, 20, 12, 0, 0, 0, time.UTC) // Newer but should be ignored
+
+	entityCount := int64(42)
+	statusRuns := []PolicyStatusRun{
+		{
+			ID:          "run-1",
+			Status:      "completed",
+			Reason:      "",
+			EntityCount: &entityCount,
+			CreatedAt:   time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt:   backendUpdatedAt,
+		},
+	}
+	existingRuns := []policies.RunData{
+		{
+			ID:          "run-1",
+			Status:      "completed",
+			Reason:      "",
+			EntityCount: &entityCount,
+			CreatedAt:   time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt:   existingUpdatedAt,
+		},
+	}
+
+	runs := convertToRunData(statusRuns, existingRuns)
+
+	require.Len(t, runs, 1)
+	assert.Equal(t, existingUpdatedAt, runs[0].UpdatedAt, "UpdatedAt should be preserved when status, reason, entity count unchanged")
+}
+
+func TestConvertToRunData_UpdatedAtChangedWhenStatusChanges(t *testing.T) {
+	existingUpdatedAt := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	backendUpdatedAt := time.Date(2024, 1, 20, 12, 0, 0, 0, time.UTC)
+
+	entityCount := int64(42)
+	statusRuns := []PolicyStatusRun{
+		{
+			ID:          "run-1",
+			Status:      "failed", // Changed from completed
+			Reason:      "",
+			EntityCount: &entityCount,
+			CreatedAt:   time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt:   backendUpdatedAt,
+		},
+	}
+	existingRuns := []policies.RunData{
+		{
+			ID:          "run-1",
+			Status:      "completed",
+			Reason:      "",
+			EntityCount: &entityCount,
+			CreatedAt:   time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt:   existingUpdatedAt,
+		},
+	}
+
+	runs := convertToRunData(statusRuns, existingRuns)
+
+	require.Len(t, runs, 1)
+	assert.Equal(t, backendUpdatedAt, runs[0].UpdatedAt, "UpdatedAt should be updated when status changes")
+}
+
+func TestConvertToRunData_UpdatedAtChangedWhenReasonChanges(t *testing.T) {
+	existingUpdatedAt := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	backendUpdatedAt := time.Date(2024, 1, 20, 12, 0, 0, 0, time.UTC)
+
+	entityCount := int64(42)
+	statusRuns := []PolicyStatusRun{
+		{
+			ID:          "run-1",
+			Status:      "completed",
+			Reason:      "policy error", // Changed
+			EntityCount: &entityCount,
+			CreatedAt:   time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt:   backendUpdatedAt,
+		},
+	}
+	existingRuns := []policies.RunData{
+		{
+			ID:          "run-1",
+			Status:      "completed",
+			Reason:      "",
+			EntityCount: &entityCount,
+			CreatedAt:   time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt:   existingUpdatedAt,
+		},
+	}
+
+	runs := convertToRunData(statusRuns, existingRuns)
+
+	require.Len(t, runs, 1)
+	assert.Equal(t, backendUpdatedAt, runs[0].UpdatedAt, "UpdatedAt should be updated when reason changes")
+}
+
+func TestConvertToRunData_UpdatedAtChangedWhenEntityCountChanges(t *testing.T) {
+	existingUpdatedAt := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	backendUpdatedAt := time.Date(2024, 1, 20, 12, 0, 0, 0, time.UTC)
+
+	entityCountOld := int64(42)
+	entityCountNew := int64(100)
+	statusRuns := []PolicyStatusRun{
+		{
+			ID:          "run-1",
+			Status:      "completed",
+			Reason:      "",
+			EntityCount: &entityCountNew, // Changed
+			CreatedAt:   time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt:   backendUpdatedAt,
+		},
+	}
+	existingRuns := []policies.RunData{
+		{
+			ID:          "run-1",
+			Status:      "completed",
+			Reason:      "",
+			EntityCount: &entityCountOld,
+			CreatedAt:   time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt:   existingUpdatedAt,
+		},
+	}
+
+	runs := convertToRunData(statusRuns, existingRuns)
+
+	require.Len(t, runs, 1)
+	assert.Equal(t, backendUpdatedAt, runs[0].UpdatedAt, "UpdatedAt should be updated when entity count changes")
+}
+
+func TestConvertToRunData_UpdatedAtFromBackendWhenNewRun(t *testing.T) {
+	// When run doesn't exist in existing runs, use backend's UpdatedAt
+	backendUpdatedAt := time.Date(2024, 1, 20, 12, 0, 0, 0, time.UTC)
+
+	statusRuns := []PolicyStatusRun{
+		{
+			ID:        "run-new",
+			Status:    "completed",
+			Reason:    "",
+			CreatedAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt: backendUpdatedAt,
+		},
+	}
+	existingRuns := []policies.RunData{} // No existing runs
+
+	runs := convertToRunData(statusRuns, existingRuns)
+
+	require.Len(t, runs, 1)
+	assert.Equal(t, backendUpdatedAt, runs[0].UpdatedAt, "UpdatedAt should come from backend for new run")
+}
+
+func TestConvertToRunData_UpdatedAtPreservedWithNilEntityCount(t *testing.T) {
+	// Both nil entity counts should be considered equal
+	existingUpdatedAt := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	backendUpdatedAt := time.Date(2024, 1, 20, 12, 0, 0, 0, time.UTC)
+
+	statusRuns := []PolicyStatusRun{
+		{
+			ID:          "run-1",
+			Status:      "completed",
+			Reason:      "",
+			EntityCount: nil,
+			CreatedAt:   time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt:   backendUpdatedAt,
+		},
+	}
+	existingRuns := []policies.RunData{
+		{
+			ID:          "run-1",
+			Status:      "completed",
+			Reason:      "",
+			EntityCount: nil,
+			CreatedAt:   time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt:   existingUpdatedAt,
+		},
+	}
+
+	runs := convertToRunData(statusRuns, existingRuns)
+
+	require.Len(t, runs, 1)
+	assert.Equal(t, existingUpdatedAt, runs[0].UpdatedAt, "UpdatedAt should be preserved when both entity counts are nil")
+}
+
+func TestConvertToRunData_UpdatedAtChangedWhenEntityCountNilToValue(t *testing.T) {
+	// Going from nil to a value is a change
+	existingUpdatedAt := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	backendUpdatedAt := time.Date(2024, 1, 20, 12, 0, 0, 0, time.UTC)
+	entityCount := int64(42)
+
+	statusRuns := []PolicyStatusRun{
+		{
+			ID:          "run-1",
+			Status:      "completed",
+			Reason:      "",
+			EntityCount: &entityCount,
+			CreatedAt:   time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt:   backendUpdatedAt,
+		},
+	}
+	existingRuns := []policies.RunData{
+		{
+			ID:          "run-1",
+			Status:      "completed",
+			Reason:      "",
+			EntityCount: nil,
+			CreatedAt:   time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt:   existingUpdatedAt,
+		},
+	}
+
+	runs := convertToRunData(statusRuns, existingRuns)
+
+	require.Len(t, runs, 1)
+	assert.Equal(t, backendUpdatedAt, runs[0].UpdatedAt, "UpdatedAt should be updated when entity count changes from nil to value")
+}
+
+func TestConvertToRunData_WithNilExistingRuns(t *testing.T) {
+	// When existingRuns is nil, all runs should use backend's UpdatedAt
+	backendUpdatedAt := time.Date(2024, 1, 20, 12, 0, 0, 0, time.UTC)
+
+	statusRuns := []PolicyStatusRun{
+		{
+			ID:        "run-1",
+			Status:    "completed",
+			CreatedAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt: backendUpdatedAt,
+		},
+	}
+
+	runs := convertToRunData(statusRuns, nil)
+
+	require.Len(t, runs, 1)
+	assert.Equal(t, backendUpdatedAt, runs[0].UpdatedAt)
+}

--- a/agent/policies/repo.go
+++ b/agent/policies/repo.go
@@ -2,8 +2,12 @@ package policies
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 )
+
+// ErrPolicyNotFound is returned when a policy cannot be found by name or ID.
+var ErrPolicyNotFound = errors.New("policy not found")
 
 // PolicyRepo is the interface for policy repositories
 type PolicyRepo interface {
@@ -34,7 +38,7 @@ func (p *policyMemRepo) GetByName(policyName string) (PolicyData, error) {
 	if ok {
 		return p.Get(id)
 	}
-	return PolicyData{}, errors.New("policy name not found")
+	return PolicyData{}, fmt.Errorf("%w: %s", ErrPolicyNotFound, policyName)
 }
 
 // NewMemRepo creates a new in-memory policy repository
@@ -149,11 +153,11 @@ func (p *policyMemRepo) UpdateRuns(policyName string, runs []RunData) error {
 	defer p.mu.Unlock()
 	policyID, ok := p.nameMap[policyName]
 	if !ok {
-		return errors.New("policy name not found")
+		return fmt.Errorf("%w: %s", ErrPolicyNotFound, policyName)
 	}
 	policy, ok := p.db[policyID]
 	if !ok {
-		return errors.New("unknown policy ID")
+		return fmt.Errorf("%w: %s", ErrPolicyNotFound, policyID)
 	}
 	policy.Runs = runs
 	p.db[policyID] = policy

--- a/agent/policies/repo_test.go
+++ b/agent/policies/repo_test.go
@@ -464,7 +464,7 @@ func TestUpdateRuns_NonExistentPolicy(t *testing.T) {
 
 	err = repo.UpdateRuns("non-existent-policy", runs)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "policy name not found")
+	assert.ErrorIs(t, err, policies.ErrPolicyNotFound)
 }
 
 func TestUpdateRuns_GetAllIncludesRuns(t *testing.T) {


### PR DESCRIPTION
This pull request updates how policy run data is synchronized from the backend by ensuring the `UpdatedAt` timestamp only changes if there is a meaningful update (status, reason, or entity count). This prevents unnecessary updates and helps maintain accurate run histories.

**Backend policy run synchronization improvements:**

* Added a new helper function `getExistingRuns` to retrieve existing runs for a policy, enabling comparison with incoming backend data.
* Enhanced `convertToRunData` to accept existing runs and only update the `UpdatedAt` timestamp if the run's status, reason, or entity count has changed, preserving accurate update times.
* Introduced `entityCountEqual` helper to compare entity count values safely, including handling of `nil` pointers.
* Updated the backend monitor logic to use the new `getExistingRuns` and revised `convertToRunData` for more precise run updates.