### PR TITLE
chore: specify min api version to work around dependency issue

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,6 +36,10 @@ jobs:
         with:
           go-version: '1.25.x'
           check-latest: true
+      - name: Configure Docker min API version
+        run: |
+          echo '{"min-api-version": "1.40"}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
       - name: Run go build
         run: go build ./...
       - name: Install additional dependencies
@@ -45,7 +49,7 @@ jobs:
       - name: Run go test
         id: go-test
         run: |
-          DOCKER_MIN_API_VERSION="1.40" make test-coverage
+          make test-coverage
           echo 'coverage-report<<EOF' >> $GITHUB_OUTPUT
           cat .coverage/test-report.md >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,8 +25,6 @@ jobs:
   go-test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    env:
-      DOCKER_MIN_API_VERSION: "1.40"
     defaults:
       run:
         working-directory: .
@@ -47,7 +45,7 @@ jobs:
       - name: Run go test
         id: go-test
         run: |
-          make test-coverage
+          DOCKER_MIN_API_VERSION="1.40" make test-coverage
           echo 'coverage-report<<EOF' >> $GITHUB_OUTPUT
           cat .coverage/test-report.md >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,6 +25,8 @@ jobs:
   go-test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      DOCKER_MIN_API_VERSION: "1.40"
     defaults:
       run:
         working-directory: .

--- a/agent/secretsmgr/vault_test.go
+++ b/agent/secretsmgr/vault_test.go
@@ -837,6 +837,7 @@ func TestNew(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			manager := New(logger, tt.config)
+
 			assert.NotNil(t, manager)
 			assert.Equal(t, tt.expectedType, fmt.Sprintf("%T", manager))
 		})

--- a/agent/secretsmgr/vault_test.go
+++ b/agent/secretsmgr/vault_test.go
@@ -837,7 +837,6 @@ func TestNew(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			manager := New(logger, tt.config)
-
 			assert.NotNil(t, manager)
 			assert.Equal(t, tt.expectedType, fmt.Sprintf("%T", manager))
 		})


### PR DESCRIPTION
This pull request makes a small update to the test workflow configuration by setting the `DOCKER_MIN_API_VERSION` environment variable for the `go-test` job in `.github/workflows/tests.yaml`. This ensures that tests run with a minimum Docker API version requirement.