### PR TITLE
fix: route agent telemetry metrics and traces to telemetry topic

### DIFF
--- a/agent/otlpbridge/handlers.go
+++ b/agent/otlpbridge/handlers.go
@@ -9,11 +9,29 @@ import (
 	collectormetrics "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	collectortrace "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
 
 	"github.com/netboxlabs/orb-agent/agent/policies"
 )
 
 const diodePolicyNameAttributeKey = "diode.metadata.policy_name"
+
+// isIngestRequest reports whether any of the provided resources carry the
+// diode.metadata.policy_name attribute, indicating the payload is Diode data
+// that should be routed to the ingest topic rather than the telemetry topic.
+func isIngestRequest(resources []*resourcev1.Resource) bool {
+	for _, r := range resources {
+		if r == nil {
+			continue
+		}
+		for _, attr := range r.Attributes {
+			if attr != nil && attr.Key == diodePolicyNameAttributeKey && attr.Value != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
 
 // Trace service handler
 type traceServer struct {
@@ -26,9 +44,25 @@ func (s *traceServer) Export(ctx context.Context, req *collectortrace.ExportTrac
 	if pub == nil {
 		return nil, fmt.Errorf("publisher not yet initialized")
 	}
-	topic := s.bridge.GetIngestTopic()
-	if topic == "" {
-		return nil, fmt.Errorf("topic not yet initialized")
+
+	resources := make([]*resourcev1.Resource, 0, len(req.ResourceSpans))
+	for _, rs := range req.ResourceSpans {
+		if rs != nil {
+			resources = append(resources, rs.Resource)
+		}
+	}
+
+	var topic string
+	if isIngestRequest(resources) {
+		topic = s.bridge.GetIngestTopic()
+		if topic == "" {
+			return nil, fmt.Errorf("ingest topic not yet initialized")
+		}
+	} else {
+		topic = s.bridge.GetTelemetryTopic()
+		if topic == "" {
+			return nil, fmt.Errorf("telemetry topic not yet initialized")
+		}
 	}
 
 	payload, err := s.bridge.enc.Marshal(req)
@@ -52,9 +86,25 @@ func (s *metricsServer) Export(ctx context.Context, req *collectormetrics.Export
 	if pub == nil {
 		return nil, fmt.Errorf("publisher not yet initialized")
 	}
-	topic := s.bridge.GetIngestTopic()
-	if topic == "" {
-		return nil, fmt.Errorf("topic not yet initialized")
+
+	resources := make([]*resourcev1.Resource, 0, len(req.ResourceMetrics))
+	for _, rm := range req.ResourceMetrics {
+		if rm != nil {
+			resources = append(resources, rm.Resource)
+		}
+	}
+
+	var topic string
+	if isIngestRequest(resources) {
+		topic = s.bridge.GetIngestTopic()
+		if topic == "" {
+			return nil, fmt.Errorf("ingest topic not yet initialized")
+		}
+	} else {
+		topic = s.bridge.GetTelemetryTopic()
+		if topic == "" {
+			return nil, fmt.Errorf("telemetry topic not yet initialized")
+		}
 	}
 
 	payload, err := s.bridge.enc.Marshal(req)
@@ -95,21 +145,23 @@ func (s *logsServer) Export(ctx context.Context, req *collectorlogs.ExportLogsSe
 	return &collectorlogs.ExportLogsServiceResponse{}, nil
 }
 
-// isIngestRequest checks if the request contains a policy_name attribute in resource or scope attributes
+// isIngestRequest checks if the request contains a policy_name attribute in
+// resource attributes or, for backward compatibility, in scope attributes.
 func (s *logsServer) isIngestRequest(req *collectorlogs.ExportLogsServiceRequest) bool {
+	resources := make([]*resourcev1.Resource, 0, len(req.ResourceLogs))
+	for _, rl := range req.ResourceLogs {
+		if rl != nil {
+			resources = append(resources, rl.Resource)
+		}
+	}
+	if isIngestRequest(resources) {
+		return true
+	}
+	// Backward compatibility: also check ScopeLogs attributes.
 	for _, rl := range req.ResourceLogs {
 		if rl == nil {
 			continue
 		}
-		// Check Resource attributes first
-		if rl.Resource != nil && rl.Resource.Attributes != nil {
-			for _, attr := range rl.Resource.Attributes {
-				if attr != nil && attr.Key == diodePolicyNameAttributeKey && attr.Value != nil {
-					return true
-				}
-			}
-		}
-		// Also check Scope attributes for backward compatibility
 		for _, sl := range rl.ScopeLogs {
 			if sl == nil || sl.Scope == nil || sl.Scope.Attributes == nil {
 				continue

--- a/agent/otlpbridge/handlers_test.go
+++ b/agent/otlpbridge/handlers_test.go
@@ -7,6 +7,10 @@ import (
 	collectorlogs "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	collectormetrics "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	collectortrace "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	metricsv1 "go.opentelemetry.io/proto/otlp/metrics/v1"
+	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
 type fakePublisher struct {
@@ -20,59 +24,105 @@ func (f *fakePublisher) Publish(_ context.Context, topic string, payload []byte)
 	return nil
 }
 
-func TestTraceHandler_Export_Publishes(t *testing.T) {
-	fp := &fakePublisher{}
-	bridge := &BridgeServer{
-		enc: ProtobufEncoder{},
+// diodeResource returns a resource carrying the diode.metadata.policy_name attribute.
+func diodeResource() *resourcev1.Resource {
+	return &resourcev1.Resource{
+		Attributes: []*commonv1.KeyValue{
+			{
+				Key:   diodePolicyNameAttributeKey,
+				Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: "my-policy"}},
+			},
+		},
 	}
+}
+
+func newBridgeWithTopics(enc Encoder) (*BridgeServer, *fakePublisher) {
+	fp := &fakePublisher{}
+	bridge := &BridgeServer{enc: enc}
 	bridge.SetPublisher(fp)
-	bridge.SetIngestTopic("traces")
+	bridge.SetIngestTopic("ingest")
+	bridge.SetTelemetryTopic("telemetry")
+	return bridge, fp
+}
+
+// ---------------------------------------------------------------------------
+// Trace handler
+// ---------------------------------------------------------------------------
+
+func TestTraceHandler_Export_AgentTelemetry_PublishesToTelemetry(t *testing.T) {
+	bridge, fp := newBridgeWithTopics(ProtobufEncoder{})
 	s := &traceServer{bridge: bridge}
 	_, err := s.Export(context.Background(), &collectortrace.ExportTraceServiceRequest{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if fp.topic != "traces" {
-		t.Fatalf("unexpected topic: %s", fp.topic)
+	if fp.topic != "telemetry" {
+		t.Fatalf("expected telemetry topic, got %q", fp.topic)
 	}
-	// Verify that Publish was called (topic should be set)
-	// Empty requests produce empty or nil payloads, which is expected
 }
 
-func TestMetricsHandler_Export_Publishes(t *testing.T) {
-	fp := &fakePublisher{}
-	bridge := &BridgeServer{
-		enc: ProtobufEncoder{},
+func TestTraceHandler_Export_DiodeData_PublishesToIngest(t *testing.T) {
+	bridge, fp := newBridgeWithTopics(ProtobufEncoder{})
+	s := &traceServer{bridge: bridge}
+	req := &collectortrace.ExportTraceServiceRequest{
+		ResourceSpans: []*tracev1.ResourceSpans{
+			{Resource: diodeResource()},
+		},
 	}
-	bridge.SetPublisher(fp)
-	bridge.SetIngestTopic("metrics")
+	_, err := s.Export(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fp.topic != "ingest" {
+		t.Fatalf("expected ingest topic, got %q", fp.topic)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Metrics handler
+// ---------------------------------------------------------------------------
+
+func TestMetricsHandler_Export_AgentTelemetry_PublishesToTelemetry(t *testing.T) {
+	bridge, fp := newBridgeWithTopics(ProtobufEncoder{})
 	s := &metricsServer{bridge: bridge}
 	_, err := s.Export(context.Background(), &collectormetrics.ExportMetricsServiceRequest{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if fp.topic != "metrics" {
-		t.Fatalf("unexpected topic: %s", fp.topic)
+	if fp.topic != "telemetry" {
+		t.Fatalf("expected telemetry topic, got %q", fp.topic)
 	}
-	// Verify that Publish was called (topic should be set)
-	// Empty requests produce empty or nil payloads, which is expected
 }
 
-func TestLogsHandler_Export_Publishes(t *testing.T) {
-	fp := &fakePublisher{}
-	bridge := &BridgeServer{
-		enc: ProtobufEncoder{},
+func TestMetricsHandler_Export_DiodeData_PublishesToIngest(t *testing.T) {
+	bridge, fp := newBridgeWithTopics(ProtobufEncoder{})
+	s := &metricsServer{bridge: bridge}
+	req := &collectormetrics.ExportMetricsServiceRequest{
+		ResourceMetrics: []*metricsv1.ResourceMetrics{
+			{Resource: diodeResource()},
+		},
 	}
-	bridge.SetPublisher(fp)
-	bridge.SetTelemetryTopic("logs")
+	_, err := s.Export(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fp.topic != "ingest" {
+		t.Fatalf("expected ingest topic, got %q", fp.topic)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Logs handler
+// ---------------------------------------------------------------------------
+
+func TestLogsHandler_Export_AgentTelemetry_PublishesToTelemetry(t *testing.T) {
+	bridge, fp := newBridgeWithTopics(ProtobufEncoder{})
 	s := &logsServer{bridge: bridge}
 	_, err := s.Export(context.Background(), &collectorlogs.ExportLogsServiceRequest{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if fp.topic != "logs" {
-		t.Fatalf("unexpected topic: %s", fp.topic)
+	if fp.topic != "telemetry" {
+		t.Fatalf("expected telemetry topic, got %q", fp.topic)
 	}
-	// Verify that Publish was called (topic should be set)
-	// Empty requests produce empty or nil payloads, which is expected
 }


### PR DESCRIPTION
## Summary

- Metrics and traces without the `diode.metadata.policy_name` resource attribute were unconditionally routed to the ingest topic; they should go to the telemetry topic
- Introduces a shared package-level `isIngestRequest([]*resourcev1.Resource) bool` helper used by all three signal handlers to avoid duplication
- The logs handler is refactored to delegate to the shared helper, retaining its scope-attribute fallback for backward compatibility

## Test plan

- [ ] `TestTraceHandler_Export_AgentTelemetry_PublishesToTelemetry` — empty trace request routes to telemetry topic
- [ ] `TestTraceHandler_Export_DiodeData_PublishesToIngest` — trace request with `diode.metadata.policy_name` routes to ingest topic
- [ ] `TestMetricsHandler_Export_AgentTelemetry_PublishesToTelemetry` — empty metrics request routes to telemetry topic
- [ ] `TestMetricsHandler_Export_DiodeData_PublishesToIngest` — metrics request with `diode.metadata.policy_name` routes to ingest topic
- [ ] `TestLogsHandler_Export_AgentTelemetry_PublishesToTelemetry` — empty logs request routes to telemetry topic
- [ ] `go test ./agent/otlpbridge/...` passes
- [ ] `golangci-lint run ./agent/otlpbridge/...` reports 0 issues

Made with [Cursor](https://cursor.com)