### PR TITLE
fix: resolve agent hang on shutdown when stop signal sent during active scan

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -123,7 +123,7 @@ func (a *orbAgent) startBackends(agentCtx context.Context, cfgBackends map[strin
 			a.otlpShutdown = otlpShutdown
 			defer func() {
 				if err != nil {
-					a.shutdownOTLP(agentCtx)
+					a.shutdownOTLP()
 				}
 			}()
 		}
@@ -269,6 +269,7 @@ func (a *orbAgent) Stop(ctx context.Context) {
 			}
 		}
 	}
+	a.shutdownOTLP()
 	if err := a.configManager.Stop(ctx); err != nil {
 		a.logger.Error("error while stopping config manager", slog.Any("error", err))
 	}
@@ -276,7 +277,6 @@ func (a *orbAgent) Stop(ctx context.Context) {
 	if a.cancelFunction != nil {
 		a.cancelFunction()
 	}
-	a.shutdownOTLP(ctx)
 	a.logger.Debug("stopping agent with number of go routines and go calls", "goroutines", runtime.NumGoroutine(), "gocalls", runtime.NumCgoCall())
 	defer func() {
 		if a.cancelFunction != nil {
@@ -285,17 +285,14 @@ func (a *orbAgent) Stop(ctx context.Context) {
 	}()
 }
 
-func (a *orbAgent) shutdownOTLP(ctx context.Context) {
+func (a *orbAgent) shutdownOTLP() {
 	shutdown := a.otlpShutdown
 	if shutdown == nil {
 		return
 	}
 	a.otlpShutdown = nil
 
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	shutdownCtx, cancel := context.WithTimeout(ctx, otlpShutdownTimeout)
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), otlpShutdownTimeout)
 	defer cancel()
 
 	if err := shutdown(shutdownCtx); err != nil {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"runtime"
+	"sync"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -35,14 +36,15 @@ type Agent interface {
 }
 
 type orbAgent struct {
-	logger         *slog.Logger
-	config         config.Config
-	backends       map[string]backend.Backend
-	backendsCommon config.BackendCommons
-	debug          bool
-	ctx            context.Context
-	cancelFunction context.CancelFunc
-	otlpShutdown   func(context.Context) error
+	logger           *slog.Logger
+	config           config.Config
+	backends         map[string]backend.Backend
+	backendsCommon   config.BackendCommons
+	debug            bool
+	ctx              context.Context
+	cancelFunction   context.CancelFunc
+	otlpShutdown     func(context.Context) error
+	otlpShutdownOnce sync.Once
 
 	policyManager       policymgr.PolicyManager
 	configManager       configmgr.Manager
@@ -286,20 +288,21 @@ func (a *orbAgent) Stop(ctx context.Context) {
 }
 
 func (a *orbAgent) shutdownOTLP() {
-	shutdown := a.otlpShutdown
-	if shutdown == nil {
-		return
-	}
-	a.otlpShutdown = nil
+	a.otlpShutdownOnce.Do(func() {
+		shutdown := a.otlpShutdown
+		if shutdown == nil {
+			return
+		}
 
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), otlpShutdownTimeout)
-	defer cancel()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), otlpShutdownTimeout)
+		defer cancel()
 
-	if err := shutdown(shutdownCtx); err != nil {
-		a.logger.Error("error while shutting down OTLP log exporter", "error", err)
-		return
-	}
-	a.logger.Debug("shut down OTLP log exporter")
+		if err := shutdown(shutdownCtx); err != nil {
+			a.logger.Error("error while shutting down OTLP log exporter", "error", err)
+			return
+		}
+		a.logger.Debug("shut down OTLP log exporter")
+	})
 }
 
 func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason string) error {

--- a/agent/otlpbridge/server.go
+++ b/agent/otlpbridge/server.go
@@ -120,13 +120,11 @@ func (s *BridgeServer) Start(ctx context.Context) error {
 	collectorlogs.RegisterLogsServiceServer(s.ingestGRPCServer, &logsServer{bridge: s})
 
 	go func() {
-		err := s.ingestGRPCServer.Serve(lis)
-		if err != nil {
+		if err := s.ingestGRPCServer.Serve(lis); err != nil {
 			s.logger.Error("failed to serve gRPC server", "error", err)
-		} else {
-			s.logger.Info("OTLP bridge server started")
 		}
 	}()
+	s.logger.Info("OTLP bridge server started")
 	return nil
 }
 


### PR DESCRIPTION
This pull request refactors the OTLP shutdown logic in the `orbAgent` and improves the logging behavior in the OTLP bridge server. The main focus is on simplifying the shutdown process by removing unnecessary context passing and ensuring consistent logging.

OTLP shutdown refactoring:

* Changed the `shutdownOTLP` method in `agent/agent.go` to no longer require a context parameter, instead always using a background context with timeout. This simplifies shutdown calls and avoids potential nil context issues.
* Updated all calls to `shutdownOTLP` in `agent/agent.go` to remove the context argument, ensuring consistency with the new method signature. [[1]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bL126-R126) [[2]](diffhunk://#diff-62b6ad581fe3a3059ae8c85ef0f31dde4092bfdecfa7d6857c470bcacaa8cc8bR272-L279)

Logging improvements:

* Moved the "OTLP bridge server started" log statement in `agent/otlpbridge/server.go` outside the gRPC serving goroutine, so it always logs when the server starts, regardless of serve errors.