### PR TITLE
ci: remove JFrog Artifactory publishing

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -16,19 +16,17 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 env:
   GO_VERSION: '1.25'
-  REGISTRY: netboxlabs.jfrog.io
-  IMAGE_NAME: obs-builds/orb-agent
+  REGISTRY: docker.io
+  IMAGE_NAME: netboxlabs/orb-agent
 
 jobs:
   build:
     name: Build (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     permissions:
-      id-token: write
       contents: read
       packages: write
     strategy:
@@ -46,21 +44,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
-      - name: Setup JFrog CLI
-        id: setup-jfrog-cli
-        uses: jfrog/setup-jfrog-cli@ff5cb544114ffc152db9cea1cd3d5978d5074946 # v4.5.11
-        env:
-          JF_URL: https://netboxlabs.jfrog.io
-          JF_PROJECT: obs
-        with:
-          oidc-provider-name: github-ci
-
-      - name: Login to JFrog Artifactory
+      - name: Login to Docker Hub
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ steps.setup-jfrog-cli.outputs.oidc-user }}
-          password: ${{ steps.setup-jfrog-cli.outputs.oidc-token }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set build info
         run: |
@@ -101,7 +89,6 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: build
     permissions:
-      id-token: write
       contents: read
       packages: write
     steps:
@@ -115,37 +102,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
-      - name: Setup JFrog CLI
-        id: setup-jfrog-cli
-        uses: jfrog/setup-jfrog-cli@ff5cb544114ffc152db9cea1cd3d5978d5074946 # v4.5.11
-        env:
-          JF_URL: https://netboxlabs.jfrog.io
-          JF_PROJECT: obs
-        with:
-          oidc-provider-name: github-ci
-
-      - name: Login to JFrog Artifactory
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ steps.setup-jfrog-cli.outputs.oidc-user }}
-          password: ${{ steps.setup-jfrog-cli.outputs.oidc-token }}
-
       - name: Login to Docker Hub
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Create manifest list and push to JFrog
+      - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
             --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.docker_tag || 'develop' }} \
             $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
-
-      - name: Copy manifest to Docker Hub
-        run: |
-          docker buildx imagetools create \
-            --tag netboxlabs/orb-agent:${{ github.event.inputs.docker_tag || 'develop' }} \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.docker_tag || 'develop' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,6 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  id-token: write
 
 jobs:
   get-next-version:
@@ -125,14 +124,13 @@ jobs:
     runs-on: ${{ matrix.runner }}
     if: needs.get-next-version.outputs.new-release-published == 'true'
     permissions:
-      id-token: write
       contents: read
       packages: write
     env:
       BUILD_VERSION: ${{ needs.get-next-version.outputs.new-release-version }}
       BUILD_COMMIT: ${{ needs.get-next-version.outputs.short-sha }}
-      REGISTRY: netboxlabs.jfrog.io
-      IMAGE_NAME: obs-builds/${{ github.event.repository.name }}
+      REGISTRY: docker.io
+      IMAGE_NAME: netboxlabs/orb-agent
     strategy:
       fail-fast: true
       matrix:
@@ -148,21 +146,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
-      - name: Setup JFrog CLI
-        id: setup-jfrog-cli
-        uses: jfrog/setup-jfrog-cli@ff5cb544114ffc152db9cea1cd3d5978d5074946 # v4.5.11
-        env:
-          JF_URL: https://netboxlabs.jfrog.io
-          JF_PROJECT: obs
-        with:
-          oidc-provider-name: github-ci
-
-      - name: Login to JFrog Artifactory
+      - name: Login to Docker Hub
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ steps.setup-jfrog-cli.outputs.oidc-user }}
-          password: ${{ steps.setup-jfrog-cli.outputs.oidc-token }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set build info
         run: |
@@ -202,13 +190,12 @@ jobs:
     needs: [get-next-version, build]
     if: needs.get-next-version.outputs.new-release-published == 'true'
     permissions:
-      id-token: write
       contents: read
       packages: write
     env:
       BUILD_VERSION: ${{ needs.get-next-version.outputs.new-release-version }}
-      REGISTRY: netboxlabs.jfrog.io
-      IMAGE_NAME: obs-builds/${{ github.event.repository.name }}
+      REGISTRY: docker.io
+      IMAGE_NAME: netboxlabs/orb-agent
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
@@ -220,42 +207,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
-      - name: Setup JFrog CLI
-        id: setup-jfrog-cli
-        uses: jfrog/setup-jfrog-cli@ff5cb544114ffc152db9cea1cd3d5978d5074946 # v4.5.11
-        env:
-          JF_URL: https://netboxlabs.jfrog.io
-          JF_PROJECT: obs
-        with:
-          oidc-provider-name: github-ci
-
-      - name: Login to JFrog Artifactory
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ steps.setup-jfrog-cli.outputs.oidc-user }}
-          password: ${{ steps.setup-jfrog-cli.outputs.oidc-token }}
-
       - name: Login to Docker Hub
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Create manifest list and push to JFrog
+      - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
             --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
             --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.BUILD_VERSION }} \
             $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
-
-      - name: Copy manifests to Docker Hub
-        run: |
-          docker buildx imagetools create \
-            --tag netboxlabs/${{ env.APP_NAME }}:latest \
-            --tag netboxlabs/${{ env.APP_NAME }}:${{ env.BUILD_VERSION }} \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
 
   semantic-release:
     name: Semantic release


### PR DESCRIPTION
## Summary
- Simplify multi-arch Docker build to push directly to Docker Hub
- Remove unused intermediate registry steps from `release.yaml` and `develop.yaml`

## Test plan
- [ ] Verify workflow YAML is valid
- [ ] Confirm multi-arch images push to Docker Hub on next develop/release build

🤖 Generated with [Claude Code](https://claude.com/claude-code)