### PR TITLE
chore: run tests when dependencies change

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,6 +58,7 @@ jobs:
         if: always()
         run: cat .coverage/test-report.md
       - name: Find comment
+        if: github.event_name == 'pull_request'
         uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e #v3.1.0
         id: existing-comment
         with:
@@ -65,6 +66,7 @@ jobs:
           comment-author: 'github-actions[bot]'
           body-includes: Go test coverage
       - name: Post comment
+        if: github.event_name == 'pull_request'
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 #v4.0.0
         with:
           comment-id: ${{ steps.existing-comment.outputs.comment-id }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,11 +6,15 @@ on:
     paths:
       - "agent/**"
       - "cmd/**"
+      - "go.mod"
+      - "go.sum"
       - "!agent/docker/**"
   pull_request:
     paths:
       - "agent/**"
       - "cmd/**"
+      - "go.mod"
+      - "go.sum"
       - "!agent/docker/**"
 
 concurrency:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to ensure that changes to Go module files will trigger CI tests. This helps catch dependency-related issues earlier in the development process.

Workflow trigger improvements:

* Updated `.github/workflows/tests.yaml` to include `go.mod` and `go.sum` in the list of paths that trigger the workflow for both `push` and `pull_request` events.