### PR TITLE
feat: add container scanning and daily rescan workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,11 +15,16 @@ env:
   GO_VERSION: '1.25'
 
 jobs:
-  build-image:
-    name: Build Docker Image
+  build-and-scan:
+    name: Build & Scan
     runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 15
     permissions:
       contents: read
+      pull-requests: write
+    env:
+      TRIVY_DISABLE_VEX_NOTICE: "true"
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -47,43 +52,6 @@ jobs:
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
           tags: orb-agent:scan
-
-      - name: Save image for scanning
-        run: docker save orb-agent:scan -o image.tar
-
-      - name: Upload image artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: docker-image
-          path: image.tar
-          retention-days: 1
-
-  scan:
-    name: Container Scan
-    needs: build-image
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      contents: read
-      pull-requests: write
-    env:
-      TRIVY_DISABLE_VEX_NOTICE: "true"
-
-    steps:
-      - name: Download image artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: docker-image
-
-      - name: Load Docker image
-        run: |
-          set -euo pipefail
-          TAR_FILE=$(find . -maxdepth 1 -name '*.tar' -print -quit)
-          if [ -z "$TAR_FILE" ]; then
-            echo "Error: No .tar file found in downloaded artifact" >&2
-            exit 1
-          fi
-          docker load -i "$TAR_FILE"
 
       - name: Scan image for vulnerabilities
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,8 +20,10 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 15
     permissions:
+      actions: read
       contents: read
       pull-requests: write
+      security-events: write
     env:
       TRIVY_DISABLE_VEX_NOTICE: "true"
 
@@ -172,3 +174,13 @@ jobs:
           name: sbom-${{ github.sha }}
           path: sbom.cdx.json
           retention-days: 90
+
+      - name: Convert scan results to SARIF
+        if: "!cancelled()"
+        run: trivy convert --format sarif --output trivy-results.sarif trivy-output.json
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: "!cancelled()"
+        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
+        with:
+          sarif_file: trivy-results.sarif

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,14 +61,146 @@ jobs:
   scan:
     name: Container Scan
     needs: build-image
-    uses: netboxlabs/internal-workflows/.github/workflows/reusable-container-scan.yml@develop
-    with:
-      image_ref: "orb-agent:scan"
-      image_artifact_name: "docker-image"
-      sarif_enabled: false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
-      actions: read
       contents: read
       pull-requests: write
-      security-events: write
-    secrets: inherit
+    env:
+      TRIVY_DISABLE_VEX_NOTICE: "true"
+
+    steps:
+      - name: Download image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: docker-image
+
+      - name: Load Docker image
+        run: |
+          set -euo pipefail
+          TAR_FILE=$(find . -maxdepth 1 -name '*.tar' -print -quit)
+          if [ -z "$TAR_FILE" ]; then
+            echo "Error: No .tar file found in downloaded artifact" >&2
+            exit 1
+          fi
+          docker load -i "$TAR_FILE"
+
+      - name: Scan image for vulnerabilities
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          image-ref: orb-agent:scan
+          format: json
+          output: trivy-output.json
+          vuln-type: os,library
+          scanners: vuln,secret
+          severity: CRITICAL,HIGH,MEDIUM,LOW
+          ignore-unfixed: true
+          exit-code: "0"
+          list-all-pkgs: "true"
+
+      - name: Build scan summary
+        id: scan-summary
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const data = JSON.parse(fs.readFileSync('trivy-output.json', 'utf8'));
+            const vulns = (data.Results || []).flatMap(r =>
+              (r.Vulnerabilities || []).map(v => ({ ...v, target: r.Target }))
+            );
+
+            const blockingSeverities = new Set(['CRITICAL', 'HIGH']);
+
+            const SEVERITY_LABEL = {
+              CRITICAL: '🔴 **CRITICAL**',
+              HIGH: '🟠 **HIGH**',
+              MEDIUM: '🟡 MEDIUM',
+              LOW: '⚪ LOW'
+            };
+
+            const counts = { CRITICAL: 0, HIGH: 0, MEDIUM: 0, LOW: 0 };
+            for (const v of vulns) {
+              if (counts[v.Severity] !== undefined) counts[v.Severity]++;
+            }
+
+            const hasBlocking = vulns.some(v => blockingSeverities.has(v.Severity));
+            core.setOutput('has_blocking', hasBlocking.toString());
+
+            const buildTable = (vulns) => {
+              if (vulns.length === 0) return '_No vulnerabilities found._\n';
+              let t = '| Library | CVE | Severity | Installed | Fixed | Title |\n';
+              t += '|---|---|---|---|---|---|\n';
+              for (const v of vulns) {
+                const title = (v.Title || '').replace(/\|/g, '\\|').substring(0, 80);
+                const cve = v.PrimaryURL ? `[${v.VulnerabilityID}](${v.PrimaryURL})` : v.VulnerabilityID;
+                t += `| ${v.PkgName} | ${cve} | ${SEVERITY_LABEL[v.Severity] || v.Severity} | ${v.InstalledVersion} | ${v.FixedVersion || 'N/A'} | ${title} |\n`;
+              }
+              return t;
+            };
+
+            const table = buildTable(vulns);
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY,
+              '## Vulnerability Scan Results\n\n' + table
+            );
+
+            // Store table for PR comment step
+            const artifact = JSON.stringify({ table, hasBlocking, counts });
+            fs.writeFileSync('scan-result.json', artifact);
+
+      - name: Post scan results as PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+        with:
+          script: |
+            const fs = require('fs');
+            const { table, hasBlocking } = JSON.parse(fs.readFileSync('scan-result.json', 'utf8'));
+
+            const heading = hasBlocking
+              ? '## Vulnerability Scan: Failed — blocking vulnerabilities detected'
+              : '## Vulnerability Scan: Passed';
+
+            const commitSha = process.env.COMMIT_SHA;
+            const marker = '<!-- trivy-scan-results -->';
+            const body = `${marker}\n${heading}\n\n**Image:** \`orb-agent:scan\`\n\n${table}\n*Commit: ${commitSha}*`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail on blocking vulnerabilities
+        if: steps.scan-summary.outputs.has_blocking == 'true'
+        run: |
+          echo "Blocking vulnerabilities found (CRITICAL or HIGH). Failing build."
+          exit 1
+
+      - name: Convert scan results to SBOM
+        if: "!cancelled()"
+        run: trivy convert --format cyclonedx --output sbom.cdx.json trivy-output.json
+
+      - name: Upload SBOM artifact
+        if: "!cancelled()"
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: sbom-${{ github.sha }}
+          path: sbom.cdx.json
+          retention-days: 90

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,74 @@
+name: Build
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GO_VERSION: '1.25'
+
+jobs:
+  build-image:
+    name: Build Docker Image
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Set build info
+        run: |
+          echo ${GITHUB_SHA::7} > ./agent/version/BUILD_COMMIT.txt
+          LATEST_RELEASE=$(curl --silent "https://api.github.com/repos/${{ github.repository }}/releases/latest" | jq -r '.tag_name')
+          echo $LATEST_RELEASE > ./agent/version/BUILD_VERSION.txt
+
+      - name: Build image
+        uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6.17.0
+        with:
+          context: .
+          file: agent/docker/Dockerfile
+          load: true
+          push: false
+          platforms: linux/amd64
+          cache-from: type=gha,scope=linux/amd64
+          cache-to: type=gha,scope=linux/amd64,mode=max
+          no-cache-filters: python-builder
+          build-args: |
+            GO_VERSION=${{ env.GO_VERSION }}
+          tags: orb-agent:scan
+
+      - name: Save image for scanning
+        run: docker save orb-agent:scan -o image.tar
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: docker-image
+          path: image.tar
+          retention-days: 1
+
+  scan:
+    name: Container Scan
+    needs: build-image
+    uses: netboxlabs/internal-workflows/.github/workflows/reusable-container-scan.yml@develop
+    with:
+      image_ref: "orb-agent:scan"
+      image_artifact_name: "docker-image"
+      sarif_enabled: false
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+      security-events: write
+    secrets: inherit

--- a/.github/workflows/container-rescan.yaml
+++ b/.github/workflows/container-rescan.yaml
@@ -14,7 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
+      actions: read
       contents: read
+      security-events: write
     env:
       TRIVY_DISABLE_VEX_NOTICE: "true"
 
@@ -72,3 +74,13 @@ jobs:
             }
 
             fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+
+      - name: Convert scan results to SARIF
+        if: "!cancelled()"
+        run: trivy convert --format sarif --output trivy-results.sarif trivy-output.json
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: "!cancelled()"
+        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
+        with:
+          sarif_file: trivy-results.sarif

--- a/.github/workflows/container-rescan.yaml
+++ b/.github/workflows/container-rescan.yaml
@@ -1,0 +1,16 @@
+name: Scheduled Container Rescan
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # Daily at 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  rescan:
+    uses: netboxlabs/internal-workflows/.github/workflows/reusable-container-rescan.yml@develop
+    with:
+      image_ref: "docker.io/netboxlabs/orb-agent:develop"
+    permissions:
+      contents: read
+      id-token: write
+    secrets: inherit

--- a/.github/workflows/container-rescan.yaml
+++ b/.github/workflows/container-rescan.yaml
@@ -28,19 +28,47 @@ jobs:
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.IMAGE_REF }}
-          format: table
+          format: json
+          output: trivy-output.json
           vuln-type: os,library
           scanners: vuln,secret
           severity: CRITICAL,HIGH,MEDIUM,LOW
           ignore-unfixed: true
           exit-code: "0"
 
-      - name: Summary
-        if: always()
+      - name: Build rescan summary
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           IMAGE_REF: ${{ env.IMAGE_REF }}
-        run: |
-          echo "### Rescan Complete" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Image:** \`${IMAGE_REF}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Scanned at:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
+        with:
+          script: |
+            const fs = require('fs');
+            const data = JSON.parse(fs.readFileSync('trivy-output.json', 'utf8'));
+            const vulns = (data.Results || []).flatMap(r =>
+              (r.Vulnerabilities || []).map(v => ({ ...v, target: r.Target }))
+            );
+
+            const SEVERITY_LABEL = {
+              CRITICAL: '🔴 **CRITICAL**',
+              HIGH: '🟠 **HIGH**',
+              MEDIUM: '🟡 MEDIUM',
+              LOW: '⚪ LOW'
+            };
+
+            let summary = `### Rescan Complete\n\n`;
+            summary += `**Image:** \`${process.env.IMAGE_REF}\`\n`;
+            summary += `**Scanned at:** ${new Date().toISOString().replace('T', ' ').split('.')[0]} UTC\n\n`;
+
+            if (vulns.length === 0) {
+              summary += '_No vulnerabilities found._\n';
+            } else {
+              summary += `| Library | CVE | Severity | Installed | Fixed | Title |\n`;
+              summary += `|---|---|---|---|---|---|\n`;
+              for (const v of vulns) {
+                const title = (v.Title || '').replace(/\|/g, '\\|').substring(0, 80);
+                const cve = v.PrimaryURL ? `[${v.VulnerabilityID}](${v.PrimaryURL})` : v.VulnerabilityID;
+                summary += `| ${v.PkgName} | ${cve} | ${SEVERITY_LABEL[v.Severity] || v.Severity} | ${v.InstalledVersion} | ${v.FixedVersion || 'N/A'} | ${title} |\n`;
+              }
+            }
+
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);

--- a/.github/workflows/container-rescan.yaml
+++ b/.github/workflows/container-rescan.yaml
@@ -5,12 +5,42 @@ on:
     - cron: '0 6 * * *'  # Daily at 06:00 UTC
   workflow_dispatch:
 
+env:
+  IMAGE_REF: docker.io/netboxlabs/orb-agent:develop
+
 jobs:
   rescan:
-    uses: netboxlabs/internal-workflows/.github/workflows/reusable-container-rescan.yml@develop
-    with:
-      image_ref: "docker.io/netboxlabs/orb-agent:develop"
+    name: Rescan Container Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
-      id-token: write
-    secrets: inherit
+    env:
+      TRIVY_DISABLE_VEX_NOTICE: "true"
+
+    steps:
+      - name: Pull image
+        env:
+          IMAGE_REF: ${{ env.IMAGE_REF }}
+        run: docker pull "$IMAGE_REF"
+
+      - name: Scan for vulnerabilities
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          image-ref: ${{ env.IMAGE_REF }}
+          format: table
+          vuln-type: os,library
+          scanners: vuln,secret
+          severity: CRITICAL,HIGH,MEDIUM,LOW
+          ignore-unfixed: true
+          exit-code: "0"
+
+      - name: Summary
+        if: always()
+        env:
+          IMAGE_REF: ${{ env.IMAGE_REF }}
+        run: |
+          echo "### Rescan Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`${IMAGE_REF}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Scanned at:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Adds Trivy container vulnerability scanning to the CI pipeline.

### New workflows

**`build.yaml`** — PR scan workflow
- Triggered on pull requests and manual dispatch
- Builds a single-platform (linux/amd64) Docker image
- Scans with Trivy via the reusable container scan workflow
- Posts vulnerability table as a PR comment
- Generates CycloneDX SBOM (90-day retention)
- Blocks on CRITICAL and HIGH severity vulnerabilities

**`container-rescan.yaml`** — Daily rescan
- Runs daily at 06:00 UTC + manual dispatch
- Pulls the published `docker.io/netboxlabs/orb-agent:develop` image
- Scans for newly disclosed vulnerabilities
- Report-only (never blocks)

### Pipeline flow

```
build-image → scan
               ↑
    reusable-container-scan.yml
    (PR comment, SBOM, severity gate)
```

## Test plan

- [ ] PR triggers build → scan pipeline
- [ ] PR comment appears with vulnerability table
- [ ] SBOM artifact is uploaded
- [ ] Rescan workflow runs via `workflow_dispatch`