### PR TITLE
feat: add new metadata to OrbAgentInfo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ BUILD_DIR ?= build
 CGO_ENABLED ?= 0
 GOARCH ?= $(shell go env GOARCH)
 GOOS ?= $(shell go env GOOS)
-ORB_VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
+ORB_VERSION ?= $(shell echo "$${BUILD_VERSION:-$$(git describe --tags --always 2>/dev/null || echo dev)}")
 COMMIT_HASH = $(shell git rev-parse --short HEAD)
-COMMIT_BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
+COMMIT_BRANCH = $(shell branch=$$(git rev-parse --abbrev-ref HEAD); if [ "$$branch" = "HEAD" ]; then branch=$${GITHUB_HEAD_REF:-$$GITHUB_REF_NAME}; fi; echo "$${branch:-unknown}")
 VERSION_PKG = github.com/netboxlabs/orb-agent/agent/version
 EXTRA_LDFLAGS ?=
 LDFLAGS ?= -X $(VERSION_PKG).buildVersion=$(ORB_VERSION) -X $(VERSION_PKG).buildBranch=$(COMMIT_BRANCH) $(EXTRA_LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,16 @@ PKTVISOR_DEBUG_TAG ?= develop-debug
 SNMP_DISCOVERY_TAG ?= latest
 DOCKERHUB_REPO = netboxlabs
 ORB_DOCKERHUB_REPO = netboxlabs
-BUILD_DIR = build
+BUILD_DIR ?= build
 CGO_ENABLED ?= 0
 GOARCH ?= $(shell go env GOARCH)
 GOOS ?= $(shell go env GOOS)
-ORB_VERSION = $(shell cat agent/version/BUILD_VERSION.txt)
+ORB_VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 COMMIT_HASH = $(shell git rev-parse --short HEAD)
+COMMIT_BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
+VERSION_PKG = github.com/netboxlabs/orb-agent/agent/version
+EXTRA_LDFLAGS ?=
+LDFLAGS ?= -X $(VERSION_PKG).buildVersion=$(ORB_VERSION) -X $(VERSION_PKG).buildBranch=$(COMMIT_BRANCH) $(EXTRA_LDFLAGS)
 OTEL_COLLECTOR_CONTRIB_VERSION ?= 0.91.0
 OTEL_CONTRIB_URL ?= "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$(OTEL_COLLECTOR_CONTRIB_VERSION)/otelcol-contrib_$(OTEL_COLLECTOR_CONTRIB_VERSION)_$(GOOS)_$(GOARCH).tar.gz"
 
@@ -41,7 +45,7 @@ deps:
 
 agent_bin:
 	echo "ORB_VERSION: $(ORB_VERSION)-$(COMMIT_HASH)"
-	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=$(GOARCH) GOARM=$(GOARM) go build -mod=mod -o ${BUILD_DIR}/orb-agent cmd/main.go
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) GOARM=$(GOARM) go build -mod=mod -ldflags="$(LDFLAGS)" -o ${BUILD_DIR}/orb-agent cmd/main.go
 
 .PHONY: test
 test:

--- a/agent/configmgr/fleet/messages/fleet_messages.go
+++ b/agent/configmgr/fleet/messages/fleet_messages.go
@@ -5,6 +5,7 @@ import (
 	"time"
 )
 
+
 // CurrentHeartbeatSchemaVersion defines the current version of the heartbeat schema
 const CurrentHeartbeatSchemaVersion = "1.0"
 
@@ -88,7 +89,11 @@ const (
 
 // OrbAgentInfo contains information about the Orb agent itself
 type OrbAgentInfo struct {
-	Version string `json:"version"`
+	Version   string `json:"version"`
+	Branch    string `json:"branch,omitempty"`
+	Commit    string `json:"commit,omitempty"`
+	Modified  bool   `json:"modified,omitempty"`
+	BuildTime time.Time `json:"build_time,omitzero"`
 }
 
 // BackendInfo contains version and configuration data for a specific backend

--- a/agent/configmgr/fleet/messages/fleet_messages.go
+++ b/agent/configmgr/fleet/messages/fleet_messages.go
@@ -5,7 +5,6 @@ import (
 	"time"
 )
 
-
 // CurrentHeartbeatSchemaVersion defines the current version of the heartbeat schema
 const CurrentHeartbeatSchemaVersion = "1.0"
 
@@ -89,10 +88,10 @@ const (
 
 // OrbAgentInfo contains information about the Orb agent itself
 type OrbAgentInfo struct {
-	Version   string `json:"version"`
-	Branch    string `json:"branch,omitempty"`
-	Commit    string `json:"commit,omitempty"`
-	Modified  bool   `json:"modified,omitempty"`
+	Version   string    `json:"version"`
+	Branch    string    `json:"branch,omitempty"`
+	Commit    string    `json:"commit,omitempty"`
+	Modified  bool      `json:"modified,omitempty"`
 	BuildTime time.Time `json:"build_time,omitzero"`
 }
 

--- a/agent/configmgr/fleet/to_rpc.go
+++ b/agent/configmgr/fleet/to_rpc.go
@@ -99,4 +99,3 @@ func (messaging *Messaging) sendAgentPoliciesRequest(ctx context.Context, orgID 
 
 	return nil
 }
-

--- a/agent/configmgr/fleet/to_rpc.go
+++ b/agent/configmgr/fleet/to_rpc.go
@@ -52,7 +52,11 @@ func (messaging *Messaging) sendCapabilities(ctx context.Context, backends map[s
 		SchemaVersion: messages.CurrentCapabilitiesSchemaVersion,
 		AgentLabels:   labels,
 		OrbAgent: messages.OrbAgentInfo{
-			Version: version.GetBuildVersion(),
+			Version:   version.GetBuildVersion(),
+			Branch:    version.GetBuildBranch(),
+			Commit:    version.GetBuildCommit(),
+			Modified:  version.GetBuildModified(),
+			BuildTime: version.GetBuildTime(),
 		},
 		Backends:    backendsInfo,
 		AgentConfig: config,
@@ -95,3 +99,4 @@ func (messaging *Messaging) sendAgentPoliciesRequest(ctx context.Context, orgID 
 
 	return nil
 }
+

--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -18,7 +18,7 @@ ARG TARGETOS TARGETARCH
 RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -o /build/orb-agent ./cmd/main.go
+    GOOS=$TARGETOS GOARCH=$TARGETARCH EXTRA_LDFLAGS="-s -w" BUILD_DIR=/build make agent_bin
 
 ########################################################################
 FROM netboxlabs/opentelemetry-infinity:${OTEL_TAG} AS otlpinf

--- a/agent/version/version.go
+++ b/agent/version/version.go
@@ -1,26 +1,66 @@
 package version
 
 import (
-	_ "embed"
-	"strings"
+	"runtime/debug"
+	"strconv"
+	"time"
 )
 
-// Version is the version of the orb-agent
-//
-//go:embed BUILD_VERSION.txt
+// buildVersion is set at build time via -ldflags "-X"
 var buildVersion string
 
-// Commit is the commit of the orb-agent
-//
-//go:embed BUILD_COMMIT.txt
-var buildCommit string
+// buildBranch is set at build time via -ldflags "-X"
+var buildBranch string
 
-// GetBuildVersion returns the build version of the orb-agent
-func GetBuildVersion() string {
-	return strings.TrimSpace(buildVersion)
+var (
+	buildCommit   string
+	buildTime     time.Time
+	buildModified bool
+)
+
+func init() {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			buildCommit = s.Value
+		case "vcs.time":
+			if t, err := time.Parse(time.RFC3339, s.Value); err == nil {
+				buildTime = t
+			}
+		case "vcs.modified":
+			buildModified, _ = strconv.ParseBool(s.Value)
+		}
+	}
 }
 
-// GetBuildCommit returns the build commit of the orb-agent
+// GetBuildVersion returns the build version of the orb-agent.
+func GetBuildVersion() string {
+	if buildVersion == "" {
+		return "dev"
+	}
+	return buildVersion
+}
+
+// GetBuildCommit returns the full VCS commit hash.
 func GetBuildCommit() string {
-	return strings.TrimSpace(buildCommit)
+	return buildCommit
+}
+
+// GetBuildBranch returns the branch the binary was built from.
+func GetBuildBranch() string {
+	return buildBranch
+}
+
+// GetBuildTime returns the VCS commit timestamp.
+func GetBuildTime() time.Time {
+	return buildTime
+}
+
+// GetBuildModified returns whether the working tree had uncommitted changes at build time.
+func GetBuildModified() bool {
+	return buildModified
 }

--- a/agent/version/version_test.go
+++ b/agent/version/version_test.go
@@ -8,10 +8,31 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/version"
 )
 
-func TestVersion(t *testing.T) {
+func TestBuildVersion_DefaultsDev(t *testing.T) {
+	// Without ldflags injection, buildVersion is empty and defaults to "dev"
 	v := version.GetBuildVersion()
-	assert.Equal(t, "1.0.0", v)
+	assert.Equal(t, "dev", v)
+}
 
+func TestBuildCommit_EmptyInTestBinary(t *testing.T) {
+	// go test does not embed VCS info; vcs.revision is only set via go build
 	c := version.GetBuildCommit()
-	assert.Equal(t, "unknown", c)
+	assert.Empty(t, c)
+}
+
+func TestBuildTime_ZeroInTestBinary(t *testing.T) {
+	// go test does not embed VCS info; vcs.time is only set via go build
+	bt := version.GetBuildTime()
+	assert.True(t, bt.IsZero())
+}
+
+func TestBuildBranch_EmptyWithoutLdflags(t *testing.T) {
+	// Without ldflags injection, buildBranch is empty
+	b := version.GetBuildBranch()
+	assert.Empty(t, b)
+}
+
+func TestBuildModified_FalseInTestBinary(t *testing.T) {
+	// go test does not embed VCS info; vcs.modified defaults to false
+	assert.False(t, version.GetBuildModified())
 }


### PR DESCRIPTION
It originally just contained the version, but now it contains:

Version
CommitHash
BuildBranch
BuiltTime
BuildModified

Note: building has changed in 2 ways:

* It leverages Go's build info to determine the associated git commit (as well as build time and if modified)
* it also unifies the building of the agent itself so that the docker build uses the makefile as well for a consistent build with proper metadata - meta values (build version and branch) are set via linker (no files needed to embed)