### PR TITLE
fix: (configmgr) Azure DevOps git fallback using system git

### DIFF
--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -32,6 +32,12 @@ import (
 // IsAzureDevOpsURL reports whether url points to an Azure DevOps repository.
 // Azure DevOps is incompatible with go-git's pack protocol negotiation; these
 // repos require a system git fallback.
+//
+// TODO: Remove IsAzureDevOpsURL, cloneWithSystemGit, fetchWithSystemGit, and
+// the ADO branches in Start()/schedule()/Stop() once go-git v6 is released.
+// Full multi_ack/multi_ack_detailed support was merged to go-git main at
+// commit 14eabbda76d37e2dfcfa25b3ac236f2365adb6da but targets v6.
+// Tracking issue: https://github.com/go-git/go-git/issues/64
 func IsAzureDevOpsURL(rawURL string) bool {
 	return strings.Contains(rawURL, "dev.azure.com") ||
 		strings.Contains(rawURL, "visualstudio.com")

--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -82,7 +82,7 @@ func writeAskpassScript(password string) (string, error) {
 		_ = os.Remove(f.Name())
 		return "", fmt.Errorf("failed to write askpass script: %w", err)
 	}
-	if err := os.Chmod(f.Name(), 0700); err != nil {
+	if err := os.Chmod(f.Name(), 0o700); err != nil {
 		_ = os.Remove(f.Name())
 		return "", fmt.Errorf("failed to chmod askpass script: %w", err)
 	}

--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"net/url"
 	"os"
 	"os/exec"
 	"slices"
@@ -68,6 +67,35 @@ type (
 	}
 )
 
+// writeAskpassScript writes a minimal GIT_ASKPASS helper script to a temp
+// file that echoes the password without exposing it in argv.  The script is
+// chmod 0700 so only the current user can read or execute it.  The caller is
+// responsible for removing the file when done.
+func writeAskpassScript(password string) (string, error) {
+	f, err := os.CreateTemp("", "git-askpass-*.sh")
+	if err != nil {
+		return "", fmt.Errorf("failed to create askpass script: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	script := "#!/bin/sh\necho " + shellescape(password) + "\n"
+	if _, err := f.WriteString(script); err != nil {
+		_ = os.Remove(f.Name())
+		return "", fmt.Errorf("failed to write askpass script: %w", err)
+	}
+	if err := os.Chmod(f.Name(), 0700); err != nil {
+		_ = os.Remove(f.Name())
+		return "", fmt.Errorf("failed to chmod askpass script: %w", err)
+	}
+	return f.Name(), nil
+}
+
+// shellescape single-quote escapes a string for safe embedding in a POSIX
+// shell script.
+func shellescape(s string) string {
+	// Wrap in single quotes; any literal single quote inside becomes '\''
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
 // cloneWithSystemGit clones the repository using the system git binary to a
 // temporary directory.  It is used as a fallback for hosts (e.g. Azure DevOps)
 // that are incompatible with go-git's pack-protocol negotiation.
@@ -86,13 +114,16 @@ func (gc *gitConfigManager) cloneWithSystemGit(branch string) (string, *gitv5.Re
 
 	switch gc.config.Auth {
 	case "basic":
-		u, err := url.Parse(gc.config.URL)
+		askpass, err := writeAskpassScript(gc.config.Password)
 		if err != nil {
 			_ = os.RemoveAll(dir)
-			return "", nil, fmt.Errorf("failed to parse git URL: %w", err)
+			return "", nil, err
 		}
-		u.User = url.UserPassword(gc.config.Username, gc.config.Password)
-		cloneURL = u.String()
+		defer func() { _ = os.Remove(askpass) }()
+		env = append(env,
+			"GIT_ASKPASS="+askpass,
+			"GIT_USERNAME="+gc.config.Username,
+		)
 	case "ssh":
 		if gc.config.PrivateKey != "" {
 			env = append(env,
@@ -137,12 +168,15 @@ func (gc *gitConfigManager) fetchWithSystemGit() error {
 	fetchURL := gc.config.URL
 	switch gc.config.Auth {
 	case "basic":
-		u, err := url.Parse(gc.config.URL)
+		askpass, err := writeAskpassScript(gc.config.Password)
 		if err != nil {
-			return fmt.Errorf("failed to parse git URL for fetch: %w", err)
+			return err
 		}
-		u.User = url.UserPassword(gc.config.Username, gc.config.Password)
-		fetchURL = u.String()
+		defer func() { _ = os.Remove(askpass) }()
+		env = append(env,
+			"GIT_ASKPASS="+askpass,
+			"GIT_USERNAME="+gc.config.Username,
+		)
 	case "ssh":
 		if gc.config.PrivateKey != "" {
 			env = append(env,

--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -114,20 +114,33 @@ func (gc *gitConfigManager) cloneWithSystemGit(branch string) (string, *gitv5.Re
 	return dir, repo, nil
 }
 
-// fetchWithSystemGit runs "git fetch --all" in the on-disk clone directory.
+// fetchWithSystemGit runs "git fetch" with an explicit refspec to update refs/heads/<branch>.
 // Used for scheduled updates when the system git fallback is active.
 func (gc *gitConfigManager) fetchWithSystemGit() error {
 	if gc.tempDir == "" {
 		return errors.New("system git fallback not initialized; clone must be called first")
 	}
 	env := append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
-	if gc.config.Auth == "ssh" && gc.config.PrivateKey != "" {
-		env = append(env,
-			"GIT_SSH_COMMAND=ssh -i '"+gc.config.PrivateKey+
-				"' -o StrictHostKeyChecking=no -o BatchMode=yes")
+
+	fetchURL := gc.config.URL
+	switch gc.config.Auth {
+	case "basic":
+		u, err := url.Parse(gc.config.URL)
+		if err != nil {
+			return fmt.Errorf("failed to parse git URL for fetch: %w", err)
+		}
+		u.User = url.UserPassword(gc.config.Username, gc.config.Password)
+		fetchURL = u.String()
+	case "ssh":
+		if gc.config.PrivateKey != "" {
+			env = append(env,
+				"GIT_SSH_COMMAND=ssh -i '"+gc.config.PrivateKey+
+					"' -o StrictHostKeyChecking=no -o BatchMode=yes")
+		}
 	}
 
-	cmd := exec.Command("git", "-C", gc.tempDir, "fetch", "--all")
+	refspec := "refs/heads/" + gc.config.Branch + ":refs/heads/" + gc.config.Branch
+	cmd := exec.Command("git", "-C", gc.tempDir, "fetch", fetchURL, refspec)
 	cmd.Env = env
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("system git fetch failed: %w\n%s", err, out)

--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -71,13 +71,17 @@ type (
 // file that echoes the password without exposing it in argv.  The script is
 // chmod 0700 so only the current user can read or execute it.  The caller is
 // responsible for removing the file when done.
-func writeAskpassScript(password string) (string, error) {
+func writeAskpassScript(username, password string) (string, error) {
 	f, err := os.CreateTemp("", "git-askpass-*.sh")
 	if err != nil {
 		return "", fmt.Errorf("failed to create askpass script: %w", err)
 	}
 	defer func() { _ = f.Close() }()
-	script := "#!/bin/sh\necho " + shellescape(password) + "\n"
+	// Git calls GIT_ASKPASS with the prompt text as $1.  We match on
+	// "username" (case-insensitive) to return the right value for each prompt.
+	script := "#!/bin/sh\ncase \"$1\" in\n  *[Uu]sername*) echo " +
+		shellescape(username) + " ;;\n  *) echo " +
+		shellescape(password) + " ;;\nesac\n"
 	if _, err := f.WriteString(script); err != nil {
 		_ = os.Remove(f.Name())
 		return "", fmt.Errorf("failed to write askpass script: %w", err)
@@ -114,7 +118,7 @@ func (gc *gitConfigManager) cloneWithSystemGit(branch string) (string, *gitv5.Re
 
 	switch gc.config.Auth {
 	case "basic":
-		askpass, err := writeAskpassScript(gc.config.Password)
+		askpass, err := writeAskpassScript(gc.config.Username, gc.config.Password)
 		if err != nil {
 			_ = os.RemoveAll(dir)
 			return "", nil, err
@@ -168,7 +172,7 @@ func (gc *gitConfigManager) fetchWithSystemGit() error {
 	fetchURL := gc.config.URL
 	switch gc.config.Auth {
 	case "basic":
-		askpass, err := writeAskpassScript(gc.config.Password)
+		askpass, err := writeAskpassScript(gc.config.Username, gc.config.Password)
 		if err != nil {
 			return err
 		}

--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -7,9 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"os/exec"
 	"slices"
-	"strings"
 
 	"github.com/go-co-op/gocron/v2"
 	gitv5 "github.com/go-git/go-git/v5"
@@ -27,20 +25,6 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/policymgr"
 )
-
-// IsAzureDevOpsURL reports whether url points to an Azure DevOps repository.
-// Azure DevOps is incompatible with go-git's pack protocol negotiation; these
-// repos require a system git fallback.
-//
-// TODO: Remove IsAzureDevOpsURL, cloneWithSystemGit, fetchWithSystemGit, and
-// the ADO branches in Start()/schedule()/Stop() once go-git v6 is released.
-// Full multi_ack/multi_ack_detailed support was merged to go-git main at
-// commit 14eabbda76d37e2dfcfa25b3ac236f2365adb6da but targets v6.
-// Tracking issue: https://github.com/go-git/go-git/issues/64
-func IsAzureDevOpsURL(rawURL string) bool {
-	return strings.Contains(rawURL, "dev.azure.com") ||
-		strings.Contains(rawURL, "visualstudio.com")
-}
 
 var _ Manager = (*gitConfigManager)(nil)
 
@@ -66,137 +50,6 @@ type (
 		Name    string
 	}
 )
-
-// writeAskpassScript writes a minimal GIT_ASKPASS helper script to a temp
-// file that echoes the password without exposing it in argv.  The script is
-// chmod 0700 so only the current user can read or execute it.  The caller is
-// responsible for removing the file when done.
-func writeAskpassScript(username, password string) (string, error) {
-	f, err := os.CreateTemp("", "git-askpass-*.sh")
-	if err != nil {
-		return "", fmt.Errorf("failed to create askpass script: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-	// Git calls GIT_ASKPASS with the prompt text as $1.  We match on
-	// "username" (case-insensitive) to return the right value for each prompt.
-	script := "#!/bin/sh\ncase \"$1\" in\n  *[Uu]sername*) echo " +
-		shellescape(username) + " ;;\n  *) echo " +
-		shellescape(password) + " ;;\nesac\n"
-	if _, err := f.WriteString(script); err != nil {
-		_ = os.Remove(f.Name())
-		return "", fmt.Errorf("failed to write askpass script: %w", err)
-	}
-	if err := os.Chmod(f.Name(), 0o700); err != nil {
-		_ = os.Remove(f.Name())
-		return "", fmt.Errorf("failed to chmod askpass script: %w", err)
-	}
-	return f.Name(), nil
-}
-
-// shellescape single-quote escapes a string for safe embedding in a POSIX
-// shell script.
-func shellescape(s string) string {
-	// Wrap in single quotes; any literal single quote inside becomes '\''
-	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
-}
-
-// cloneWithSystemGit clones the repository using the system git binary to a
-// temporary directory.  It is used as a fallback for hosts (e.g. Azure DevOps)
-// that are incompatible with go-git's pack-protocol negotiation.
-// The caller is responsible for removing the returned directory when done.
-func (gc *gitConfigManager) cloneWithSystemGit(branch string) (string, *gitv5.Repository, error) {
-	dir, err := os.MkdirTemp("", "orb-git-*")
-	if err != nil {
-		return "", nil, fmt.Errorf("failed to create temp dir for git clone: %w", err)
-	}
-
-	cloneURL := gc.config.URL
-	env := append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
-	if gc.config.SkipTLS {
-		env = append(env, "GIT_SSL_NO_VERIFY=true")
-	}
-
-	switch gc.config.Auth {
-	case "basic":
-		askpass, err := writeAskpassScript(gc.config.Username, gc.config.Password)
-		if err != nil {
-			_ = os.RemoveAll(dir)
-			return "", nil, err
-		}
-		defer func() { _ = os.Remove(askpass) }()
-		env = append(env,
-			"GIT_ASKPASS="+askpass,
-			"GIT_USERNAME="+gc.config.Username,
-		)
-	case "ssh":
-		if gc.config.PrivateKey != "" {
-			env = append(env,
-				"GIT_SSH_COMMAND=ssh -i '"+gc.config.PrivateKey+
-					"' -o StrictHostKeyChecking=no -o BatchMode=yes")
-		}
-	}
-
-	args := []string{"clone"}
-	if branch != "" {
-		args = append(args, "--branch", branch, "--single-branch")
-	}
-	args = append(args, cloneURL, dir)
-
-	cmd := exec.Command("git", args...)
-	cmd.Env = env
-	if out, err := cmd.CombinedOutput(); err != nil {
-		_ = os.RemoveAll(dir)
-		return "", nil, fmt.Errorf("system git clone failed: %w\n%s", err, out)
-	}
-
-	repo, err := gitv5.PlainOpen(dir)
-	if err != nil {
-		_ = os.RemoveAll(dir)
-		return "", nil, fmt.Errorf("failed to open cloned repo: %w", err)
-	}
-
-	return dir, repo, nil
-}
-
-// fetchWithSystemGit runs "git fetch" with an explicit refspec to update refs/heads/<branch>.
-// Used for scheduled updates when the system git fallback is active.
-func (gc *gitConfigManager) fetchWithSystemGit() error {
-	if gc.tempDir == "" {
-		return errors.New("system git fallback not initialized; clone must be called first")
-	}
-	env := append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
-	if gc.config.SkipTLS {
-		env = append(env, "GIT_SSL_NO_VERIFY=true")
-	}
-
-	fetchURL := gc.config.URL
-	switch gc.config.Auth {
-	case "basic":
-		askpass, err := writeAskpassScript(gc.config.Username, gc.config.Password)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = os.Remove(askpass) }()
-		env = append(env,
-			"GIT_ASKPASS="+askpass,
-			"GIT_USERNAME="+gc.config.Username,
-		)
-	case "ssh":
-		if gc.config.PrivateKey != "" {
-			env = append(env,
-				"GIT_SSH_COMMAND=ssh -i '"+gc.config.PrivateKey+
-					"' -o StrictHostKeyChecking=no -o BatchMode=yes")
-		}
-	}
-
-	refspec := "refs/heads/" + gc.config.Branch + ":refs/heads/" + gc.config.Branch
-	cmd := exec.Command("git", "-C", gc.tempDir, "fetch", "--update-head-ok", fetchURL, refspec)
-	cmd.Env = env
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("system git fetch failed: %w\n%s", err, out)
-	}
-	return nil
-}
 
 func (gc *gitConfigManager) readPolicies(tree *object.Tree, matchingPolicies []string) (map[policyPath]policyData, error) {
 	policiesByPath := make(map[policyPath]policyData)

--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"slices"
+	"strings"
 
 	"github.com/go-co-op/gocron/v2"
 	gitv5 "github.com/go-git/go-git/v5"
@@ -23,6 +24,14 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/policymgr"
 )
+
+// IsAzureDevOpsURL reports whether url points to an Azure DevOps repository.
+// Azure DevOps is incompatible with go-git's pack protocol negotiation; these
+// repos require a system git fallback.
+func IsAzureDevOpsURL(rawURL string) bool {
+	return strings.Contains(rawURL, "dev.azure.com") ||
+		strings.Contains(rawURL, "visualstudio.com")
+}
 
 var _ Manager = (*gitConfigManager)(nil)
 

--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -87,8 +87,8 @@ func (gc *gitConfigManager) cloneWithSystemGit(branch string) (string, *gitv5.Re
 	case "ssh":
 		if gc.config.PrivateKey != "" {
 			env = append(env,
-				"GIT_SSH_COMMAND=ssh -i "+gc.config.PrivateKey+
-					" -o StrictHostKeyChecking=no -o BatchMode=yes")
+				"GIT_SSH_COMMAND=ssh -i '"+gc.config.PrivateKey+
+					"' -o StrictHostKeyChecking=no -o BatchMode=yes")
 		}
 	}
 
@@ -117,11 +117,14 @@ func (gc *gitConfigManager) cloneWithSystemGit(branch string) (string, *gitv5.Re
 // fetchWithSystemGit runs "git fetch --all" in the on-disk clone directory.
 // Used for scheduled updates when the system git fallback is active.
 func (gc *gitConfigManager) fetchWithSystemGit() error {
+	if gc.tempDir == "" {
+		return errors.New("system git fallback not initialized; clone must be called first")
+	}
 	env := append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 	if gc.config.Auth == "ssh" && gc.config.PrivateKey != "" {
 		env = append(env,
-			"GIT_SSH_COMMAND=ssh -i "+gc.config.PrivateKey+
-				" -o StrictHostKeyChecking=no -o BatchMode=yes")
+			"GIT_SSH_COMMAND=ssh -i '"+gc.config.PrivateKey+
+				"' -o StrictHostKeyChecking=no -o BatchMode=yes")
 	}
 
 	cmd := exec.Command("git", "-C", gc.tempDir, "fetch", "--all")

--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -3,8 +3,12 @@ package configmgr
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
+	"net/url"
+	"os"
+	"os/exec"
 	"slices"
 	"strings"
 
@@ -46,6 +50,7 @@ type gitConfigManager struct {
 	version          int32
 	matchPolicyPaths []string
 	namespace        uuid.UUID
+	tempDir          string // non-empty when using system git fallback (Azure DevOps)
 }
 
 type (
@@ -56,6 +61,76 @@ type (
 		Name    string
 	}
 )
+
+// cloneWithSystemGit clones the repository using the system git binary to a
+// temporary directory.  It is used as a fallback for hosts (e.g. Azure DevOps)
+// that are incompatible with go-git's pack-protocol negotiation.
+// The caller is responsible for removing the returned directory when done.
+func (gc *gitConfigManager) cloneWithSystemGit(branch string) (string, *gitv5.Repository, error) {
+	dir, err := os.MkdirTemp("", "orb-git-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create temp dir for git clone: %w", err)
+	}
+
+	cloneURL := gc.config.URL
+	env := append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+
+	switch gc.config.Auth {
+	case "basic":
+		u, err := url.Parse(gc.config.URL)
+		if err != nil {
+			_ = os.RemoveAll(dir)
+			return "", nil, fmt.Errorf("failed to parse git URL: %w", err)
+		}
+		u.User = url.UserPassword(gc.config.Username, gc.config.Password)
+		cloneURL = u.String()
+	case "ssh":
+		if gc.config.PrivateKey != "" {
+			env = append(env,
+				"GIT_SSH_COMMAND=ssh -i "+gc.config.PrivateKey+
+					" -o StrictHostKeyChecking=no -o BatchMode=yes")
+		}
+	}
+
+	args := []string{"clone"}
+	if branch != "" {
+		args = append(args, "--branch", branch, "--single-branch")
+	}
+	args = append(args, cloneURL, dir)
+
+	cmd := exec.Command("git", args...)
+	cmd.Env = env
+	if out, err := cmd.CombinedOutput(); err != nil {
+		_ = os.RemoveAll(dir)
+		return "", nil, fmt.Errorf("system git clone failed: %w\n%s", err, out)
+	}
+
+	repo, err := gitv5.PlainOpen(dir)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		return "", nil, fmt.Errorf("failed to open cloned repo: %w", err)
+	}
+
+	return dir, repo, nil
+}
+
+// fetchWithSystemGit runs "git fetch --all" in the on-disk clone directory.
+// Used for scheduled updates when the system git fallback is active.
+func (gc *gitConfigManager) fetchWithSystemGit() error {
+	env := append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if gc.config.Auth == "ssh" && gc.config.PrivateKey != "" {
+		env = append(env,
+			"GIT_SSH_COMMAND=ssh -i "+gc.config.PrivateKey+
+				" -o StrictHostKeyChecking=no -o BatchMode=yes")
+	}
+
+	cmd := exec.Command("git", "-C", gc.tempDir, "fetch", "--all")
+	cmd.Env = env
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("system git fetch failed: %w\n%s", err, out)
+	}
+	return nil
+}
 
 func (gc *gitConfigManager) readPolicies(tree *object.Tree, matchingPolicies []string) (map[policyPath]policyData, error) {
 	policiesByPath := make(map[policyPath]policyData)

--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -461,68 +461,93 @@ func (gc *gitConfigManager) Start(cfg config.Config, backends map[string]backend
 		return err
 	}
 
-	// Open an in-memory repository
-	repo, err := gitv5.Init(memory.NewStorage(), nil)
-	if err != nil {
-		return err
-	}
+	var branchName string
 
-	// Add the remote
-	if _, err = repo.CreateRemote(&gitconfig.RemoteConfig{
-		Name: "origin",
-		URLs: []string{gc.config.URL},
-	}); err != nil {
-		return err
-	}
+	if IsAzureDevOpsURL(gc.config.URL) {
+		gc.logger.Info("Azure DevOps URL detected, using system git fallback", "url", gc.config.URL)
+		branchName = gc.config.Branch // may be empty; cloneWithSystemGit handles that
 
-	// Fetch all branches and references
-	if err = repo.Fetch(&gitv5.FetchOptions{
-		RemoteName:      "origin",
-		Auth:            gc.authMethod,
-		InsecureSkipTLS: gc.config.SkipTLS,
-	}); err != nil && err != gitv5.NoErrAlreadyUpToDate {
-		return err
-	}
+		var dir string
+		dir, gc.repo, err = gc.cloneWithSystemGit(branchName)
+		if err != nil {
+			return err
+		}
+		gc.tempDir = dir
 
-	// Get the remote reference list
-	remote, err := repo.Remote("origin")
-	if err != nil {
-		return err
-	}
+		// If no branch was specified, read the actual branch from HEAD
+		if branchName == "" {
+			head, err := gc.repo.Head()
+			if err != nil {
+				_ = os.RemoveAll(gc.tempDir)
+				return fmt.Errorf("failed to read HEAD after system git clone: %w", err)
+			}
+			branchName = head.Name().Short()
+			gc.logger.Info("detected default branch", "branch", branchName)
+		}
+	} else {
+		// Open an in-memory repository
+		repo, err := gitv5.Init(memory.NewStorage(), nil)
+		if err != nil {
+			return err
+		}
 
-	refs, err := remote.List(&gitv5.ListOptions{Auth: gc.authMethod, InsecureSkipTLS: gc.config.SkipTLS})
-	if err != nil {
-		return err
-	}
+		// Add the remote
+		if _, err = repo.CreateRemote(&gitconfig.RemoteConfig{
+			Name: "origin",
+			URLs: []string{gc.config.URL},
+		}); err != nil {
+			return err
+		}
 
-	// Find the default branch
-	branchName := gc.config.Branch
-	if branchName == "" {
-		for _, ref := range refs {
-			if ref.Name().IsBranch() {
-				branchName = ref.Name().Short()
-				gc.logger.Info("detected default branch", "branch", branchName)
-				break
+		// Fetch all branches and references
+		if err = repo.Fetch(&gitv5.FetchOptions{
+			RemoteName:      "origin",
+			Auth:            gc.authMethod,
+			InsecureSkipTLS: gc.config.SkipTLS,
+		}); err != nil && err != gitv5.NoErrAlreadyUpToDate {
+			return err
+		}
+
+		// Get the remote reference list
+		remote, err := repo.Remote("origin")
+		if err != nil {
+			return err
+		}
+
+		refs, err := remote.List(&gitv5.ListOptions{Auth: gc.authMethod, InsecureSkipTLS: gc.config.SkipTLS})
+		if err != nil {
+			return err
+		}
+
+		// Find the default branch
+		branchName = gc.config.Branch
+		if branchName == "" {
+			for _, ref := range refs {
+				if ref.Name().IsBranch() {
+					branchName = ref.Name().Short()
+					gc.logger.Info("detected default branch", "branch", branchName)
+					break
+				}
+			}
+
+			if branchName == "" {
+				return errors.New("failed to detect default branch, repository might be empty")
 			}
 		}
 
-		if branchName == "" {
-			return errors.New("failed to detect default branch, repository might be empty")
+		gc.logger.Info("cloning repository", "url", gc.config.URL, "branch", branchName)
+
+		// Now clone the repository with the determined branch
+		gc.repo, err = gitv5.Clone(memory.NewStorage(), nil, &gitv5.CloneOptions{
+			Auth:            gc.authMethod,
+			URL:             gc.config.URL,
+			ReferenceName:   plumbing.NewBranchReferenceName(branchName),
+			SingleBranch:    true,
+			InsecureSkipTLS: gc.config.SkipTLS,
+		})
+		if err != nil {
+			return err
 		}
-	}
-
-	gc.logger.Info("cloning repository", "url", gc.config.URL, "branch", branchName)
-
-	// Now clone the repository with the determined branch
-	gc.repo, err = gitv5.Clone(memory.NewStorage(), nil, &gitv5.CloneOptions{
-		Auth:            gc.authMethod,
-		URL:             gc.config.URL,
-		ReferenceName:   plumbing.NewBranchReferenceName(branchName),
-		SingleBranch:    true,
-		InsecureSkipTLS: gc.config.SkipTLS,
-	})
-	if err != nil {
-		return err
 	}
 
 	gc.config.Branch = branchName

--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -80,6 +80,9 @@ func (gc *gitConfigManager) cloneWithSystemGit(branch string) (string, *gitv5.Re
 
 	cloneURL := gc.config.URL
 	env := append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if gc.config.SkipTLS {
+		env = append(env, "GIT_SSL_NO_VERIFY=true")
+	}
 
 	switch gc.config.Auth {
 	case "basic":
@@ -127,6 +130,9 @@ func (gc *gitConfigManager) fetchWithSystemGit() error {
 		return errors.New("system git fallback not initialized; clone must be called first")
 	}
 	env := append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if gc.config.SkipTLS {
+		env = append(env, "GIT_SSL_NO_VERIFY=true")
+	}
 
 	fetchURL := gc.config.URL
 	switch gc.config.Auth {
@@ -146,7 +152,7 @@ func (gc *gitConfigManager) fetchWithSystemGit() error {
 	}
 
 	refspec := "refs/heads/" + gc.config.Branch + ":refs/heads/" + gc.config.Branch
-	cmd := exec.Command("git", "-C", gc.tempDir, "fetch", fetchURL, refspec)
+	cmd := exec.Command("git", "-C", gc.tempDir, "fetch", "--update-head-ok", fetchURL, refspec)
 	cmd.Env = env
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("system git fetch failed: %w\n%s", err, out)

--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -459,6 +459,7 @@ func (gc *gitConfigManager) schedule(cfg config.Config, backends map[string]back
 
 func (gc *gitConfigManager) Start(cfg config.Config, backends map[string]backend.Backend) error {
 	var err error
+	var startOK bool
 	gc.version = 1
 	gc.config = cfg.OrbAgent.ConfigManager.Sources.Git
 
@@ -506,12 +507,17 @@ func (gc *gitConfigManager) Start(cfg config.Config, backends map[string]backend
 			return err
 		}
 		gc.tempDir = dir
+		defer func() {
+			if !startOK {
+				_ = os.RemoveAll(gc.tempDir)
+				gc.tempDir = ""
+			}
+		}()
 
 		// If no branch was specified, read the actual branch from HEAD
 		if branchName == "" {
 			head, err := gc.repo.Head()
 			if err != nil {
-				_ = os.RemoveAll(gc.tempDir)
 				return fmt.Errorf("failed to read HEAD after system git clone: %w", err)
 			}
 			branchName = head.Name().Short()
@@ -653,6 +659,7 @@ func (gc *gitConfigManager) Start(cfg config.Config, backends map[string]backend
 		gc.scheduler.Start()
 	}
 
+	startOK = true
 	return nil
 }
 

--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -636,7 +636,13 @@ func (gc *gitConfigManager) GetContext(ctx context.Context) context.Context {
 	return ctx
 }
 
-// Stop is a no-op for git config manager.
+// Stop cleans up resources held by the git config manager.
 func (gc *gitConfigManager) Stop(_ context.Context) error {
+	if gc.tempDir != "" {
+		if err := os.RemoveAll(gc.tempDir); err != nil {
+			gc.logger.Error("failed to remove git temp dir", "path", gc.tempDir, "error", err)
+		}
+		gc.tempDir = ""
+	}
 	return nil
 }

--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -301,15 +301,23 @@ func (gc *gitConfigManager) schedule(cfg config.Config, backends map[string]back
 	gc.logger.Debug("Running scheduled Git Config Manager task")
 
 	// Fetch latest updates from remote
-	err := gc.repo.Fetch(&gitv5.FetchOptions{
-		RemoteName:      "origin",
-		Auth:            gc.authMethod,
-		InsecureSkipTLS: gc.config.SkipTLS,
-		RefSpecs:        []gitconfig.RefSpec{"refs/heads/*:refs/heads/*"},
-	})
-	if err != nil && err != gitv5.NoErrAlreadyUpToDate {
-		gc.logger.Error("Failed to fetch latest changes", "error", err)
-		return
+	if gc.tempDir != "" {
+		// Azure DevOps fallback: use system git
+		if err := gc.fetchWithSystemGit(); err != nil {
+			gc.logger.Error("Failed to fetch latest changes", "error", err)
+			return
+		}
+	} else {
+		err := gc.repo.Fetch(&gitv5.FetchOptions{
+			RemoteName:      "origin",
+			Auth:            gc.authMethod,
+			InsecureSkipTLS: gc.config.SkipTLS,
+			RefSpecs:        []gitconfig.RefSpec{"refs/heads/*:refs/heads/*"},
+		})
+		if err != nil && err != gitv5.NoErrAlreadyUpToDate {
+			gc.logger.Error("Failed to fetch latest changes", "error", err)
+			return
+		}
 	}
 
 	// Get the latest reference (HEAD)

--- a/agent/configmgr/git_ado.go
+++ b/agent/configmgr/git_ado.go
@@ -1,0 +1,161 @@
+package configmgr
+
+// TODO: Delete this entire file once go-git v6 is released.
+// go-git v6 adds full multi_ack/multi_ack_detailed pack-protocol support,
+// which makes the system-git fallback for Azure DevOps unnecessary.
+// Tracking: https://github.com/go-git/go-git/issues/64
+// Merged to go-git main at commit 14eabbda76d37e2dfcfa25b3ac236f2365adb6da.
+//
+// When removing: delete this file and remove the three IsAzureDevOpsURL /
+// gc.tempDir branches in Start(), schedule(), and Stop() in git.go.
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	gitv5 "github.com/go-git/go-git/v5"
+)
+
+// IsAzureDevOpsURL reports whether rawURL points to an Azure DevOps
+// repository. Azure DevOps is incompatible with go-git's pack-protocol
+// negotiation, so these repos require a system-git fallback.
+func IsAzureDevOpsURL(rawURL string) bool {
+	return strings.Contains(rawURL, "dev.azure.com") ||
+		strings.Contains(rawURL, "visualstudio.com")
+}
+
+// writeAskpassScript writes a minimal GIT_ASKPASS helper script to a temp
+// file. Git calls the script with the prompt text as $1; the script replies
+// with the username or password depending on the prompt, without ever
+// exposing credentials in argv. The script is chmod 0o700 so only the
+// current user can read or execute it. The caller is responsible for
+// removing the file when done.
+func writeAskpassScript(username, password string) (string, error) {
+	f, err := os.CreateTemp("", "git-askpass-*.sh")
+	if err != nil {
+		return "", fmt.Errorf("failed to create askpass script: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	// Git calls GIT_ASKPASS with the prompt text as $1.  We match on
+	// "username" (case-insensitive) to return the right value for each prompt.
+	script := "#!/bin/sh\ncase \"$1\" in\n  *[Uu]sername*) echo " +
+		shellescape(username) + " ;;\n  *) echo " +
+		shellescape(password) + " ;;\nesac\n"
+	if _, err := f.WriteString(script); err != nil {
+		_ = os.Remove(f.Name())
+		return "", fmt.Errorf("failed to write askpass script: %w", err)
+	}
+	if err := os.Chmod(f.Name(), 0o700); err != nil {
+		_ = os.Remove(f.Name())
+		return "", fmt.Errorf("failed to chmod askpass script: %w", err)
+	}
+	return f.Name(), nil
+}
+
+// shellescape single-quote escapes a string for safe embedding in a POSIX
+// shell script.
+func shellescape(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+// cloneWithSystemGit clones the repository using the system git binary to a
+// temporary directory. It is used as a fallback for hosts (e.g. Azure DevOps)
+// that are incompatible with go-git's pack-protocol negotiation.
+// The caller is responsible for removing the returned directory when done.
+func (gc *gitConfigManager) cloneWithSystemGit(branch string) (string, *gitv5.Repository, error) {
+	dir, err := os.MkdirTemp("", "orb-git-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to create temp dir for git clone: %w", err)
+	}
+
+	cloneURL := gc.config.URL
+	env := append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if gc.config.SkipTLS {
+		env = append(env, "GIT_SSL_NO_VERIFY=true")
+	}
+
+	switch gc.config.Auth {
+	case "basic":
+		askpass, err := writeAskpassScript(gc.config.Username, gc.config.Password)
+		if err != nil {
+			_ = os.RemoveAll(dir)
+			return "", nil, err
+		}
+		defer func() { _ = os.Remove(askpass) }()
+		env = append(env,
+			"GIT_ASKPASS="+askpass,
+			"GIT_USERNAME="+gc.config.Username,
+		)
+	case "ssh":
+		if gc.config.PrivateKey != "" {
+			env = append(env,
+				"GIT_SSH_COMMAND=ssh -i '"+gc.config.PrivateKey+
+					"' -o StrictHostKeyChecking=no -o BatchMode=yes")
+		}
+	}
+
+	args := []string{"clone"}
+	if branch != "" {
+		args = append(args, "--branch", branch, "--single-branch")
+	}
+	args = append(args, cloneURL, dir)
+
+	cmd := exec.Command("git", args...)
+	cmd.Env = env
+	if out, err := cmd.CombinedOutput(); err != nil {
+		_ = os.RemoveAll(dir)
+		return "", nil, fmt.Errorf("system git clone failed: %w\n%s", err, out)
+	}
+
+	repo, err := gitv5.PlainOpen(dir)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		return "", nil, fmt.Errorf("failed to open cloned repo: %w", err)
+	}
+
+	return dir, repo, nil
+}
+
+// fetchWithSystemGit runs "git fetch" with an explicit refspec to update
+// refs/heads/<branch>. Used for scheduled updates when the system-git
+// fallback is active.
+func (gc *gitConfigManager) fetchWithSystemGit() error {
+	if gc.tempDir == "" {
+		return errors.New("system git fallback not initialized; clone must be called first")
+	}
+	env := append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if gc.config.SkipTLS {
+		env = append(env, "GIT_SSL_NO_VERIFY=true")
+	}
+
+	fetchURL := gc.config.URL
+	switch gc.config.Auth {
+	case "basic":
+		askpass, err := writeAskpassScript(gc.config.Username, gc.config.Password)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = os.Remove(askpass) }()
+		env = append(env,
+			"GIT_ASKPASS="+askpass,
+			"GIT_USERNAME="+gc.config.Username,
+		)
+	case "ssh":
+		if gc.config.PrivateKey != "" {
+			env = append(env,
+				"GIT_SSH_COMMAND=ssh -i '"+gc.config.PrivateKey+
+					"' -o StrictHostKeyChecking=no -o BatchMode=yes")
+		}
+	}
+
+	refspec := "refs/heads/" + gc.config.Branch + ":refs/heads/" + gc.config.Branch
+	cmd := exec.Command("git", "-C", gc.tempDir, "fetch", "--update-head-ok", fetchURL, refspec)
+	cmd.Env = env
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("system git fetch failed: %w\n%s", err, out)
+	}
+	return nil
+}

--- a/agent/configmgr/git_ado.go
+++ b/agent/configmgr/git_ado.go
@@ -24,6 +24,7 @@ import (
 // negotiation, so these repos require a system-git fallback.
 func IsAzureDevOpsURL(rawURL string) bool {
 	return strings.Contains(rawURL, "dev.azure.com") ||
+		strings.Contains(rawURL, "ssh.dev.azure.com") ||
 		strings.Contains(rawURL, "visualstudio.com")
 }
 

--- a/agent/configmgr/git_ado.go
+++ b/agent/configmgr/git_ado.go
@@ -91,6 +91,12 @@ func (gc *gitConfigManager) cloneWithSystemGit(branch string) (string, *gitv5.Re
 		)
 	case "ssh":
 		if gc.config.PrivateKey != "" {
+			// NOTE: passphrase-protected keys are not supported in this fallback
+			// path. BatchMode=yes disables prompting, and wiring SSH_ASKPASS for
+			// passphrases requires OpenSSH >= 8.4 (SSH_ASKPASS_REQUIRE=force).
+			// In practice ADO SSH keys are unprotected deploy keys; if a
+			// passphrase is needed, unlock the key via ssh-agent before starting
+			// the agent. This limitation goes away when go-git v6 is released.
 			env = append(env,
 				"GIT_SSH_COMMAND=ssh -i '"+gc.config.PrivateKey+
 					"' -o StrictHostKeyChecking=no -o BatchMode=yes")
@@ -145,6 +151,8 @@ func (gc *gitConfigManager) fetchWithSystemGit() error {
 		)
 	case "ssh":
 		if gc.config.PrivateKey != "" {
+			// See note in cloneWithSystemGit: passphrase-protected keys are not
+			// supported without ssh-agent pre-unlocking the key.
 			env = append(env,
 				"GIT_SSH_COMMAND=ssh -i '"+gc.config.PrivateKey+
 					"' -o StrictHostKeyChecking=no -o BatchMode=yes")

--- a/agent/configmgr/git_test.go
+++ b/agent/configmgr/git_test.go
@@ -230,7 +230,9 @@ func TestGitStartAzureDevOpsURLFallback(t *testing.T) {
 	// Create a source repo with selector.yaml + policy.yaml.
 	sourceDir, err := os.MkdirTemp("", "ado-source-*")
 	require.NoError(t, err)
-	defer os.RemoveAll(sourceDir)
+	defer func() {
+		require.NoError(t, os.RemoveAll(sourceDir))
+	}()
 
 	sourceRepo, err := gitv5.PlainInit(sourceDir, false)
 	require.NoError(t, err)
@@ -266,7 +268,9 @@ backend1:
 	// Create a bare clone to act as the remote.
 	bareDir, err := os.MkdirTemp("", "ado-bare-*")
 	require.NoError(t, err)
-	defer os.RemoveAll(bareDir)
+	defer func() {
+		require.NoError(t, os.RemoveAll(bareDir))
+	}()
 
 	bareRepoPath := filepath.Join(bareDir, "repo.git")
 	out, err := exec.Command("git", "clone", "--bare", sourceDir, bareRepoPath).CombinedOutput()

--- a/agent/configmgr/git_test.go
+++ b/agent/configmgr/git_test.go
@@ -3,6 +3,7 @@ package configmgr_test
 import (
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -214,4 +215,105 @@ backend1:
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no policies match the selector")
 	pMgr.AssertNotCalled(t, "ManagePolicy", mock.Anything)
+}
+
+// TestGitStartAzureDevOpsURLFallback verifies that an Azure DevOps URL triggers
+// the system git fallback path.  A local bare repo is used as the "remote"; a
+// git URL rewrite (via GIT_CONFIG_GLOBAL) redirects the dev.azure.com URL to
+// the filesystem so the test runs without network access.
+func TestGitStartAzureDevOpsURLFallback(t *testing.T) {
+	// Skip if system git is not available.
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("system git not found, skipping ADO fallback test")
+	}
+
+	// Create a source repo with selector.yaml + policy.yaml.
+	sourceDir, err := os.MkdirTemp("", "ado-source-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(sourceDir)
+
+	sourceRepo, err := gitv5.PlainInit(sourceDir, false)
+	require.NoError(t, err)
+
+	selectorContent := `
+ado_selector:
+  selector:
+    env: test
+  policies:
+    ado_policy:
+      enabled: true
+      path: "policy.yaml"
+`
+	policyContent := `
+backend1:
+  ado_policy:
+    key: value
+`
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "selector.yaml"), []byte(selectorContent), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "policy.yaml"), []byte(policyContent), 0o644))
+
+	wt, err := sourceRepo.Worktree()
+	require.NoError(t, err)
+	_, err = wt.Add("selector.yaml")
+	require.NoError(t, err)
+	_, err = wt.Add("policy.yaml")
+	require.NoError(t, err)
+	_, err = wt.Commit("initial commit", &gitv5.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@test.com", When: time.Now()},
+	})
+	require.NoError(t, err)
+
+	// Create a bare clone to act as the remote.
+	bareDir, err := os.MkdirTemp("", "ado-bare-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(bareDir)
+
+	bareRepoPath := filepath.Join(bareDir, "repo.git")
+	out, err := exec.Command("git", "clone", "--bare", sourceDir, bareRepoPath).CombinedOutput()
+	require.NoError(t, err, "bare clone failed: %s", out)
+
+	// Write a gitconfig that rewrites the ADO URL to the local bare repo.
+	adoURL := "https://dev.azure.com/test/org/_git/testrepo"
+	localURL := "file://" + bareRepoPath
+	gitconfigContent := "[url \"" + localURL + "\"]\n\tinsteadOf = " + adoURL + "\n"
+	gitconfigPath := filepath.Join(t.TempDir(), "test-gitconfig")
+	require.NoError(t, os.WriteFile(gitconfigPath, []byte(gitconfigContent), 0o644))
+
+	// Point git at our test config so the URL rewrite takes effect.
+	t.Setenv("GIT_CONFIG_GLOBAL", gitconfigPath)
+
+	// Confirm URL detection.
+	require.True(t, configmgr.IsAzureDevOpsURL(adoURL), "expected IsAzureDevOpsURL to return true")
+
+	pMgr := new(mockPolicyManager)
+	cfg := config.Config{
+		OrbAgent: config.OrbAgent{
+			Labels: map[string]string{"env": "test"},
+			ConfigManager: config.ManagerConfig{
+				Active: "git",
+				Sources: config.Sources{
+					Git: config.GitManager{
+						URL:    adoURL,
+						Branch: "", // auto-detect
+						Auth:   "none",
+					},
+				},
+			},
+		},
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	gc := configmgr.New(logger, pMgr, "git", &mockBackendState{})
+
+	backends := map[string]backend.Backend{
+		"backend1": &mockBackend{name: "backend1"},
+	}
+
+	pMgr.On("ManagePolicy", mock.MatchedBy(func(p config.PolicyPayload) bool {
+		return p.Backend == "backend1" && p.Action == "manage"
+	})).Return()
+
+	err = gc.Start(cfg, backends)
+	require.NoError(t, err, "Start() via system git fallback should succeed")
+	pMgr.AssertCalled(t, "ManagePolicy", mock.Anything)
 }

--- a/agent/configmgr/git_test.go
+++ b/agent/configmgr/git_test.go
@@ -17,6 +17,27 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/configmgr"
 )
 
+// TestIsAzureDevOpsURL tests the IsAzureDevOpsURL helper function.
+func TestIsAzureDevOpsURL(t *testing.T) {
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		{"https://dev.azure.com/org/proj/_git/repo", true},
+		{"git@ssh.dev.azure.com:v3/org/proj/repo", true},
+		{"https://org.visualstudio.com/proj/_git/repo", true},
+		{"org@vs-ssh.visualstudio.com:v3/org/proj/repo", true},
+		{"https://github.com/org/repo.git", false},
+		{"file:///tmp/repo", false},
+		{"git@github.com:org/repo.git", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			require.Equal(t, tt.want, configmgr.IsAzureDevOpsURL(tt.url))
+		})
+	}
+}
+
 // TestGitStart tests the Start method of gitConfigManager.
 func TestGitStart(t *testing.T) {
 	// Create a temporary directory for the fake remote repository.

--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -47,7 +47,7 @@ FROM python:3.14-slim-trixie
 
 RUN \
     apt update && \
-    apt install --yes --no-install-recommends nmap openssh-client tini && \
+    apt install --yes --no-install-recommends git nmap openssh-client tini && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /opt/orb

--- a/docs/config_samples.md
+++ b/docs/config_samples.md
@@ -1,6 +1,113 @@
 # Configuration Samples
 Here is a collection of configuration samples supported by orb agent
 
+## Git Config Manager
+
+The Git config manager fetches policies from a Git repository and applies them dynamically. See the [full Git config manager documentation](configs/git.md) for all options.
+
+### Public repository (no auth)
+
+```yaml
+orb:
+  labels:
+    region: EU
+    pop: ams02
+  config_manager:
+    active: git
+    sources:
+      git:
+        url: "https://github.com/myorg/policyrepo"
+        schedule: "* * * * *"
+  backends:
+    network_discovery:
+    device_discovery:
+    common:
+      diode:
+        target: grpc://192.168.0.100:8080/diode
+        client_id: ${DIODE_CLIENT_ID}
+        client_secret: ${DIODE_CLIENT_SECRET}
+        agent_name: agent01
+```
+
+### HTTPS with token (GitHub / Azure DevOps PAT)
+
+```yaml
+orb:
+  labels:
+    region: EU
+    pop: ams02
+  config_manager:
+    active: git
+    sources:
+      git:
+        url: "https://github.com/myorg/policyrepo"
+        auth: "basic"
+        username: "myuser"
+        password: ${GIT_TOKEN}
+        schedule: "* * * * *"
+  backends:
+    network_discovery:
+    common:
+      diode:
+        target: grpc://192.168.0.100:8080/diode
+        client_id: ${DIODE_CLIENT_ID}
+        client_secret: ${DIODE_CLIENT_SECRET}
+        agent_name: agent01
+```
+
+Run command:
+```bash
+docker run \
+  -v /local/orb:/opt/orb \
+  -e GIT_TOKEN=${GIT_TOKEN} \
+  -e DIODE_CLIENT_ID=${DIODE_CLIENT_ID} \
+  -e DIODE_CLIENT_SECRET=${DIODE_CLIENT_SECRET} \
+  netboxlabs/orb-agent:latest run -c /opt/orb/agent.yaml
+```
+
+### SSH key authentication (GitHub / GitLab)
+
+First, generate a known_hosts file and an SSH key pair:
+
+```bash
+ssh-keyscan github.com > /local/orb/known_hosts
+ssh-keygen -t ed25519 -f /local/orb/id_ed25519 -N ""
+# Add the contents of /local/orb/id_ed25519.pub as a deploy key in your repository
+```
+
+```yaml
+orb:
+  labels:
+    region: EU
+    pop: ams02
+  config_manager:
+    active: git
+    sources:
+      git:
+        url: "git@github.com:myorg/policyrepo.git"
+        auth: "ssh"
+        private_key: "/opt/orb/id_ed25519"
+        schedule: "* * * * *"
+  backends:
+    network_discovery:
+    common:
+      diode:
+        target: grpc://192.168.0.100:8080/diode
+        client_id: ${DIODE_CLIENT_ID}
+        client_secret: ${DIODE_CLIENT_SECRET}
+        agent_name: agent01
+```
+
+Run command:
+```bash
+docker run \
+  -v /local/orb:/opt/orb \
+  -e SSH_KNOWN_HOSTS=/opt/orb/known_hosts \
+  -e DIODE_CLIENT_ID=${DIODE_CLIENT_ID} \
+  -e DIODE_CLIENT_SECRET=${DIODE_CLIENT_SECRET} \
+  netboxlabs/orb-agent:latest run -c /opt/orb/agent.yaml
+```
+
 ## Device-discovery backend
 This sample configuration file demonstrates the device discovery backend connecting to a Cisco router at 192.168.0.5. It retrieves device, interface, and IP information, then sends the data to a [diode](https://github.com/netboxlabs/diode) server running at 192.168.0.100.
 

--- a/docs/configs/git.md
+++ b/docs/configs/git.md
@@ -35,8 +35,51 @@ orb:
 | branch | string | no  |  the git branch that should be used by the agent. If not specified, the default branch will be used   |
 | auth | string | no | it can be either 'basic' or 'ssh'. The basic authentication supports both password or token. If not specified, no auth will be used (public repository) |
 | username | string | no | username used for authentication |
-| password | string | no | the password used for authentication. If the auth method is 'basic' it should cointains the password or auth token. If the method is 'ssh' it should contains the password for the ssh certificate file |
-| private_key | string | no | the path for the ssh certificate file |
+| password | string | no | the password used for authentication. If the auth method is 'basic' it should contain the password or auth token. If the method is 'ssh' it should contain the passphrase for the private key file (leave empty for unprotected keys) |
+| private_key | string | no | the path to the SSH private key file |
+| skip_tls | bool | no | skip TLS certificate verification when connecting to the repository (default: false). Useful for self-signed or private CA certificates |
+
+## SSH Authentication
+
+When using `auth: ssh`, the agent uses the configured private key to authenticate with the Git server.
+
+### Known Hosts
+
+SSH connections require host key verification to prevent man-in-the-middle attacks. The agent reads known hosts from a file specified by the `SSH_KNOWN_HOSTS` environment variable. If the variable is not set, the agent looks for the standard `~/.ssh/known_hosts` file.
+
+To generate a `known_hosts` file for your Git server:
+
+```bash
+# GitHub
+ssh-keyscan github.com > /opt/orb/known_hosts
+
+# GitLab
+ssh-keyscan gitlab.com > /opt/orb/known_hosts
+
+# Azure DevOps
+ssh-keyscan -p 22 ssh.dev.azure.com > /opt/orb/known_hosts
+
+# Any other host
+ssh-keyscan your.git.host >> /opt/orb/known_hosts
+```
+
+Then pass the file to the container:
+
+```bash
+docker run \
+  -v /local/orb:/opt/orb \
+  -e SSH_KNOWN_HOSTS=/opt/orb/known_hosts \
+  netboxlabs/orb-agent:latest run -c /opt/orb/agent.yaml
+```
+
+### Generating an SSH Key Pair
+
+```bash
+ssh-keygen -t ed25519 -f /local/orb/id_ed25519 -N ""
+# Then add the contents of /local/orb/id_ed25519.pub to your Git provider's SSH keys
+```
+
+> **Note:** Azure DevOps requires RSA keys. Use `ssh-keygen -t rsa -b 4096` instead.
 
 ## Git Repository Structure
 


### PR DESCRIPTION
## Summary

- Adds `IsAzureDevOpsURL` detection for `dev.azure.com` and `visualstudio.com` URLs
- For ADO repos, `Start()` clones via system `git` binary to a temp directory then opens the clone with go-git — bypassing go-git's incompatible pack-protocol negotiation
- Scheduled fetches on ADO repos also use system `git fetch` with an explicit refspec (`refs/heads/<branch>:refs/heads/<branch>`) so change detection works correctly
- Basic and SSH (key file + agent) auth are forwarded to the system git command
- Temp directory is cleaned up in `Stop()`
- Non-ADO repos are completely unaffected (existing in-memory go-git path unchanged)

## Background

go-git v5 lacks `multi_ack`/`multi_ack_detailed` protocol support required by Azure DevOps ([go-git/go-git#64](https://github.com/go-git/go-git/issues/64)). The fix has landed in go-git main but targets v6 (unreleased). This PR adopts the same approach used by Pulumi ([pulumi/pulumi#22217](https://github.com/pulumi/pulumi/pull/22217)): detect ADO URLs and route to the system `git` binary.

This unblocks the Rockwell deployment.

## Test Plan

- [x] `go test ./agent/configmgr/...` — all pass
- [x] `go build ./...` — clean
- [x] Manual: configure agent with an Azure DevOps HTTPS URL and verify clone + policy application succeeds
- [x] Manual: configure agent with an Azure DevOps SSH URL and verify clone + policy application succeeds
- [x] Manual: verify scheduled fetch detects new commits on ADO repo
- [x] Manual: verify non-ADO GitHub/GitLab repos continue to work via the in-memory path

🤖 Generated with [Claude Code](https://claude.com/claude-code)