### PR TITLE
feat: add Source column to vulnerability scan tables

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,12 +98,13 @@ jobs:
 
             const buildTable = (vulns) => {
               if (vulns.length === 0) return '_No vulnerabilities found._\n';
-              let t = '| Library | CVE | Severity | Installed | Fixed | Title |\n';
-              t += '|---|---|---|---|---|---|\n';
+              let t = '| Source | Library | CVE | Severity | Installed | Fixed | Title |\n';
+              t += '|---|---|---|---|---|---|---|\n';
               for (const v of vulns) {
                 const title = (v.Title || '').replace(/\|/g, '\\|').substring(0, 80);
                 const cve = v.PrimaryURL ? `[${v.VulnerabilityID}](${v.PrimaryURL})` : v.VulnerabilityID;
-                t += `| ${v.PkgName} | ${cve} | ${SEVERITY_LABEL[v.Severity] || v.Severity} | ${v.InstalledVersion} | ${v.FixedVersion || 'N/A'} | ${title} |\n`;
+                const source = (v.target || '').replace(/\|/g, '\\|');
+                t += `| ${source} | ${v.PkgName} | ${cve} | ${SEVERITY_LABEL[v.Severity] || v.Severity} | ${v.InstalledVersion} | ${v.FixedVersion || 'N/A'} | ${title} |\n`;
               }
               return t;
             };

--- a/.github/workflows/container-rescan.yaml
+++ b/.github/workflows/container-rescan.yaml
@@ -64,12 +64,13 @@ jobs:
             if (vulns.length === 0) {
               summary += '_No vulnerabilities found._\n';
             } else {
-              summary += `| Library | CVE | Severity | Installed | Fixed | Title |\n`;
-              summary += `|---|---|---|---|---|---|\n`;
+              summary += `| Source | Library | CVE | Severity | Installed | Fixed | Title |\n`;
+              summary += `|---|---|---|---|---|---|---|\n`;
               for (const v of vulns) {
                 const title = (v.Title || '').replace(/\|/g, '\\|').substring(0, 80);
                 const cve = v.PrimaryURL ? `[${v.VulnerabilityID}](${v.PrimaryURL})` : v.VulnerabilityID;
-                summary += `| ${v.PkgName} | ${cve} | ${SEVERITY_LABEL[v.Severity] || v.Severity} | ${v.InstalledVersion} | ${v.FixedVersion || 'N/A'} | ${title} |\n`;
+                const source = (v.target || '').replace(/\|/g, '\\|');
+                summary += `| ${source} | ${v.PkgName} | ${cve} | ${SEVERITY_LABEL[v.Severity] || v.Severity} | ${v.InstalledVersion} | ${v.FixedVersion || 'N/A'} | ${title} |\n`;
               }
             }
 


### PR DESCRIPTION
Add a Source column to the vulnerability tables in container scan and rescan workflows. Shows where each vulnerability originates (OS package layer, Go binary, Python package, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)