### PR TITLE
chore: add netbox_id per-target config for PK-based device matching

### DIFF
--- a/docs/backends/device_discovery.md
+++ b/docs/backends/device_discovery.md
@@ -128,6 +128,7 @@ The scope defines a list of devices that can be accessed and pulled data.
 | driver | string | no  | If defined, connect using the specified NAPALM driver. If not set, all installed drivers are tried (or the `discovery_drivers` list if configured). |
 | optional_args | map | no  | NAPALM optional arguments defined [here](https://napalm.readthedocs.io/en/latest/support/#list-of-supported-optional-arguments). Commonly used: `ssh_config_file` for jumphost support (see [SSH Configuration guide](./device_discovery_ssh.md)), `canonical_int` for interface naming, `timeout` for slow connections. |
 | override_defaults | map | no | Allows overriding of any defaults for a specific device in the scope |
+| netbox_id | integer | no | NetBox device primary key. When set, the diode plugin matches the device by PK instead of by name. Ignored when hostname is a subnet or IP range. |
 
 ### SSH Configuration and Jumphost Support
 
@@ -203,6 +204,7 @@ orb:
           - hostname: myhost.com
             username: remote
             password: 12345
+            netbox_id: 42
             override_defaults:
               role: router
               location: Row B

--- a/docs/backends/snmp_discovery.md
+++ b/docs/backends/snmp_discovery.md
@@ -81,6 +81,7 @@ Each target in the `targets` list can include:
 | port | integer | no | SNMP port (defaults to 161) |
 | authentication | map | no | Target-specific authentication (overrides policy-level authentication) |
 | override_defaults | map | no | Allows overriding of any defaults for a specific target in the scope |
+| netbox_id | integer | no | NetBox device primary key. When set, the diode plugin matches the device by PK instead of by name. Ignored when host is a subnet or IP range. |
 
 #### Authentication Parameters
 | Parameter | Type | Required | Description |
@@ -135,6 +136,7 @@ scope:
     - host: "192.168.2.2-10" # range support
     - host: "10.0.0.1"
       port: 162  # Non-standard SNMP port
+      netbox_id: 42
       override_defaults:
         role: "switch"
         tags: ["custom"]


### PR DESCRIPTION
## Summary

- Documents the new optional `netbox_id` integer field for both device-discovery and snmp-discovery target config
- Enables PK-based device matching in the diode-netbox-plugin (netboxlabs/diode-netbox-plugin#158)
- Adds parameter to target tables and YAML examples in both backend docs

## Related

- Implementation PR in orb-discovery: netboxlabs/orb-discovery#319

🤖 Generated with [Claude Code](https://claude.com/claude-code)