### PR TITLE
fix: OBS-2208 add Start(ctx) signature and startup retry with exponential backoff

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -254,7 +254,7 @@ func (a *orbAgent) Start(ctx context.Context, cancelFunc context.CancelFunc) err
 		return err
 	}
 
-	if err = a.configManager.Start(a.config, a.backends); err != nil {
+	if err = a.configManager.Start(agentCtx, a.config, a.backends); err != nil {
 		return err
 	}
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -20,7 +20,7 @@ type mockConfigManager struct {
 	stopCalled bool
 }
 
-func (m *mockConfigManager) Start(_ config.Config, _ map[string]backend.Backend) error {
+func (m *mockConfigManager) Start(_ context.Context, _ config.Config, _ map[string]backend.Backend) error {
 	return nil
 }
 func (m *mockConfigManager) GetContext(ctx context.Context) context.Context { return ctx }
@@ -114,19 +114,15 @@ func TestStart_FleetConfig_OverridesExistingOTLPGrpcURL(t *testing.T) {
 	orbAgent := agent.(*orbAgent)
 	orbAgent.secretsManager = &mockSecretsManager{}
 	orbAgent.policyManager = &mockPolicyManager{repo: repo}
+	orbAgent.configManager = &mockConfigManager{} // avoid real fleet startup
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Start will fail when trying to start backends, but we can check the config before that
 	err = orbAgent.Start(ctx, cancel)
-	// We expect an error because there are no actual backends configured
-	// But the important thing is that the config was modified
-	require.Error(t, err)
+	require.NoError(t, err)
 
-	// Verify the config was modified by checking backendsCommon which is set in startBackends
-	// The OTLP configuration happens before startBackends, so backendsCommon should have the updated value
-	// Default port is 4317
+	// Verify the OTLP gRPC URL was overridden before backends started
 	assert.Equal(t, "grpc://localhost:4317", orbAgent.backendsCommon.Otlp.Grpc)
 }
 
@@ -157,16 +153,14 @@ func TestStart_FleetConfig_CreatesOTLPSectionWhenMissing(t *testing.T) {
 	orbAgent := agent.(*orbAgent)
 	orbAgent.secretsManager = &mockSecretsManager{}
 	orbAgent.policyManager = &mockPolicyManager{repo: repo}
+	orbAgent.configManager = &mockConfigManager{} // avoid real fleet startup
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	err = orbAgent.Start(ctx, cancel)
-	require.Error(t, err) // Expected to fail when starting backends
+	require.NoError(t, err)
 
-	// Verify the config was modified by checking backendsCommon which is set in startBackends
-	// The OTLP configuration happens before startBackends, so backendsCommon should have the updated value
-	// Default port is 4317
 	assert.Equal(t, "grpc://localhost:4317", orbAgent.backendsCommon.Otlp.Grpc)
 }
 
@@ -193,16 +187,16 @@ func TestStart_FleetConfig_CreatesCommonBackendWhenMissing(t *testing.T) {
 	orbAgent := agent.(*orbAgent)
 	orbAgent.secretsManager = &mockSecretsManager{}
 	orbAgent.policyManager = &mockPolicyManager{repo: repo}
+	orbAgent.configManager = &mockConfigManager{} // avoid real fleet startup
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	err = orbAgent.Start(ctx, cancel)
-	require.Error(t, err) // Expected to fail when starting backends
+	require.NoError(t, err)
 
-	// Verify the config was modified by checking backendsCommon which is set in startBackends
-	// The OTLP configuration happens before startBackends, so backendsCommon should have the updated value
-	// Default port is 4317
+	// The OTLP override creates the "common" backend with the grpc URL before
+	// startBackends extracts it into backendsCommon (and deletes the key).
 	assert.Equal(t, "grpc://localhost:4317", orbAgent.backendsCommon.Otlp.Grpc)
 }
 
@@ -277,14 +271,16 @@ func TestStart_FleetConfig_UsesConfiguredGRPCPort(t *testing.T) {
 	orbAgent := agent.(*orbAgent)
 	orbAgent.secretsManager = &mockSecretsManager{}
 	orbAgent.policyManager = &mockPolicyManager{repo: repo}
+	orbAgent.configManager = &mockConfigManager{} // avoid real fleet startup
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	err = orbAgent.Start(ctx, cancel)
-	require.Error(t, err) // Expected to fail when starting backends
+	require.NoError(t, err)
 
-	// Verify the config was modified with the custom port
-	expectedURL := "grpc://localhost:9999"
-	assert.Equal(t, expectedURL, orbAgent.backendsCommon.Otlp.Grpc, "grpc URL should use configured port")
+	// The OTLP override runs before startBackends, which extracts common config
+	// into backendsCommon and then deletes the "common" key from the map.
+	// Verify the extracted config has the custom port.
+	assert.Equal(t, "grpc://localhost:9999", orbAgent.backendsCommon.Otlp.Grpc, "grpc URL should use configured port")
 }

--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -126,6 +126,24 @@ func (fleetManager *FleetConfigManager) Start(ctx context.Context, cfg config.Co
 	// a single monitorCancel() call.
 	fleetManager.monitorCtx, fleetManager.monitorCancel = context.WithCancel(context.Background())
 
+	// Register OnReadyHook before the retry loop so it fires on the initial
+	// connection (OnConnectionUp runs synchronously before Connect returns).
+	fleetManager.connection.AddOnReadyHook(func(cm *autopaho.ConnectionManager, topics fleet.TokenResponseTopics) {
+		if fleetManager.otlpBridge == nil {
+			fleetManager.logger.Error("OTLP bridge not initialized, cannot bind to MQTT")
+			return
+		}
+
+		// Create publisher adapter and bind to bridge
+		pub := otlpbridge.NewCMAdapterPublisher(cm)
+		fleetManager.otlpBridge.SetPublisher(pub)
+		fleetManager.otlpBridge.SetIngestTopic(topics.Ingest)
+		fleetManager.otlpBridge.SetTelemetryTopic(topics.Telemetry)
+		fleetManager.logger.Info("OTLP bridge bound to Fleet MQTT",
+			slog.String("ingest_topic", topics.Ingest),
+			slog.String("telemetry_topic", topics.Telemetry))
+	})
+
 	// Retry loop for token fetch + MQTT connect. These depend on external services
 	// (token endpoint, MQTT broker) that may not be up yet at agent startup.
 	// AuthError (401/403) is permanent — bad credentials won't be fixed by retrying.
@@ -214,24 +232,6 @@ func (fleetManager *FleetConfigManager) Start(ctx context.Context, cfg config.Co
 			}
 		}
 	}()
-
-	// Register MQTTOnReadyHook to bind publisher and topics to the OTLP bridge
-	// The bridge server is already started earlier in Start(), so we only need to bind MQTT here
-	fleetManager.connection.AddOnReadyHook(func(cm *autopaho.ConnectionManager, topics fleet.TokenResponseTopics) {
-		if fleetManager.otlpBridge == nil {
-			fleetManager.logger.Error("OTLP bridge not initialized, cannot bind to MQTT")
-			return
-		}
-
-		// Create publisher adapter and bind to bridge
-		pub := otlpbridge.NewCMAdapterPublisher(cm)
-		fleetManager.otlpBridge.SetPublisher(pub)
-		fleetManager.otlpBridge.SetIngestTopic(topics.Ingest)
-		fleetManager.otlpBridge.SetTelemetryTopic(topics.Telemetry)
-		fleetManager.logger.Info("OTLP bridge bound to Fleet MQTT",
-			slog.String("ingest_topic", topics.Ingest),
-			slog.String("telemetry_topic", topics.Telemetry))
-	})
 
 	// Start goroutine to handle reconnect requests (JWT refresh)
 	fleetManager.goroutinesWg.Add(1)

--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -2,6 +2,7 @@ package configmgr
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -77,9 +78,7 @@ func newFleetConfigManagerWithConnection(logger *slog.Logger, pMgr policymgr.Pol
 }
 
 // Start initializes and starts the Fleet configuration manager
-func (fleetManager *FleetConfigManager) Start(cfg config.Config, backends map[string]backend.Backend) error {
-	ctx := context.Background()
-
+func (fleetManager *FleetConfigManager) Start(ctx context.Context, cfg config.Config, backends map[string]backend.Backend) error {
 	var err error
 	cfg.OrbAgent.ConfigManager.Sources.Fleet.TokenURL, err = config.ResolveEnv(cfg.OrbAgent.ConfigManager.Sources.Fleet.TokenURL)
 	if err != nil {
@@ -98,61 +97,13 @@ func (fleetManager *FleetConfigManager) Start(cfg config.Config, backends map[st
 		"token_url", cfg.OrbAgent.ConfigManager.Sources.Fleet.TokenURL,
 		"client_id", cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientID)
 
-	// call the token url to get the token
 	timeout := 30 * time.Second
 	if cfg.OrbAgent.ConfigManager.Sources.Fleet.Timeout != nil && *cfg.OrbAgent.ConfigManager.Sources.Fleet.Timeout > 0 {
 		timeout = time.Duration(*cfg.OrbAgent.ConfigManager.Sources.Fleet.Timeout) * time.Second
 	}
-	token, err := fleetManager.authTokenManager.GetToken(ctx,
-		cfg.OrbAgent.ConfigManager.Sources.Fleet.TokenURL,
-		cfg.OrbAgent.ConfigManager.Sources.Fleet.SkipTLS, timeout,
-		cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientID,
-		cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientSecret)
-	if err != nil {
-		return err
-	}
 
-	jwtClaims, err := fleet.ParseJWTClaims(token.AccessToken)
-	if err != nil {
-		return fmt.Errorf("failed to parse JWT claims: %w", err)
-	}
-
-	// generate topics from JWT claims and config agent_id using hardcoded templates
-	topics, err := fleet.GenerateTopicsFromTemplate(jwtClaims)
-	if err != nil {
-		return fmt.Errorf("failed to generate topics: %w", err)
-	}
-
-	fleetManager.logger.Info("generated topics from JWT",
-		"heartbeat_topic", topics.Heartbeat,
-		"capabilities_topic", topics.Capabilities,
-		"inbox_topic", topics.Inbox,
-		"outbox_topic", topics.Outbox,
-		"otlp_topic", topics.Ingest,
-		"telemetry_topic", topics.Telemetry)
-
-	connectionDetails := fleet.ConnectionDetails{
-		MQTTURL:  jwtClaims.MqttURL,
-		Token:    token.AccessToken,
-		AgentID:  jwtClaims.AgentID,
-		Topics:   *topics,
-		ClientID: cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientID,
-		Zone:     jwtClaims.Zone,
-	}
-	configYaml, err := fleetManager.configToSafeString(cfg)
-	if err != nil {
-		return fmt.Errorf("failed to convert config to safe string: %w", err)
-	}
-
-	// Store connection state for reconnection
-	fleetManager.config = cfg
-	fleetManager.backends = backends
-	fleetManager.labels = cfg.OrbAgent.Labels
-	fleetManager.configYaml = string(configYaml)
-	fleetManager.connectionDetails = connectionDetails
-
-	// Start OTLP bridge server early, before MQTT connection
-	// This ensures port binding errors are detected immediately and propagate to fail the agent startup
+	// Start OTLP bridge server early, before MQTT connection.
+	// Port binding errors are local/permanent so we fail immediately.
 	grpcPort := 4317
 	if cfg.OrbAgent.ConfigManager.Sources.Fleet.OTLPBridgeGRPCPort != nil {
 		grpcPort = *cfg.OrbAgent.ConfigManager.Sources.Fleet.OTLPBridgeGRPCPort
@@ -175,9 +126,53 @@ func (fleetManager *FleetConfigManager) Start(cfg config.Config, backends map[st
 	// a single monitorCancel() call.
 	fleetManager.monitorCtx, fleetManager.monitorCancel = context.WithCancel(context.Background())
 
-	err = fleetManager.connection.Connect(ctx, connectionDetails, backends, cfg.OrbAgent.Labels, string(configYaml))
-	if err != nil {
-		return err
+	// Retry loop for token fetch + MQTT connect. These depend on external services
+	// (token endpoint, MQTT broker) that may not be up yet at agent startup.
+	// AuthError (401/403) is permanent — bad credentials won't be fixed by retrying.
+	const maxStartupRetries = 0 // 0 = unlimited; agent retries until ctx is cancelled
+	startupBackoff := 5 * time.Second
+	const maxStartupBackoff = 2 * time.Minute
+	var attempt int
+	for {
+		attempt++
+		startupErr := fleetManager.startConnection(ctx, cfg, backends, timeout)
+		if startupErr == nil {
+			break
+		}
+
+		// Non-retriable: bad credentials
+		var authErr *fleet.AuthError
+		if errors.As(startupErr, &authErr) {
+			_ = fleetManager.otlpBridge.Stop(context.Background())
+			return fmt.Errorf("startup aborted, credentials rejected: %w", startupErr)
+		}
+
+		if maxStartupRetries > 0 && attempt >= maxStartupRetries {
+			_ = fleetManager.otlpBridge.Stop(context.Background())
+			return fmt.Errorf("startup failed after %d attempts: %w", attempt, startupErr)
+		}
+
+		// Defense-in-depth: tear down any lingering connection manager from the
+		// failed attempt before retrying. Connect() has its own guard, but an
+		// explicit teardown here ensures no leaked manager can reconnect in the
+		// background. Disconnect is nil-safe.
+		disconnectCtx, disconnectCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = fleetManager.connection.Disconnect(disconnectCtx, "")
+		disconnectCancel()
+
+		fleetManager.logger.Warn("startup attempt failed, retrying",
+			"attempt", attempt,
+			"error", startupErr,
+			"retry_in", startupBackoff)
+
+		select {
+		case <-ctx.Done():
+			_ = fleetManager.otlpBridge.Stop(context.Background())
+			return fmt.Errorf("startup cancelled: %w", ctx.Err())
+		case <-time.After(startupBackoff):
+		}
+
+		startupBackoff = min(startupBackoff*2, maxStartupBackoff)
 	}
 	fleetManager.connected.Store(true)
 
@@ -253,6 +248,61 @@ func (fleetManager *FleetConfigManager) Start(cfg config.Config, backends map[st
 	}()
 
 	return nil
+}
+
+// startConnection performs the token fetch, JWT parse, topic generation, and MQTT connect.
+// It is called by Start's retry loop. Transient failures (network, broker down) return a
+// plain error that the caller retries; permanent failures (bad credentials) return an
+// *fleet.AuthError that the caller surfaces immediately.
+func (fleetManager *FleetConfigManager) startConnection(ctx context.Context, cfg config.Config, backends map[string]backend.Backend, timeout time.Duration) error {
+	token, err := fleetManager.authTokenManager.GetToken(ctx,
+		cfg.OrbAgent.ConfigManager.Sources.Fleet.TokenURL,
+		cfg.OrbAgent.ConfigManager.Sources.Fleet.SkipTLS, timeout,
+		cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientID,
+		cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientSecret)
+	if err != nil {
+		return err
+	}
+
+	jwtClaims, err := fleet.ParseJWTClaims(token.AccessToken)
+	if err != nil {
+		return fmt.Errorf("failed to parse JWT claims: %w", err)
+	}
+
+	topics, err := fleet.GenerateTopicsFromTemplate(jwtClaims)
+	if err != nil {
+		return fmt.Errorf("failed to generate topics: %w", err)
+	}
+
+	fleetManager.logger.Info("generated topics from JWT",
+		"heartbeat_topic", topics.Heartbeat,
+		"capabilities_topic", topics.Capabilities,
+		"inbox_topic", topics.Inbox,
+		"outbox_topic", topics.Outbox,
+		"otlp_topic", topics.Ingest,
+		"telemetry_topic", topics.Telemetry)
+
+	connectionDetails := fleet.ConnectionDetails{
+		MQTTURL:  jwtClaims.MqttURL,
+		Token:    token.AccessToken,
+		AgentID:  jwtClaims.AgentID,
+		Topics:   *topics,
+		ClientID: cfg.OrbAgent.ConfigManager.Sources.Fleet.ClientID,
+		Zone:     jwtClaims.Zone,
+	}
+	configYaml, err := fleetManager.configToSafeString(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to convert config to safe string: %w", err)
+	}
+
+	// Store connection state for reconnection
+	fleetManager.config = cfg
+	fleetManager.backends = backends
+	fleetManager.labels = cfg.OrbAgent.Labels
+	fleetManager.configYaml = string(configYaml)
+	fleetManager.connectionDetails = connectionDetails
+
+	return fleetManager.connection.Connect(ctx, connectionDetails, backends, cfg.OrbAgent.Labels, string(configYaml))
 }
 
 // runReconnectWorker processes signals from reconnectChan, retrying token refresh with exponential

--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -254,6 +254,9 @@ func (fleetManager *FleetConfigManager) Start(ctx context.Context, cfg config.Co
 // It is called by Start's retry loop. Transient failures (network, broker down) return a
 // plain error that the caller retries; permanent failures (bad credentials) return an
 // *fleet.AuthError that the caller surfaces immediately.
+//
+// ctx is used for short-lived startup work (token fetch, JWT parse). The MQTT connection
+// itself uses fleetManager.monitorCtx so it outlives the startup context.
 func (fleetManager *FleetConfigManager) startConnection(ctx context.Context, cfg config.Config, backends map[string]backend.Backend, timeout time.Duration) error {
 	token, err := fleetManager.authTokenManager.GetToken(ctx,
 		cfg.OrbAgent.ConfigManager.Sources.Fleet.TokenURL,
@@ -302,7 +305,9 @@ func (fleetManager *FleetConfigManager) startConnection(ctx context.Context, cfg
 	fleetManager.configYaml = string(configYaml)
 	fleetManager.connectionDetails = connectionDetails
 
-	return fleetManager.connection.Connect(ctx, connectionDetails, backends, cfg.OrbAgent.Labels, string(configYaml))
+	// Use monitorCtx for the MQTT connection so it outlives the caller's startup
+	// context. monitorCtx is cancelled by Stop(), which is the correct lifecycle.
+	return fleetManager.connection.Connect(fleetManager.monitorCtx, connectionDetails, backends, cfg.OrbAgent.Labels, string(configYaml))
 }
 
 // runReconnectWorker processes signals from reconnectChan, retrying token refresh with exponential

--- a/agent/configmgr/fleet/auth.go
+++ b/agent/configmgr/fleet/auth.go
@@ -102,6 +102,10 @@ func (fleetManager *AuthTokenManager) GetToken(ctx context.Context, tokenURL str
 
 	fleetManager.logger.Debug("sending token request", "url", tokenURL, "data", redact.SensitiveData(data), "client_id", clientID)
 
+	// Note that errors below are logged with Warn level, but returned as errors to allow callers
+	// to distinguish between transient errors (e.g. network issues) and auth failures
+	// (e.g. invalid credentials). The caller can choose to retry on transient errors,
+	// but should not retry on auth failures without fixing the credentials.
 	resp, err := httpClient.Do(req.WithContext(ctx))
 	if err != nil {
 		fleetManager.logger.Warn("failed to send token request", "error", err, "token_url", tokenURL)

--- a/agent/configmgr/fleet/auth.go
+++ b/agent/configmgr/fleet/auth.go
@@ -20,6 +20,17 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/redact"
 )
 
+// AuthError indicates a non-retriable authentication failure (e.g. HTTP 401/403).
+// Callers should not retry when they receive this error — the credentials are wrong.
+type AuthError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *AuthError) Error() string {
+	return fmt.Sprintf("authentication failed (HTTP %d)", e.StatusCode)
+}
+
 // AuthTokenManager manages auth tokens
 type AuthTokenManager struct {
 	mu             sync.RWMutex
@@ -93,27 +104,30 @@ func (fleetManager *AuthTokenManager) GetToken(ctx context.Context, tokenURL str
 
 	resp, err := httpClient.Do(req.WithContext(ctx))
 	if err != nil {
-		fleetManager.logger.Error("failed to send token request", "error", err, "token_url", tokenURL)
+		fleetManager.logger.Warn("failed to send token request", "error", err, "token_url", tokenURL)
 		return nil, fmt.Errorf("failed to send request to %s: %w", tokenURL, err)
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
-			fleetManager.logger.Error("failed to close response body", "error", err)
+			fleetManager.logger.Warn("failed to close response body", "error", err)
 		}
 	}()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		fleetManager.logger.Error("failed to read response body", "error", err, "status_code", resp.StatusCode)
+		fleetManager.logger.Warn("failed to read response body", "error", err, "status_code", resp.StatusCode)
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		fleetManager.logger.Error("token request failed",
+		fleetManager.logger.Warn("token request failed",
 			"status_code", resp.StatusCode,
 			"response", string(body),
 			"token_url", tokenURL,
 			"client_id", clientID)
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return nil, &AuthError{StatusCode: resp.StatusCode, Body: string(body)}
+		}
 		return nil, fmt.Errorf("token request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -195,6 +209,26 @@ func (fleetManager *AuthTokenManager) RefreshToken(ctx context.Context) (*TokenR
 
 	fleetManager.logger.Debug("refreshing JWT token")
 	return fleetManager.GetToken(ctx, tokenURL, skipTLS, timeout, clientID, clientSecret)
+}
+
+// GetFreshToken returns the cached access token if it is still valid, otherwise
+// performs an HTTP refresh and returns the new token. This avoids redundant HTTP
+// calls when the token monitor has already refreshed proactively.
+func (fleetManager *AuthTokenManager) GetFreshToken(ctx context.Context) (string, error) {
+	fleetManager.mu.RLock()
+	token := fleetManager.lastToken
+	expired := fleetManager.lastToken == nil || time.Now().After(fleetManager.tokenExpiresAt)
+	fleetManager.mu.RUnlock()
+
+	if !expired {
+		return token.AccessToken, nil
+	}
+
+	resp, err := fleetManager.RefreshToken(ctx)
+	if err != nil {
+		return "", err
+	}
+	return resp.AccessToken, nil
 }
 
 // IsTokenExpired checks if the current token is expired or will expire soon

--- a/agent/configmgr/fleet/auth_test.go
+++ b/agent/configmgr/fleet/auth_test.go
@@ -601,3 +601,106 @@ func TestAuthTokenManager_RefreshToken(t *testing.T) {
 	newExpiryTime := authTokenManager.GetTokenExpiryTime()
 	assert.WithinDuration(t, newFutureExpiry.Add(-5*time.Minute), newExpiryTime, 1*time.Second)
 }
+
+func TestAuthTokenManager_GetFreshToken_ReturnsCachedWhenValid(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mgr := NewAuthTokenManager(logger)
+
+	// Seed a token that expires in 1 hour
+	jwtToken := RawJWTWithClaims(map[string]any{
+		"exp": time.Now().Add(1 * time.Hour).Unix(),
+		"iat": time.Now().Unix(),
+	})
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(TokenResponse{
+			AccessToken: jwtToken,
+			ExpiresIn:   3600,
+		})
+	}))
+	defer server.Close()
+
+	_, err := mgr.GetToken(context.Background(), server.URL, true, 30*time.Second, "client", "secret")
+	require.NoError(t, err)
+
+	// GetFreshToken should return the cached token without any HTTP call.
+	// (The server is still up, but we verify by checking the returned value matches.)
+	token, err := mgr.GetFreshToken(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, jwtToken, token)
+}
+
+func TestAuthTokenManager_GetFreshToken_RefreshesWhenExpired(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mgr := NewAuthTokenManager(logger)
+
+	// Seed a token that is already expired
+	expiredJWT := RawJWTWithClaims(map[string]any{
+		"exp": time.Now().Add(-1 * time.Hour).Unix(),
+		"iat": time.Now().Add(-2 * time.Hour).Unix(),
+	})
+
+	// First server: returns an expired token
+	server1 := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(TokenResponse{
+			AccessToken: expiredJWT,
+			ExpiresIn:   0,
+		})
+	}))
+	defer server1.Close()
+
+	_, err := mgr.GetToken(context.Background(), server1.URL, true, 30*time.Second, "client", "secret")
+	require.NoError(t, err)
+
+	// Now point to a server that returns a fresh token
+	freshJWT := RawJWTWithClaims(map[string]any{
+		"exp": time.Now().Add(1 * time.Hour).Unix(),
+		"iat": time.Now().Unix(),
+	})
+	server2 := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(TokenResponse{
+			AccessToken: freshJWT,
+			ExpiresIn:   3600,
+		})
+	}))
+	defer server2.Close()
+	mgr.tokenURL = server2.URL
+
+	// GetFreshToken should detect expiry and refresh
+	token, err := mgr.GetFreshToken(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, freshJWT, token)
+}
+
+func TestAuthTokenManager_GetFreshToken_PropagatesRefreshError(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mgr := NewAuthTokenManager(logger)
+
+	// Seed an expired token
+	expiredJWT := RawJWTWithClaims(map[string]any{
+		"exp": time.Now().Add(-1 * time.Hour).Unix(),
+		"iat": time.Now().Add(-2 * time.Hour).Unix(),
+	})
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(TokenResponse{
+			AccessToken: expiredJWT,
+			ExpiresIn:   0,
+		})
+	}))
+	defer server.Close()
+
+	_, err := mgr.GetToken(context.Background(), server.URL, true, 30*time.Second, "client", "secret")
+	require.NoError(t, err)
+
+	// Point to a server that returns 500
+	serverErr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer serverErr.Close()
+	mgr.tokenURL = serverErr.URL
+
+	// GetFreshToken should propagate the error
+	_, err = mgr.GetFreshToken(context.Background())
+	assert.Error(t, err)
+}

--- a/agent/configmgr/fleet/auth_test.go
+++ b/agent/configmgr/fleet/auth_test.go
@@ -75,7 +75,10 @@ func TestFleetConfigManager_GetToken_HTTPError(t *testing.T) {
 	// Assert
 	assert.Error(t, err)
 	assert.Nil(t, token)
-	assert.Contains(t, err.Error(), "token request failed")
+	assert.Contains(t, err.Error(), "authentication failed")
+	var authErr *AuthError
+	assert.ErrorAs(t, err, &authErr)
+	assert.Equal(t, http.StatusUnauthorized, authErr.StatusCode)
 }
 
 func TestFleetConfigManager_GetToken_InvalidJSON(t *testing.T) {

--- a/agent/configmgr/fleet/connection.go
+++ b/agent/configmgr/fleet/connection.go
@@ -427,7 +427,11 @@ func (connection *MQTTConnection) Disconnect(ctx context.Context, heartbeatTopic
 	// Set shutdown flag first to prevent new messages from being enqueued
 	connection.shuttingDown.Store(true)
 
-	connection.heartbeater.stop(heartbeatTopic, connection.publishToTopic)
+	// Only attempt the offline heartbeat if we have a real topic; callers like
+	// the startup retry loop pass "" when no session was ever established.
+	if heartbeatTopic != "" {
+		connection.heartbeater.stop(heartbeatTopic, connection.publishToTopic)
+	}
 	// Disconnect first to stop receiving new messages, then stop the worker
 	err := connection.connectionManager.Disconnect(ctx)
 	connection.stopDispatchWorker()

--- a/agent/configmgr/fleet/connection.go
+++ b/agent/configmgr/fleet/connection.go
@@ -416,8 +416,12 @@ func (connection *MQTTConnection) Reconnect(ctx context.Context, details Connect
 	return nil
 }
 
-// Disconnect disconnects from the MQTT broker
+// Disconnect disconnects from the MQTT broker. It is nil-safe: calling
+// Disconnect when no connection manager exists is a no-op.
 func (connection *MQTTConnection) Disconnect(ctx context.Context, heartbeatTopic string) error {
+	if connection.connectionManager == nil {
+		return nil
+	}
 	// Set shutdown flag first to prevent new messages from being enqueued
 	connection.shuttingDown.Store(true)
 

--- a/agent/configmgr/fleet/connection.go
+++ b/agent/configmgr/fleet/connection.go
@@ -136,8 +136,9 @@ func (connection *MQTTConnection) stopDispatchWorker() {
 	<-connection.dispatchWorkerDone
 }
 
-// Connect connects to the MQTT broker. It is safe to call repeatedly (e.g.
-// from a startup retry loop): dispatch channels are always freshly allocated.
+// Connect connects to the MQTT broker. It is safe to call after a previous
+// failed Connect (e.g. from a startup retry loop): any existing dispatch
+// worker and connection manager are torn down before reinitializing.
 func (connection *MQTTConnection) Connect(ctx context.Context, details ConnectionDetails, backends map[string]backend.Backend, labels map[string]string, configFile string) error {
 	// Parse the ORB URL
 	serverURL, err := url.Parse(details.MQTTURL)
@@ -146,8 +147,17 @@ func (connection *MQTTConnection) Connect(ctx context.Context, details Connectio
 		return err
 	}
 
-	// Reinitialize dispatch channels after validation so a parse error doesn't
-	// leave unstarted channels that stopDispatchWorker would block on forever.
+	// Tear down any prior state so repeated Connect calls don't leak goroutines.
+	// Only needed when a previous Connect left a running connection manager.
+	if connection.connectionManager != nil {
+		teardownCtx, teardownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = connection.connectionManager.Disconnect(teardownCtx)
+		teardownCancel()
+		connection.connectionManager = nil
+		connection.stopDispatchWorker()
+	}
+
+	// Reinitialize dispatch channels after validation and teardown.
 	connection.dispatchQueue = make(chan dispatchJob, 100)
 	connection.dispatchWorkerDone = make(chan struct{})
 	connection.shuttingDown.Store(false)

--- a/agent/configmgr/fleet/connection.go
+++ b/agent/configmgr/fleet/connection.go
@@ -139,18 +139,18 @@ func (connection *MQTTConnection) stopDispatchWorker() {
 // Connect connects to the MQTT broker. It is safe to call repeatedly (e.g.
 // from a startup retry loop): dispatch channels are always freshly allocated.
 func (connection *MQTTConnection) Connect(ctx context.Context, details ConnectionDetails, backends map[string]backend.Backend, labels map[string]string, configFile string) error {
-	// Reinitialize dispatch channels so Connect is safe to call after a
-	// previous failure that closed them via stopDispatchWorker.
-	connection.dispatchQueue = make(chan dispatchJob, 100)
-	connection.dispatchWorkerDone = make(chan struct{})
-	connection.shuttingDown.Store(false)
-
 	// Parse the ORB URL
 	serverURL, err := url.Parse(details.MQTTURL)
 	if err != nil {
 		connection.logger.Error("failed to parse MQTT URL", "url", details.MQTTURL, "error", err)
 		return err
 	}
+
+	// Reinitialize dispatch channels after validation so a parse error doesn't
+	// leave unstarted channels that stopDispatchWorker would block on forever.
+	connection.dispatchQueue = make(chan dispatchJob, 100)
+	connection.dispatchWorkerDone = make(chan struct{})
+	connection.shuttingDown.Store(false)
 
 	// Store topics for hook callbacks
 	connection.connectionTopics = details.Topics

--- a/agent/configmgr/fleet/connection.go
+++ b/agent/configmgr/fleet/connection.go
@@ -136,8 +136,15 @@ func (connection *MQTTConnection) stopDispatchWorker() {
 	<-connection.dispatchWorkerDone
 }
 
-// Connect connects to the MQTT broker
+// Connect connects to the MQTT broker. It is safe to call repeatedly (e.g.
+// from a startup retry loop): dispatch channels are always freshly allocated.
 func (connection *MQTTConnection) Connect(ctx context.Context, details ConnectionDetails, backends map[string]backend.Backend, labels map[string]string, configFile string) error {
+	// Reinitialize dispatch channels so Connect is safe to call after a
+	// previous failure that closed them via stopDispatchWorker.
+	connection.dispatchQueue = make(chan dispatchJob, 100)
+	connection.dispatchWorkerDone = make(chan struct{})
+	connection.shuttingDown.Store(false)
+
 	// Parse the ORB URL
 	serverURL, err := url.Parse(details.MQTTURL)
 	if err != nil {
@@ -394,11 +401,6 @@ func (connection *MQTTConnection) Reconnect(ctx context.Context, details Connect
 			// Continue anyway to try to establish new connection
 		}
 		connection.stopDispatchWorker()
-
-		// Create new channels for the next connection and reset shutdown flag
-		connection.dispatchQueue = make(chan dispatchJob, 100)
-		connection.dispatchWorkerDone = make(chan struct{})
-		connection.shuttingDown.Store(false)
 	}
 
 	// Reset failure counters

--- a/agent/configmgr/fleet_test.go
+++ b/agent/configmgr/fleet_test.go
@@ -112,8 +112,12 @@ func TestFleetConfigManager_Start_TokenError(t *testing.T) {
 
 	backends := make(map[string]backend.Backend)
 
+	// Use a short-lived context so the startup retry loop exits quickly.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
 	// Act
-	err := fleetManager.Start(cfg, backends)
+	err := fleetManager.Start(ctx, cfg, backends)
 
 	// Assert
 	assert.Error(t, err)
@@ -171,13 +175,15 @@ func TestFleetConfigManager_Start_ConnectError(t *testing.T) {
 
 	backends := make(map[string]backend.Backend)
 
+	// Use a short-lived context so the startup retry loop exits quickly.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
 	// Act
-	err := fleetManager.Start(cfg, backends)
+	err := fleetManager.Start(ctx, cfg, backends)
 
 	// Assert
 	assert.Error(t, err)
-	// Verify the error is from the mock connection (no 30s wait)
-	assert.Contains(t, err.Error(), "mqtt connection failed")
 }
 
 func TestFleetConfigManager_GetContext(t *testing.T) {
@@ -261,20 +267,26 @@ func TestFleetConfigManager_Start_WithJWTTopicGeneration(t *testing.T) {
 	// Mock backends
 	backends := make(map[string]backend.Backend)
 
+	// Use a short-lived context so the startup retry loop exits quickly.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
 	// The Start method should succeed in generating topics from JWT claims,
 	// but fail at the MQTT connection step (which is mocked to return an error)
-	err := fleetManager.Start(cfg, backends)
+	err := fleetManager.Start(ctx, cfg, backends)
 
 	// We expect an error because the mock connection returns an error,
 	// but we want to verify that topic generation succeeded
 	// (The error should be related to MQTT connection, not JWT parsing)
 	require.Error(t, err)
-	// The error should be the mocked connection error
+	// The error may be the mocked connection error or context cancellation from the retry loop.
 	errorMsg := strings.ToLower(err.Error())
 	assert.True(t,
 		strings.Contains(errorMsg, "mqtt") ||
-			strings.Contains(errorMsg, "connection"),
-		"Expected connection-related error, got: %s", err.Error())
+			strings.Contains(errorMsg, "connection") ||
+			strings.Contains(errorMsg, "cancelled") ||
+			strings.Contains(errorMsg, "deadline"),
+		"Expected connection-related or cancellation error, got: %s", err.Error())
 }
 
 func TestFleetConfigManager_configToSafeString(t *testing.T) {
@@ -1170,8 +1182,8 @@ func TestFleetConfigManager_Start_OTLPBridgePortInUse(t *testing.T) {
 	}
 	fleetManager := newFleetConfigManagerWithConnection(logger, mockPMgr, &mockBackendState{}, mockConn)
 
-	// Act
-	err = fleetManager.Start(cfg, backends)
+	// Act — port binding is before the retry loop, so this fails immediately.
+	err = fleetManager.Start(context.Background(), cfg, backends)
 
 	// Assert
 	require.Error(t, err, "Start() should fail when port is in use")
@@ -1233,8 +1245,12 @@ func TestFleetConfigManager_Start_OTLPBridgeStartsBeforeMQTT(t *testing.T) {
 
 	backends := make(map[string]backend.Backend)
 
+	// Use a short-lived context so the startup retry loop exits quickly.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
 	// Act
-	err := fleetManager.Start(cfg, backends)
+	err := fleetManager.Start(ctx, cfg, backends)
 
 	// Assert
 	// Even though MQTT connection fails, we should verify that:

--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -348,7 +348,7 @@ func (gc *gitConfigManager) schedule(cfg config.Config, backends map[string]back
 	}
 }
 
-func (gc *gitConfigManager) Start(cfg config.Config, backends map[string]backend.Backend) error {
+func (gc *gitConfigManager) Start(_ context.Context, cfg config.Config, backends map[string]backend.Backend) error {
 	var err error
 	var startOK bool
 	gc.version = 1

--- a/agent/configmgr/git_test.go
+++ b/agent/configmgr/git_test.go
@@ -1,6 +1,7 @@
 package configmgr_test
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -137,7 +138,7 @@ backend1:
 			payload.Action == "manage"
 	})).Return()
 
-	err = gc.Start(cfg, backends)
+	err = gc.Start(context.Background(), cfg, backends)
 	require.NoError(t, err)
 }
 
@@ -211,7 +212,7 @@ backend1:
 		"backend1": &mockBackend{name: "backend1"},
 	}
 
-	err = gc.Start(cfg, backends)
+	err = gc.Start(context.Background(), cfg, backends)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no policies match the selector")
 	pMgr.AssertNotCalled(t, "ManagePolicy", mock.Anything)
@@ -317,7 +318,7 @@ backend1:
 		return p.Backend == "backend1" && p.Action == "manage"
 	})).Return()
 
-	err = gc.Start(cfg, backends)
+	err = gc.Start(context.Background(), cfg, backends)
 	require.NoError(t, err, "Start() via system git fallback should succeed")
 	pMgr.AssertCalled(t, "ManagePolicy", mock.Anything)
 }

--- a/agent/configmgr/local.go
+++ b/agent/configmgr/local.go
@@ -19,7 +19,7 @@ type localConfigManager struct {
 	pMgr   policymgr.PolicyManager
 }
 
-func (lc *localConfigManager) Start(cfg config.Config, backends map[string]backend.Backend) error {
+func (lc *localConfigManager) Start(_ context.Context, cfg config.Config, backends map[string]backend.Backend) error {
 	if cfg.OrbAgent.Policies == nil {
 		return errors.New("no policies specified")
 	}

--- a/agent/configmgr/local_test.go
+++ b/agent/configmgr/local_test.go
@@ -1,6 +1,7 @@
 package configmgr_test
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"testing"
@@ -51,7 +52,7 @@ func TestLocalConfigManager(t *testing.T) {
 
 		// Create and start the manager
 		mgr := configmgr.New(logger, pMgr, cfg.Active, &mockBackendState{})
-		err := mgr.Start(testConfig, backends)
+		err := mgr.Start(context.Background(), testConfig, backends)
 
 		// Verify
 		assert.NoError(t, err)
@@ -70,7 +71,7 @@ func TestLocalConfigManager(t *testing.T) {
 
 		// Create the manager
 		mgr := configmgr.New(logger, pMgr, cfg.Active, &mockBackendState{})
-		err := mgr.Start(testConfig, backends)
+		err := mgr.Start(context.Background(), testConfig, backends)
 
 		// Should return an error
 		assert.Error(t, err)
@@ -99,7 +100,7 @@ func TestLocalConfigManager(t *testing.T) {
 
 		// Create the manager
 		mgr := configmgr.New(logger, pMgr, cfg.Active, &mockBackendState{})
-		err := mgr.Start(testConfig, backends)
+		err := mgr.Start(context.Background(), testConfig, backends)
 
 		// Should return an error
 		assert.Error(t, err)

--- a/agent/configmgr/manager.go
+++ b/agent/configmgr/manager.go
@@ -11,7 +11,7 @@ import (
 
 // Manager is the interface for configuration manager
 type Manager interface {
-	Start(cfg config.Config, backends map[string]backend.Backend) error
+	Start(ctx context.Context, cfg config.Config, backends map[string]backend.Backend) error
 	GetContext(ctx context.Context) context.Context
 	Stop(ctx context.Context) error
 }


### PR DESCRIPTION
Add context.Context parameter to Manager.Start() interface so callers can cancel startup.

Implement a retry loop in FleetConfigManager.Start() that retries token fetch + MQTT connect with exponential backoff (5s to 2min), allowing the agent to wait for infrastructure services at startup.

Introduce AuthError type (HTTP 401/403) as a non-retriable sentinel so bad credentials fail immediately without wasting retries.

Make MQTTConnection.Disconnect nil-safe to support cleanup during retry loop when Connect was never reached. Change transient auth failure log levels from Error to Warn (as we want errors to only log as such if they require attention)