### PR TITLE
fix: OBS-2208 add publish queue to OTLP bridge for MQTT resilience

### DIFF
--- a/.github/golangci.yaml
+++ b/.github/golangci.yaml
@@ -1,6 +1,7 @@
 version: "2"
 run:
   modules-download-mode: readonly
+  relative-path-mode: gomod
 linters:
   enable:
     - bodyclose

--- a/agent/otlpbridge/handlers.go
+++ b/agent/otlpbridge/handlers.go
@@ -2,7 +2,6 @@ package otlpbridge
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 
 	collectorlogs "go.opentelemetry.io/proto/otlp/collector/logs/v1"
@@ -40,11 +39,6 @@ type traceServer struct {
 }
 
 func (s *traceServer) Export(ctx context.Context, req *collectortrace.ExportTraceServiceRequest) (*collectortrace.ExportTraceServiceResponse, error) {
-	pub := s.bridge.GetPublisher()
-	if pub == nil {
-		return nil, fmt.Errorf("publisher not yet initialized")
-	}
-
 	resources := make([]*resourcev1.Resource, 0, len(req.ResourceSpans))
 	for _, rs := range req.ResourceSpans {
 		if rs != nil {
@@ -52,24 +46,11 @@ func (s *traceServer) Export(ctx context.Context, req *collectortrace.ExportTrac
 		}
 	}
 
-	var topic string
-	if isIngestRequest(resources) {
-		topic = s.bridge.GetIngestTopic()
-		if topic == "" {
-			return nil, fmt.Errorf("ingest topic not yet initialized")
-		}
-	} else {
-		topic = s.bridge.GetTelemetryTopic()
-		if topic == "" {
-			return nil, fmt.Errorf("telemetry topic not yet initialized")
-		}
-	}
-
 	payload, err := s.bridge.enc.Marshal(req)
 	if err != nil {
 		return nil, err
 	}
-	if err := pub.Publish(ctx, topic, payload); err != nil {
+	if err := s.bridge.Enqueue(ctx, isIngestRequest(resources), payload); err != nil {
 		return nil, err
 	}
 	return &collectortrace.ExportTraceServiceResponse{}, nil
@@ -82,11 +63,6 @@ type metricsServer struct {
 }
 
 func (s *metricsServer) Export(ctx context.Context, req *collectormetrics.ExportMetricsServiceRequest) (*collectormetrics.ExportMetricsServiceResponse, error) {
-	pub := s.bridge.GetPublisher()
-	if pub == nil {
-		return nil, fmt.Errorf("publisher not yet initialized")
-	}
-
 	resources := make([]*resourcev1.Resource, 0, len(req.ResourceMetrics))
 	for _, rm := range req.ResourceMetrics {
 		if rm != nil {
@@ -94,24 +70,11 @@ func (s *metricsServer) Export(ctx context.Context, req *collectormetrics.Export
 		}
 	}
 
-	var topic string
-	if isIngestRequest(resources) {
-		topic = s.bridge.GetIngestTopic()
-		if topic == "" {
-			return nil, fmt.Errorf("ingest topic not yet initialized")
-		}
-	} else {
-		topic = s.bridge.GetTelemetryTopic()
-		if topic == "" {
-			return nil, fmt.Errorf("telemetry topic not yet initialized")
-		}
-	}
-
 	payload, err := s.bridge.enc.Marshal(req)
 	if err != nil {
 		return nil, err
 	}
-	if err := pub.Publish(ctx, topic, payload); err != nil {
+	if err := s.bridge.Enqueue(ctx, isIngestRequest(resources), payload); err != nil {
 		return nil, err
 	}
 	return &collectormetrics.ExportMetricsServiceResponse{}, nil
@@ -124,23 +87,19 @@ type logsServer struct {
 }
 
 func (s *logsServer) Export(ctx context.Context, req *collectorlogs.ExportLogsServiceRequest) (*collectorlogs.ExportLogsServiceResponse, error) {
-	pub := s.bridge.GetPublisher()
-	if pub == nil {
-		return nil, fmt.Errorf("publisher not yet initialized")
-	}
-	if s.isIngestRequest(req) {
+	isIngest := s.isIngestRequest(req)
+	if isIngest {
 		repo := s.bridge.GetPolicyRepo()
 		enrichLogsWithDatasets(req, repo)
 		s.bridge.logger.Info("ingesting enriched logs with dataset_ids", "request", req)
-		err := s.publishToIngestTopic(ctx, req, pub)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		err := s.publishToTelemetryTopic(ctx, req, pub)
-		if err != nil {
-			return nil, err
-		}
+	}
+
+	payload, err := s.bridge.enc.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.bridge.Enqueue(ctx, isIngest, payload); err != nil {
+		return nil, err
 	}
 	return &collectorlogs.ExportLogsServiceResponse{}, nil
 }
@@ -174,35 +133,6 @@ func (s *logsServer) isIngestRequest(req *collectorlogs.ExportLogsServiceRequest
 		}
 	}
 	return false
-}
-
-func (s *logsServer) publishToIngestTopic(ctx context.Context, req *collectorlogs.ExportLogsServiceRequest, pub Publisher) error {
-	topic := s.bridge.GetIngestTopic()
-	if topic == "" {
-		return fmt.Errorf("ingest topic not yet initialized")
-	}
-
-	return s.publish(ctx, req, pub, topic)
-}
-
-func (s *logsServer) publishToTelemetryTopic(ctx context.Context, req *collectorlogs.ExportLogsServiceRequest, pub Publisher) error {
-	topic := s.bridge.GetTelemetryTopic()
-	if topic == "" {
-		return fmt.Errorf("telemetry topic not yet initialized")
-	}
-
-	return s.publish(ctx, req, pub, topic)
-}
-
-func (s *logsServer) publish(ctx context.Context, req *collectorlogs.ExportLogsServiceRequest, pub Publisher, topic string) error {
-	payload, err := s.bridge.enc.Marshal(req)
-	if err != nil {
-		return err
-	}
-	if err := pub.Publish(ctx, topic, payload); err != nil {
-		return err
-	}
-	return nil
 }
 
 // enrichLogsWithDatasets adds dataset_ids to ScopeLogs attributes based on policy_name.

--- a/agent/otlpbridge/handlers_test.go
+++ b/agent/otlpbridge/handlers_test.go
@@ -70,8 +70,7 @@ func newBridgeWithTopics(_ Encoder) (*BridgeServer, *fakePublisher) {
 
 func TestTraceHandler_Export_AgentTelemetry_PublishesToTelemetry(t *testing.T) {
 	bridge, fp := newBridgeWithTopics(ProtobufEncoder{})
-	//nolint:errcheck // err doesn't matter
-	defer bridge.Stop(context.Background())
+	defer func() { _ = bridge.Stop(context.Background()) }()
 	s := &traceServer{bridge: bridge}
 	_, err := s.Export(context.Background(), &collectortrace.ExportTraceServiceRequest{})
 	if err != nil {
@@ -84,8 +83,7 @@ func TestTraceHandler_Export_AgentTelemetry_PublishesToTelemetry(t *testing.T) {
 
 func TestTraceHandler_Export_DiodeData_PublishesToIngest(t *testing.T) {
 	bridge, fp := newBridgeWithTopics(ProtobufEncoder{})
-	//nolint:errcheck // err doesn't matter
-	defer bridge.Stop(context.Background())
+	defer func() { _ = bridge.Stop(context.Background()) }()
 	s := &traceServer{bridge: bridge}
 	req := &collectortrace.ExportTraceServiceRequest{
 		ResourceSpans: []*tracev1.ResourceSpans{
@@ -107,8 +105,7 @@ func TestTraceHandler_Export_DiodeData_PublishesToIngest(t *testing.T) {
 
 func TestMetricsHandler_Export_AgentTelemetry_PublishesToTelemetry(t *testing.T) {
 	bridge, fp := newBridgeWithTopics(ProtobufEncoder{})
-	//nolint:errcheck // err doesn't matter
-	defer bridge.Stop(context.Background())
+	defer func() { _ = bridge.Stop(context.Background()) }()
 	s := &metricsServer{bridge: bridge}
 	_, err := s.Export(context.Background(), &collectormetrics.ExportMetricsServiceRequest{})
 	if err != nil {
@@ -121,8 +118,7 @@ func TestMetricsHandler_Export_AgentTelemetry_PublishesToTelemetry(t *testing.T)
 
 func TestMetricsHandler_Export_DiodeData_PublishesToIngest(t *testing.T) {
 	bridge, fp := newBridgeWithTopics(ProtobufEncoder{})
-	//nolint:errcheck // err doesn't matter
-	defer bridge.Stop(context.Background())
+	defer func() { _ = bridge.Stop(context.Background()) }()
 	s := &metricsServer{bridge: bridge}
 	req := &collectormetrics.ExportMetricsServiceRequest{
 		ResourceMetrics: []*metricsv1.ResourceMetrics{
@@ -144,8 +140,7 @@ func TestMetricsHandler_Export_DiodeData_PublishesToIngest(t *testing.T) {
 
 func TestLogsHandler_Export_AgentTelemetry_PublishesToTelemetry(t *testing.T) {
 	bridge, fp := newBridgeWithTopics(ProtobufEncoder{})
-	//nolint:errcheck // err doesn't matter
-	defer bridge.Stop(context.Background())
+	defer func() { _ = bridge.Stop(context.Background()) }()
 	s := &logsServer{bridge: bridge}
 	_, err := s.Export(context.Background(), &collectorlogs.ExportLogsServiceRequest{})
 	if err != nil {
@@ -164,8 +159,7 @@ func TestBridge_Enqueue_QueuesDrainsOnReady(t *testing.T) {
 	fp := &fakePublisher{}
 	bridge, _ := NewBridgeServer(BridgeConfig{Encoding: "protobuf"}, nil, nil)
 	bridge.initialBackoff = 5 * time.Millisecond
-	//nolint:errcheck // err doesn't matter
-	defer bridge.Stop(context.Background())
+	defer func() { _ = bridge.Stop(context.Background()) }()
 
 	// Enqueue before publisher is set — should queue, not error.
 	if err := bridge.Enqueue(context.Background(), false, []byte("hello")); err != nil {

--- a/agent/otlpbridge/handlers_test.go
+++ b/agent/otlpbridge/handlers_test.go
@@ -70,6 +70,7 @@ func newBridgeWithTopics(_ Encoder) (*BridgeServer, *fakePublisher) {
 
 func TestTraceHandler_Export_AgentTelemetry_PublishesToTelemetry(t *testing.T) {
 	bridge, fp := newBridgeWithTopics(ProtobufEncoder{})
+	//nolint:errcheck // err doesn't matter
 	defer bridge.Stop(context.Background())
 	s := &traceServer{bridge: bridge}
 	_, err := s.Export(context.Background(), &collectortrace.ExportTraceServiceRequest{})
@@ -83,6 +84,7 @@ func TestTraceHandler_Export_AgentTelemetry_PublishesToTelemetry(t *testing.T) {
 
 func TestTraceHandler_Export_DiodeData_PublishesToIngest(t *testing.T) {
 	bridge, fp := newBridgeWithTopics(ProtobufEncoder{})
+	//nolint:errcheck // err doesn't matter
 	defer bridge.Stop(context.Background())
 	s := &traceServer{bridge: bridge}
 	req := &collectortrace.ExportTraceServiceRequest{
@@ -105,6 +107,7 @@ func TestTraceHandler_Export_DiodeData_PublishesToIngest(t *testing.T) {
 
 func TestMetricsHandler_Export_AgentTelemetry_PublishesToTelemetry(t *testing.T) {
 	bridge, fp := newBridgeWithTopics(ProtobufEncoder{})
+	//nolint:errcheck // err doesn't matter
 	defer bridge.Stop(context.Background())
 	s := &metricsServer{bridge: bridge}
 	_, err := s.Export(context.Background(), &collectormetrics.ExportMetricsServiceRequest{})
@@ -118,6 +121,7 @@ func TestMetricsHandler_Export_AgentTelemetry_PublishesToTelemetry(t *testing.T)
 
 func TestMetricsHandler_Export_DiodeData_PublishesToIngest(t *testing.T) {
 	bridge, fp := newBridgeWithTopics(ProtobufEncoder{})
+	//nolint:errcheck // err doesn't matter
 	defer bridge.Stop(context.Background())
 	s := &metricsServer{bridge: bridge}
 	req := &collectormetrics.ExportMetricsServiceRequest{
@@ -140,6 +144,7 @@ func TestMetricsHandler_Export_DiodeData_PublishesToIngest(t *testing.T) {
 
 func TestLogsHandler_Export_AgentTelemetry_PublishesToTelemetry(t *testing.T) {
 	bridge, fp := newBridgeWithTopics(ProtobufEncoder{})
+	//nolint:errcheck // err doesn't matter
 	defer bridge.Stop(context.Background())
 	s := &logsServer{bridge: bridge}
 	_, err := s.Export(context.Background(), &collectorlogs.ExportLogsServiceRequest{})
@@ -159,6 +164,7 @@ func TestBridge_Enqueue_QueuesDrainsOnReady(t *testing.T) {
 	fp := &fakePublisher{}
 	bridge, _ := NewBridgeServer(BridgeConfig{Encoding: "protobuf"}, nil, nil)
 	bridge.initialBackoff = 5 * time.Millisecond
+	//nolint:errcheck // err doesn't matter
 	defer bridge.Stop(context.Background())
 
 	// Enqueue before publisher is set — should queue, not error.

--- a/agent/otlpbridge/handlers_test.go
+++ b/agent/otlpbridge/handlers_test.go
@@ -2,8 +2,11 @@ package otlpbridge
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/require"
 	collectorlogs "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	collectormetrics "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	collectortrace "go.opentelemetry.io/proto/otlp/collector/trace/v1"
@@ -14,14 +17,29 @@ import (
 )
 
 type fakePublisher struct {
+	mu      sync.Mutex
 	topic   string
 	payload []byte
 }
 
 func (f *fakePublisher) Publish(_ context.Context, topic string, payload []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	f.topic = topic
 	f.payload = append([]byte(nil), payload...)
 	return nil
+}
+
+func (f *fakePublisher) getTopic() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.topic
+}
+
+func (f *fakePublisher) getPayload() []byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.payload
 }
 
 // diodeResource returns a resource carrying the diode.metadata.policy_name attribute.
@@ -39,6 +57,7 @@ func diodeResource() *resourcev1.Resource {
 func newBridgeWithTopics(_ Encoder) (*BridgeServer, *fakePublisher) {
 	fp := &fakePublisher{}
 	bridge, _ := NewBridgeServer(BridgeConfig{Encoding: "protobuf"}, nil, nil)
+	bridge.initialBackoff = 5 * time.Millisecond
 	bridge.SetPublisher(fp)
 	bridge.SetIngestTopic("ingest")
 	bridge.SetTelemetryTopic("telemetry")
@@ -51,18 +70,20 @@ func newBridgeWithTopics(_ Encoder) (*BridgeServer, *fakePublisher) {
 
 func TestTraceHandler_Export_AgentTelemetry_PublishesToTelemetry(t *testing.T) {
 	bridge, fp := newBridgeWithTopics(ProtobufEncoder{})
+	defer bridge.Stop(context.Background())
 	s := &traceServer{bridge: bridge}
 	_, err := s.Export(context.Background(), &collectortrace.ExportTraceServiceRequest{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if fp.topic != "telemetry" {
-		t.Fatalf("expected telemetry topic, got %q", fp.topic)
-	}
+	require.Eventually(t, func() bool {
+		return fp.getTopic() == "telemetry"
+	}, time.Second, time.Millisecond)
 }
 
 func TestTraceHandler_Export_DiodeData_PublishesToIngest(t *testing.T) {
 	bridge, fp := newBridgeWithTopics(ProtobufEncoder{})
+	defer bridge.Stop(context.Background())
 	s := &traceServer{bridge: bridge}
 	req := &collectortrace.ExportTraceServiceRequest{
 		ResourceSpans: []*tracev1.ResourceSpans{
@@ -73,9 +94,9 @@ func TestTraceHandler_Export_DiodeData_PublishesToIngest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if fp.topic != "ingest" {
-		t.Fatalf("expected ingest topic, got %q", fp.topic)
-	}
+	require.Eventually(t, func() bool {
+		return fp.getTopic() == "ingest"
+	}, time.Second, time.Millisecond)
 }
 
 // ---------------------------------------------------------------------------
@@ -84,18 +105,20 @@ func TestTraceHandler_Export_DiodeData_PublishesToIngest(t *testing.T) {
 
 func TestMetricsHandler_Export_AgentTelemetry_PublishesToTelemetry(t *testing.T) {
 	bridge, fp := newBridgeWithTopics(ProtobufEncoder{})
+	defer bridge.Stop(context.Background())
 	s := &metricsServer{bridge: bridge}
 	_, err := s.Export(context.Background(), &collectormetrics.ExportMetricsServiceRequest{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if fp.topic != "telemetry" {
-		t.Fatalf("expected telemetry topic, got %q", fp.topic)
-	}
+	require.Eventually(t, func() bool {
+		return fp.getTopic() == "telemetry"
+	}, time.Second, time.Millisecond)
 }
 
 func TestMetricsHandler_Export_DiodeData_PublishesToIngest(t *testing.T) {
 	bridge, fp := newBridgeWithTopics(ProtobufEncoder{})
+	defer bridge.Stop(context.Background())
 	s := &metricsServer{bridge: bridge}
 	req := &collectormetrics.ExportMetricsServiceRequest{
 		ResourceMetrics: []*metricsv1.ResourceMetrics{
@@ -106,9 +129,9 @@ func TestMetricsHandler_Export_DiodeData_PublishesToIngest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if fp.topic != "ingest" {
-		t.Fatalf("expected ingest topic, got %q", fp.topic)
-	}
+	require.Eventually(t, func() bool {
+		return fp.getTopic() == "ingest"
+	}, time.Second, time.Millisecond)
 }
 
 // ---------------------------------------------------------------------------
@@ -117,14 +140,15 @@ func TestMetricsHandler_Export_DiodeData_PublishesToIngest(t *testing.T) {
 
 func TestLogsHandler_Export_AgentTelemetry_PublishesToTelemetry(t *testing.T) {
 	bridge, fp := newBridgeWithTopics(ProtobufEncoder{})
+	defer bridge.Stop(context.Background())
 	s := &logsServer{bridge: bridge}
 	_, err := s.Export(context.Background(), &collectorlogs.ExportLogsServiceRequest{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if fp.topic != "telemetry" {
-		t.Fatalf("expected telemetry topic, got %q", fp.topic)
-	}
+	require.Eventually(t, func() bool {
+		return fp.getTopic() == "telemetry"
+	}, time.Second, time.Millisecond)
 }
 
 // ---------------------------------------------------------------------------
@@ -134,24 +158,24 @@ func TestLogsHandler_Export_AgentTelemetry_PublishesToTelemetry(t *testing.T) {
 func TestBridge_Enqueue_QueuesDrainsOnReady(t *testing.T) {
 	fp := &fakePublisher{}
 	bridge, _ := NewBridgeServer(BridgeConfig{Encoding: "protobuf"}, nil, nil)
+	bridge.initialBackoff = 5 * time.Millisecond
+	defer bridge.Stop(context.Background())
 
 	// Enqueue before publisher is set — should queue, not error.
 	if err := bridge.Enqueue(context.Background(), false, []byte("hello")); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if fp.topic != "" {
-		t.Fatalf("expected no publish yet, got topic %q", fp.topic)
+	if fp.getTopic() != "" {
+		t.Fatalf("expected no publish yet, got topic %q", fp.getTopic())
 	}
 
-	// Setting publisher + topics drains the queue.
+	// Setting publisher + topics lets the writer goroutine drain the queue.
 	bridge.SetPublisher(fp)
 	bridge.SetIngestTopic("ingest")
 	bridge.SetTelemetryTopic("telemetry")
 
-	if fp.topic != "telemetry" {
-		t.Fatalf("expected queued message to drain to telemetry, got %q", fp.topic)
-	}
-	if string(fp.payload) != "hello" {
-		t.Fatalf("expected payload 'hello', got %q", string(fp.payload))
-	}
+	require.Eventually(t, func() bool {
+		return fp.getTopic() == "telemetry"
+	}, time.Second, time.Millisecond)
+	require.Equal(t, "hello", string(fp.getPayload()))
 }

--- a/agent/otlpbridge/handlers_test.go
+++ b/agent/otlpbridge/handlers_test.go
@@ -2,6 +2,7 @@ package otlpbridge
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 	"testing"
 	"time"
@@ -56,7 +57,7 @@ func diodeResource() *resourcev1.Resource {
 
 func newBridgeWithTopics(_ Encoder) (*BridgeServer, *fakePublisher) {
 	fp := &fakePublisher{}
-	bridge, _ := NewBridgeServer(BridgeConfig{Encoding: "protobuf"}, nil, nil)
+	bridge, _ := NewBridgeServer(BridgeConfig{Encoding: "protobuf"}, nil, slog.Default())
 	bridge.initialBackoff = 5 * time.Millisecond
 	bridge.SetPublisher(fp)
 	bridge.SetIngestTopic("ingest")
@@ -157,7 +158,7 @@ func TestLogsHandler_Export_AgentTelemetry_PublishesToTelemetry(t *testing.T) {
 
 func TestBridge_Enqueue_QueuesDrainsOnReady(t *testing.T) {
 	fp := &fakePublisher{}
-	bridge, _ := NewBridgeServer(BridgeConfig{Encoding: "protobuf"}, nil, nil)
+	bridge, _ := NewBridgeServer(BridgeConfig{Encoding: "protobuf"}, nil, slog.Default())
 	bridge.initialBackoff = 5 * time.Millisecond
 	defer func() { _ = bridge.Stop(context.Background()) }()
 

--- a/agent/otlpbridge/handlers_test.go
+++ b/agent/otlpbridge/handlers_test.go
@@ -36,9 +36,9 @@ func diodeResource() *resourcev1.Resource {
 	}
 }
 
-func newBridgeWithTopics(enc Encoder) (*BridgeServer, *fakePublisher) {
+func newBridgeWithTopics(_ Encoder) (*BridgeServer, *fakePublisher) {
 	fp := &fakePublisher{}
-	bridge := &BridgeServer{enc: enc}
+	bridge, _ := NewBridgeServer(BridgeConfig{Encoding: "protobuf"}, nil, nil)
 	bridge.SetPublisher(fp)
 	bridge.SetIngestTopic("ingest")
 	bridge.SetTelemetryTopic("telemetry")
@@ -124,5 +124,34 @@ func TestLogsHandler_Export_AgentTelemetry_PublishesToTelemetry(t *testing.T) {
 	}
 	if fp.topic != "telemetry" {
 		t.Fatalf("expected telemetry topic, got %q", fp.topic)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pending queue
+// ---------------------------------------------------------------------------
+
+func TestBridge_Enqueue_QueuesDrainsOnReady(t *testing.T) {
+	fp := &fakePublisher{}
+	bridge, _ := NewBridgeServer(BridgeConfig{Encoding: "protobuf"}, nil, nil)
+
+	// Enqueue before publisher is set — should queue, not error.
+	if err := bridge.Enqueue(context.Background(), false, []byte("hello")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fp.topic != "" {
+		t.Fatalf("expected no publish yet, got topic %q", fp.topic)
+	}
+
+	// Setting publisher + topics drains the queue.
+	bridge.SetPublisher(fp)
+	bridge.SetIngestTopic("ingest")
+	bridge.SetTelemetryTopic("telemetry")
+
+	if fp.topic != "telemetry" {
+		t.Fatalf("expected queued message to drain to telemetry, got %q", fp.topic)
+	}
+	if string(fp.payload) != "hello" {
+		t.Fatalf("expected payload 'hello', got %q", string(fp.payload))
 	}
 }

--- a/agent/otlpbridge/mqtt.go
+++ b/agent/otlpbridge/mqtt.go
@@ -54,15 +54,17 @@ func NewMQTTPublisher(ctx context.Context, mqttURL, jwt string) (*MQTTPublisher,
 	return &MQTTPublisher{cm: cm}, nil
 }
 
-// Publish sends the payload to the topic with QoS 0.
+// Publish enqueues the payload for delivery to the topic with QoS 0.
+// Returns an error only if the message could not be added to the local queue.
 func (p *MQTTPublisher) Publish(ctx context.Context, topic string, payload []byte) error {
-	_, err := p.cm.Publish(ctx, &paho.Publish{
-		Topic:   topic,
-		Payload: payload,
-		QoS:     0,
-		Retain:  false,
+	return p.cm.PublishViaQueue(ctx, &autopaho.QueuePublish{
+		Publish: &paho.Publish{
+			Topic:   topic,
+			Payload: payload,
+			QoS:     0,
+			Retain:  false,
+		},
 	})
-	return err
 }
 
 // Close disconnects from the broker.

--- a/agent/otlpbridge/publisher_adapter.go
+++ b/agent/otlpbridge/publisher_adapter.go
@@ -8,6 +8,9 @@ import (
 )
 
 // CMAdapterPublisher adapts autopaho.ConnectionManager to implement Publisher.
+// It uses synchronous Publish so that MQTT failures propagate back to the OTLP
+// client as errors, providing natural backpressure. The BridgeServer's own
+// bounded pending queue handles buffering before the connection is ready.
 type CMAdapterPublisher struct {
 	cm *autopaho.ConnectionManager
 }
@@ -17,7 +20,9 @@ func NewCMAdapterPublisher(cm *autopaho.ConnectionManager) *CMAdapterPublisher {
 	return &CMAdapterPublisher{cm: cm}
 }
 
-// Publish sends the payload to the topic with QoS 0.
+// Publish sends the payload synchronously to the topic with QoS 0.
+// Returns an error if the MQTT connection is down, allowing the caller
+// to apply backpressure or retry rather than buffering unboundedly.
 func (p *CMAdapterPublisher) Publish(ctx context.Context, topic string, payload []byte) error {
 	_, err := p.cm.Publish(ctx, &paho.Publish{
 		Topic:   topic,

--- a/agent/otlpbridge/rotation_test.go
+++ b/agent/otlpbridge/rotation_test.go
@@ -1,0 +1,298 @@
+package otlpbridge
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	collectormetrics "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// ---------------------------------------------------------------------------
+// recordingPublisher — thread-safe publisher that records every message
+// ---------------------------------------------------------------------------
+
+type publishedMsg struct {
+	topic   string
+	payload []byte
+}
+
+type recordingPublisher struct {
+	mu       sync.Mutex
+	messages []publishedMsg
+}
+
+func (r *recordingPublisher) Publish(_ context.Context, topic string, payload []byte) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.messages = append(r.messages, publishedMsg{topic: topic, payload: append([]byte(nil), payload...)})
+	return nil
+}
+
+func (r *recordingPublisher) snapshot() []publishedMsg {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]publishedMsg, len(r.messages))
+	copy(out, r.messages)
+	return out
+}
+
+// parseSeq extracts the integer suffix from payloads like "rot-0042" or "pre-0007".
+func parseSeq(payload []byte) (int, error) {
+	s := string(payload)
+	idx := strings.LastIndex(s, "-")
+	if idx < 0 {
+		return 0, fmt.Errorf("no dash in %q", s)
+	}
+	return strconv.Atoi(s[idx+1:])
+}
+
+// collectAll merges snapshots from multiple publishers into one slice.
+func collectAll(pubs ...*recordingPublisher) []publishedMsg {
+	var all []publishedMsg
+	for _, p := range pubs {
+		all = append(all, p.snapshot()...)
+	}
+	return all
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Enqueue-level zero-data-loss through rotation cycles
+// ---------------------------------------------------------------------------
+
+func TestBridge_ZeroDataLoss_CredentialRotation(t *testing.T) {
+	t.Parallel()
+
+	const (
+		preReadyCount   = 50
+		steadyCount     = 200
+		rotationCount   = 1000
+		rotationsTotal  = 3
+		msgsPerRotation = rotationCount / rotationsTotal // ~333
+		rotationPoint   = msgsPerRotation / 3            // simulate rotation after ~1/3 of each batch
+		ingestTopic     = "ingest/test"
+		telTopic        = "telemetry/test"
+	)
+
+	ctx := context.Background()
+	bridge, err := NewBridgeServer(BridgeConfig{Encoding: "protobuf"}, nil, nil)
+	require.NoError(t, err)
+
+	// ---- Phase 1: pre-ready queuing (startup) ----
+	pub1 := &recordingPublisher{}
+
+	for i := 0; i < preReadyCount; i++ {
+		require.NoError(t, bridge.Enqueue(ctx, false, []byte(fmt.Sprintf("pre-%04d", i))))
+	}
+	assert.Empty(t, pub1.snapshot(), "nothing should be published before ready")
+
+	bridge.SetPublisher(pub1)
+	bridge.SetIngestTopic(ingestTopic)
+	bridge.SetTelemetryTopic(telTopic)
+
+	msgs := pub1.snapshot()
+	require.Len(t, msgs, preReadyCount, "all pre-ready messages should drain")
+	for i, m := range msgs {
+		assert.Equal(t, fmt.Sprintf("pre-%04d", i), string(m.payload), "pre-ready ordering")
+		assert.Equal(t, telTopic, m.topic)
+	}
+
+	// ---- Phase 2: steady-state publishing ----
+	for i := 0; i < steadyCount; i++ {
+		isIngest := i%3 == 0
+		require.NoError(t, bridge.Enqueue(ctx, isIngest, []byte(fmt.Sprintf("steady-%04d", i))))
+	}
+
+	steadyMsgs := pub1.snapshot()[preReadyCount:]
+	require.Len(t, steadyMsgs, steadyCount, "all steady-state messages should publish")
+	for i, m := range steadyMsgs {
+		expectedTopic := telTopic
+		if i%3 == 0 {
+			expectedTopic = ingestTopic
+		}
+		assert.Equal(t, expectedTopic, m.topic, "topic routing for steady-%04d", i)
+	}
+
+	// ---- Phase 3: rotation under concurrent load ----
+	// We accumulate publishers across rotations to verify total count at the end.
+	var allPubs []*recordingPublisher
+	allPubs = append(allPubs, pub1) // pub1 will also receive some rotation messages
+
+	globalSeq := 0 // tracks sequence across all rotation cycles
+	for rot := 0; rot < rotationsTotal; rot++ {
+		triggerRotation := make(chan struct{})
+		rotationDone := make(chan struct{})
+		batchSize := msgsPerRotation
+		if rot == rotationsTotal-1 {
+			// Last batch gets any remainder
+			batchSize = rotationCount - (msgsPerRotation * (rotationsTotal - 1))
+		}
+
+		startSeq := globalSeq
+		enqueueErrs := make(chan error, batchSize)
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < batchSize; i++ {
+				seq := startSeq + i
+				if err := bridge.Enqueue(ctx, false, []byte(fmt.Sprintf("rot-%04d", seq))); err != nil {
+					enqueueErrs <- fmt.Errorf("rot-%04d: %w", seq, err)
+				}
+				if i == rotationPoint {
+					close(triggerRotation)
+					<-rotationDone
+				}
+			}
+			close(enqueueErrs)
+		}()
+
+		// Wait for sender to reach rotation point
+		<-triggerRotation
+
+		// Simulate rotation: clear publisher so the bridge buffers
+		bridge.ClearPublisher()
+
+		// Let some messages queue while publisher is nil
+		// Then restore with a new publisher
+		newPub := &recordingPublisher{}
+		allPubs = append(allPubs, newPub)
+		bridge.SetPublisher(newPub)
+		bridge.SetIngestTopic(ingestTopic)
+		bridge.SetTelemetryTopic(telTopic)
+		close(rotationDone)
+
+		wg.Wait()
+		for err := range enqueueErrs {
+			t.Errorf("enqueue failed during rotation %d: %v", rot, err)
+		}
+		globalSeq += batchSize
+	}
+
+	// ---- Verification ----
+	allMsgs := collectAll(allPubs...)
+	// Filter to only rotation messages (skip pre- and steady- prefixed)
+	var rotMsgs []publishedMsg
+	for _, m := range allMsgs {
+		if strings.HasPrefix(string(m.payload), "rot-") {
+			rotMsgs = append(rotMsgs, m)
+		}
+	}
+
+	require.Equal(t, rotationCount, len(rotMsgs),
+		"expected exactly %d rotation messages, got %d (zero data loss)", rotationCount, len(rotMsgs))
+
+	// Check no duplicates, no gaps
+	seen := make(map[int]bool)
+	for _, m := range rotMsgs {
+		seq, err := parseSeq(m.payload)
+		require.NoError(t, err)
+		assert.False(t, seen[seq], "duplicate sequence number: %d", seq)
+		seen[seq] = true
+	}
+	for i := 0; i < rotationCount; i++ {
+		assert.True(t, seen[i], "missing sequence number: %d", i)
+	}
+
+	// Check ordering within each publisher: sequences should be monotonically increasing
+	for idx, pub := range allPubs {
+		msgs := pub.snapshot()
+		var seqs []int
+		for _, m := range msgs {
+			if !strings.HasPrefix(string(m.payload), "rot-") {
+				continue
+			}
+			seq, err := parseSeq(m.payload)
+			require.NoError(t, err)
+			seqs = append(seqs, seq)
+		}
+		assert.True(t, sort.IntsAreSorted(seqs),
+			"publisher %d: rotation messages not in order: %v", idx, seqs)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Full gRPC path — handler → marshal → Enqueue → publish
+// ---------------------------------------------------------------------------
+
+func TestBridge_ZeroDataLoss_GRPCPath(t *testing.T) {
+	t.Parallel()
+
+	const (
+		preReadyCount = 20
+		steadyCount   = 40
+		rotationCount = 40
+		ingestTopic   = "ingest/grpc-test"
+		telTopic      = "telemetry/grpc-test"
+	)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	bridge, err := NewBridgeServer(BridgeConfig{ListenAddr: ":0", Encoding: "json"}, nil, logger)
+	require.NoError(t, err)
+	require.NoError(t, bridge.Start(context.Background()))
+	defer func() { _ = bridge.Stop(context.Background()) }()
+
+	// Connect a gRPC metrics client to the bridge.
+	// Extract the port and dial localhost explicitly — listener.Addr() on ":0"
+	// may return a wildcard like "[::]:<port>" which isn't reliably dialable.
+	_, port, err := net.SplitHostPort(bridge.listener.Addr().String())
+	require.NoError(t, err)
+	conn, err := grpc.NewClient("localhost:"+port, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+	client := collectormetrics.NewMetricsServiceClient(conn)
+
+	// Helper: send one empty ExportMetricsServiceRequest
+	sendOne := func() {
+		_, err := client.Export(context.Background(), &collectormetrics.ExportMetricsServiceRequest{})
+		require.NoError(t, err)
+	}
+
+	// ---- Phase 1: pre-ready — bridge queues ----
+	for i := 0; i < preReadyCount; i++ {
+		sendOne()
+	}
+
+	pub1 := &recordingPublisher{}
+	bridge.SetPublisher(pub1)
+	bridge.SetIngestTopic(ingestTopic)
+	bridge.SetTelemetryTopic(telTopic)
+
+	require.Equal(t, preReadyCount, len(pub1.snapshot()),
+		"all pre-ready gRPC requests should drain")
+
+	// ---- Phase 2: steady-state ----
+	for i := 0; i < steadyCount; i++ {
+		sendOne()
+	}
+	require.Equal(t, preReadyCount+steadyCount, len(pub1.snapshot()))
+
+	// ---- Phase 3: rotation ----
+	bridge.ClearPublisher()
+
+	for i := 0; i < rotationCount; i++ {
+		sendOne()
+	}
+
+	pub2 := &recordingPublisher{}
+	bridge.SetPublisher(pub2)
+	bridge.SetIngestTopic(ingestTopic)
+	bridge.SetTelemetryTopic(telTopic)
+
+	// ---- Verification ----
+	total := len(pub1.snapshot()) + len(pub2.snapshot())
+	require.Equal(t, preReadyCount+steadyCount+rotationCount, total,
+		"zero data loss through gRPC path: expected %d, got %d",
+		preReadyCount+steadyCount+rotationCount, total)
+}

--- a/agent/otlpbridge/rotation_test.go
+++ b/agent/otlpbridge/rotation_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -88,6 +89,8 @@ func TestBridge_ZeroDataLoss_CredentialRotation(t *testing.T) {
 	ctx := context.Background()
 	bridge, err := NewBridgeServer(BridgeConfig{Encoding: "protobuf"}, nil, nil)
 	require.NoError(t, err)
+	bridge.initialBackoff = 5 * time.Millisecond
+	defer bridge.Stop(context.Background())
 
 	// ---- Phase 1: pre-ready queuing (startup) ----
 	pub1 := &recordingPublisher{}
@@ -101,8 +104,12 @@ func TestBridge_ZeroDataLoss_CredentialRotation(t *testing.T) {
 	bridge.SetIngestTopic(ingestTopic)
 	bridge.SetTelemetryTopic(telTopic)
 
-	msgs := pub1.snapshot()
-	require.Len(t, msgs, preReadyCount, "all pre-ready messages should drain")
+	// Wait for the writer goroutine to drain all pre-ready messages.
+	require.Eventually(t, func() bool {
+		return len(pub1.snapshot()) >= preReadyCount
+	}, 5*time.Second, time.Millisecond, "all pre-ready messages should drain")
+
+	msgs := pub1.snapshot()[:preReadyCount]
 	for i, m := range msgs {
 		assert.Equal(t, fmt.Sprintf("pre-%04d", i), string(m.payload), "pre-ready ordering")
 		assert.Equal(t, telTopic, m.topic)
@@ -114,8 +121,11 @@ func TestBridge_ZeroDataLoss_CredentialRotation(t *testing.T) {
 		require.NoError(t, bridge.Enqueue(ctx, isIngest, []byte(fmt.Sprintf("steady-%04d", i))))
 	}
 
-	steadyMsgs := pub1.snapshot()[preReadyCount:]
-	require.Len(t, steadyMsgs, steadyCount, "all steady-state messages should publish")
+	require.Eventually(t, func() bool {
+		return len(pub1.snapshot()) >= preReadyCount+steadyCount
+	}, 5*time.Second, time.Millisecond, "all steady-state messages should publish")
+
+	steadyMsgs := pub1.snapshot()[preReadyCount : preReadyCount+steadyCount]
 	for i, m := range steadyMsgs {
 		expectedTopic := telTopic
 		if i%3 == 0 {
@@ -180,6 +190,19 @@ func TestBridge_ZeroDataLoss_CredentialRotation(t *testing.T) {
 		globalSeq += batchSize
 	}
 
+	// Wait for the writer goroutine to publish all rotation messages.
+	require.Eventually(t, func() bool {
+		allMsgs := collectAll(allPubs...)
+		var count int
+		for _, m := range allMsgs {
+			if strings.HasPrefix(string(m.payload), "rot-") {
+				count++
+			}
+		}
+		return count == rotationCount
+	}, 10*time.Second, 10*time.Millisecond,
+		"expected all %d rotation messages to be published", rotationCount)
+
 	// ---- Verification ----
 	allMsgs := collectAll(allPubs...)
 	// Filter to only rotation messages (skip pre- and steady- prefixed)
@@ -240,6 +263,7 @@ func TestBridge_ZeroDataLoss_GRPCPath(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	bridge, err := NewBridgeServer(BridgeConfig{ListenAddr: ":0", Encoding: "json"}, nil, logger)
 	require.NoError(t, err)
+	bridge.initialBackoff = 5 * time.Millisecond
 	require.NoError(t, bridge.Start(context.Background()))
 	defer func() { _ = bridge.Stop(context.Background()) }()
 
@@ -269,14 +293,18 @@ func TestBridge_ZeroDataLoss_GRPCPath(t *testing.T) {
 	bridge.SetIngestTopic(ingestTopic)
 	bridge.SetTelemetryTopic(telTopic)
 
-	require.Equal(t, preReadyCount, len(pub1.snapshot()),
+	require.Eventually(t, func() bool {
+		return len(pub1.snapshot()) >= preReadyCount
+	}, 5*time.Second, time.Millisecond,
 		"all pre-ready gRPC requests should drain")
 
 	// ---- Phase 2: steady-state ----
 	for i := 0; i < steadyCount; i++ {
 		sendOne()
 	}
-	require.Equal(t, preReadyCount+steadyCount, len(pub1.snapshot()))
+	require.Eventually(t, func() bool {
+		return len(pub1.snapshot()) >= preReadyCount+steadyCount
+	}, 5*time.Second, time.Millisecond)
 
 	// ---- Phase 3: rotation ----
 	bridge.ClearPublisher()
@@ -291,8 +319,9 @@ func TestBridge_ZeroDataLoss_GRPCPath(t *testing.T) {
 	bridge.SetTelemetryTopic(telTopic)
 
 	// ---- Verification ----
-	total := len(pub1.snapshot()) + len(pub2.snapshot())
-	require.Equal(t, preReadyCount+steadyCount+rotationCount, total,
-		"zero data loss through gRPC path: expected %d, got %d",
-		preReadyCount+steadyCount+rotationCount, total)
+	require.Eventually(t, func() bool {
+		return len(pub1.snapshot())+len(pub2.snapshot()) >= preReadyCount+steadyCount+rotationCount
+	}, 5*time.Second, time.Millisecond,
+		"zero data loss through gRPC path: expected %d",
+		preReadyCount+steadyCount+rotationCount)
 }

--- a/agent/otlpbridge/rotation_test.go
+++ b/agent/otlpbridge/rotation_test.go
@@ -90,6 +90,7 @@ func TestBridge_ZeroDataLoss_CredentialRotation(t *testing.T) {
 	bridge, err := NewBridgeServer(BridgeConfig{Encoding: "protobuf"}, nil, nil)
 	require.NoError(t, err)
 	bridge.initialBackoff = 5 * time.Millisecond
+	//nolint:errcheck // err doesn't matter
 	defer bridge.Stop(context.Background())
 
 	// ---- Phase 1: pre-ready queuing (startup) ----

--- a/agent/otlpbridge/rotation_test.go
+++ b/agent/otlpbridge/rotation_test.go
@@ -87,11 +87,11 @@ func TestBridge_ZeroDataLoss_CredentialRotation(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	bridge, err := NewBridgeServer(BridgeConfig{Encoding: "protobuf"}, nil, nil)
+	bridge, err := NewBridgeServer(BridgeConfig{Encoding: "protobuf"}, nil, slog.Default())
 	require.NoError(t, err)
 	bridge.initialBackoff = 5 * time.Millisecond
-	//nolint:errcheck // err doesn't matter
-	defer bridge.Stop(context.Background())
+	require.NoError(t, bridge.Start(ctx))
+	defer func() { _ = bridge.Stop(context.Background()) }()
 
 	// ---- Phase 1: pre-ready queuing (startup) ----
 	pub1 := &recordingPublisher{}

--- a/agent/otlpbridge/server.go
+++ b/agent/otlpbridge/server.go
@@ -25,13 +25,18 @@ const (
 	maxRetryBackoff        = 30 * time.Second
 )
 
-// pendingPublish holds a marshaled OTLP payload queued before the MQTT publisher was ready.
+// pendingPublish holds a marshaled OTLP payload queued for publishing.
 type pendingPublish struct {
 	isIngest bool
 	payload  []byte
 }
 
 // BridgeServer holds the lifecycle for the OTLP → MQTT bridge server.
+//
+// Incoming OTLP payloads are placed on a buffered channel (msgCh) by Enqueue.
+// A single writer goroutine consumes from the channel and publishes to MQTT,
+// retrying with exponential backoff when the publisher is unavailable or a
+// publish fails.
 type BridgeServer struct {
 	cfg              BridgeConfig
 	enc              Encoder
@@ -39,8 +44,7 @@ type BridgeServer struct {
 	listener         net.Listener
 	closeOnce        sync.Once
 
-	// Shared runtime state — publisher and topics are set by the OnReadyHook
-	// after the MQTT connection is established.
+	// Publisher and topics — set after the MQTT connection is established.
 	mu             sync.RWMutex
 	publisher      Publisher
 	ingestTopic    string
@@ -48,23 +52,20 @@ type BridgeServer struct {
 	policyRepo     policies.PolicyRepo
 	logger         *slog.Logger
 
-	// Lifecycle context — cancelled by Stop() to unblock in-flight drains and
-	// scheduled retry goroutines.
+	// Lifecycle context — cancelled by Stop() to unblock the writer goroutine.
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	// Pending publish queue — messages received before MQTT is ready are held
-	// here and drained once publisher + topics are all set.
-	pendingMu      sync.Mutex
-	pending        []pendingPublish
-	ready          bool
-	draining       bool
-	maxPending     int
-	pendingDropped int64
-	retryBackoff   time.Duration
+	// Buffered channel serves as the bounded FIFO queue. A single writer
+	// goroutine consumes from it and publishes to MQTT.
+	msgCh chan pendingPublish
+
+	// initialBackoff is the starting retry delay used by the writer goroutine.
+	// Defaults to initialRetryBackoff; tests override it for speed.
+	initialBackoff time.Duration
 }
 
-// NewBridgeServer builds a BridgeServer but does not start it.
+// NewBridgeServer builds a BridgeServer and starts its writer goroutine.
 func NewBridgeServer(cfg BridgeConfig, policyRepo policies.PolicyRepo, logger *slog.Logger) (*BridgeServer, error) {
 	enc, err := buildEncoder(cfg.Encoding)
 	if err != nil {
@@ -75,7 +76,18 @@ func NewBridgeServer(cfg BridgeConfig, policyRepo policies.PolicyRepo, logger *s
 		maxPending = defaultMaxPendingQueue
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	return &BridgeServer{cfg: cfg, enc: enc, policyRepo: policyRepo, logger: logger, maxPending: maxPending, ctx: ctx, cancel: cancel}, nil
+	s := &BridgeServer{
+		cfg:            cfg,
+		enc:            enc,
+		policyRepo:     policyRepo,
+		logger:         logger,
+		ctx:            ctx,
+		cancel:         cancel,
+		msgCh:          make(chan pendingPublish, maxPending),
+		initialBackoff: initialRetryBackoff,
+	}
+	go s.writer()
+	return s, nil
 }
 
 func buildEncoder(name string) (Encoder, error) {
@@ -94,15 +106,13 @@ func (s *BridgeServer) SetPublisher(pub Publisher) {
 	s.mu.Lock()
 	s.publisher = pub
 	s.mu.Unlock()
-	s.checkReady()
 }
 
-// SetIngestTopic sets the topic for publishing.
+// SetIngestTopic sets the topic for ingest publishing.
 func (s *BridgeServer) SetIngestTopic(topic string) {
 	s.mu.Lock()
 	s.ingestTopic = topic
 	s.mu.Unlock()
-	s.checkReady()
 }
 
 // SetTelemetryTopic sets the telemetry topic for publishing.
@@ -110,223 +120,68 @@ func (s *BridgeServer) SetTelemetryTopic(topic string) {
 	s.mu.Lock()
 	s.telemetryTopic = topic
 	s.mu.Unlock()
-	s.checkReady()
 }
 
-// ClearPublisher clears the publisher and marks the bridge as not ready,
-// causing Enqueue to buffer messages until a new publisher is set via
-// SetPublisher. Call this before MQTT disconnect/reconnect to prevent
-// publish failures during the reconnect window.
+// ClearPublisher clears the publisher, causing the writer goroutine to retry
+// with backoff until a new publisher is set via SetPublisher.
 func (s *BridgeServer) ClearPublisher() {
+	s.mu.Lock()
+	s.publisher = nil
+	s.mu.Unlock()
+}
+
+// writer is the single goroutine that consumes from msgCh and publishes.
+func (s *BridgeServer) writer() {
 	for {
-		s.pendingMu.Lock()
-		if s.draining {
-			s.pendingMu.Unlock()
-			time.Sleep(time.Millisecond)
-			continue
-		}
-
-		// Prevent new drains from starting while transitioning the bridge back
-		// to the not-ready state, then clear the publisher.
-		s.ready = false
-		s.retryBackoff = 0
-
-		s.mu.Lock()
-		s.publisher = nil
-		s.mu.Unlock()
-
-		s.pendingMu.Unlock()
-		return
-	}
-}
-
-// checkReady checks whether publisher and both topics are set. If so, it drains
-// any pending messages that were queued before the MQTT connection was ready.
-func (s *BridgeServer) checkReady() {
-	s.mu.RLock()
-	allSet := s.publisher != nil && s.ingestTopic != "" && s.telemetryTopic != ""
-	s.mu.RUnlock()
-	if allSet {
-		s.drainPending()
-	}
-}
-
-// publishBatch publishes a slice of pending messages. On failure it re-queues the
-// remaining messages (including the one that failed) and clears the draining flag.
-// Returns true if all messages were published, false if a failure occurred.
-func (s *BridgeServer) publishBatch(pub Publisher, msgs []pendingPublish, ingest, telemetry string, published *int) bool {
-	for i, msg := range msgs {
-		topic := telemetry
-		if msg.isIngest {
-			topic = ingest
-		}
-		if err := pub.Publish(s.ctx, topic, msg.payload); err != nil {
-			if s.logger != nil {
-				s.logger.Warn("publish failed during drain, re-queuing remaining messages",
-					"published", *published, "remaining", len(msgs)-i, "error", err)
-			}
-			s.pendingMu.Lock()
-			s.pending = append(msgs[i:], s.pending...)
-			// Enforce the bounded-buffer guarantee: if the combined re-queued
-			// batch + newly arrived messages exceeds maxPending, truncate to
-			// cap. We keep the oldest (head) to preserve FIFO ordering —
-			// consistent with Enqueue rejecting new messages when full.
-			if s.maxPending > 0 && len(s.pending) > s.maxPending {
-				excess := len(s.pending) - s.maxPending
-				s.pending = s.pending[:s.maxPending]
-				s.pendingDropped += int64(excess)
-				if s.logger != nil {
-					s.logger.Warn("truncated re-queued pending messages to maxPending",
-						"max_pending", s.maxPending, "dropped", excess)
-				}
-			}
-			s.draining = false
-			s.pendingMu.Unlock()
-			return false
-		}
-		(*published)++
-	}
-	return true
-}
-
-// drainPending flushes queued messages and marks the bridge as ready for direct
-// publishing. Must only be called when publisher + topics are set.
-// Ready is set *after* the drain completes so that concurrent Enqueue calls
-// continue to queue (preserving FIFO order) until the backlog is flushed.
-func (s *BridgeServer) drainPending() {
-	s.pendingMu.Lock()
-	if s.ready || s.draining {
-		s.pendingMu.Unlock()
-		return
-	}
-	s.draining = true
-	queued := s.pending
-	dropped := s.pendingDropped
-	s.pending = nil
-	s.pendingDropped = 0
-	s.pendingMu.Unlock()
-
-	s.mu.RLock()
-	pub := s.publisher
-	ingest := s.ingestTopic
-	telemetry := s.telemetryTopic
-	s.mu.RUnlock()
-
-	// Guard against ClearPublisher() racing between setting draining=true and
-	// here. Re-queue everything and let the next SetPublisher → checkReady
-	// cycle re-trigger the drain.
-	if pub == nil {
-		s.pendingMu.Lock()
-		s.pending = append(queued, s.pending...)
-		if s.maxPending > 0 && len(s.pending) > s.maxPending {
-			excess := len(s.pending) - s.maxPending
-			s.pending = s.pending[:s.maxPending]
-			s.pendingDropped += int64(excess)
-		}
-		s.draining = false
-		s.pendingMu.Unlock()
-		return
-	}
-
-	published := 0
-	if !s.publishBatch(pub, queued, ingest, telemetry, &published) {
-		s.scheduleRetryDrain()
-		return
-	}
-
-	// Drain anything that arrived while we were flushing, then mark ready.
-	s.pendingMu.Lock()
-	for len(s.pending) > 0 {
-		extra := s.pending
-		dropped += s.pendingDropped
-		s.pending = nil
-		s.pendingDropped = 0
-		s.pendingMu.Unlock()
-
-		if !s.publishBatch(pub, extra, ingest, telemetry, &published) {
-			s.scheduleRetryDrain()
-			return
-		}
-		s.pendingMu.Lock()
-	}
-	s.draining = false
-	s.ready = true
-	s.retryBackoff = 0
-	s.pendingMu.Unlock()
-
-	if s.logger != nil && published > 0 {
-		s.logger.Info("drained pending OTLP messages", "count", published, "dropped_while_pending", dropped)
-	}
-}
-
-// scheduleRetryDrain re-triggers drainPending after a delay so that messages
-// re-queued by a failed publishBatch are not stuck indefinitely. Uses
-// exponential backoff (capped at maxRetryBackoff) and respects the server's
-// lifecycle context so pending retries are cancelled on Stop().
-func (s *BridgeServer) scheduleRetryDrain() {
-	s.pendingMu.Lock()
-	backoff := s.retryBackoff
-	if backoff == 0 {
-		backoff = initialRetryBackoff
-	}
-	s.retryBackoff = min(backoff*2, maxRetryBackoff)
-	s.pendingMu.Unlock()
-
-	go func() {
 		select {
+		case msg := <-s.msgCh:
+			s.publishWithRetry(msg)
 		case <-s.ctx.Done():
 			return
-		case <-time.After(backoff):
-			s.drainPending()
 		}
-	}()
+	}
 }
 
-// Enqueue marshaled OTLP data for publishing. Before the MQTT connection is
-// ready the payload is queued in memory (up to maxPending messages). When the
-// queue is full, new messages are rejected with ResourceExhausted so the OTLP
-// client can back off and retry. Once ready, publishes directly.
-func (s *BridgeServer) Enqueue(ctx context.Context, isIngest bool, payload []byte) error {
-	s.pendingMu.Lock()
-	if !s.ready {
-		if s.maxPending > 0 && len(s.pending) >= s.maxPending {
-			s.pendingDropped++
-			if s.logger != nil && (s.pendingDropped == 1 || s.pendingDropped%100 == 0) {
-				s.logger.Warn("pending OTLP queue full, rejecting message",
-					"max_pending", s.maxPending, "total_dropped", s.pendingDropped)
+// publishWithRetry publishes a single message, retrying with exponential
+// backoff when no publisher is available or a publish call fails.
+func (s *BridgeServer) publishWithRetry(msg pendingPublish) {
+	backoff := s.initialBackoff
+	for {
+		s.mu.RLock()
+		pub := s.publisher
+		topic := s.telemetryTopic
+		if msg.isIngest {
+			topic = s.ingestTopic
+		}
+		s.mu.RUnlock()
+
+		if pub != nil {
+			if err := pub.Publish(s.ctx, topic, msg.payload); err == nil {
+				return
+			} else if s.logger != nil {
+				s.logger.Warn("OTLP publish failed, retrying", "error", err, "backoff", backoff)
 			}
-			s.pendingMu.Unlock()
-			return status.Error(codes.ResourceExhausted, "OTLP pending queue is full")
 		}
-		s.pending = append(s.pending, pendingPublish{isIngest: isIngest, payload: payload})
-		s.pendingMu.Unlock()
-		return nil
-	}
-	s.pendingMu.Unlock()
 
-	s.mu.RLock()
-	pub := s.publisher
-	topic := s.telemetryTopic
-	if isIngest {
-		topic = s.ingestTopic
-	}
-	s.mu.RUnlock()
-
-	// Guard against ClearPublisher() racing between the ready check above and
-	// the mu.RLock here. If publisher was cleared, buffer instead of panicking.
-	if pub == nil {
-		s.pendingMu.Lock()
-		if s.maxPending > 0 && len(s.pending) >= s.maxPending {
-			s.pendingDropped++
-			s.pendingMu.Unlock()
-			return status.Error(codes.ResourceExhausted, "OTLP pending queue is full")
+		select {
+		case <-time.After(backoff):
+			backoff = min(backoff*2, maxRetryBackoff)
+		case <-s.ctx.Done():
+			return
 		}
-		s.pending = append(s.pending, pendingPublish{isIngest: isIngest, payload: payload})
-		s.pendingMu.Unlock()
-		return nil
 	}
+}
 
-	return pub.Publish(ctx, topic, payload)
+// Enqueue adds a marshaled OTLP payload to the publish queue. Returns
+// ResourceExhausted if the queue is full, providing backpressure to the
+// OTLP client.
+func (s *BridgeServer) Enqueue(_ context.Context, isIngest bool, payload []byte) error {
+	select {
+	case s.msgCh <- pendingPublish{isIngest: isIngest, payload: payload}:
+		return nil
+	default:
+		return status.Error(codes.ResourceExhausted, "OTLP pending queue is full")
+	}
 }
 
 // GetIngestTopic returns the current ingest topic.
@@ -380,8 +235,8 @@ func (s *BridgeServer) Start(ctx context.Context) error {
 func (s *BridgeServer) Stop(_ context.Context) error {
 	var err error
 	s.closeOnce.Do(func() {
-		// Cancel the lifecycle context first to unblock in-flight drains
-		// and scheduled retry goroutines.
+		// Cancel the lifecycle context first to unblock the writer goroutine
+		// and any in-flight retry sleeps.
 		if s.cancel != nil {
 			s.cancel()
 		}

--- a/agent/otlpbridge/server.go
+++ b/agent/otlpbridge/server.go
@@ -160,19 +160,15 @@ func (s *BridgeServer) publishWithRetry(msg pendingPublish) {
 		s.mu.RUnlock()
 
 		if pub != nil && topic != "" {
-			if err := pub.Publish(s.ctx, topic, msg.payload); err == nil {
+			err := pub.Publish(s.ctx, topic, msg.payload)
+			if err == nil {
 				return
-			} else {
-				failures++
-				if s.logger != nil {
-					s.logger.Warn("OTLP publish failed, retrying", "error", err, "attempt", failures, "backoff", backoff)
-				}
-				if failures >= maxPublishRetries {
-					if s.logger != nil {
-						s.logger.Warn("OTLP publish retries exhausted, dropping message", "max_retries", maxPublishRetries)
-					}
-					return
-				}
+			}
+			failures++
+			s.logger.Warn("OTLP publish failed, retrying", "error", err, "attempt", failures, "backoff", backoff)
+			if failures >= maxPublishRetries {
+				s.logger.Warn("OTLP publish retries exhausted, dropping message", "max_retries", maxPublishRetries)
+				return
 			}
 		}
 

--- a/agent/otlpbridge/server.go
+++ b/agent/otlpbridge/server.go
@@ -144,11 +144,13 @@ func (s *BridgeServer) writer() {
 }
 
 // publishWithRetry publishes a single message, retrying with exponential
-// backoff when no publisher is available or a publish call fails. Retries
-// are bounded to prevent a single poison message from blocking the queue.
+// backoff when no publisher is available or a publish call fails. Only
+// actual publish failures count toward the retry budget; waiting for
+// publisher/topic readiness does not consume attempts.
 func (s *BridgeServer) publishWithRetry(msg pendingPublish) {
 	backoff := s.initialBackoff
-	for attempt := 0; attempt < maxPublishRetries; attempt++ {
+	failures := 0
+	for {
 		s.mu.RLock()
 		pub := s.publisher
 		topic := s.telemetryTopic
@@ -160,8 +162,17 @@ func (s *BridgeServer) publishWithRetry(msg pendingPublish) {
 		if pub != nil && topic != "" {
 			if err := pub.Publish(s.ctx, topic, msg.payload); err == nil {
 				return
-			} else if s.logger != nil {
-				s.logger.Warn("OTLP publish failed, retrying", "error", err, "attempt", attempt+1, "backoff", backoff)
+			} else {
+				failures++
+				if s.logger != nil {
+					s.logger.Warn("OTLP publish failed, retrying", "error", err, "attempt", failures, "backoff", backoff)
+				}
+				if failures >= maxPublishRetries {
+					if s.logger != nil {
+						s.logger.Warn("OTLP publish retries exhausted, dropping message", "max_retries", maxPublishRetries)
+					}
+					return
+				}
 			}
 		}
 
@@ -171,9 +182,6 @@ func (s *BridgeServer) publishWithRetry(msg pendingPublish) {
 		case <-s.ctx.Done():
 			return
 		}
-	}
-	if s.logger != nil {
-		s.logger.Warn("OTLP publish retries exhausted, dropping message", "max_retries", maxPublishRetries)
 	}
 }
 

--- a/agent/otlpbridge/server.go
+++ b/agent/otlpbridge/server.go
@@ -155,7 +155,7 @@ func (s *BridgeServer) publishWithRetry(msg pendingPublish) {
 		}
 		s.mu.RUnlock()
 
-		if pub != nil {
+		if pub != nil && topic != "" {
 			if err := pub.Publish(s.ctx, topic, msg.payload); err == nil {
 				return
 			} else if s.logger != nil {
@@ -235,13 +235,14 @@ func (s *BridgeServer) Start(ctx context.Context) error {
 func (s *BridgeServer) Stop(_ context.Context) error {
 	var err error
 	s.closeOnce.Do(func() {
-		// Cancel the lifecycle context first to unblock the writer goroutine
-		// and any in-flight retry sleeps.
-		if s.cancel != nil {
-			s.cancel()
-		}
+		// Drain in-flight RPCs first so no Export handler enqueues after the
+		// writer goroutine exits. GracefulStop blocks until all active RPCs
+		// complete, then we cancel the writer context to flush remaining items.
 		if s.ingestGRPCServer != nil {
 			s.ingestGRPCServer.GracefulStop()
+		}
+		if s.cancel != nil {
+			s.cancel()
 		}
 		if s.listener != nil {
 			_ = s.listener.Close()

--- a/agent/otlpbridge/server.go
+++ b/agent/otlpbridge/server.go
@@ -23,6 +23,7 @@ const (
 	defaultMaxPendingQueue = 1000
 	initialRetryBackoff    = 2 * time.Second
 	maxRetryBackoff        = 30 * time.Second
+	maxPublishRetries      = 10
 )
 
 // pendingPublish holds a marshaled OTLP payload queued for publishing.
@@ -143,10 +144,11 @@ func (s *BridgeServer) writer() {
 }
 
 // publishWithRetry publishes a single message, retrying with exponential
-// backoff when no publisher is available or a publish call fails.
+// backoff when no publisher is available or a publish call fails. Retries
+// are bounded to prevent a single poison message from blocking the queue.
 func (s *BridgeServer) publishWithRetry(msg pendingPublish) {
 	backoff := s.initialBackoff
-	for {
+	for attempt := 0; attempt < maxPublishRetries; attempt++ {
 		s.mu.RLock()
 		pub := s.publisher
 		topic := s.telemetryTopic
@@ -159,7 +161,7 @@ func (s *BridgeServer) publishWithRetry(msg pendingPublish) {
 			if err := pub.Publish(s.ctx, topic, msg.payload); err == nil {
 				return
 			} else if s.logger != nil {
-				s.logger.Warn("OTLP publish failed, retrying", "error", err, "backoff", backoff)
+				s.logger.Warn("OTLP publish failed, retrying", "error", err, "attempt", attempt+1, "backoff", backoff)
 			}
 		}
 
@@ -169,6 +171,9 @@ func (s *BridgeServer) publishWithRetry(msg pendingPublish) {
 		case <-s.ctx.Done():
 			return
 		}
+	}
+	if s.logger != nil {
+		s.logger.Warn("OTLP publish retries exhausted, dropping message", "max_retries", maxPublishRetries)
 	}
 }
 

--- a/agent/otlpbridge/server.go
+++ b/agent/otlpbridge/server.go
@@ -7,14 +7,29 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"time"
 
 	collectorlogs "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	collectormetrics "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	collectortrace "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/netboxlabs/orb-agent/agent/policies"
 )
+
+const (
+	defaultMaxPendingQueue = 1000
+	initialRetryBackoff    = 2 * time.Second
+	maxRetryBackoff        = 30 * time.Second
+)
+
+// pendingPublish holds a marshaled OTLP payload queued before the MQTT publisher was ready.
+type pendingPublish struct {
+	isIngest bool
+	payload  []byte
+}
 
 // BridgeServer holds the lifecycle for the OTLP → MQTT bridge server.
 type BridgeServer struct {
@@ -24,13 +39,29 @@ type BridgeServer struct {
 	listener         net.Listener
 	closeOnce        sync.Once
 
-	// Shared runtime state
+	// Shared runtime state — publisher and topics are set by the OnReadyHook
+	// after the MQTT connection is established.
 	mu             sync.RWMutex
 	publisher      Publisher
 	ingestTopic    string
 	telemetryTopic string
 	policyRepo     policies.PolicyRepo
 	logger         *slog.Logger
+
+	// Lifecycle context — cancelled by Stop() to unblock in-flight drains and
+	// scheduled retry goroutines.
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	// Pending publish queue — messages received before MQTT is ready are held
+	// here and drained once publisher + topics are all set.
+	pendingMu      sync.Mutex
+	pending        []pendingPublish
+	ready          bool
+	draining       bool
+	maxPending     int
+	pendingDropped int64
+	retryBackoff   time.Duration
 }
 
 // NewBridgeServer builds a BridgeServer but does not start it.
@@ -39,7 +70,12 @@ func NewBridgeServer(cfg BridgeConfig, policyRepo policies.PolicyRepo, logger *s
 	if err != nil {
 		return nil, err
 	}
-	return &BridgeServer{cfg: cfg, enc: enc, policyRepo: policyRepo, logger: logger}, nil
+	maxPending := cfg.MaxPendingQueue
+	if maxPending <= 0 {
+		maxPending = defaultMaxPendingQueue
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	return &BridgeServer{cfg: cfg, enc: enc, policyRepo: policyRepo, logger: logger, maxPending: maxPending, ctx: ctx, cancel: cancel}, nil
 }
 
 func buildEncoder(name string) (Encoder, error) {
@@ -56,39 +92,251 @@ func buildEncoder(name string) (Encoder, error) {
 // SetPublisher sets the publisher for OTLP payloads.
 func (s *BridgeServer) SetPublisher(pub Publisher) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.publisher = pub
+	s.mu.Unlock()
+	s.checkReady()
 }
 
 // SetIngestTopic sets the topic for publishing.
 func (s *BridgeServer) SetIngestTopic(topic string) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.ingestTopic = topic
+	s.mu.Unlock()
+	s.checkReady()
 }
 
-// GetPublisher returns the current publisher (for handlers).
-func (s *BridgeServer) GetPublisher() Publisher {
+// SetTelemetryTopic sets the telemetry topic for publishing.
+func (s *BridgeServer) SetTelemetryTopic(topic string) {
+	s.mu.Lock()
+	s.telemetryTopic = topic
+	s.mu.Unlock()
+	s.checkReady()
+}
+
+// ClearPublisher clears the publisher and marks the bridge as not ready,
+// causing Enqueue to buffer messages until a new publisher is set via
+// SetPublisher. Call this before MQTT disconnect/reconnect to prevent
+// publish failures during the reconnect window.
+func (s *BridgeServer) ClearPublisher() {
+	for {
+		s.pendingMu.Lock()
+		if s.draining {
+			s.pendingMu.Unlock()
+			time.Sleep(time.Millisecond)
+			continue
+		}
+
+		// Prevent new drains from starting while transitioning the bridge back
+		// to the not-ready state, then clear the publisher.
+		s.ready = false
+		s.retryBackoff = 0
+
+		s.mu.Lock()
+		s.publisher = nil
+		s.mu.Unlock()
+
+		s.pendingMu.Unlock()
+		return
+	}
+}
+
+// checkReady checks whether publisher and both topics are set. If so, it drains
+// any pending messages that were queued before the MQTT connection was ready.
+func (s *BridgeServer) checkReady() {
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.publisher
+	allSet := s.publisher != nil && s.ingestTopic != "" && s.telemetryTopic != ""
+	s.mu.RUnlock()
+	if allSet {
+		s.drainPending()
+	}
 }
 
-// GetIngestTopic returns the current topic (for handlers).
+// publishBatch publishes a slice of pending messages. On failure it re-queues the
+// remaining messages (including the one that failed) and clears the draining flag.
+// Returns true if all messages were published, false if a failure occurred.
+func (s *BridgeServer) publishBatch(pub Publisher, msgs []pendingPublish, ingest, telemetry string, published *int) bool {
+	for i, msg := range msgs {
+		topic := telemetry
+		if msg.isIngest {
+			topic = ingest
+		}
+		if err := pub.Publish(s.ctx, topic, msg.payload); err != nil {
+			if s.logger != nil {
+				s.logger.Warn("publish failed during drain, re-queuing remaining messages",
+					"published", *published, "remaining", len(msgs)-i, "error", err)
+			}
+			s.pendingMu.Lock()
+			s.pending = append(msgs[i:], s.pending...)
+			// Enforce the bounded-buffer guarantee: if the combined re-queued
+			// batch + newly arrived messages exceeds maxPending, truncate to
+			// cap. We keep the oldest (head) to preserve FIFO ordering —
+			// consistent with Enqueue rejecting new messages when full.
+			if s.maxPending > 0 && len(s.pending) > s.maxPending {
+				excess := len(s.pending) - s.maxPending
+				s.pending = s.pending[:s.maxPending]
+				s.pendingDropped += int64(excess)
+				if s.logger != nil {
+					s.logger.Warn("truncated re-queued pending messages to maxPending",
+						"max_pending", s.maxPending, "dropped", excess)
+				}
+			}
+			s.draining = false
+			s.pendingMu.Unlock()
+			return false
+		}
+		(*published)++
+	}
+	return true
+}
+
+// drainPending flushes queued messages and marks the bridge as ready for direct
+// publishing. Must only be called when publisher + topics are set.
+// Ready is set *after* the drain completes so that concurrent Enqueue calls
+// continue to queue (preserving FIFO order) until the backlog is flushed.
+func (s *BridgeServer) drainPending() {
+	s.pendingMu.Lock()
+	if s.ready || s.draining {
+		s.pendingMu.Unlock()
+		return
+	}
+	s.draining = true
+	queued := s.pending
+	dropped := s.pendingDropped
+	s.pending = nil
+	s.pendingDropped = 0
+	s.pendingMu.Unlock()
+
+	s.mu.RLock()
+	pub := s.publisher
+	ingest := s.ingestTopic
+	telemetry := s.telemetryTopic
+	s.mu.RUnlock()
+
+	// Guard against ClearPublisher() racing between setting draining=true and
+	// here. Re-queue everything and let the next SetPublisher → checkReady
+	// cycle re-trigger the drain.
+	if pub == nil {
+		s.pendingMu.Lock()
+		s.pending = append(queued, s.pending...)
+		if s.maxPending > 0 && len(s.pending) > s.maxPending {
+			excess := len(s.pending) - s.maxPending
+			s.pending = s.pending[:s.maxPending]
+			s.pendingDropped += int64(excess)
+		}
+		s.draining = false
+		s.pendingMu.Unlock()
+		return
+	}
+
+	published := 0
+	if !s.publishBatch(pub, queued, ingest, telemetry, &published) {
+		s.scheduleRetryDrain()
+		return
+	}
+
+	// Drain anything that arrived while we were flushing, then mark ready.
+	s.pendingMu.Lock()
+	for len(s.pending) > 0 {
+		extra := s.pending
+		dropped += s.pendingDropped
+		s.pending = nil
+		s.pendingDropped = 0
+		s.pendingMu.Unlock()
+
+		if !s.publishBatch(pub, extra, ingest, telemetry, &published) {
+			s.scheduleRetryDrain()
+			return
+		}
+		s.pendingMu.Lock()
+	}
+	s.draining = false
+	s.ready = true
+	s.retryBackoff = 0
+	s.pendingMu.Unlock()
+
+	if s.logger != nil && published > 0 {
+		s.logger.Info("drained pending OTLP messages", "count", published, "dropped_while_pending", dropped)
+	}
+}
+
+// scheduleRetryDrain re-triggers drainPending after a delay so that messages
+// re-queued by a failed publishBatch are not stuck indefinitely. Uses
+// exponential backoff (capped at maxRetryBackoff) and respects the server's
+// lifecycle context so pending retries are cancelled on Stop().
+func (s *BridgeServer) scheduleRetryDrain() {
+	s.pendingMu.Lock()
+	backoff := s.retryBackoff
+	if backoff == 0 {
+		backoff = initialRetryBackoff
+	}
+	s.retryBackoff = min(backoff*2, maxRetryBackoff)
+	s.pendingMu.Unlock()
+
+	go func() {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-time.After(backoff):
+			s.drainPending()
+		}
+	}()
+}
+
+// Enqueue marshaled OTLP data for publishing. Before the MQTT connection is
+// ready the payload is queued in memory (up to maxPending messages). When the
+// queue is full, new messages are rejected with ResourceExhausted so the OTLP
+// client can back off and retry. Once ready, publishes directly.
+func (s *BridgeServer) Enqueue(ctx context.Context, isIngest bool, payload []byte) error {
+	s.pendingMu.Lock()
+	if !s.ready {
+		if s.maxPending > 0 && len(s.pending) >= s.maxPending {
+			s.pendingDropped++
+			if s.logger != nil && (s.pendingDropped == 1 || s.pendingDropped%100 == 0) {
+				s.logger.Warn("pending OTLP queue full, rejecting message",
+					"max_pending", s.maxPending, "total_dropped", s.pendingDropped)
+			}
+			s.pendingMu.Unlock()
+			return status.Error(codes.ResourceExhausted, "OTLP pending queue is full")
+		}
+		s.pending = append(s.pending, pendingPublish{isIngest: isIngest, payload: payload})
+		s.pendingMu.Unlock()
+		return nil
+	}
+	s.pendingMu.Unlock()
+
+	s.mu.RLock()
+	pub := s.publisher
+	topic := s.telemetryTopic
+	if isIngest {
+		topic = s.ingestTopic
+	}
+	s.mu.RUnlock()
+
+	// Guard against ClearPublisher() racing between the ready check above and
+	// the mu.RLock here. If publisher was cleared, buffer instead of panicking.
+	if pub == nil {
+		s.pendingMu.Lock()
+		if s.maxPending > 0 && len(s.pending) >= s.maxPending {
+			s.pendingDropped++
+			s.pendingMu.Unlock()
+			return status.Error(codes.ResourceExhausted, "OTLP pending queue is full")
+		}
+		s.pending = append(s.pending, pendingPublish{isIngest: isIngest, payload: payload})
+		s.pendingMu.Unlock()
+		return nil
+	}
+
+	return pub.Publish(ctx, topic, payload)
+}
+
+// GetIngestTopic returns the current ingest topic.
 func (s *BridgeServer) GetIngestTopic() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.ingestTopic
 }
 
-// SetTelemetryTopic sets the telemetry topic for publishing.
-func (s *BridgeServer) SetTelemetryTopic(topic string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.telemetryTopic = topic
-}
-
-// GetTelemetryTopic returns the current telemetry topic (for handlers).
+// GetTelemetryTopic returns the current telemetry topic.
 func (s *BridgeServer) GetTelemetryTopic() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -132,6 +380,11 @@ func (s *BridgeServer) Start(ctx context.Context) error {
 func (s *BridgeServer) Stop(_ context.Context) error {
 	var err error
 	s.closeOnce.Do(func() {
+		// Cancel the lifecycle context first to unblock in-flight drains
+		// and scheduled retry goroutines.
+		if s.cancel != nil {
+			s.cancel()
+		}
 		if s.ingestGRPCServer != nil {
 			s.ingestGRPCServer.GracefulStop()
 		}

--- a/agent/otlpbridge/server_test.go
+++ b/agent/otlpbridge/server_test.go
@@ -113,3 +113,51 @@ func TestBridgeServer_Start_ErrorMessageFormat(t *testing.T) {
 		strings.Contains(errorMsg, "use") || strings.Contains(errorMsg, "bind"),
 		"error message should mention port in use or bind failure: %s", err.Error())
 }
+
+func TestBridgeServer_Enqueue_BoundedQueue(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	cfg := BridgeConfig{
+		ListenAddr:      ":0",
+		Encoding:        "json",
+		MaxPendingQueue: 5,
+	}
+	bridge, err := NewBridgeServer(cfg, nil, logger)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Enqueue up to the limit — all should succeed.
+	for i := 0; i < 5; i++ {
+		require.NoError(t, bridge.Enqueue(ctx, false, []byte(fmt.Sprintf("msg-%d", i))))
+	}
+
+	// Enqueue beyond the limit — should return ResourceExhausted.
+	for i := 5; i < 8; i++ {
+		err = bridge.Enqueue(ctx, false, []byte(fmt.Sprintf("msg-%d", i)))
+		require.Error(t, err, "enqueue beyond limit should fail")
+		assert.Contains(t, err.Error(), "queue is full")
+	}
+
+	// Queue should still contain the original 5 messages (no eviction).
+	bridge.pendingMu.Lock()
+	assert.Equal(t, 5, len(bridge.pending), "queue should be capped at MaxPendingQueue")
+	assert.Equal(t, int64(3), bridge.pendingDropped, "should have counted 3 rejections")
+	assert.Equal(t, "msg-0", string(bridge.pending[0].payload))
+	assert.Equal(t, "msg-4", string(bridge.pending[4].payload))
+	bridge.pendingMu.Unlock()
+}
+
+func TestBridgeServer_Enqueue_DefaultQueueLimit(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	cfg := BridgeConfig{
+		ListenAddr: ":0",
+		Encoding:   "json",
+		// MaxPendingQueue = 0 → should use default
+	}
+	bridge, err := NewBridgeServer(cfg, nil, logger)
+	require.NoError(t, err)
+
+	assert.Equal(t, defaultMaxPendingQueue, bridge.maxPending, "should use default when MaxPendingQueue is 0")
+}

--- a/agent/otlpbridge/server_test.go
+++ b/agent/otlpbridge/server_test.go
@@ -124,8 +124,7 @@ func TestBridgeServer_Enqueue_BoundedQueue(t *testing.T) {
 	}
 	bridge, err := NewBridgeServer(cfg, nil, logger)
 	require.NoError(t, err)
-	//nolint:errcheck // err doesn't matter
-	defer bridge.Stop(context.Background())
+	defer func() { _ = bridge.Stop(context.Background()) }()
 
 	ctx := context.Background()
 
@@ -158,8 +157,7 @@ func TestBridgeServer_Enqueue_DefaultQueueLimit(t *testing.T) {
 	bridge, err := NewBridgeServer(cfg, nil, logger)
 	require.NoError(t, err)
 
-	//nolint:errcheck // err doesn't matter
-	defer bridge.Stop(context.Background())
+	defer func() { _ = bridge.Stop(context.Background()) }()
 
 	assert.Equal(t, defaultMaxPendingQueue, cap(bridge.msgCh), "should use default when MaxPendingQueue is 0")
 }

--- a/agent/otlpbridge/server_test.go
+++ b/agent/otlpbridge/server_test.go
@@ -124,6 +124,7 @@ func TestBridgeServer_Enqueue_BoundedQueue(t *testing.T) {
 	}
 	bridge, err := NewBridgeServer(cfg, nil, logger)
 	require.NoError(t, err)
+	//nolint:errcheck // err doesn't matter
 	defer bridge.Stop(context.Background())
 
 	ctx := context.Background()
@@ -157,6 +158,7 @@ func TestBridgeServer_Enqueue_DefaultQueueLimit(t *testing.T) {
 	bridge, err := NewBridgeServer(cfg, nil, logger)
 	require.NoError(t, err)
 
+	//nolint:errcheck // err doesn't matter
 	defer bridge.Stop(context.Background())
 
 	assert.Equal(t, defaultMaxPendingQueue, cap(bridge.msgCh), "should use default when MaxPendingQueue is 0")

--- a/agent/otlpbridge/server_test.go
+++ b/agent/otlpbridge/server_test.go
@@ -124,28 +124,26 @@ func TestBridgeServer_Enqueue_BoundedQueue(t *testing.T) {
 	}
 	bridge, err := NewBridgeServer(cfg, nil, logger)
 	require.NoError(t, err)
+	defer bridge.Stop(context.Background())
 
 	ctx := context.Background()
 
-	// Enqueue up to the limit — all should succeed.
+	// Fill the channel buffer.
 	for i := 0; i < 5; i++ {
 		require.NoError(t, bridge.Enqueue(ctx, false, []byte(fmt.Sprintf("msg-%d", i))))
 	}
 
-	// Enqueue beyond the limit — should return ResourceExhausted.
-	for i := 5; i < 8; i++ {
-		err = bridge.Enqueue(ctx, false, []byte(fmt.Sprintf("msg-%d", i)))
-		require.Error(t, err, "enqueue beyond limit should fail")
-		assert.Contains(t, err.Error(), "queue is full")
+	// Beyond the limit — should return ResourceExhausted.
+	// The writer goroutine may have pulled at most 1 message from the channel,
+	// so we verify that most attempts beyond the limit are rejected.
+	var rejected int
+	for i := 5; i < 10; i++ {
+		if err := bridge.Enqueue(ctx, false, []byte(fmt.Sprintf("msg-%d", i))); err != nil {
+			assert.Contains(t, err.Error(), "queue is full")
+			rejected++
+		}
 	}
-
-	// Queue should still contain the original 5 messages (no eviction).
-	bridge.pendingMu.Lock()
-	assert.Equal(t, 5, len(bridge.pending), "queue should be capped at MaxPendingQueue")
-	assert.Equal(t, int64(3), bridge.pendingDropped, "should have counted 3 rejections")
-	assert.Equal(t, "msg-0", string(bridge.pending[0].payload))
-	assert.Equal(t, "msg-4", string(bridge.pending[4].payload))
-	bridge.pendingMu.Unlock()
+	assert.GreaterOrEqual(t, rejected, 4, "most messages beyond the limit should be rejected")
 }
 
 func TestBridgeServer_Enqueue_DefaultQueueLimit(t *testing.T) {
@@ -159,5 +157,7 @@ func TestBridgeServer_Enqueue_DefaultQueueLimit(t *testing.T) {
 	bridge, err := NewBridgeServer(cfg, nil, logger)
 	require.NoError(t, err)
 
-	assert.Equal(t, defaultMaxPendingQueue, bridge.maxPending, "should use default when MaxPendingQueue is 0")
+	defer bridge.Stop(context.Background())
+
+	assert.Equal(t, defaultMaxPendingQueue, cap(bridge.msgCh), "should use default when MaxPendingQueue is 0")
 }

--- a/agent/otlpbridge/types.go
+++ b/agent/otlpbridge/types.go
@@ -26,6 +26,7 @@ type ProtoMessage interface {
 
 // BridgeConfig holds runtime configuration for the OTLP → MQTT bridge.
 type BridgeConfig struct {
-	ListenAddr string
-	Encoding   string // "protobuf" | "json"
+	ListenAddr      string
+	Encoding        string // "protobuf" | "json"
+	MaxPendingQueue int    // max queued messages before MQTT is ready; 0 = default (1000)
 }


### PR DESCRIPTION
Add a bounded message queue to the OTLP bridge so that messages received before or during MQTT disconnection (e.g. credential rotation) are buffered rather than dropped. Messages are automatically drained once the publisher reconnects.

Key changes:
- Move publish logic from individual handlers into a central enqueue method on BridgeServer with a configurable queue limit (default 1000 messages)
- Add drain loop that flushes queued messages when publisher becomes ready
- Add PublisherAdapter interface to decouple from concrete MQTT client
- Add rotation_test.go with zero-data-loss integration tests
- Add server_test.go with queue bounding and startup tests