### PR TITLE
fix: race condition leads to sending on closed channel

### DIFF
--- a/agent/configmgr/fleet/connection.go
+++ b/agent/configmgr/fleet/connection.go
@@ -108,28 +108,42 @@ type MQTTConnector interface {
 // startDispatchWorker starts the worker goroutine that processes dispatch jobs sequentially.
 // The worker exits when dispatchStop is closed — dispatchQueue itself is never closed,
 // which eliminates the "send on closed channel" panic that can occur when senders race
-// with shutdown.
+// with shutdown. Any jobs already buffered in dispatchQueue are drained before exit.
 func (connection *MQTTConnection) startDispatchWorker() {
 	go func() {
 		defer close(connection.dispatchWorkerDone)
 		for {
 			select {
 			case job := <-connection.dispatchQueue:
-				err := connection.messaging.DispatchToHandlers(
-					context.Background(),
-					job.payload,
-					job.orgID,
-					job.agentID,
-					job.topicActions,
-				)
-				if err != nil {
-					connection.logger.Error("failed to dispatch to handlers", "error", err)
-				}
+				connection.processJob(job)
 			case <-connection.dispatchStop:
-				return
+				// Drain any jobs buffered in the queue before exiting,
+				// matching the old for-range drain-on-close behaviour.
+				for {
+					select {
+					case job := <-connection.dispatchQueue:
+						connection.processJob(job)
+					default:
+						return
+					}
+				}
 			}
 		}
 	}()
+}
+
+// processJob dispatches a single job to message handlers.
+func (connection *MQTTConnection) processJob(job dispatchJob) {
+	err := connection.messaging.DispatchToHandlers(
+		context.Background(),
+		job.payload,
+		job.orgID,
+		job.agentID,
+		job.topicActions,
+	)
+	if err != nil {
+		connection.logger.Error("failed to dispatch to handlers", "error", err)
+	}
 }
 
 // stopDispatchWorker stops the dispatch worker and waits for it to finish.

--- a/agent/configmgr/fleet/connection.go
+++ b/agent/configmgr/fleet/connection.go
@@ -40,6 +40,7 @@ type MQTTConnection struct {
 	connectionTopics         TokenResponseTopics
 	reconnectChan            chan struct{}
 	dispatchQueue            chan dispatchJob
+	dispatchStop             chan struct{} // signal the worker to exit (never close dispatchQueue)
 	dispatchWorkerDone       chan struct{}
 	shuttingDown             atomic.Bool
 	capabilitiesFailCount    int
@@ -61,6 +62,7 @@ func NewMQTTConnection(logger *slog.Logger, pMgr policymgr.PolicyManager, resetC
 		topicHandlers:      make(map[string]TopicMessageHandler),
 		reconnectChan:      reconnectChan,
 		dispatchQueue:      make(chan dispatchJob, 100), // Buffered channel to prevent blocking MQTT acks
+		dispatchStop:       make(chan struct{}),
 		dispatchWorkerDone: make(chan struct{}),
 	}
 }
@@ -103,26 +105,36 @@ type MQTTConnector interface {
 	RegisterTopicHandler(topic string, handler TopicMessageHandler)
 }
 
-// startDispatchWorker starts the worker goroutine that processes dispatch jobs sequentially
+// startDispatchWorker starts the worker goroutine that processes dispatch jobs sequentially.
+// The worker exits when dispatchStop is closed — dispatchQueue itself is never closed,
+// which eliminates the "send on closed channel" panic that can occur when senders race
+// with shutdown.
 func (connection *MQTTConnection) startDispatchWorker() {
 	go func() {
 		defer close(connection.dispatchWorkerDone)
-		for job := range connection.dispatchQueue {
-			err := connection.messaging.DispatchToHandlers(
-				context.Background(),
-				job.payload,
-				job.orgID,
-				job.agentID,
-				job.topicActions,
-			)
-			if err != nil {
-				connection.logger.Error("failed to dispatch to handlers", "error", err)
+		for {
+			select {
+			case job := <-connection.dispatchQueue:
+				err := connection.messaging.DispatchToHandlers(
+					context.Background(),
+					job.payload,
+					job.orgID,
+					job.agentID,
+					job.topicActions,
+				)
+				if err != nil {
+					connection.logger.Error("failed to dispatch to handlers", "error", err)
+				}
+			case <-connection.dispatchStop:
+				return
 			}
 		}
 	}()
 }
 
-// stopDispatchWorker stops the dispatch worker and waits for it to finish
+// stopDispatchWorker stops the dispatch worker and waits for it to finish.
+// It closes dispatchStop (not dispatchQueue) to signal the worker, so
+// concurrent senders never hit "send on closed channel".
 func (connection *MQTTConnection) stopDispatchWorker() {
 	// If the worker is already done (dispatchWorkerDone is closed), do nothing.
 	select {
@@ -131,8 +143,8 @@ func (connection *MQTTConnection) stopDispatchWorker() {
 	default:
 	}
 
-	// First time stopping: close the queue to signal the worker to exit, then wait for it.
-	close(connection.dispatchQueue)
+	// Signal the worker to exit, then wait for it to finish.
+	close(connection.dispatchStop)
 	<-connection.dispatchWorkerDone
 }
 
@@ -159,6 +171,7 @@ func (connection *MQTTConnection) Connect(ctx context.Context, details Connectio
 
 	// Reinitialize dispatch channels after validation and teardown.
 	connection.dispatchQueue = make(chan dispatchJob, 100)
+	connection.dispatchStop = make(chan struct{})
 	connection.dispatchWorkerDone = make(chan struct{})
 	connection.shuttingDown.Store(false)
 

--- a/agent/configmgr/fleet/connection.go
+++ b/agent/configmgr/fleet/connection.go
@@ -339,33 +339,33 @@ func (connection *MQTTConnection) Connect(ctx context.Context, details Connectio
 					}
 					orgID := parts[1]
 
-						// Hold dispatchMu while checking shuttingDown and sending on
-						// dispatchQueue so stopDispatchWorker cannot close the queue
-						// between the check and the send.
-						connection.dispatchMu.Lock()
-						if connection.shuttingDown {
-							connection.dispatchMu.Unlock()
-							connection.logger.Debug("ignoring message during shutdown", "topic", pr.Packet.Topic)
-							return true, nil
-						}
+					// Hold dispatchMu while checking shuttingDown and sending on
+					// dispatchQueue so stopDispatchWorker cannot close the queue
+					// between the check and the send.
+					connection.dispatchMu.Lock()
+					if connection.shuttingDown {
+						connection.dispatchMu.Unlock()
+						connection.logger.Debug("ignoring message during shutdown", "topic", pr.Packet.Topic)
+						return true, nil
+					}
 
-						select {
-						case connection.dispatchQueue <- dispatchJob{
+					select {
+					case connection.dispatchQueue <- dispatchJob{
 						payload: pr.Packet.Payload,
 						orgID:   orgID,
 						agentID: details.AgentID,
 						topicActions: TopicActions{
 							Subscribe:   connection.subscribeToTopic,
-								Publish:     connection.publishToTopic,
-								Unsubscribe: connection.unsubscribeFromTopic,
-							},
-						}:
-							connection.dispatchMu.Unlock()
-						default:
-							connection.dispatchMu.Unlock()
-							// Queue is full - log warning and process synchronously as fallback
-							connection.logger.Warn("dispatch queue full, processing synchronously", "topic", pr.Packet.Topic)
-							err := connection.messaging.DispatchToHandlers(
+							Publish:     connection.publishToTopic,
+							Unsubscribe: connection.unsubscribeFromTopic,
+						},
+					}:
+						connection.dispatchMu.Unlock()
+					default:
+						connection.dispatchMu.Unlock()
+						// Queue is full - log warning and process synchronously as fallback
+						connection.logger.Warn("dispatch queue full, processing synchronously", "topic", pr.Packet.Topic)
+						err := connection.messaging.DispatchToHandlers(
 							context.Background(),
 							pr.Packet.Payload,
 							orgID,

--- a/agent/configmgr/fleet/connection.go
+++ b/agent/configmgr/fleet/connection.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/eclipse/paho.golang/autopaho"
@@ -40,9 +39,9 @@ type MQTTConnection struct {
 	connectionTopics         TokenResponseTopics
 	reconnectChan            chan struct{}
 	dispatchQueue            chan dispatchJob
-	dispatchStop             chan struct{} // signal the worker to exit (never close dispatchQueue)
 	dispatchWorkerDone       chan struct{}
-	shuttingDown             atomic.Bool
+	dispatchMu               sync.Mutex // guards shuttingDown + dispatchQueue close
+	shuttingDown             bool
 	capabilitiesFailCount    int
 	groupMembershipFailCount int
 	heartbeatFailCount       int
@@ -62,7 +61,6 @@ func NewMQTTConnection(logger *slog.Logger, pMgr policymgr.PolicyManager, resetC
 		topicHandlers:      make(map[string]TopicMessageHandler),
 		reconnectChan:      reconnectChan,
 		dispatchQueue:      make(chan dispatchJob, 100), // Buffered channel to prevent blocking MQTT acks
-		dispatchStop:       make(chan struct{}),
 		dispatchWorkerDone: make(chan struct{}),
 	}
 }
@@ -106,28 +104,11 @@ type MQTTConnector interface {
 }
 
 // startDispatchWorker starts the worker goroutine that processes dispatch jobs sequentially.
-// The worker exits when dispatchStop is closed — dispatchQueue itself is never closed,
-// which eliminates the "send on closed channel" panic that can occur when senders race
-// with shutdown. Any jobs already buffered in dispatchQueue are drained before exit.
 func (connection *MQTTConnection) startDispatchWorker() {
 	go func() {
 		defer close(connection.dispatchWorkerDone)
-		for {
-			select {
-			case job := <-connection.dispatchQueue:
-				connection.processJob(job)
-			case <-connection.dispatchStop:
-				// Drain any jobs buffered in the queue before exiting,
-				// matching the old for-range drain-on-close behaviour.
-				for {
-					select {
-					case job := <-connection.dispatchQueue:
-						connection.processJob(job)
-					default:
-						return
-					}
-				}
-			}
+		for job := range connection.dispatchQueue {
+			connection.processJob(job)
 		}
 	}()
 }
@@ -147,19 +128,30 @@ func (connection *MQTTConnection) processJob(job dispatchJob) {
 }
 
 // stopDispatchWorker stops the dispatch worker and waits for it to finish.
-// It closes dispatchStop (not dispatchQueue) to signal the worker, so
-// concurrent senders never hit "send on closed channel".
+// All reads of dispatchWorkerDone and dispatchQueue are done under dispatchMu
+// so that senders and concurrent stoppers cannot race with the queue close.
 func (connection *MQTTConnection) stopDispatchWorker() {
-	// If the worker is already done (dispatchWorkerDone is closed), do nothing.
+	connection.dispatchMu.Lock()
+
+	done := connection.dispatchWorkerDone
 	select {
-	case <-connection.dispatchWorkerDone:
+	case <-done:
+		connection.dispatchMu.Unlock()
 		return
 	default:
 	}
 
-	// Signal the worker to exit, then wait for it to finish.
-	close(connection.dispatchStop)
-	<-connection.dispatchWorkerDone
+	if connection.shuttingDown {
+		connection.dispatchMu.Unlock()
+		<-done
+		return
+	}
+
+	connection.shuttingDown = true
+	close(connection.dispatchQueue)
+	connection.dispatchMu.Unlock()
+
+	<-done
 }
 
 // Connect connects to the MQTT broker. It is safe to call after a previous
@@ -184,10 +176,11 @@ func (connection *MQTTConnection) Connect(ctx context.Context, details Connectio
 	}
 
 	// Reinitialize dispatch channels after validation and teardown.
+	connection.dispatchMu.Lock()
 	connection.dispatchQueue = make(chan dispatchJob, 100)
-	connection.dispatchStop = make(chan struct{})
 	connection.dispatchWorkerDone = make(chan struct{})
-	connection.shuttingDown.Store(false)
+	connection.shuttingDown = false
+	connection.dispatchMu.Unlock()
 
 	// Store topics for hook callbacks
 	connection.connectionTopics = details.Topics
@@ -346,28 +339,33 @@ func (connection *MQTTConnection) Connect(ctx context.Context, details Connectio
 					}
 					orgID := parts[1]
 
-					// Check if we're shutting down to avoid sending to a closed channel
-					if connection.shuttingDown.Load() {
-						connection.logger.Debug("ignoring message during shutdown", "topic", pr.Packet.Topic)
-						return true, nil
-					}
+						// Hold dispatchMu while checking shuttingDown and sending on
+						// dispatchQueue so stopDispatchWorker cannot close the queue
+						// between the check and the send.
+						connection.dispatchMu.Lock()
+						if connection.shuttingDown {
+							connection.dispatchMu.Unlock()
+							connection.logger.Debug("ignoring message during shutdown", "topic", pr.Packet.Topic)
+							return true, nil
+						}
 
-					select {
-					case connection.dispatchQueue <- dispatchJob{
+						select {
+						case connection.dispatchQueue <- dispatchJob{
 						payload: pr.Packet.Payload,
 						orgID:   orgID,
 						agentID: details.AgentID,
 						topicActions: TopicActions{
 							Subscribe:   connection.subscribeToTopic,
-							Publish:     connection.publishToTopic,
-							Unsubscribe: connection.unsubscribeFromTopic,
-						},
-					}:
-						// Job enqueued successfully
-					default:
-						// Queue is full - log warning and process synchronously as fallback
-						connection.logger.Warn("dispatch queue full, processing synchronously", "topic", pr.Packet.Topic)
-						err := connection.messaging.DispatchToHandlers(
+								Publish:     connection.publishToTopic,
+								Unsubscribe: connection.unsubscribeFromTopic,
+							},
+						}:
+							connection.dispatchMu.Unlock()
+						default:
+							connection.dispatchMu.Unlock()
+							// Queue is full - log warning and process synchronously as fallback
+							connection.logger.Warn("dispatch queue full, processing synchronously", "topic", pr.Packet.Topic)
+							err := connection.messaging.DispatchToHandlers(
 							context.Background(),
 							pr.Packet.Payload,
 							orgID,
@@ -427,8 +425,6 @@ func (connection *MQTTConnection) Reconnect(ctx context.Context, details Connect
 	// Disconnect the existing connection
 	if connection.connectionManager != nil {
 		// Set shutdown flag first to prevent new messages from being enqueued
-		connection.shuttingDown.Store(true)
-
 		disconnectCtx, cancel := context.WithTimeout(ctx, timeout)
 		connection.heartbeater.stop(details.Topics.Heartbeat, connection.publishToTopic)
 		err := connection.connectionManager.Disconnect(disconnectCtx)
@@ -461,8 +457,6 @@ func (connection *MQTTConnection) Disconnect(ctx context.Context, heartbeatTopic
 	if connection.connectionManager == nil {
 		return nil
 	}
-	// Set shutdown flag first to prevent new messages from being enqueued
-	connection.shuttingDown.Store(true)
 
 	// Only attempt the offline heartbeat if we have a real topic; callers like
 	// the startup retry loop pass "" when no session was ever established.

--- a/agent/configmgr/fleet/connection_test.go
+++ b/agent/configmgr/fleet/connection_test.go
@@ -121,7 +121,8 @@ func TestFleetConfigManager_Connect_ValidURL(t *testing.T) {
 		strings.Contains(err.Error(), "context deadline exceeded") ||
 			strings.Contains(err.Error(), "connection refused") ||
 			strings.Contains(err.Error(), "no such host") ||
-			strings.Contains(err.Error(), "server denied connect"),
+			strings.Contains(err.Error(), "server denied connect") ||
+			strings.Contains(err.Error(), "connection manager shutting down"),
 		"Expected connection-related error, got: %v", err)
 }
 

--- a/agent/configmgr/fleet/connection_test.go
+++ b/agent/configmgr/fleet/connection_test.go
@@ -218,10 +218,9 @@ func TestDispatchQueue_HandlesQueueFull(t *testing.T) {
 }
 
 // TestDispatchQueue_NoPanicOnConcurrentShutdown exercises the race window between
-// sending on dispatchQueue and closing it during shutdown. Before the fix (using a
-// separate stop channel), closing the dispatch channel while senders are in-flight
-// can cause "panic: send on closed channel" — even with the shuttingDown atomic
-// check, because the close can happen between the check and the send.
+// sending on dispatchQueue and closing it during shutdown. The send path should
+// follow the same locking protocol as production so stopDispatchWorker cannot
+// close the queue between the shutdown check and the send.
 //
 // Run with: go test -race -count=100 -run TestDispatchQueue_NoPanicOnConcurrentShutdown
 func TestDispatchQueue_NoPanicOnConcurrentShutdown(t *testing.T) {
@@ -249,8 +248,9 @@ func TestDispatchQueue_NoPanicOnConcurrentShutdown(t *testing.T) {
 				}
 			}()
 			for j := 0; j < sendsPerGoroutine; j++ {
-				// This mirrors connection.go:322-357 exactly
-				if connection.shuttingDown.Load() {
+				connection.dispatchMu.Lock()
+				if connection.shuttingDown {
+					connection.dispatchMu.Unlock()
 					return
 				}
 				select {
@@ -264,7 +264,9 @@ func TestDispatchQueue_NoPanicOnConcurrentShutdown(t *testing.T) {
 						Unsubscribe: func(_ string) error { return nil },
 					},
 				}:
+					connection.dispatchMu.Unlock()
 				default:
+					connection.dispatchMu.Unlock()
 				}
 			}
 		}()
@@ -272,7 +274,6 @@ func TestDispatchQueue_NoPanicOnConcurrentShutdown(t *testing.T) {
 
 	// Let senders build up pressure, then trigger concurrent shutdown
 	time.Sleep(1 * time.Millisecond)
-	connection.shuttingDown.Store(true)
 	connection.stopDispatchWorker()
 
 	wg.Wait()
@@ -323,4 +324,156 @@ func TestDispatchQueue_DrainsOnShutdown(t *testing.T) {
 
 	assert.Equal(t, int32(numJobs), processed.Load(),
 		"all buffered jobs must be drained before worker exits")
+}
+
+// TestDispatchQueue_LateEnqueueAfterWorkerExit_IsNotOrphaned captures the race
+// where a sender has already entered the guarded send path while shutdown is in
+// progress. The lock coupling between the send path and stopDispatchWorker must
+// ensure either the job is processed or the sender observes shutdown and skips it.
+func TestDispatchQueue_LateEnqueueAfterWorkerExit_IsNotOrphaned(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mockPMgr := &mockPolicyManagerForFleet{}
+	resetChan := make(chan struct{}, 1)
+	reconnectChan := make(chan struct{}, 1)
+	connection := NewMQTTConnection(logger, mockPMgr, resetChan, reconnectChan, &mockBackendState{})
+
+	payload := []byte(`{"schema_version":"1.0","func":"group_membership","payload":{"full_list":false,"groups":[{"group_id":"late-send","name":"Late"}]}}`)
+	var processed atomic.Int32
+	checked := make(chan struct{})
+	proceed := make(chan struct{})
+	sendDone := make(chan bool, 1)
+	stopDone := make(chan struct{})
+
+	connection.startDispatchWorker()
+
+	go func() {
+		// Mirror the production send path: hold dispatchMu across the
+		// shuttingDown check and the send attempt.
+		connection.dispatchMu.Lock()
+		if connection.shuttingDown {
+			connection.dispatchMu.Unlock()
+			sendDone <- false
+			return
+		}
+		close(checked)
+		<-proceed
+
+		select {
+		case connection.dispatchQueue <- dispatchJob{
+			payload: payload,
+			orgID:   "test-org",
+			agentID: "test-agent",
+			topicActions: TopicActions{
+				Subscribe: func(_ string) error {
+					processed.Add(1)
+					return nil
+				},
+				Publish:     func(_ context.Context, _ string, _ []byte) error { return nil },
+				Unsubscribe: func(_ string) error { return nil },
+			},
+		}:
+			connection.dispatchMu.Unlock()
+			sendDone <- true
+		default:
+			connection.dispatchMu.Unlock()
+			sendDone <- false
+		}
+	}()
+
+	<-checked
+
+	go func() {
+		connection.stopDispatchWorker()
+		close(stopDone)
+	}()
+
+	select {
+	case <-stopDone:
+		t.Fatal("stopDispatchWorker should wait for the in-flight guarded sender")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	close(proceed)
+
+	select {
+	case sent := <-sendDone:
+		if !sent {
+			t.Fatal("expected in-flight guarded sender to enqueue successfully")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for guarded sender")
+	}
+
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for stopDispatchWorker to finish")
+	}
+
+	assert.Equal(t, int32(1), processed.Load(),
+		"an in-flight guarded send should be processed before the worker exits")
+}
+
+// TestDispatchQueue_ConcurrentStopDispatchWorker_NoPanic verifies that two
+// concurrent teardown callers do not both attempt to close dispatchStop.
+func TestDispatchQueue_ConcurrentStopDispatchWorker_NoPanic(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mockPMgr := &mockPolicyManagerForFleet{}
+	resetChan := make(chan struct{}, 1)
+	reconnectChan := make(chan struct{}, 1)
+	connection := NewMQTTConnection(logger, mockPMgr, resetChan, reconnectChan, &mockBackendState{})
+
+	payload := []byte(`{"schema_version":"1.0","func":"group_membership","payload":{"full_list":false,"groups":[{"group_id":"stop-race","name":"StopRace"}]}}`)
+	jobStarted := make(chan struct{})
+	releaseJob := make(chan struct{})
+
+	connection.dispatchQueue <- dispatchJob{
+		payload: payload,
+		orgID:   "test-org",
+		agentID: "test-agent",
+		topicActions: TopicActions{
+			Subscribe: func(_ string) error {
+				close(jobStarted)
+				<-releaseJob
+				return nil
+			},
+			Publish:     func(_ context.Context, _ string, _ []byte) error { return nil },
+			Unsubscribe: func(_ string) error { return nil },
+		},
+	}
+
+	connection.startDispatchWorker()
+
+	select {
+	case <-jobStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for dispatch worker to begin processing")
+	}
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	var panics atomic.Int32
+
+	stopper := func() {
+		defer wg.Done()
+		defer func() {
+			if recover() != nil {
+				panics.Add(1)
+			}
+		}()
+		<-start
+		connection.stopDispatchWorker()
+	}
+
+	wg.Add(2)
+	go stopper()
+	go stopper()
+
+	close(start)
+	time.Sleep(10 * time.Millisecond)
+	close(releaseJob)
+	wg.Wait()
+
+	assert.Equal(t, int32(0), panics.Load(),
+		"concurrent stopDispatchWorker calls should not panic")
 }

--- a/agent/configmgr/fleet/connection_test.go
+++ b/agent/configmgr/fleet/connection_test.go
@@ -281,3 +281,46 @@ func TestDispatchQueue_NoPanicOnConcurrentShutdown(t *testing.T) {
 		t.Fatalf("detected %d panic(s) from send on closed channel — race condition exists", p)
 	}
 }
+
+// TestDispatchQueue_DrainsOnShutdown verifies that jobs already buffered in the
+// dispatch queue are fully processed before the worker exits, even though we
+// use a stop channel instead of closing the queue.
+func TestDispatchQueue_DrainsOnShutdown(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mockPMgr := &mockPolicyManagerForFleet{}
+	resetChan := make(chan struct{}, 1)
+	reconnectChan := make(chan struct{}, 1)
+	connection := NewMQTTConnection(logger, mockPMgr, resetChan, reconnectChan, &mockBackendState{})
+
+	var processed atomic.Int32
+	const numJobs = 50
+
+	// Use a group_membership payload with at least one group so the handler
+	// actually calls Subscribe, letting us count processed jobs.
+	payload := []byte(`{"schema_version":"1.0","func":"group_membership","payload":{"full_list":false,"groups":[{"group_id":"drain-test","name":"Drain"}]}}`)
+
+	// Fill the queue WITHOUT starting the worker, so all jobs are buffered.
+	for i := 0; i < numJobs; i++ {
+		connection.dispatchQueue <- dispatchJob{
+			payload: payload,
+			orgID:   "test-org",
+			agentID: "test-agent",
+			topicActions: TopicActions{
+				Subscribe: func(_ string) error {
+					processed.Add(1)
+					return nil
+				},
+				Publish:     func(_ context.Context, _ string, _ []byte) error { return nil },
+				Unsubscribe: func(_ string) error { return nil },
+			},
+		}
+	}
+
+	// Now start the worker and immediately stop it — the drain loop must
+	// process all 50 buffered jobs before the worker reports done.
+	connection.startDispatchWorker()
+	connection.stopDispatchWorker()
+
+	assert.Equal(t, int32(numJobs), processed.Load(),
+		"all buffered jobs must be drained before worker exits")
+}

--- a/agent/configmgr/fleet/connection_test.go
+++ b/agent/configmgr/fleet/connection_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -213,5 +214,70 @@ func TestDispatchQueue_HandlesQueueFull(t *testing.T) {
 		t.Fatal("Queue should be full")
 	default:
 		// Expected - queue is full
+	}
+}
+
+// TestDispatchQueue_NoPanicOnConcurrentShutdown exercises the race window between
+// sending on dispatchQueue and closing it during shutdown. Before the fix (using a
+// separate stop channel), closing the dispatch channel while senders are in-flight
+// can cause "panic: send on closed channel" — even with the shuttingDown atomic
+// check, because the close can happen between the check and the send.
+//
+// Run with: go test -race -count=100 -run TestDispatchQueue_NoPanicOnConcurrentShutdown
+func TestDispatchQueue_NoPanicOnConcurrentShutdown(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mockPMgr := &mockPolicyManagerForFleet{}
+	resetChan := make(chan struct{}, 1)
+	reconnectChan := make(chan struct{}, 1)
+	connection := NewMQTTConnection(logger, mockPMgr, resetChan, reconnectChan, &mockBackendState{})
+
+	connection.startDispatchWorker()
+
+	const numSenders = 50
+	const sendsPerGoroutine = 200
+	var wg sync.WaitGroup
+	var panics atomic.Int32
+
+	// Spawn many goroutines that mirror the OnPublishReceived send path
+	for i := 0; i < numSenders; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					panics.Add(1)
+				}
+			}()
+			for j := 0; j < sendsPerGoroutine; j++ {
+				// This mirrors connection.go:322-357 exactly
+				if connection.shuttingDown.Load() {
+					return
+				}
+				select {
+				case connection.dispatchQueue <- dispatchJob{
+					payload: []byte(`{}`),
+					orgID:   "test-org",
+					agentID: "test-agent",
+					topicActions: TopicActions{
+						Subscribe:   func(_ string) error { return nil },
+						Publish:     func(_ context.Context, _ string, _ []byte) error { return nil },
+						Unsubscribe: func(_ string) error { return nil },
+					},
+				}:
+				default:
+				}
+			}
+		}()
+	}
+
+	// Let senders build up pressure, then trigger concurrent shutdown
+	time.Sleep(1 * time.Millisecond)
+	connection.shuttingDown.Store(true)
+	connection.stopDispatchWorker()
+
+	wg.Wait()
+
+	if p := panics.Load(); p > 0 {
+		t.Fatalf("detected %d panic(s) from send on closed channel — race condition exists", p)
 	}
 }


### PR DESCRIPTION
The paho MQTT client invokes OnPublishReceived callbacks from its own goroutine. Our callback enqueues a dispatchJob onto a buffered channel (dispatchQueue). During shutdown or reconnect, stopDispatchWorker closes that channel to signal the worker to drain and exit. This creates a classic race:

OnPublishReceived goroutine checks shuttingDown → false
Another goroutine calls stopDispatchWorker → close(dispatchQueue)
OnPublishReceived sends on the now-closed channel → panic: send on closed channel
The previous atomic.Bool flag narrowed the window but couldn't eliminate it — the check and the send weren't atomic.

