### PR TITLE
fix(OBS-2686): Terminate in-flight runs when agent shuts down

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -14,6 +14,7 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/configmgr"
+	"github.com/netboxlabs/orb-agent/agent/policies"
 	"github.com/netboxlabs/orb-agent/agent/policymgr"
 	"github.com/netboxlabs/orb-agent/agent/redact"
 	"github.com/netboxlabs/orb-agent/agent/secretsmgr"
@@ -272,6 +273,13 @@ func (a *orbAgent) Stop(ctx context.Context) {
 		}
 	}
 	a.shutdownOTLP()
+	if a.policyManager != nil {
+		if repo := a.policyManager.GetRepo(); repo != nil {
+			if err := repo.FailNonTerminalRuns(policies.RunFailureReasonAgentStopped); err != nil {
+				a.logger.Error("error while finalizing policy runs on shutdown", slog.Any("error", err))
+			}
+		}
+	}
 	if err := a.configManager.Stop(ctx); err != nil {
 		a.logger.Error("error while stopping config manager", slog.Any("error", err))
 	}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -19,13 +19,22 @@ import (
 // mockConfigManager implements configmgr.Manager for testing Stop delegation
 type mockConfigManager struct {
 	stopCalled bool
+	// onStop runs at the start of Stop (before stopCalled is set). Use it to
+	// assert ordering relative to other shutdown side effects.
+	onStop func()
 }
 
 func (m *mockConfigManager) Start(_ context.Context, _ config.Config, _ map[string]backend.Backend) error {
 	return nil
 }
 func (m *mockConfigManager) GetContext(ctx context.Context) context.Context { return ctx }
-func (m *mockConfigManager) Stop(_ context.Context) error                   { m.stopCalled = true; return nil }
+func (m *mockConfigManager) Stop(_ context.Context) error {
+	if m.onStop != nil {
+		m.onStop()
+	}
+	m.stopCalled = true
+	return nil
+}
 
 func TestAgentStop_DelegatesToConfigManagerStop(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
@@ -58,7 +67,16 @@ func TestAgentStop_FailNonTerminalRunsBeforeConfigManagerStop(t *testing.T) {
 		},
 	}))
 
-	cm := &mockConfigManager{}
+	cm := &mockConfigManager{
+		onStop: func() {
+			pd, err := repo.Get("p1")
+			require.NoError(t, err)
+			require.Len(t, pd.Runs, 1)
+			assert.Equal(t, "failed", pd.Runs[0].Status,
+				"run must already be finalized when configManager.Stop is invoked (FailNonTerminalRuns before Stop)")
+			assert.Equal(t, policies.RunFailureReasonAgentStopped, pd.Runs[0].Reason)
+		},
+	}
 	a := &orbAgent{
 		logger:        logger,
 		backends:      map[string]backend.Backend{},
@@ -67,7 +85,7 @@ func TestAgentStop_FailNonTerminalRunsBeforeConfigManagerStop(t *testing.T) {
 	}
 	a.Stop(context.Background())
 
-	assert.True(t, cm.stopCalled, "configManager.Stop must run after FailNonTerminalRuns")
+	assert.True(t, cm.stopCalled, "expected configManager.Stop to complete")
 	pd, err := repo.Get("p1")
 	require.NoError(t, err)
 	require.Len(t, pd.Runs, 1)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,6 +42,37 @@ func TestAgentStop_DelegatesToConfigManagerStop(t *testing.T) {
 	a.Stop(context.Background())
 
 	assert.True(t, mockMgr.stopCalled, "expected configManager.Stop to be called")
+}
+
+func TestAgentStop_FailNonTerminalRunsBeforeConfigManagerStop(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	now := time.Now().UTC()
+	require.NoError(t, repo.Update(policies.PolicyData{
+		ID:       "p1",
+		Name:     "policy-one",
+		Datasets: map[string]bool{"d1": true},
+		Runs: []policies.RunData{
+			{ID: "run-1", Status: "running", CreatedAt: now, UpdatedAt: now},
+		},
+	}))
+
+	cm := &mockConfigManager{}
+	a := &orbAgent{
+		logger:        logger,
+		backends:      map[string]backend.Backend{},
+		policyManager: &mockPolicyManager{repo: repo},
+		configManager: cm,
+	}
+	a.Stop(context.Background())
+
+	assert.True(t, cm.stopCalled, "configManager.Stop must run after FailNonTerminalRuns")
+	pd, err := repo.Get("p1")
+	require.NoError(t, err)
+	require.Len(t, pd.Runs, 1)
+	assert.Equal(t, "failed", pd.Runs[0].Status)
+	assert.Equal(t, policies.RunFailureReasonAgentStopped, pd.Runs[0].Reason)
 }
 
 // mockPolicyManager implements policymgr.PolicyManager for testing

--- a/agent/configmgr/fleet/from_rpc_test.go
+++ b/agent/configmgr/fleet/from_rpc_test.go
@@ -112,6 +112,11 @@ func (m *mockPolicyRepo) UpdateRuns(policyName string, runs []policies.RunData) 
 	return args.Error(0)
 }
 
+func (m *mockPolicyRepo) FailNonTerminalRuns(reason string) error {
+	args := m.Called(reason)
+	return args.Error(0)
+}
+
 func TestMessageHandlers_DispatchToHandlers(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 

--- a/agent/configmgr/fleet/heartbeats_test.go
+++ b/agent/configmgr/fleet/heartbeats_test.go
@@ -19,11 +19,38 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/configmgr/fleet/messages"
 	"github.com/netboxlabs/orb-agent/agent/policies"
+	"github.com/netboxlabs/orb-agent/agent/policymgr"
 )
 
 func init() {
 	heartbeatTickInterval = 50 * time.Millisecond
 }
+
+// testPolicyManagerWithRepo implements policymgr.PolicyManager by delegating
+// GetPolicyState / GetRepo to an in-memory repo (for shutdown / heartbeat payload tests).
+type testPolicyManagerWithRepo struct {
+	repo policies.PolicyRepo
+}
+
+func (t *testPolicyManagerWithRepo) ManagePolicy(_ config.PolicyPayload) {}
+
+func (t *testPolicyManagerWithRepo) RemovePolicyDataset(_ string, _ string, _ backend.Backend) {}
+
+func (t *testPolicyManagerWithRepo) GetPolicyState() ([]policies.PolicyData, error) {
+	return t.repo.GetAll()
+}
+
+func (t *testPolicyManagerWithRepo) GetRepo() policies.PolicyRepo { return t.repo }
+
+func (t *testPolicyManagerWithRepo) ApplyBackendPolicies(_ backend.Backend) error { return nil }
+
+func (t *testPolicyManagerWithRepo) RemoveBackendPolicies(_ backend.Backend, _ bool) error {
+	return nil
+}
+
+func (t *testPolicyManagerWithRepo) RemovePolicy(_ string, _ string, _ string) error { return nil }
+
+var _ policymgr.PolicyManager = (*testPolicyManagerWithRepo)(nil)
 
 // mockPublishFunc is a testify mock for the publish function
 type mockPublishFunc struct {
@@ -171,6 +198,71 @@ func TestHeartbeater_SendSingleHeartbeat_OfflineState(t *testing.T) {
 	require.NoError(t, json.Unmarshal(payload, &hbMsg))
 	assert.Equal(t, messages.State(messages.Offline), hbMsg.State,
 		"Offline heartbeat must carry State=Offline, not State=Online")
+}
+
+// TestHeartbeater_OfflineHeartbeat_IncludesFailedRunsAfterFailNonTerminalRuns verifies that
+// after FailNonTerminalRuns (as in orbAgent.Stop before Fleet shutdown), an offline heartbeat
+// payload includes failed runs with the shutdown reason (OBS-2686).
+func TestHeartbeater_OfflineHeartbeat_IncludesFailedRunsAfterFailNonTerminalRuns(t *testing.T) {
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	now := time.Now().UTC()
+	before := now.Add(-30 * time.Minute)
+	require.NoError(t, repo.Update(policies.PolicyData{
+		ID:       "pol-id-1",
+		Name:     "network-scan",
+		Backend:  "network-discovery",
+		Version:  1,
+		Datasets: map[string]bool{"ds1": true},
+		GroupIDs: map[string]bool{},
+		State:    policies.Running,
+		Runs: []policies.RunData{
+			{ID: "run-a", Status: "running", CreatedAt: before, UpdatedAt: before},
+			{ID: "run-b", Status: "completed", CreatedAt: before, UpdatedAt: before},
+		},
+	}))
+	require.NoError(t, repo.FailNonTerminalRuns(policies.RunFailureReasonAgentStopped))
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	pm := &testPolicyManagerWithRepo{repo: repo}
+	groupManager := newGroupManager()
+	hb := &heartbeater{
+		logger:         logger,
+		heartbeatCtx:   context.Background(),
+		backendState:   &mockBackendState{},
+		policyManager:  pm,
+		groupRetriever: &groupManager,
+	}
+
+	var captured []byte
+	publishFunc := func(_ context.Context, _ string, payload []byte) error {
+		captured = payload
+		return nil
+	}
+
+	hb.sendSingleHeartbeat(context.Background(), "fleet/hb", publishFunc, "agent-1", time.Now(), messages.Offline, nil)
+	require.NotEmpty(t, captured)
+
+	var msg messages.Heartbeat
+	require.NoError(t, json.Unmarshal(captured, &msg))
+	pi, ok := msg.PolicyState["pol-id-1"]
+	require.True(t, ok, "policy state should include policy id key")
+	require.Len(t, pi.Runs, 2)
+
+	var runA, runB *messages.RunStateInfo
+	for i := range pi.Runs {
+		switch pi.Runs[i].ID {
+		case "run-a":
+			runA = &pi.Runs[i]
+		case "run-b":
+			runB = &pi.Runs[i]
+		}
+	}
+	require.NotNil(t, runA)
+	require.NotNil(t, runB)
+	assert.Equal(t, "failed", runA.Status)
+	assert.Equal(t, policies.RunFailureReasonAgentStopped, runA.Reason)
+	assert.Equal(t, "completed", runB.Status)
 }
 
 func TestHeartbeater_SendSingleHeartbeat_PublishError(t *testing.T) {

--- a/agent/policies/repo.go
+++ b/agent/policies/repo.go
@@ -22,6 +22,7 @@ type PolicyRepo interface {
 	RemoveDataset(policyID string, datasetID string) (bool, error)
 	EnsureGroupID(policyID string, agentGroupID string) error
 	UpdateRuns(policyName string, runs []RunData) error
+	FailNonTerminalRuns(reason string) error
 }
 
 type policyMemRepo struct {
@@ -175,7 +176,7 @@ func (p *policyMemRepo) UpdateRuns(policyName string, runs []RunData) error {
 			// Existing run: always preserve CreatedAt
 			runs[i].CreatedAt = existing.CreatedAt
 
-			if isTerminalStatus(existing.Status) {
+			if IsTerminalRunStatus(existing.Status) {
 				// Run already finished; freeze UpdatedAt so
 				// UpdatedAt − CreatedAt reflects the final run duration.
 				runs[i].UpdatedAt = existing.UpdatedAt
@@ -192,7 +193,7 @@ func (p *policyMemRepo) UpdateRuns(policyName string, runs []RunData) error {
 			// For terminal runs seen for the first time (e.g. after agent restart),
 			// preserve the backend's UpdatedAt so UpdatedAt − CreatedAt reflects
 			// actual run duration rather than agent poll time.
-			if runs[i].UpdatedAt.IsZero() || !isTerminalStatus(runs[i].Status) {
+			if runs[i].UpdatedAt.IsZero() || !IsTerminalRunStatus(runs[i].Status) {
 				runs[i].UpdatedAt = now
 			}
 		}
@@ -200,6 +201,31 @@ func (p *policyMemRepo) UpdateRuns(policyName string, runs []RunData) error {
 
 	policy.Runs = runs
 	p.db[policyID] = policy
+	return nil
+}
+
+// FailNonTerminalRuns marks every non-terminal run as failed with the given reason.
+// Terminal runs (completed, failed) are unchanged.
+func (p *policyMemRepo) FailNonTerminalRuns(reason string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	now := time.Now().UTC()
+	for policyID, policy := range p.db {
+		changed := false
+		for i := range policy.Runs {
+			if IsTerminalRunStatus(policy.Runs[i].Status) {
+				continue
+			}
+			policy.Runs[i].PolicyID = policyID
+			policy.Runs[i].Status = "failed"
+			policy.Runs[i].Reason = reason
+			policy.Runs[i].UpdatedAt = now
+			changed = true
+		}
+		if changed {
+			p.db[policyID] = policy
+		}
+	}
 	return nil
 }
 

--- a/agent/policies/repo_test.go
+++ b/agent/policies/repo_test.go
@@ -809,3 +809,95 @@ func TestUpdateRuns_GetAllIncludesRuns(t *testing.T) {
 	}
 	assert.True(t, foundPolicy2, "Policy 2 should be found in GetAll()")
 }
+
+func TestIsTerminalRunStatus(t *testing.T) {
+	t.Parallel()
+	assert.True(t, policies.IsTerminalRunStatus("completed"))
+	assert.True(t, policies.IsTerminalRunStatus("failed"))
+	assert.False(t, policies.IsTerminalRunStatus("running"))
+	assert.False(t, policies.IsTerminalRunStatus(""))
+	assert.False(t, policies.IsTerminalRunStatus("pending"))
+}
+
+func TestFailNonTerminalRuns_EmptyRepo(t *testing.T) {
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	require.NoError(t, repo.FailNonTerminalRuns(policies.RunFailureReasonAgentStopped))
+}
+
+func TestFailNonTerminalRuns_MarksRunningAndPreservesTerminal(t *testing.T) {
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	now := time.Now().UTC()
+	before := now.Add(-time.Hour)
+	pd := policies.PolicyData{
+		ID:       "policy-a",
+		Name:     "net-pol",
+		Backend:  "network-discovery",
+		Version:  1,
+		Datasets: map[string]bool{"ds1": true},
+		GroupIDs: map[string]bool{},
+		State:    policies.Running,
+		Runs: []policies.RunData{
+			{ID: "run-running", Status: "running", CreatedAt: before, UpdatedAt: before},
+			{ID: "run-custom", Status: "queued", CreatedAt: before, UpdatedAt: before},
+			{ID: "run-done", Status: "completed", CreatedAt: before, UpdatedAt: before},
+			{ID: "run-fail", Status: "failed", Reason: "discovery error", CreatedAt: before, UpdatedAt: before},
+		},
+	}
+	require.NoError(t, repo.Update(pd))
+
+	afterStart := time.Now().UTC()
+	require.NoError(t, repo.FailNonTerminalRuns("custom shutdown reason"))
+
+	out, err := repo.Get("policy-a")
+	require.NoError(t, err)
+	require.Len(t, out.Runs, 4)
+
+	byID := make(map[string]policies.RunData, len(out.Runs))
+	for _, r := range out.Runs {
+		byID[r.ID] = r
+	}
+
+	assert.Equal(t, "failed", byID["run-running"].Status)
+	assert.Equal(t, "custom shutdown reason", byID["run-running"].Reason)
+	assert.True(t, !byID["run-running"].UpdatedAt.Before(afterStart))
+
+	assert.Equal(t, "failed", byID["run-custom"].Status)
+	assert.Equal(t, "custom shutdown reason", byID["run-custom"].Reason)
+
+	assert.Equal(t, "completed", byID["run-done"].Status)
+	assert.Equal(t, before, byID["run-done"].UpdatedAt)
+
+	assert.Equal(t, "failed", byID["run-fail"].Status)
+	assert.Equal(t, "discovery error", byID["run-fail"].Reason)
+	assert.Equal(t, before, byID["run-fail"].UpdatedAt)
+}
+
+func TestFailNonTerminalRuns_MultiplePolicies(t *testing.T) {
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	now := time.Now().UTC()
+	require.NoError(t, repo.Update(policies.PolicyData{
+		ID:       "p1",
+		Name:     "a",
+		Datasets: map[string]bool{"d": true},
+		Runs:     []policies.RunData{{ID: "r1", Status: "running", CreatedAt: now, UpdatedAt: now}},
+	}))
+	require.NoError(t, repo.Update(policies.PolicyData{
+		ID:       "p2",
+		Name:     "b",
+		Datasets: map[string]bool{"d": true},
+		Runs:     []policies.RunData{{ID: "r2", Status: "running", CreatedAt: now, UpdatedAt: now}},
+	}))
+	require.NoError(t, repo.FailNonTerminalRuns(policies.RunFailureReasonAgentStopped))
+
+	p1, err := repo.Get("p1")
+	require.NoError(t, err)
+	assert.Equal(t, "failed", p1.Runs[0].Status)
+	assert.Equal(t, policies.RunFailureReasonAgentStopped, p1.Runs[0].Reason)
+
+	p2, err := repo.Get("p2")
+	require.NoError(t, err)
+	assert.Equal(t, "failed", p2.Runs[0].Status)
+}

--- a/agent/policies/types.go
+++ b/agent/policies/types.go
@@ -81,9 +81,13 @@ func (s *PolicyState) Scan(value any) error {
 // Value returns the value of the PolicyState
 func (s PolicyState) Value() (driver.Value, error) { return s.String(), nil }
 
-// isTerminalStatus returns true if the run status represents a finished run
+// RunFailureReasonAgentStopped is reported when non-terminal runs are finalized
+// because the agent shut down intentionally (e.g. SIGTERM/SIGINT).
+const RunFailureReasonAgentStopped = "Run interrupted: agent was intentionally stopped"
+
+// IsTerminalRunStatus returns true if the run status represents a finished run
 // whose timestamps should no longer be updated.
-func isTerminalStatus(status string) bool {
+func IsTerminalRunStatus(status string) bool {
 	switch status {
 	case "completed", "failed":
 		return true


### PR DESCRIPTION
## Summary
Implements [OBS-2686](https://linear.app/netboxlabs/issue/OBS-2686): on graceful shutdown, non-terminal discovery runs are marked `failed` with a stable reason (`Run interrupted: agent was intentionally stopped`) **before** the config manager stops, so the Fleet offline heartbeat includes updated policy/run state.

## Changes
- **policies**: `FailNonTerminalRuns`, exported `IsTerminalRunStatus`, `RunFailureReasonAgentStopped`.
- **agent**: invoke finalization after OTLP shutdown, before `configManager.Stop` (nil-safe for tests).
- **tests**: repo coverage, agent Stop behavior, offline heartbeat JSON includes failed runs; `mockPolicyRepo` updated.

## Commits
1. `feat(policies): add FailNonTerminalRuns...`
2. `feat(agent): finalize non-terminal runs before config manager stops...`
3. `test: cover heartbeat payload and mocks...`

Made with [Cursor](https://cursor.com)