### PR TITLE
docs(OBS-1284): document interface_exclude_patterns for snmp-discovery and device-discovery

### DIFF
--- a/docs/backends/device_discovery.md
+++ b/docs/backends/device_discovery.md
@@ -69,6 +69,7 @@ Current supported defaults:
 | role  | str  | Device role (e.g., switch) (defaults to 'undefined' if not specified) |
 | if_type | str | Default interface type when no pattern matches (defaults to 'other' if not specified) |
 | interface_patterns | list | User-defined interface type patterns (see [Interface Type Matching](./device_discovery_interface.md)) |
+| interface_exclude_patterns | list | Regex patterns to exclude interfaces (and their IPs) from ingestion (see [Interface Exclusion](./device_discovery_interface.md#interface-exclusion-patterns)) |
 | location | str | Device location |
 | tenant | str/map | Device tenant |
 | description | str  | General description   |
@@ -169,6 +170,9 @@ orb:
                 type: "10gbase-x-sfpp"
               - match: "^Loopback.*"
                 type: "virtual"
+            interface_exclude_patterns:
+              - "^tap.*"
+              - "^veth.*"
             location: Row A
             tenant: NetBox Labs
             description: for all

--- a/docs/backends/device_discovery_interface.md
+++ b/docs/backends/device_discovery_interface.md
@@ -63,6 +63,47 @@ interface_patterns:
 # User pattern wins even though built-in is more specific
 ```
 
+## Interface Exclusion Patterns
+
+Use `interface_exclude_patterns` to prevent specific interfaces — and their associated IP addresses — from being ingested into NetBox. This is useful for filtering out virtual or host-only interfaces (TAP, veth, loopback, etc.) that are not relevant to your network inventory.
+
+### Configuration
+
+```yaml
+defaults:
+  interface_exclude_patterns:
+    - "^tap.*"      # exclude TAP interfaces (e.g. tap103i0)
+    - "^veth.*"     # exclude veth pairs
+    - "^docker.*"   # exclude Docker bridge interfaces
+```
+
+### Rules
+
+- Patterns are **case-sensitive** regular expressions matched against the full interface name
+- A pattern matches anywhere in the name — use `^` to anchor to the start (e.g. `^tap` matches `tap0` but not `mytap0`)
+- When an interface is excluded, **all IP addresses assigned to it are also suppressed**
+- The `override_defaults` field on a device replaces the global list wholesale (same behaviour as `interface_patterns`)
+
+### Per-Device Override
+
+```yaml
+defaults:
+  interface_exclude_patterns:
+    - "^tap.*"
+scope:
+  - hostname: 192.168.1.1
+    username: admin
+    password: secret
+    override_defaults:
+      interface_exclude_patterns:
+        - "^tap.*"
+        - "^veth.*"   # this device also excludes veth interfaces
+```
+
+### Invalid Patterns
+
+Invalid regex patterns are logged as warnings and skipped. Valid patterns in the same list are still applied.
+
 ## Built-In Patterns
 
 When no user patterns are configured (or none match), the system automatically applies built-in patterns for common network equipment:

--- a/docs/backends/snmp_discovery.md
+++ b/docs/backends/snmp_discovery.md
@@ -50,6 +50,7 @@ SNMP discovery policies are broken down into two subsections: `config` and `scop
 | location | string | no | Default location for discovered devices |
 | role | string | no | Default role for discovered devices |
 | interface_patterns | list  | no | User-defined interface type patterns (see [Interface Type Matching](./snmp_discovery_interface.md)) |
+| interface_exclude_patterns | list | no | Regex patterns to exclude interfaces (and their IPs) from ingestion (see [Interface Exclusion](./snmp_discovery_interface.md#interface-exclusion-patterns)) |
 
 ##### Nested Defaults
 | Parameter | Type | Description |
@@ -126,6 +127,9 @@ config:
         type: "1000base-t"
       - match: "^(TenGigE|Te).*"
         type: "10gbase-x-sfpp"
+    interface_exclude_patterns:
+      - "^tap.*"
+      - "^veth.*"
     device:
       description: "SNMP discovered device"
       comments: "Automatically discovered via SNMP"

--- a/docs/backends/snmp_discovery_interface.md
+++ b/docs/backends/snmp_discovery_interface.md
@@ -160,6 +160,46 @@ interface_patterns:
 # User pattern wins over SNMP ifType and built-in patterns
 ```
 
+## Interface Exclusion Patterns
+
+Use `interface_exclude_patterns` to prevent specific interfaces — and their associated IP addresses — from being ingested into NetBox. This is useful for filtering out virtual or host-only interfaces (TAP, veth, loopback, etc.) that are not relevant to your network inventory.
+
+### Configuration
+
+```yaml
+defaults:
+  interface_exclude_patterns:
+    - "^tap.*"      # exclude TAP interfaces (e.g. tap103i0)
+    - "^veth.*"     # exclude veth pairs
+    - "^docker.*"   # exclude Docker bridge interfaces
+```
+
+### Rules
+
+- Patterns are **case-sensitive** regular expressions matched against the full interface name
+- A pattern matches anywhere in the name — use `^` to anchor to the start (e.g. `^tap` matches `tap0` but not `mytap0`)
+- When an interface is excluded, **all IP addresses assigned to it are also suppressed**
+- The `override_defaults` field on a target replaces the global list wholesale (same behaviour as `interface_patterns`)
+
+### Per-Target Override
+
+```yaml
+defaults:
+  interface_exclude_patterns:
+    - "^tap.*"
+scope:
+  targets:
+    - host: "192.168.1.1"
+      override_defaults:
+        interface_exclude_patterns:
+          - "^tap.*"
+          - "^veth.*"   # this target also excludes veth interfaces
+```
+
+### Invalid Patterns
+
+Invalid regex patterns are logged as warnings and skipped. Valid patterns in the same list are still applied.
+
 ## SNMP ifType Mappings
 
 Standard IANA interface types from SNMP `ifType` (`.1.3.6.1.2.1.2.2.1.3`) are automatically mapped:


### PR DESCRIPTION
## Summary

Documents the new `interface_exclude_patterns` config field added in netboxlabs/orb-discovery#360.

- Adds `interface_exclude_patterns` to the Defaults Parameters table in both `snmp_discovery.md` and `device_discovery.md`
- Adds a dedicated **Interface Exclusion Patterns** section to both `snmp_discovery_interface.md` and `device_discovery_interface.md` covering config syntax, matching rules, IP suppression, per-target override, and invalid pattern handling
- Updates YAML examples in both backend docs to show the new field alongside `interface_patterns`

## Related

- Implementation PR: netboxlabs/orb-discovery#360

🤖 Generated with [Claude Code](https://claude.com/claude-code)