### PR TITLE
fix(fleet): fix race condition causing offline heartbeat to be intermittently lost on shutdown

### DIFF
--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -209,45 +209,7 @@ func (fleetManager *FleetConfigManager) Start(ctx context.Context, cfg config.Co
 	fleetManager.goroutinesWg.Add(1)
 	go func() {
 		defer fleetManager.goroutinesWg.Done()
-		for {
-			select {
-			case <-fleetManager.monitorCtx.Done():
-				fleetManager.logger.Info("reset handler stopped")
-				return
-			case _, ok := <-fleetManager.resetChan:
-				if !ok {
-					return
-				}
-				fleetManager.logger.Info("agent reset requested, reconnecting MQTT connection")
-
-				// Snapshot connection details under the read lock so we get a consistent view
-				// even if the reconnect worker is concurrently writing after a token refresh.
-				fleetManager.connMu.RLock()
-				details := fleetManager.connectionDetails
-				fleetManager.connMu.RUnlock()
-
-				if fleetManager.otlpBridge != nil {
-					fleetManager.otlpBridge.ClearPublisher()
-				}
-
-				// Disconnect first. Use connCtx for timeout so the offline heartbeat
-				// inside Disconnect() still has a live parent context.
-				disconnectCtx, cancel := context.WithTimeout(fleetManager.connCtx, timeout)
-				err := fleetManager.connection.Disconnect(disconnectCtx, details.Topics.Heartbeat)
-				cancel()
-				if err != nil {
-					fleetManager.logger.Error("failed to disconnect during reset", "error", err)
-				}
-
-				// Reconnect: connCtx governs the new connection's lifetime; monitorCtx
-				// bounds the AwaitConnection wait so Stop() isn't blocked if the broker
-				// is unreachable during the reset.
-				err = fleetManager.connection.Connect(fleetManager.connCtx, fleetManager.monitorCtx, details, fleetManager.backends, fleetManager.labels, fleetManager.configYaml)
-				if err != nil {
-					fleetManager.logger.Error("failed to reconnect during reset", "error", err)
-				}
-			}
-		}
+		fleetManager.runResetHandler(timeout)
 	}()
 
 	// Start goroutine to handle reconnect requests (JWT refresh)
@@ -325,6 +287,53 @@ func (fleetManager *FleetConfigManager) startConnection(ctx context.Context, cfg
 	// connCtx governs the connection's lifetime; ctx (the startup context) bounds
 	// the AwaitConnection wait so a cancelled startup doesn't hang indefinitely.
 	return fleetManager.connection.Connect(fleetManager.connCtx, ctx, connectionDetails, backends, cfg.OrbAgent.Labels, string(configYaml))
+}
+
+// runResetHandler processes signals from resetChan, performing a clean MQTT disconnect followed
+// by reconnect using the latest stored connection details. It uses connCtx (not monitorCtx) as
+// the disconnect timeout parent so the offline heartbeat goroutine still has a live context.
+// monitorCtx bounds the AwaitConnection wait during reconnect, so Stop() is never blocked by an
+// in-flight reset when the broker is unreachable.
+func (fleetManager *FleetConfigManager) runResetHandler(timeout time.Duration) {
+	for {
+		select {
+		case <-fleetManager.monitorCtx.Done():
+			fleetManager.logger.Info("reset handler stopped")
+			return
+		case _, ok := <-fleetManager.resetChan:
+			if !ok {
+				return
+			}
+			fleetManager.logger.Info("agent reset requested, reconnecting MQTT connection")
+
+			// Snapshot connection details under the read lock so we get a consistent view
+			// even if the reconnect worker is concurrently writing after a token refresh.
+			fleetManager.connMu.RLock()
+			details := fleetManager.connectionDetails
+			fleetManager.connMu.RUnlock()
+
+			if fleetManager.otlpBridge != nil {
+				fleetManager.otlpBridge.ClearPublisher()
+			}
+
+			// Disconnect first. Use connCtx for timeout so the offline heartbeat
+			// inside Disconnect() still has a live parent context.
+			disconnectCtx, cancel := context.WithTimeout(fleetManager.connCtx, timeout)
+			err := fleetManager.connection.Disconnect(disconnectCtx, details.Topics.Heartbeat)
+			cancel()
+			if err != nil {
+				fleetManager.logger.Error("failed to disconnect during reset", "error", err)
+			}
+
+			// Reconnect: connCtx governs the new connection's lifetime; monitorCtx
+			// bounds the AwaitConnection wait so Stop() isn't blocked if the broker
+			// is unreachable during the reset.
+			err = fleetManager.connection.Connect(fleetManager.connCtx, fleetManager.monitorCtx, details, fleetManager.backends, fleetManager.labels, fleetManager.configYaml)
+			if err != nil {
+				fleetManager.logger.Error("failed to reconnect during reset", "error", err)
+			}
+		}
+	}
 }
 
 // runReconnectWorker processes signals from reconnectChan, retrying token refresh with exponential

--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -48,9 +48,9 @@ type FleetConfigManager struct {
 	// monitorCtx. monitorCtx cancellation stops background workers; connCtx is
 	// only cancelled after Disconnect() in Stop(), ensuring the heartbeat goroutine
 	// can still publish the offline heartbeat while the connection is alive.
-	connCtx    context.Context
-	connCancel context.CancelFunc
-	connected  atomic.Bool    // true only after connection.Connect() succeeds
+	connCtx      context.Context
+	connCancel   context.CancelFunc
+	connected    atomic.Bool    // true only after connection.Connect() succeeds
 	goroutinesWg sync.WaitGroup // tracks goroutines started in Start(); Wait()ed in Stop() before Disconnect
 }
 

--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -44,8 +44,14 @@ type FleetConfigManager struct {
 	connectionDetails fleet.ConnectionDetails
 	monitorCtx        context.Context
 	monitorCancel     context.CancelFunc
-	connected         atomic.Bool    // true only after connection.Connect() succeeds
-	goroutinesWg      sync.WaitGroup // tracks goroutines started in Start(); Wait()ed in Stop() before Disconnect
+	// connCtx/connCancel control the MQTT connection lifetime independently of
+	// monitorCtx. monitorCtx cancellation stops background workers; connCtx is
+	// only cancelled after Disconnect() in Stop(), ensuring the heartbeat goroutine
+	// can still publish the offline heartbeat while the connection is alive.
+	connCtx    context.Context
+	connCancel context.CancelFunc
+	connected  atomic.Bool    // true only after connection.Connect() succeeds
+	goroutinesWg sync.WaitGroup // tracks goroutines started in Start(); Wait()ed in Stop() before Disconnect
 }
 
 func newFleetConfigManager(logger *slog.Logger, pMgr policymgr.PolicyManager, backendState backend.StateRetriever) *FleetConfigManager {
@@ -125,6 +131,11 @@ func (fleetManager *FleetConfigManager) Start(ctx context.Context, cfg config.Co
 	// monitor, and reset handler so that Stop() can terminate all goroutines with
 	// a single monitorCancel() call.
 	fleetManager.monitorCtx, fleetManager.monitorCancel = context.WithCancel(context.Background())
+
+	// connCtx is independent of monitorCtx: it controls the MQTT connection and
+	// is the parent for heartbeat goroutines. It is cancelled by Stop() only after
+	// Disconnect() returns, so the offline heartbeat is always sent on a live connection.
+	fleetManager.connCtx, fleetManager.connCancel = context.WithCancel(context.Background())
 
 	// Register OnReadyHook before the retry loop so it fires on the initial
 	// connection (OnConnectionUp runs synchronously before Connect returns).
@@ -219,17 +230,18 @@ func (fleetManager *FleetConfigManager) Start(ctx context.Context, cfg config.Co
 					fleetManager.otlpBridge.ClearPublisher()
 				}
 
-				// Disconnect first — use monitorCtx so Stop() cancellation aborts in-flight resets.
-				disconnectCtx, cancel := context.WithTimeout(fleetManager.monitorCtx, timeout)
+				// Disconnect first. Use connCtx for timeout so the offline heartbeat
+				// inside Disconnect() still has a live parent context.
+				disconnectCtx, cancel := context.WithTimeout(fleetManager.connCtx, timeout)
 				err := fleetManager.connection.Disconnect(disconnectCtx, details.Topics.Heartbeat)
 				cancel()
 				if err != nil {
 					fleetManager.logger.Error("failed to disconnect during reset", "error", err)
 				}
 
-				// Reconnect using the latest connection details (updated by refreshAndReconnect after token refresh).
-				// Use monitorCtx so that a concurrent Stop() cancels a long-running connect.
-				err = fleetManager.connection.Connect(fleetManager.monitorCtx, details, fleetManager.backends, fleetManager.labels, fleetManager.configYaml)
+				// Reconnect using connCtx so the new MQTT connection shares the same
+				// independent lifecycle as the initial connection.
+				err = fleetManager.connection.Connect(fleetManager.connCtx, details, fleetManager.backends, fleetManager.labels, fleetManager.configYaml)
 				if err != nil {
 					fleetManager.logger.Error("failed to reconnect during reset", "error", err)
 				}
@@ -260,7 +272,7 @@ func (fleetManager *FleetConfigManager) Start(ctx context.Context, cfg config.Co
 // *fleet.AuthError that the caller surfaces immediately.
 //
 // ctx is used for short-lived startup work (token fetch, JWT parse). The MQTT connection
-// itself uses fleetManager.monitorCtx so it outlives the startup context.
+// itself uses fleetManager.connCtx so it outlives the startup context.
 func (fleetManager *FleetConfigManager) startConnection(ctx context.Context, cfg config.Config, backends map[string]backend.Backend, timeout time.Duration) error {
 	token, err := fleetManager.authTokenManager.GetToken(ctx,
 		cfg.OrbAgent.ConfigManager.Sources.Fleet.TokenURL,
@@ -309,9 +321,11 @@ func (fleetManager *FleetConfigManager) startConnection(ctx context.Context, cfg
 	fleetManager.configYaml = string(configYaml)
 	fleetManager.connectionDetails = connectionDetails
 
-	// Use monitorCtx for the MQTT connection so it outlives the caller's startup
-	// context. monitorCtx is cancelled by Stop(), which is the correct lifecycle.
-	return fleetManager.connection.Connect(fleetManager.monitorCtx, connectionDetails, backends, cfg.OrbAgent.Labels, string(configYaml))
+	// Use connCtx (not monitorCtx) for the MQTT connection. connCtx is independent of
+	// the background worker lifecycle — it is only cancelled in Stop() after Disconnect(),
+	// ensuring the heartbeat goroutine's parent context remains live until the offline
+	// heartbeat has been sent.
+	return fleetManager.connection.Connect(fleetManager.connCtx, connectionDetails, backends, cfg.OrbAgent.Labels, string(configYaml))
 }
 
 // runReconnectWorker processes signals from reconnectChan, retrying token refresh with exponential
@@ -355,16 +369,16 @@ func (fleetManager *FleetConfigManager) runReconnectWorker(ctx context.Context, 
 		if lastErr != nil {
 			fleetManager.logger.Error("all refresh and reconnect attempts exhausted, disconnecting agent",
 				"error", lastErr)
-			// Use a dedicated timeout context for teardown so that a hung MQTT broker cannot
-			// block the reconnect loop indefinitely; the worker's ctx is long-lived and would
-			// never expire on its own.
+			// Use connCtx (not the worker's monitorCtx-derived ctx) as the timeout
+			// parent so the disconnect isn't dead-on-arrival if Stop() has already
+			// cancelled monitorCtx concurrently.
 			fleetManager.connMu.RLock()
 			heartbeatTopic := fleetManager.connectionDetails.Topics.Heartbeat
 			fleetManager.connMu.RUnlock()
 			if fleetManager.otlpBridge != nil {
 				fleetManager.otlpBridge.ClearPublisher()
 			}
-			disconnectCtx, disconnectCancel := context.WithTimeout(ctx, timeout)
+			disconnectCtx, disconnectCancel := context.WithTimeout(fleetManager.connCtx, timeout)
 			if err := fleetManager.connection.Disconnect(disconnectCtx, heartbeatTopic); err != nil {
 				fleetManager.logger.Error("failed to disconnect after exhausted retries", "error", err)
 			}
@@ -473,8 +487,9 @@ func (fleetManager *FleetConfigManager) refreshAndReconnect(ctx context.Context,
 		fleetManager.otlpBridge.ClearPublisher()
 	}
 
-	// Reconnect with new token
-	err = fleetManager.connection.Reconnect(ctx, newConnectionDetails, fleetManager.backends, fleetManager.labels, fleetManager.configYaml, timeout)
+	// Reconnect with new token, using connCtx so the new MQTT connection's parent
+	// context is independent of the background worker lifecycle.
+	err = fleetManager.connection.Reconnect(fleetManager.connCtx, newConnectionDetails, fleetManager.backends, fleetManager.labels, fleetManager.configYaml, timeout)
 	if err != nil {
 		return fmt.Errorf("failed to reconnect: %w", err)
 	}
@@ -583,6 +598,12 @@ func (fleetManager *FleetConfigManager) Stop(ctx context.Context) error {
 			}
 			cancel()
 		}
+	}
+
+	// Cancel connCtx after Disconnect so the heartbeat goroutine's parent context
+	// remains alive until the offline heartbeat has been sent.
+	if fleetManager.connCancel != nil {
+		fleetManager.connCancel()
 	}
 
 	if fleetManager.otlpBridge != nil {

--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -239,9 +239,10 @@ func (fleetManager *FleetConfigManager) Start(ctx context.Context, cfg config.Co
 					fleetManager.logger.Error("failed to disconnect during reset", "error", err)
 				}
 
-				// Reconnect using connCtx so the new MQTT connection shares the same
-				// independent lifecycle as the initial connection.
-				err = fleetManager.connection.Connect(fleetManager.connCtx, details, fleetManager.backends, fleetManager.labels, fleetManager.configYaml)
+				// Reconnect: connCtx governs the new connection's lifetime; monitorCtx
+				// bounds the AwaitConnection wait so Stop() isn't blocked if the broker
+				// is unreachable during the reset.
+				err = fleetManager.connection.Connect(fleetManager.connCtx, fleetManager.monitorCtx, details, fleetManager.backends, fleetManager.labels, fleetManager.configYaml)
 				if err != nil {
 					fleetManager.logger.Error("failed to reconnect during reset", "error", err)
 				}
@@ -321,11 +322,9 @@ func (fleetManager *FleetConfigManager) startConnection(ctx context.Context, cfg
 	fleetManager.configYaml = string(configYaml)
 	fleetManager.connectionDetails = connectionDetails
 
-	// Use connCtx (not monitorCtx) for the MQTT connection. connCtx is independent of
-	// the background worker lifecycle — it is only cancelled in Stop() after Disconnect(),
-	// ensuring the heartbeat goroutine's parent context remains live until the offline
-	// heartbeat has been sent.
-	return fleetManager.connection.Connect(fleetManager.connCtx, connectionDetails, backends, cfg.OrbAgent.Labels, string(configYaml))
+	// connCtx governs the connection's lifetime; ctx (the startup context) bounds
+	// the AwaitConnection wait so a cancelled startup doesn't hang indefinitely.
+	return fleetManager.connection.Connect(fleetManager.connCtx, ctx, connectionDetails, backends, cfg.OrbAgent.Labels, string(configYaml))
 }
 
 // runReconnectWorker processes signals from reconnectChan, retrying token refresh with exponential
@@ -487,9 +486,10 @@ func (fleetManager *FleetConfigManager) refreshAndReconnect(ctx context.Context,
 		fleetManager.otlpBridge.ClearPublisher()
 	}
 
-	// Reconnect with new token, using connCtx so the new MQTT connection's parent
-	// context is independent of the background worker lifecycle.
-	err = fleetManager.connection.Reconnect(fleetManager.connCtx, newConnectionDetails, fleetManager.backends, fleetManager.labels, fleetManager.configYaml, timeout)
+	// connCtx governs the new connection's lifetime; ctx (monitorCtx from the
+	// reconnect worker) bounds the disconnect/AwaitConnection wait so Stop() isn't
+	// blocked by an in-flight reconnect when the broker is unreachable.
+	err = fleetManager.connection.Reconnect(fleetManager.connCtx, ctx, newConnectionDetails, fleetManager.backends, fleetManager.labels, fleetManager.configYaml, timeout)
 	if err != nil {
 		return fmt.Errorf("failed to reconnect: %w", err)
 	}

--- a/agent/configmgr/fleet/connection.go
+++ b/agent/configmgr/fleet/connection.go
@@ -94,11 +94,18 @@ type ConnectionDetails struct {
 	Zone     string
 }
 
-// MQTTConnector defines the interface for MQTT connection operations
+// MQTTConnector defines the interface for MQTT connection operations.
+//
+// Connect and Reconnect take two distinct contexts:
+//   - ctx (lifecycle): passed to autopaho.NewConnection; must remain live until
+//     the connection is intentionally torn down (typically connCtx in fleet.go).
+//   - waitCtx (wait): governs the AwaitConnection call and, for Reconnect, the
+//     disconnect-before-reconnect timeout; should be cancellable by shutdown
+//     (typically monitorCtx) so Stop() is not blocked by in-flight connect attempts.
 type MQTTConnector interface {
-	Connect(ctx context.Context, details ConnectionDetails, backends map[string]backend.Backend, labels map[string]string, configFile string) error
+	Connect(ctx context.Context, waitCtx context.Context, details ConnectionDetails, backends map[string]backend.Backend, labels map[string]string, configFile string) error
 	Disconnect(ctx context.Context, heartbeatTopic string) error
-	Reconnect(ctx context.Context, details ConnectionDetails, backends map[string]backend.Backend, labels map[string]string, configFile string, timeout time.Duration) error
+	Reconnect(ctx context.Context, waitCtx context.Context, details ConnectionDetails, backends map[string]backend.Backend, labels map[string]string, configFile string, timeout time.Duration) error
 	AddOnReadyHook(fn func(cm *autopaho.ConnectionManager, topics TokenResponseTopics))
 	RegisterTopicHandler(topic string, handler TopicMessageHandler)
 }
@@ -157,7 +164,7 @@ func (connection *MQTTConnection) stopDispatchWorker() {
 // Connect connects to the MQTT broker. It is safe to call after a previous
 // failed Connect (e.g. from a startup retry loop): any existing dispatch
 // worker and connection manager are torn down before reinitializing.
-func (connection *MQTTConnection) Connect(ctx context.Context, details ConnectionDetails, backends map[string]backend.Backend, labels map[string]string, configFile string) error {
+func (connection *MQTTConnection) Connect(ctx context.Context, waitCtx context.Context, details ConnectionDetails, backends map[string]backend.Backend, labels map[string]string, configFile string) error {
 	// Parse the ORB URL
 	serverURL, err := url.Parse(details.MQTTURL)
 	if err != nil {
@@ -402,12 +409,12 @@ func (connection *MQTTConnection) Connect(ctx context.Context, details Connectio
 		return err
 	}
 
-	// Wait for the initial connection; bound this operation with a timeout that
-	// is still cancellable from the parent.
-	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	// Wait for the initial connection using waitCtx so the caller can interrupt
+	// this wait independently of the connection's lifecycle context.
+	awaitCtx, cancel := context.WithTimeout(waitCtx, 30*time.Second)
 	defer cancel()
 
-	err = connection.connectionManager.AwaitConnection(waitCtx)
+	err = connection.connectionManager.AwaitConnection(awaitCtx)
 	if err != nil {
 		connection.logger.Error("failed to establish initial MQTT connection", "error", err)
 		connection.stopDispatchWorker()
@@ -419,13 +426,13 @@ func (connection *MQTTConnection) Connect(ctx context.Context, details Connectio
 }
 
 // Reconnect reconnects to the MQTT broker with new connection details (e.g., refreshed JWT)
-func (connection *MQTTConnection) Reconnect(ctx context.Context, details ConnectionDetails, backends map[string]backend.Backend, labels map[string]string, configFile string, timeout time.Duration) error {
+func (connection *MQTTConnection) Reconnect(ctx context.Context, waitCtx context.Context, details ConnectionDetails, backends map[string]backend.Backend, labels map[string]string, configFile string, timeout time.Duration) error {
 	connection.logger.Info("reconnecting to MQTT broker with refreshed credentials")
 
 	// Disconnect the existing connection
 	if connection.connectionManager != nil {
-		// Set shutdown flag first to prevent new messages from being enqueued
-		disconnectCtx, cancel := context.WithTimeout(ctx, timeout)
+		// Use waitCtx for the disconnect timeout so shutdown can interrupt it.
+		disconnectCtx, cancel := context.WithTimeout(waitCtx, timeout)
 		connection.heartbeater.stop(details.Topics.Heartbeat, connection.publishToTopic)
 		err := connection.connectionManager.Disconnect(disconnectCtx)
 		cancel()
@@ -441,8 +448,8 @@ func (connection *MQTTConnection) Reconnect(ctx context.Context, details Connect
 	connection.groupMembershipFailCount = 0
 	connection.heartbeatFailCount = 0
 
-	// Connect with new details
-	err := connection.Connect(ctx, details, backends, labels, configFile)
+	// Connect with new details; thread both contexts through.
+	err := connection.Connect(ctx, waitCtx, details, backends, labels, configFile)
 	if err != nil {
 		return fmt.Errorf("failed to connect during reconnect: %w", err)
 	}

--- a/agent/configmgr/fleet/connection_hooks_test.go
+++ b/agent/configmgr/fleet/connection_hooks_test.go
@@ -65,7 +65,7 @@ func TestConnect_StoresTopicsBeforeConnecting(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
-	_ = conn.Connect(ctx, details, map[string]backend.Backend{}, map[string]string{}, "")
+	_ = conn.Connect(ctx, ctx, details, map[string]backend.Backend{}, map[string]string{}, "")
 
 	if conn.connectionTopics != details.Topics {
 		t.Fatalf("expected connectionTopics to be stored before connect attempt")

--- a/agent/configmgr/fleet/connection_test.go
+++ b/agent/configmgr/fleet/connection_test.go
@@ -80,6 +80,7 @@ func TestFleetConfigManager_Connect_InvalidURL(t *testing.T) {
 	trt := TokenResponseTopics{Inbox: "test/topic"}
 	err := connection.Connect(
 		context.Background(),
+		context.Background(),
 		ConnectionDetails{MQTTURL: "://invalid-url", Token: "test_token", AgentID: "test-agent-id", Topics: trt, ClientID: "test-agent-id", Zone: "test-zone"},
 		backends,
 		map[string]string{},
@@ -106,7 +107,7 @@ func TestFleetConfigManager_Connect_ValidURL(t *testing.T) {
 	// Timeout after 100ms for faster test execution (connection will fail quickly)
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	err := connection.Connect(ctx,
+	err := connection.Connect(ctx, ctx,
 		ConnectionDetails{MQTTURL: "mqtt://localhost:1883", Token: "test_token", AgentID: "test-agent-id", Topics: trt2, ClientID: "test-agent-id", Zone: "test-zone"},
 		backends,
 		map[string]string{},

--- a/agent/configmgr/fleet/heartbeats.go
+++ b/agent/configmgr/fleet/heartbeats.go
@@ -22,7 +22,6 @@ var heartbeatTickInterval = heartbeatFreq
 
 type heartbeater struct {
 	logger         *slog.Logger
-	heartbeatCtx   context.Context
 	backendState   backend.StateRetriever
 	policyManager  policymgr.PolicyManager
 	groupRetriever GroupRetriever
@@ -35,7 +34,6 @@ type heartbeater struct {
 func newHeartbeater(logger *slog.Logger, backendState backend.StateRetriever, policyManager policymgr.PolicyManager, groupRetriever GroupRetriever) *heartbeater {
 	return &heartbeater{
 		logger:         logger,
-		heartbeatCtx:   context.Background(),
 		backendState:   backendState,
 		policyManager:  policyManager,
 		groupRetriever: groupRetriever,
@@ -78,15 +76,15 @@ func (hb *heartbeater) stop(heartbeatTopic string, publishFunc func(ctx context.
 	if cancel != nil {
 		cancel()
 		hb.wg.Wait()
-		return
 	}
 
+	// Always send the offline heartbeat here. The goroutine exits cleanly on
+	// ctx.Done() without sending it, so stop() is the sole sender — called only
+	// when the MQTT connection is still alive (before connectionManager.Disconnect).
 	hb.sendSingleHeartbeat(context.Background(), heartbeatTopic, publishFunc, "", time.Now(), messages.HeartbeatState(messages.Offline), nil)
 }
 
 func (hb *heartbeater) runHeartbeatLoop(ctx context.Context, ticker *time.Ticker, heartbeatTopic string, agentID string, publishFunc func(ctx context.Context, topic string, payload []byte) error, onFailure func()) {
-	hb.heartbeatCtx = ctx
-
 	hb.logger.Debug("start heartbeats routine")
 	hb.sendSingleHeartbeat(ctx, heartbeatTopic, publishFunc, agentID, time.Now(), messages.Online, onFailure)
 
@@ -94,8 +92,6 @@ func (hb *heartbeater) runHeartbeatLoop(ctx context.Context, ticker *time.Ticker
 		select {
 		case <-ctx.Done():
 			hb.logger.Debug("context done, stopping heartbeats routine")
-			hb.sendSingleHeartbeat(context.Background(), heartbeatTopic, publishFunc, agentID, time.Now(), messages.Offline, nil)
-			hb.heartbeatCtx = nil
 			return
 		case t := <-ticker.C:
 			hb.sendSingleHeartbeat(ctx, heartbeatTopic, publishFunc, agentID, t, messages.Online, onFailure)

--- a/agent/configmgr/fleet/heartbeats_test.go
+++ b/agent/configmgr/fleet/heartbeats_test.go
@@ -108,7 +108,6 @@ func createTestHeartbeater() *heartbeater {
 	groupManager := newGroupManager()
 	return &heartbeater{
 		logger:         logger,
-
 		backendState:   &mockBackendState{},
 		policyManager:  mockPMgr,
 		groupRetriever: &groupManager,
@@ -122,7 +121,6 @@ func createTestHeartbeaterWithBackendState(backendState *mockBackendState) *hear
 	groupManager := newGroupManager()
 	return &heartbeater{
 		logger:         logger,
-
 		backendState:   backendState,
 		policyManager:  mockPMgr,
 		groupRetriever: &groupManager,
@@ -134,7 +132,6 @@ func createTestHeartbeaterWithPolicyManager(backendState *mockBackendState, poli
 	groupManager := newGroupManager()
 	return &heartbeater{
 		logger:         logger,
-
 		backendState:   backendState,
 		policyManager:  policyManager,
 		groupRetriever: &groupManager,
@@ -227,7 +224,6 @@ func TestHeartbeater_OfflineHeartbeat_IncludesFailedRunsAfterFailNonTerminalRuns
 	groupManager := newGroupManager()
 	hb := &heartbeater{
 		logger:         logger,
-
 		backendState:   &mockBackendState{},
 		policyManager:  pm,
 		groupRetriever: &groupManager,
@@ -399,7 +395,6 @@ func TestHeartbeater_SendHeartbeats_ContextCancellation(t *testing.T) {
 
 	// Assert
 	mockPublish.AssertExpectations(t)
-
 }
 
 func TestHeartbeater_SendHeartbeats_PublishErrors(t *testing.T) {
@@ -1142,7 +1137,6 @@ func createTestHeartbeaterWithGroupManager(groupManager *GroupManager) *heartbea
 	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{}, nil).Maybe()
 	return &heartbeater{
 		logger:         logger,
-
 		backendState:   &mockBackendState{},
 		policyManager:  mockPMgr,
 		groupRetriever: groupManager,
@@ -1268,7 +1262,7 @@ func TestHeartbeater_SendSingleHeartbeat_WithCompleteState(t *testing.T) {
 	// Create heartbeater with all components
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	hb := &heartbeater{
-		logger:         logger,
+		logger: logger,
 
 		backendState:   backendState,
 		policyManager:  mockPMgr,

--- a/agent/configmgr/fleet/heartbeats_test.go
+++ b/agent/configmgr/fleet/heartbeats_test.go
@@ -108,7 +108,7 @@ func createTestHeartbeater() *heartbeater {
 	groupManager := newGroupManager()
 	return &heartbeater{
 		logger:         logger,
-		heartbeatCtx:   context.Background(),
+
 		backendState:   &mockBackendState{},
 		policyManager:  mockPMgr,
 		groupRetriever: &groupManager,
@@ -122,7 +122,7 @@ func createTestHeartbeaterWithBackendState(backendState *mockBackendState) *hear
 	groupManager := newGroupManager()
 	return &heartbeater{
 		logger:         logger,
-		heartbeatCtx:   context.Background(),
+
 		backendState:   backendState,
 		policyManager:  mockPMgr,
 		groupRetriever: &groupManager,
@@ -134,7 +134,7 @@ func createTestHeartbeaterWithPolicyManager(backendState *mockBackendState, poli
 	groupManager := newGroupManager()
 	return &heartbeater{
 		logger:         logger,
-		heartbeatCtx:   context.Background(),
+
 		backendState:   backendState,
 		policyManager:  policyManager,
 		groupRetriever: &groupManager,
@@ -148,7 +148,6 @@ func TestNewHeartbeater_HeartbeaterInitialization(t *testing.T) {
 	// Assert
 	assert.NotNil(t, fleetManager)
 	assert.NotNil(t, fleetManager.logger)
-	assert.NotNil(t, fleetManager.heartbeatCtx, "Heartbeat context should be initialized")
 }
 
 func TestHeartbeater_SendSingleHeartbeat_Success(t *testing.T) {
@@ -228,7 +227,7 @@ func TestHeartbeater_OfflineHeartbeat_IncludesFailedRunsAfterFailNonTerminalRuns
 	groupManager := newGroupManager()
 	hb := &heartbeater{
 		logger:         logger,
-		heartbeatCtx:   context.Background(),
+
 		backendState:   &mockBackendState{},
 		policyManager:  pm,
 		groupRetriever: &groupManager,
@@ -323,10 +322,8 @@ func TestHeartbeater_SendHeartbeats_InitialHeartbeat(t *testing.T) {
 	defer cancel()
 	testTopic := "test/heartbeat"
 
-	// Set up expectations for initial heartbeat (Online state)
-	mockPublish.On("Publish", mock.Anything, testTopic, mock.AnythingOfType("[]uint8")).Return(nil).Once()
-
-	// Set up expectations for final heartbeat (Offline state) when context is cancelled
+	// Only the initial Online heartbeat is expected. The offline heartbeat is sent
+	// by stop(), not by the goroutine reacting to ctx.Done().
 	mockPublish.On("Publish", mock.Anything, testTopic, mock.AnythingOfType("[]uint8")).Return(nil).Once()
 
 	// Act
@@ -335,12 +332,9 @@ func TestHeartbeater_SendHeartbeats_InitialHeartbeat(t *testing.T) {
 	// Give some time for initial heartbeat
 	time.Sleep(10 * time.Millisecond)
 
-	// Cancel context to trigger cleanup
+	// Cancel context — goroutine exits cleanly without sending an offline heartbeat
 	cancel()
 	hb.wg.Wait()
-
-	// Give time for cleanup
-	time.Sleep(10 * time.Millisecond)
 
 	// Assert
 	mockPublish.AssertExpectations(t)
@@ -355,8 +349,9 @@ func TestHeartbeater_SendHeartbeats_PeriodicHeartbeats(t *testing.T) {
 	defer cancel()
 	testTopic := "test/heartbeat"
 
-	// We expect at least 3 heartbeats: initial + at least 2 periodic + final
-	mockPublish.On("Publish", mock.Anything, testTopic, mock.AnythingOfType("[]uint8")).Return(nil).Times(4)
+	// We expect at least 3 heartbeats: initial + at least 2 periodic. The offline
+	// heartbeat is sent only by stop(), not by context cancellation.
+	mockPublish.On("Publish", mock.Anything, testTopic, mock.AnythingOfType("[]uint8")).Return(nil).Times(3)
 
 	// Act
 	hb.StartHeartbeats(ctx, testTopic, "test-agent-id", mockPublish.Publish, nil)
@@ -388,8 +383,9 @@ func TestHeartbeater_SendHeartbeats_ContextCancellation(t *testing.T) {
 		return mockPublish.Publish(ctx, topic, payload)
 	}
 
-	// Expect initial heartbeat (Online) and final heartbeat (Offline)
-	mockPublish.On("Publish", mock.Anything, testTopic, mock.AnythingOfType("[]uint8")).Return(nil).Twice()
+	// Expect only the initial Online heartbeat. Context cancellation no longer
+	// triggers an offline heartbeat from the goroutine — stop() owns that.
+	mockPublish.On("Publish", mock.Anything, testTopic, mock.AnythingOfType("[]uint8")).Return(nil).Once()
 
 	// Act
 	hb.StartHeartbeats(ctx, testTopic, "test-agent-id", publishFunc, nil)
@@ -404,8 +400,6 @@ func TestHeartbeater_SendHeartbeats_ContextCancellation(t *testing.T) {
 	// Assert
 	mockPublish.AssertExpectations(t)
 
-	// Verify context is properly cleaned up (now safe to read after goroutine finished)
-	assert.Nil(t, hb.heartbeatCtx)
 }
 
 func TestHeartbeater_SendHeartbeats_PublishErrors(t *testing.T) {
@@ -419,9 +413,8 @@ func TestHeartbeater_SendHeartbeats_PublishErrors(t *testing.T) {
 
 	publishError := errors.New("network error")
 
-	// Mock publish function to return errors - should not stop the heartbeat loop
-	// Expect initial + periodic + final heartbeat (all with errors)
-	mockPublish.On("Publish", mock.Anything, testTopic, mock.AnythingOfType("[]uint8")).Return(publishError).Times(4)
+	// Expect initial + at least 2 periodic (no offline from context cancel).
+	mockPublish.On("Publish", mock.Anything, testTopic, mock.AnythingOfType("[]uint8")).Return(publishError).Times(3)
 
 	// Act
 	hb.StartHeartbeats(ctx, testTopic, "test-agent-id", mockPublish.Publish, nil)
@@ -509,21 +502,18 @@ func TestHeartbeater_SendHeartbeats_HeartbeatStates(t *testing.T) {
 	copy(payloadsCopy, capturedPayloads)
 	mutex.Unlock()
 
-	assert.GreaterOrEqual(t, len(payloadsCopy), 2, "Should have at least initial and final heartbeats")
+	// Context cancellation no longer triggers an offline heartbeat from the goroutine.
+	// Only the initial Online heartbeat is guaranteed here.
+	assert.GreaterOrEqual(t, len(payloadsCopy), 1, "Should have at least the initial heartbeat")
 
-	// Verify all payloads are valid heartbeat messages and contain expected fields
+	// Verify all payloads are valid Online heartbeat messages.
 	for i, payload := range payloadsCopy {
 		var heartbeat messages.Heartbeat
 		err := json.Unmarshal(payload, &heartbeat)
 		require.NoError(t, err, "Heartbeat %d should be valid JSON", i)
 		assert.Equal(t, messages.CurrentHeartbeatSchemaVersion, heartbeat.SchemaVersion)
 		assert.False(t, heartbeat.TimeStamp.IsZero())
-		// Initial heartbeats are Online; final heartbeat on context cancellation should be Offline
-		if i < len(payloadsCopy)-1 {
-			assert.Equal(t, messages.State(messages.Online), heartbeat.State)
-		} else {
-			assert.Equal(t, messages.State(messages.Offline), heartbeat.State)
-		}
+		assert.Equal(t, messages.State(messages.Online), heartbeat.State)
 	}
 }
 
@@ -593,6 +583,62 @@ func TestHeartbeater_Stop_HeartbeatContent(t *testing.T) {
 	// The stop method sends an Offline heartbeat
 	assert.Equal(t, messages.State(messages.Offline), heartbeat.State)
 	assert.False(t, heartbeat.TimeStamp.IsZero())
+}
+
+// TestHeartbeater_ContextDone_OfflineHeartbeatSentByStop is a regression test for the
+// race condition where monitorCtx cancellation caused the heartbeat goroutine to send
+// the offline heartbeat against a simultaneously-closing MQTT connection (OBS-2686).
+//
+// After the fix: the goroutine exits cleanly on ctx.Done() without sending an offline
+// heartbeat. stop() is the sole sender, always called when the connection is still alive.
+func TestHeartbeater_ContextDone_OfflineHeartbeatSentByStop(t *testing.T) {
+	hb := createTestHeartbeater()
+	testTopic := "test/heartbeat"
+
+	var mu sync.Mutex
+	offlineCount := 0
+	stopCalled := make(chan struct{})
+
+	publishFunc := func(_ context.Context, _ string, payload []byte) error {
+		var hbData messages.Heartbeat
+		if err := json.Unmarshal(payload, &hbData); err != nil {
+			return nil
+		}
+		if hbData.State == messages.State(messages.Offline) {
+			mu.Lock()
+			offlineCount++
+			mu.Unlock()
+			// If offline was sent before stop() was called, the goroutine sent it
+			// while the parent context was being cancelled — the race condition.
+			select {
+			case <-stopCalled:
+			default:
+				t.Errorf("offline heartbeat sent by goroutine reacting to ctx.Done(), not by stop()")
+			}
+		}
+		return nil
+	}
+
+	parentCtx, parentCancel := context.WithCancel(context.Background())
+	hb.StartHeartbeats(parentCtx, testTopic, "agent-id", publishFunc, nil)
+	time.Sleep(20 * time.Millisecond) // let initial Online heartbeat send
+
+	// Simulate monitorCtx cancellation — the race window.
+	// Wait on the WaitGroup so we know the goroutine has fully exited before
+	// calling stop(), eliminating the timing dependency.
+	parentCancel()
+	hb.wg.Wait()
+
+	// Now call stop() (simulating Disconnect() in Stop())
+	close(stopCalled)
+	hb.stop(testTopic, publishFunc)
+
+	mu.Lock()
+	got := offlineCount
+	mu.Unlock()
+	if got != 1 {
+		t.Errorf("expected exactly 1 offline heartbeat from stop(), got %d", got)
+	}
 }
 
 func TestHeartbeater_SendSingleHeartbeat_WithBackendState(t *testing.T) {
@@ -1084,7 +1130,6 @@ func TestNewHeartbeater_WithPolicyManager(t *testing.T) {
 	// Assert
 	assert.NotNil(t, hb)
 	assert.NotNil(t, hb.logger)
-	assert.NotNil(t, hb.heartbeatCtx)
 	assert.NotNil(t, hb.backendState)
 	assert.NotNil(t, hb.policyManager)
 	assert.Equal(t, mockPMgr, hb.policyManager)
@@ -1097,7 +1142,7 @@ func createTestHeartbeaterWithGroupManager(groupManager *GroupManager) *heartbea
 	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{}, nil).Maybe()
 	return &heartbeater{
 		logger:         logger,
-		heartbeatCtx:   context.Background(),
+
 		backendState:   &mockBackendState{},
 		policyManager:  mockPMgr,
 		groupRetriever: groupManager,
@@ -1224,7 +1269,7 @@ func TestHeartbeater_SendSingleHeartbeat_WithCompleteState(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	hb := &heartbeater{
 		logger:         logger,
-		heartbeatCtx:   context.Background(),
+
 		backendState:   backendState,
 		policyManager:  mockPMgr,
 		groupRetriever: &gm,

--- a/agent/configmgr/fleet/mocks.go
+++ b/agent/configmgr/fleet/mocks.go
@@ -127,7 +127,7 @@ func (m *MockMQTTConnection) LastConnectDetails() ConnectionDetails {
 }
 
 // Connect connects to the MQTT broker
-func (m *MockMQTTConnection) Connect(_ context.Context, details ConnectionDetails, _ map[string]backend.Backend, _ map[string]string, _ string) error {
+func (m *MockMQTTConnection) Connect(_ context.Context, _ context.Context, details ConnectionDetails, _ map[string]backend.Backend, _ map[string]string, _ string) error {
 	m.mu.Lock()
 	m.connectCalled = true
 	m.lastConnectDetails = details
@@ -144,7 +144,7 @@ func (m *MockMQTTConnection) Disconnect(_ context.Context, _ string) error {
 }
 
 // Reconnect reconnects to the MQTT broker
-func (m *MockMQTTConnection) Reconnect(_ context.Context, _ ConnectionDetails, _ map[string]backend.Backend, _ map[string]string, _ string, _ time.Duration) error {
+func (m *MockMQTTConnection) Reconnect(_ context.Context, _ context.Context, _ ConnectionDetails, _ map[string]backend.Backend, _ map[string]string, _ string, _ time.Duration) error {
 	return m.ReconnectError
 }
 

--- a/agent/configmgr/fleet_stop_test.go
+++ b/agent/configmgr/fleet_stop_test.go
@@ -41,10 +41,14 @@ func TestFleetConfigManager_Stop_DisconnectsMQTT(t *testing.T) {
 
 	mgr := newFleetConfigManagerWithConnection(logger, nil, nil, mockConn)
 
-	// Simulate having successfully connected: set connected flag, heartbeat topic, and monitorCtx.
-	ctx, cancel := context.WithCancel(context.Background())
-	mgr.monitorCtx = ctx
-	mgr.monitorCancel = cancel
+	// Simulate having successfully connected: set connected flag, heartbeat topic,
+	// monitorCtx, and connCtx (both are created by Start() in production).
+	monitorCtx, monitorCancel := context.WithCancel(context.Background())
+	connCtx, connCancel := context.WithCancel(context.Background())
+	mgr.monitorCtx = monitorCtx
+	mgr.monitorCancel = monitorCancel
+	mgr.connCtx = connCtx
+	mgr.connCancel = connCancel
 	mgr.connected.Store(true)
 	mgr.connectionDetails = fleet.ConnectionDetails{
 		Topics: fleet.TokenResponseTopics{Heartbeat: "agents/test/heartbeat"},
@@ -56,6 +60,34 @@ func TestFleetConfigManager_Stop_DisconnectsMQTT(t *testing.T) {
 
 	if !mockConn.DisconnectCalled() {
 		t.Error("expected Disconnect() to be called during Stop(), but it was not")
+	}
+}
+
+// TestFleetConfigManager_Stop_ConnCtxCancelledAfterStop verifies that the MQTT
+// connection context (connCtx) is cancelled after Stop() completes, confirming it
+// has a separate lifecycle from monitorCtx and is properly cleaned up.
+func TestFleetConfigManager_Stop_ConnCtxCancelledAfterStop(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	mockConn := &fleet.MockMQTTConnection{}
+
+	mgr := newFleetConfigManagerWithConnection(logger, nil, nil, mockConn)
+	monitorCtx, monitorCancel := context.WithCancel(context.Background())
+	connCtx, connCancel := context.WithCancel(context.Background())
+	mgr.monitorCtx = monitorCtx
+	mgr.monitorCancel = monitorCancel
+	mgr.connCtx = connCtx
+	mgr.connCancel = connCancel
+	mgr.connected.Store(true)
+	mgr.connectionDetails = fleet.ConnectionDetails{
+		Topics: fleet.TokenResponseTopics{Heartbeat: "agents/test/heartbeat"},
+	}
+
+	if err := mgr.Stop(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if connCtx.Err() == nil {
+		t.Error("connCtx should be cancelled after Stop() completes")
 	}
 }
 

--- a/agent/configmgr/fleet_test.go
+++ b/agent/configmgr/fleet_test.go
@@ -1603,3 +1603,96 @@ func TestFleetConfigManager_ResetGoroutine_UsesLatestConnectionDetails(t *testin
 	assert.Equal(t, "refreshed-token", mockConn.LastConnectDetails().Token,
 		"reset goroutine should use the refreshed token, not the stale initial token")
 }
+
+// newResetHandlerManager creates a FleetConfigManager wired with a mock MQTT connection and
+// pre-initialised contexts so that runResetHandler can be invoked directly in tests.
+func newResetHandlerManager(t *testing.T, mockConn *fleet.MockMQTTConnection) *FleetConfigManager {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	mgr := newFleetConfigManagerWithConnection(logger, nil, &mockBackendState{}, mockConn)
+
+	mgr.monitorCtx, mgr.monitorCancel = context.WithCancel(context.Background())
+	mgr.connCtx, mgr.connCancel = context.WithCancel(context.Background())
+	t.Cleanup(mgr.monitorCancel)
+	t.Cleanup(mgr.connCancel)
+
+	mgr.connectionDetails = fleet.ConnectionDetails{
+		Topics: fleet.TokenResponseTopics{
+			Heartbeat: "agents/test/heartbeat",
+		},
+	}
+	mgr.backends = make(map[string]backend.Backend)
+	return mgr
+}
+
+// TestFleetConfigManager_ResetHandler_DisconnectsAndReconnectsOnReset verifies that when a
+// reset signal is received, runResetHandler calls Disconnect then Connect using the stored
+// connection details.
+func TestFleetConfigManager_ResetHandler_DisconnectsAndReconnectsOnReset(t *testing.T) {
+	mockConn := &fleet.MockMQTTConnection{}
+	mgr := newResetHandlerManager(t, mockConn)
+
+	go mgr.runResetHandler(5 * time.Second)
+
+	mgr.resetChan <- struct{}{}
+
+	require.Eventually(t, mockConn.ConnectCalled, time.Second, 10*time.Millisecond,
+		"runResetHandler should call Connect after receiving a reset signal")
+	assert.True(t, mockConn.DisconnectCalled(),
+		"runResetHandler should call Disconnect before reconnecting")
+}
+
+// TestFleetConfigManager_ResetHandler_ExitsOnMonitorCtxCancel verifies that runResetHandler
+// returns promptly when monitorCtx is cancelled, even when idle waiting for a signal.
+func TestFleetConfigManager_ResetHandler_ExitsOnMonitorCtxCancel(t *testing.T) {
+	mockConn := &fleet.MockMQTTConnection{}
+	mgr := newResetHandlerManager(t, mockConn)
+
+	done := make(chan struct{})
+	go func() {
+		mgr.runResetHandler(5 * time.Second)
+		close(done)
+	}()
+
+	mgr.monitorCancel()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("runResetHandler did not exit after monitorCtx was cancelled")
+	}
+}
+
+// TestFleetConfigManager_ResetHandler_StopAfterResetNoDeadlock verifies that calling Stop()
+// after a reset completes does not deadlock. connCtx must remain alive during the reset so the
+// offline heartbeat can publish, and must be cancelled only after Stop() finishes its own
+// Disconnect call.
+func TestFleetConfigManager_ResetHandler_StopAfterResetNoDeadlock(t *testing.T) {
+	mockConn := &fleet.MockMQTTConnection{}
+	mgr := newResetHandlerManager(t, mockConn)
+	mgr.connected.Store(true)
+
+	mgr.goroutinesWg.Add(1)
+	go func() {
+		defer mgr.goroutinesWg.Done()
+		mgr.runResetHandler(5 * time.Second)
+	}()
+
+	// Trigger and wait for a reset to complete before calling Stop.
+	mgr.resetChan <- struct{}{}
+	require.Eventually(t, mockConn.ConnectCalled, time.Second, 10*time.Millisecond,
+		"reset should complete before Stop() is called")
+
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- mgr.Stop(context.Background()) }()
+
+	select {
+	case err := <-stopDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Stop() deadlocked after a reset")
+	}
+
+	assert.ErrorIs(t, mgr.connCtx.Err(), context.Canceled,
+		"connCtx should be cancelled after Stop() completes")
+}

--- a/agent/configmgr/fleet_test.go
+++ b/agent/configmgr/fleet_test.go
@@ -1373,6 +1373,11 @@ func newReconnectWorkerManager(t *testing.T, mockConn *fleet.MockMQTTConnection,
 		},
 	}
 
+	// connCtx is normally created by Start(); initialise it here so
+	// runReconnectWorker can use it as the Disconnect timeout parent.
+	mgr.connCtx, mgr.connCancel = context.WithCancel(context.Background())
+	t.Cleanup(mgr.connCancel)
+
 	return mgr
 }
 

--- a/agent/configmgr/fleet_test.go
+++ b/agent/configmgr/fleet_test.go
@@ -1578,7 +1578,7 @@ func TestFleetConfigManager_ResetGoroutine_UsesLatestConnectionDetails(t *testin
 			_ = mgr.connection.Disconnect(disconnectCtx, details.Topics.Heartbeat)
 			cancel()
 			connectCtx := context.Background()
-			_ = mgr.connection.Connect(connectCtx, details, mgr.backends, mgr.labels, mgr.configYaml)
+			_ = mgr.connection.Connect(connectCtx, connectCtx, details, mgr.backends, mgr.labels, mgr.configYaml)
 		}
 	}()
 


### PR DESCRIPTION
## Summary

- **Root cause:** `monitorCtx` was shared between background workers and the autopaho MQTT connection. `Stop()` calling `monitorCancel()` simultaneously cancelled the heartbeat goroutine's parent context and triggered autopaho's internal disconnect. The goroutine raced to publish the offline heartbeat against a closing connection — silently failing — and `stop()` had no retry path.
- **Fix 1 (`fleet.go`):** Introduce `connCtx`/`connCancel` (derived from `context.Background()`) to control the MQTT connection lifetime independently of `monitorCtx`. All `Connect`/`Reconnect` call sites use `connCtx`. `Stop()` cancels `connCtx` only _after_ `Disconnect()` returns, so the connection is alive throughout the offline heartbeat send.
- **Fix 2 (`heartbeats.go`):** Make `stop()` the sole sender of the offline heartbeat. The goroutine now exits cleanly on `ctx.Done()` without publishing; `stop()` always sends after `wg.Wait()`. Also removes the vestigial `heartbeatCtx` field, which was written without a lock and never read in production.

## Test plan

- [x] `TestHeartbeater_ContextDone_OfflineHeartbeatSentByStop` — regression test: cancelling parent context must not cause goroutine to send offline heartbeat; `stop()` must be the sender
- [x] `TestFleetConfigManager_Stop_ConnCtxCancelledAfterStop` — verifies `connCtx` has a separate lifecycle from `monitorCtx` and is cancelled after `Stop()`
- [x] `TestFleetConfigManager_Stop_DisconnectsMQTT` — updated to initialise `connCtx`/`connCancel`, exercising the full `Stop()` path
- [x] All existing heartbeat and configmgr tests pass with updated expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)