### PR TITLE
chore: install ca-certificates in agent Docker image

### DIFF
--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -47,7 +47,8 @@ FROM python:3.14-slim-trixie
 
 RUN \
     apt update && \
-    apt install --yes --no-install-recommends git nmap openssh-client tini && \
+    apt install --yes --no-install-recommends ca-certificates git nmap openssh-client tini && \
+    update-ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /opt/orb


### PR DESCRIPTION
## Summary
- Install `ca-certificates` alongside the other runtime packages in the agent image
- Run `update-ca-certificates` so the trust store is refreshed at build time, ensuring reliable TLS to external services

## Test plan
- [x] `make agent` builds successfully
- [x] Running container can establish TLS connections to HTTPS endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)