### PR TITLE
chore: add supported platforms pages for discovery backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ orb:
 
 #### Discovery Backends
 Only the `network_discovery`, `device_discovery`, `worker` and `snmp_discovery` backends are currently supported. They do not require any special configuration.
-- [Device Discovery](./docs/backends/device_discovery.md) 
+- [Device Discovery](./docs/backends/device_discovery.md) ([supported platforms](./docs/backends/device_discovery_supported_platforms.md))
 - [Network Discovery](./docs/backends/network_discovery.md)
 - [Worker](./docs/backends/worker.md)
-- [SNMP Discovery](./docs/backends/snmp_discovery.md)
+- [SNMP Discovery](./docs/backends/snmp_discovery.md) ([supported platforms](./docs/backends/snmp_discovery_supported_platforms.md))
 
 #### Observability Backends
 Observability backends focus on collecting and exporting rich telemetry from network traffic or probes so you can feed metrics into your monitoring stack.

--- a/docs/backends/device_discovery.md
+++ b/docs/backends/device_discovery.md
@@ -60,7 +60,7 @@ Current supported options:
 | capture_running_config | bool | If True, collects the running configuration from the device and ingests it as a DeviceConfig entity (defaults to 'False' if not specified) |
 | capture_startup_config | bool | If True, collects the startup/saved configuration from the device and ingests it as a DeviceConfig entity (defaults to 'False' if not specified) |
 | sanitize_config | bool | If False, captured configuration is stored as-is without redacting sensitive values such as passwords and pre-shared keys (defaults to 'True' if not specified) |
-| discovery_drivers | list | Restrict auto-discovery to this ordered list of driver names (e.g. `[panos, huawei_vrp]`). Only used when a scope entry has no `driver` set. If not specified, only standard NAPALM drivers are tried. Custom drivers (`panos`, `panos_ssh`, `huawei_vrp`) must be listed explicitly to be used in auto-discovery. |
+| discovery_drivers | list | Restrict auto-discovery to this ordered list of driver names (e.g. `[paloalto_panos, huawei_vrp]`). Only used when a scope entry has no `driver` set. If not specified, only standard NAPALM drivers are tried. Custom drivers (`paloalto_panos`, `paloalto_panos_ssh`, `huawei_vrp`) must be listed explicitly to be used in auto-discovery. See the [supported platforms page](./device_discovery_supported_platforms.md) for the full list. |
 
 #### Defaults
 Current supported defaults:
@@ -234,7 +234,7 @@ orb:
 
 ### Custom Driver Discovery Example
 
-Use `discovery_drivers` to limit auto-discovery to a specific set of drivers. This is useful when you know the device type in advance or when using custom NAPALM drivers shipped with device-discovery (`panos`, `panos_ssh`, `huawei_vrp`).
+Use `discovery_drivers` to limit auto-discovery to a specific set of drivers. This is useful when you know the device type in advance or when using custom NAPALM drivers shipped with device-discovery (`paloalto_panos`, `paloalto_panos_ssh`, `huawei_vrp`).
 
 ```yaml
 orb:
@@ -246,8 +246,8 @@ orb:
           schedule: "0 * * * *"
           options:
             discovery_drivers:
-              - panos
-              - panos_ssh
+              - paloalto_panos
+              - paloalto_panos_ssh
           defaults:
             site: DC1
         scope:
@@ -256,7 +256,7 @@ orb:
             password: ${PANOS_PASS}
 ```
 
-In this example, only the `panos` and `panos_ssh` drivers are tried during auto-discovery for devices in this policy. If you set `driver` explicitly on a scope entry, `discovery_drivers` is ignored for that entry.
+In this example, only the `paloalto_panos` and `paloalto_panos_ssh` drivers are tried during auto-discovery for devices in this policy. If you set `driver` explicitly on a scope entry, `discovery_drivers` is ignored for that entry.
 
 ### Advanced Sample
 

--- a/docs/backends/device_discovery.md
+++ b/docs/backends/device_discovery.md
@@ -1,6 +1,8 @@
 # Device Discovery
 The device discovery backend leverages [NAPALM](https://napalm.readthedocs.io/en/latest/index.html) to connect to network devices and collect network information.
 
+For the full list of vendors and NAPALM drivers supported by this backend (standard and custom), see [Device Discovery — Supported Platforms](./device_discovery_supported_platforms.md).
+
 ## Diode Entities
 The device discovery backend uses [Diode Python SDK](https://github.com/netboxlabs/diode-sdk-python) to ingest the following entities:
 

--- a/docs/backends/device_discovery_supported_platforms.md
+++ b/docs/backends/device_discovery_supported_platforms.md
@@ -1,0 +1,83 @@
+# Device Discovery — Supported Platforms
+
+This page lists the vendors, operating systems, and NAPALM drivers supported by the [device discovery](./device_discovery.md) backend.
+
+The backend connects to network devices over SSH / NETCONF / vendor APIs via [NAPALM](https://napalm.readthedocs.io/). Support is driver-bound: a device is supported only if a corresponding NAPALM driver exists.
+
+> Compatibility note: driver presence does not guarantee that every feature on every OS version works. Vendors regularly change CLI/API behavior across releases. Report gaps via a GitHub issue against [orb-discovery](https://github.com/netboxlabs/orb-discovery/issues).
+
+## Auto-discovery behavior
+
+When a scope entry does not specify a `driver`, device-discovery attempts driver detection automatically. Only the **standard NAPALM drivers** below are tried during auto-discovery. Custom drivers must be used explicitly by either setting `driver:` on the scope entry, or by listing them in the `discovery_drivers` option (see [Custom Driver Discovery Example](./device_discovery.md#custom-driver-discovery-example)).
+
+## Standard NAPALM drivers
+
+These drivers ship with the [NAPALM](https://napalm.readthedocs.io/en/latest/support/) library and are eligible for auto-discovery.
+
+| Driver | Vendor | Platform / OS |
+|--------|--------|---------------|
+| `eos` | Arista | EOS |
+| `ios` | Cisco | IOS / IOS-XE |
+| `iosxr` | Cisco | IOS-XR (XML agent) |
+| `iosxr_netconf` | Cisco | IOS-XR (NETCONF) |
+| `junos` | Juniper | Junos |
+| `nxos` | Cisco | NX-OS (NX-API) |
+| `nxos_ssh` | Cisco | NX-OS (SSH) |
+
+## Custom NAPALM drivers (orb-discovery)
+
+These drivers are bundled with device-discovery. They are **not** tried during auto-discovery unless explicitly listed in `discovery_drivers`; otherwise set `driver:` on the scope entry.
+
+| Driver | Vendor | Platform / OS |
+|--------|--------|---------------|
+| `alcatel_aos` | Nokia / Alcatel-Lucent Enterprise | AOS |
+| `aruba_aoscx` | HPE Aruba Networking | AOS-CX (REST) |
+| `aruba_aoscx_ssh` | HPE Aruba Networking | AOS-CX (SSH) |
+| `aruba_os` | HPE Aruba Networking | ArubaOS (controllers) |
+| `aruba_osswitch` | HPE Aruba Networking | ArubaOS-Switch (ex-ProCurve) |
+| `avaya_ers` | Extreme Networks (ex-Avaya) | Ethernet Routing Switch (ERS) |
+| `brocade_fastiron` | Ruckus / CommScope (ex-Brocade) | FastIron (ICX) |
+| `brocade_netiron` | Extreme Networks (ex-Brocade) | NetIron (MLX / CES / CER) |
+| `checkpoint_gaia` | Check Point | Gaia |
+| `ciena_saos` | Ciena | SAOS |
+| `cisco_apic` | Cisco | ACI APIC |
+| `cisco_asa` | Cisco | ASA |
+| `cisco_asa_ssh` | Cisco | ASA (SSH) |
+| `cisco_ftd_ssh` | Cisco | Firepower Threat Defense (FTD) |
+| `cisco_fxos` | Cisco | FXOS |
+| `cisco_s300` | Cisco | Small Business 300/350/550 series |
+| `cisco_viptela_ssh` | Cisco | Viptela / SD-WAN |
+| `cisco_wlc` | Cisco | Wireless LAN Controller (AireOS) |
+| `cumulus_linux` | NVIDIA (ex-Cumulus) | Cumulus Linux |
+| `dell_ftos` | Dell | Force10 / FTOS |
+| `dell_powerconnect` | Dell | PowerConnect |
+| `dell_sonic` | Dell | Enterprise SONiC |
+| `ericsson_ipos` | Ericsson | IPOS (ex-Redback SmartEdge) |
+| `extreme_exos` | Extreme Networks | EXOS |
+| `extreme_slx` | Extreme Networks | SLX-OS |
+| `extreme_vsp` | Extreme Networks | VSP / VOSS |
+| `fortinet_fortios_ssh` | Fortinet | FortiOS |
+| `hp_comware` | HPE / H3C | Comware |
+| `hp_procurve` | HPE | ProCurve (legacy) |
+| `huawei_smartax` | Huawei | SmartAX (OLT) |
+| `huawei_vrp` | Huawei | VRP |
+| `mikrotik_routeros` | MikroTik | RouterOS |
+| `nokia_srl` | Nokia | SR Linux |
+| `nokia_sros` | Nokia | SR OS (gNMI/NETCONF) |
+| `nokia_sros_ssh` | Nokia | SR OS (SSH) |
+| `paloalto_panos` | Palo Alto Networks | PAN-OS (XML API) |
+| `paloalto_panos_ssh` | Palo Alto Networks | PAN-OS (SSH) |
+| `ubiquiti_edgerouter` | Ubiquiti | EdgeRouter (EdgeOS) |
+| `ubiquiti_edgeswitch` | Ubiquiti | EdgeSwitch |
+| `ubiquiti_unifiswitch` | Ubiquiti | UniFi Switch |
+
+The source for the custom drivers is maintained at [orb-discovery/device-discovery/custom_napalm](https://github.com/netboxlabs/orb-discovery/tree/develop/device-discovery/custom_napalm).
+
+## Querying supported drivers at runtime
+
+device-discovery exposes its effective driver list via its capabilities endpoint:
+
+```sh
+curl http://<agent-host>:8072/api/v1/capabilities
+# => {"supported_drivers": ["eos", "ios", "junos", ...]}
+```

--- a/docs/backends/snmp_discovery.md
+++ b/docs/backends/snmp_discovery.md
@@ -160,3 +160,36 @@ scope:
     protocol_version: "SNMPv2c"
     community: "public"
 ```
+
+## Device Model Lookup
+
+The `lookup_extensions_dir` config option points to a directory of YAML files that map SNMP `sysObjectID` OIDs to human-readable device model names. Without these files, snmp-discovery would ingest raw OIDs (for example `.1.3.6.1.4.1.9.1.489`) instead of recognizable model names (for example `catalyst2955C12`).
+
+A curated set of vendor lookup files ships with the orb-agent and orb-discovery images (see [SNMP Discovery — Supported Platforms](./snmp_discovery_supported_platforms.md)), and `lookup_extensions_dir` only needs to be set when you want to add extra files or override the bundled ones.
+
+### File format
+
+Lookup files must have a `.yaml` or `.yml` extension and contain a `devices` section keyed by OID (note the leading `.`):
+
+```yaml
+devices:
+  .1.3.6.1.4.1.9.1.1215: ciscoMwr2941DCA
+  .1.3.6.1.4.1.9.1.489: catalyst2955C12
+  .1.3.6.1.4.1.9.1.2101: ciscoASR92024TZM
+```
+
+### Overriding or extending coverage
+
+To add your own OIDs or override a bundled file:
+
+1. Identify the `sysObjectID` for your equipment (typically in vendor MIB files).
+2. Create a YAML file in the format above with OIDs prefixed by `.`.
+3. Drop the file into the directory referenced by `lookup_extensions_dir`.
+
+```sh
+# Seed a local override directory from the bundled files
+git clone https://github.com/netboxlabs/orb-discovery.git
+cp orb-discovery/snmp-discovery/data/lookup_extensions/*.yaml /opt/orb/snmp-extensions/
+```
+
+When snmp-discovery encounters a device, it reads the device's `sysObjectID`, searches the YAML files in `lookup_extensions_dir` for a match, and falls back to the raw OID when no match is found.

--- a/docs/backends/snmp_discovery.md
+++ b/docs/backends/snmp_discovery.md
@@ -1,6 +1,8 @@
 # SNMP Discovery
 The SNMP discovery backend leverages SNMP (Simple Network Management Protocol) to connect to network devices and collect network information.
 
+This backend works with any SNMPv1/v2c/v3 capable device. For the list of vendors with bundled device model lookup coverage, see [SNMP Discovery — Supported Platforms](./snmp_discovery_supported_platforms.md).
+
 ## Diode Entities
 The SNMP discovery backend uses [Diode Go SDK](https://github.com/netboxlabs/diode-sdk-go) to ingest the following entities:
 

--- a/docs/backends/snmp_discovery_supported_platforms.md
+++ b/docs/backends/snmp_discovery_supported_platforms.md
@@ -1,0 +1,87 @@
+# SNMP Discovery — Supported Platforms
+
+This page lists the vendors with bundled device model coverage for the [SNMP discovery](./snmp_discovery.md) backend.
+
+The backend works with **any SNMPv1, SNMPv2c, or SNMPv3 capable device**. Entity discovery (interfaces, IP addresses, VLANs, LAG membership) is derived from standard MIBs (IF-MIB, IP-MIB, LLDP-MIB, BRIDGE-MIB, etc.) and is therefore vendor-agnostic.
+
+What differs by vendor is the **device model name** populated in NetBox. snmp-discovery resolves a device's `sysObjectID` OID against a library of bundled YAML lookup extensions, turning the raw OID into a recognizable model name (for example `catalyst2955C12` instead of `.1.3.6.1.4.1.9.1.489`). When no match is found, the raw OID is kept.
+
+> Compatibility note: coverage of a vendor file does not guarantee that every product line or firmware variant has a model entry. Report gaps via a GitHub issue against [orb-discovery](https://github.com/netboxlabs/orb-discovery/issues).
+
+## Bundled device model lookup extensions
+
+The following vendor files ship with orb-agent and orb-discovery, providing device model resolution for their equipment:
+
+| Vendor / Family | Lookup file |
+|-----------------|-------------|
+| 3Com | `a3com.yaml` |
+| Alvarion | `alvarion.yaml` |
+| APC (Schneider Electric) | `apc.yaml` |
+| Arista | `arista.yaml` |
+| HPE Aruba Networking | `aruba.yaml` |
+| ATEN | `aten.yaml` |
+| ATTO Technology | `atto.yaml` |
+| Bachmann BlueNet 2 | `bachmann-bluenet2.yaml` |
+| Broadcom cable modem | `brcm-cm.yaml` |
+| Brocade (Ruckus / Extreme) | `brocade.yaml` |
+| Cadant | `cadant.yaml` |
+| Check Point | `checkpoint.yaml` |
+| Ciena | `ciena.yaml` |
+| Cisco | `cisco.yaml` |
+| Citrix | `citrix.yaml` |
+| Colubris (HPE) | `colubris.yaml` |
+| CyberPower | `cyberpower.yaml` |
+| DASAN Networks | `dasan.yaml` |
+| Dell Networking | `dell-networking.yaml` |
+| Dell EMC OS10 / SmartFabric | `dellemc-os10.yaml` |
+| D-Link DES-7200 | `des7200.yaml` |
+| Eaton | `eaton.yaml` |
+| Extreme Networks | `extreme.yaml` |
+| Dell Force10 | `f10.yaml` |
+| F5 Networks | `f5.yaml` |
+| Fortinet | `fortinet.yaml` |
+| FS.com | `fs.yaml` |
+| Hirschmann HM2 | `hm2.yaml` |
+| HPE | `hpe.yaml` |
+| Infoblox | `infoblox.yaml` |
+| Juniper | `juniper.yaml` |
+| Lenovo | `lenovo.yaml` |
+| NVIDIA Mellanox | `mellanox.yaml` |
+| Cisco Meraki | `meraki.yaml` |
+| MikroTik | `mikrotik.yaml` |
+| MX Digital | `mx-digital.yaml` |
+| MX | `mx.yaml` |
+| MY | `my.yaml` |
+| NetApp | `netapp.yaml` |
+| NETGEAR | `netgear.yaml` |
+| Juniper NetScreen (legacy) | `netscreen.yaml` |
+| NOS | `nos.yaml` |
+| Nutanix | `nutanix.yaml` |
+| OG | `og.yaml` |
+| Palo Alto Networks | `pan.yaml` |
+| Cisco PCube / SCE | `pcube.yaml` |
+| QTECH | `qtech.yaml` |
+| Raritan | `raritan.yaml` |
+| RDN | `rdn.yaml` |
+| Redline Communications | `redline.yaml` |
+| Rittal CMC III | `rittal-cmc-iii.yaml` |
+| Riverbed | `riverbed.yaml` |
+| Ruckus / CommScope | `ruckus.yaml` |
+| Schleifenbauer | `schleifenbauer.yaml` |
+| Silver Peak (Aruba EdgeConnect) | `silverpeak.yaml` |
+| TP-Link | `tplink.yaml` |
+| Tripp Lite (Eaton) | `tripp-lite.yaml` |
+| Ubiquiti | `ubiquiti.yaml` |
+| Vertiv | `vertiv.yaml` |
+| VMware | `vmware.yaml` |
+| WatchGuard | `watchguard.yaml` |
+| Waystream | `waystream.yaml` |
+| World Wide Packets (Ciena) | `wwp.yaml` |
+
+The authoritative list and the contents of each file live at [orb-discovery/snmp-discovery/data/lookup_extensions](https://github.com/netboxlabs/orb-discovery/tree/develop/snmp-discovery/data/lookup_extensions).
+
+Manufacturer-level resolution (SNMP enterprise number → vendor name) is handled by [`manufacturers.yaml`](https://github.com/netboxlabs/orb-discovery/blob/develop/snmp-discovery/data/manufacturers.yaml), which covers the full IANA Private Enterprise Number registry.
+
+## Extending device coverage
+
+You can add or override lookup data without rebuilding the agent. See the [Device Model Lookup](./snmp_discovery.md) section of the SNMP Discovery docs for the `lookup_extensions_dir` option and the YAML format for custom files.

--- a/docs/backends/snmp_discovery_supported_platforms.md
+++ b/docs/backends/snmp_discovery_supported_platforms.md
@@ -84,4 +84,4 @@ Manufacturer-level resolution (SNMP enterprise number → vendor name) is handle
 
 ## Extending device coverage
 
-You can add or override lookup data without rebuilding the agent. See the [Device Model Lookup](./snmp_discovery.md) section of the SNMP Discovery docs for the `lookup_extensions_dir` option and the YAML format for custom files.
+You can add or override lookup data without rebuilding the agent. See the [Device Model Lookup](./snmp_discovery.md#device-model-lookup) section of the SNMP Discovery docs for the `lookup_extensions_dir` option and the YAML format for custom files.


### PR DESCRIPTION
## Summary
- New [device_discovery_supported_platforms.md](docs/backends/device_discovery_supported_platforms.md) listing every standard and custom NAPALM driver shipped with device-discovery, mapped to vendor + platform/OS, and spelling out that auto-discovery only tries the standard set.
- New [snmp_discovery_supported_platforms.md](docs/backends/snmp_discovery_supported_platforms.md) clarifying that SNMP discovery is protocol-generic and listing the 63 bundled `lookup_extensions/*.yaml` vendor files that drive device model name resolution.
- Cross-linked from each backend page and from the README so users can find the supported matrix without digging through orb-discovery source.

## Test plan
- [x] Render the new pages in GitHub's markdown preview and verify tables + links
- [x] Confirm relative links from [README.md](README.md), [device_discovery.md](docs/backends/device_discovery.md), and [snmp_discovery.md](docs/backends/snmp_discovery.md) resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)