### PR TITLE
fix(OBS-2704): parse run targets from metadata for network-discovery v1.x

### DIFF
--- a/agent/backend/backend.go
+++ b/agent/backend/backend.go
@@ -12,13 +12,14 @@ import (
 
 // PolicyStatusRun represents a run in the backend status response
 type PolicyStatusRun struct {
-	ID          string   `json:"id"`
-	Status      string   `json:"status"`
-	Reason      string   `json:"reason"`
-	EntityCount int64    `json:"entity_count,omitzero"`
-	CreatedAt   int64    `json:"created_at"` // nanoseconds since epoch
-	UpdatedAt   int64    `json:"updated_at"` // nanoseconds since epoch
-	Targets     []string `json:"targets,omitempty"`
+	ID          string            `json:"id"`
+	Status      string            `json:"status"`
+	Reason      string            `json:"reason"`
+	EntityCount int64             `json:"entity_count,omitzero"`
+	CreatedAt   int64             `json:"created_at"` // nanoseconds since epoch
+	UpdatedAt   int64             `json:"updated_at"` // nanoseconds since epoch
+	Targets     []string          `json:"targets,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
 }
 
 // PolicyStatus represents policy status from backend status endpoint

--- a/agent/backend/backend_state.go
+++ b/agent/backend/backend_state.go
@@ -176,7 +176,7 @@ func convertToRunData(statusRuns []PolicyStatusRun) []policies.RunData {
 	runs := make([]policies.RunData, len(statusRuns))
 	for i, sr := range statusRuns {
 		targets := sr.Targets
-		if len(targets) == 0 {
+		if sr.Targets == nil {
 			targets = targetsFromMetadata(sr.Metadata)
 		}
 		runs[i] = policies.RunData{

--- a/agent/backend/backend_state.go
+++ b/agent/backend/backend_state.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -174,6 +175,10 @@ func nsToTime(ns int64) time.Time {
 func convertToRunData(statusRuns []PolicyStatusRun) []policies.RunData {
 	runs := make([]policies.RunData, len(statusRuns))
 	for i, sr := range statusRuns {
+		targets := sr.Targets
+		if len(targets) == 0 {
+			targets = targetsFromMetadata(sr.Metadata)
+		}
 		runs[i] = policies.RunData{
 			ID:          sr.ID,
 			Status:      sr.Status,
@@ -181,8 +186,26 @@ func convertToRunData(statusRuns []PolicyStatusRun) []policies.RunData {
 			EntityCount: sr.EntityCount,
 			CreatedAt:   nsToTime(sr.CreatedAt),
 			UpdatedAt:   nsToTime(sr.UpdatedAt),
-			Targets:     sr.Targets,
+			Targets:     targets,
 		}
 	}
 	return runs
+}
+
+// targetsFromMetadata extracts a targets list from the metadata map emitted by
+// discovery backends that have not yet adopted the top-level targets field.
+// network-discovery v1.x encodes targets as a JSON array string at metadata["targets"].
+func targetsFromMetadata(meta map[string]string) []string {
+	if len(meta) == 0 {
+		return nil
+	}
+	raw, ok := meta["targets"]
+	if !ok || raw == "" {
+		return nil
+	}
+	var targets []string
+	if err := json.Unmarshal([]byte(raw), &targets); err != nil {
+		return nil
+	}
+	return targets
 }

--- a/agent/backend/convert_to_run_data_test.go
+++ b/agent/backend/convert_to_run_data_test.go
@@ -182,6 +182,23 @@ func TestConvertToRunData_TopLevelTargetsTakePrecedenceOverMetadata(t *testing.T
 	assert.Equal(t, []string{"172.16.0.0/12"}, runs[0].Targets)
 }
 
+func TestConvertToRunData_ExplicitEmptyTargetsNotOverriddenByMetadata(t *testing.T) {
+	// An explicit "targets": [] on the wire must NOT fall back to metadata.
+	statusRuns := []PolicyStatusRun{
+		{
+			ID:       "run-empty",
+			Status:   "running",
+			Targets:  []string{},
+			Metadata: map[string]string{"targets": `["192.168.1.0/24"]`},
+		},
+	}
+
+	runs := convertToRunData(statusRuns)
+
+	require.Len(t, runs, 1)
+	assert.Empty(t, runs[0].Targets)
+}
+
 func TestTargetsFromMetadata_InvalidJSON(t *testing.T) {
 	meta := map[string]string{"targets": "not-valid-json"}
 	assert.Nil(t, targetsFromMetadata(meta))

--- a/agent/backend/convert_to_run_data_test.go
+++ b/agent/backend/convert_to_run_data_test.go
@@ -149,3 +149,49 @@ func TestConvertToRunData_CopiesTargets(t *testing.T) {
 	assert.Equal(t, []string{"10.0.0.1", "10.0.0.2"}, runs[0].Targets)
 	assert.Nil(t, runs[1].Targets)
 }
+
+func TestConvertToRunData_FallsBackToMetadataTargets(t *testing.T) {
+	// network-discovery v1.x encodes targets inside metadata as a JSON-array string.
+	statusRuns := []PolicyStatusRun{
+		{
+			ID:       "run-meta",
+			Status:   "running",
+			Metadata: map[string]string{"targets": `["192.168.1.0/24","10.0.0.0/8"]`},
+		},
+	}
+
+	runs := convertToRunData(statusRuns)
+
+	require.Len(t, runs, 1)
+	assert.Equal(t, []string{"192.168.1.0/24", "10.0.0.0/8"}, runs[0].Targets)
+}
+
+func TestConvertToRunData_TopLevelTargetsTakePrecedenceOverMetadata(t *testing.T) {
+	statusRuns := []PolicyStatusRun{
+		{
+			ID:       "run-both",
+			Status:   "running",
+			Targets:  []string{"172.16.0.0/12"},
+			Metadata: map[string]string{"targets": `["192.168.1.0/24"]`},
+		},
+	}
+
+	runs := convertToRunData(statusRuns)
+
+	require.Len(t, runs, 1)
+	assert.Equal(t, []string{"172.16.0.0/12"}, runs[0].Targets)
+}
+
+func TestTargetsFromMetadata_InvalidJSON(t *testing.T) {
+	meta := map[string]string{"targets": "not-valid-json"}
+	assert.Nil(t, targetsFromMetadata(meta))
+}
+
+func TestTargetsFromMetadata_MissingKey(t *testing.T) {
+	meta := map[string]string{"other": "value"}
+	assert.Nil(t, targetsFromMetadata(meta))
+}
+
+func TestTargetsFromMetadata_Nil(t *testing.T) {
+	assert.Nil(t, targetsFromMetadata(nil))
+}


### PR DESCRIPTION
## Summary

- `network-discovery` v1.15.x reports run targets in `metadata.targets` as a JSON-encoded array string, not as a top-level `targets` field
- Add `Metadata map[string]string` to `PolicyStatusRun` to capture the field
- Fall back to `targetsFromMetadata()` in `convertToRunData` when the top-level `Targets` field is absent, normalising both formats into `RunData.Targets`
- Top-level `targets` takes precedence when present (forward-compatible once the binary is updated)

## Test plan

- [ ] `go test ./agent/backend/ -run "TestConvert|TestTargets"` — all new and existing tests pass
- [ ] E2E: `test_run_response_includes_targets_field` passes end-to-end against a locally-built agent image

🤖 Generated with [Claude Code](https://claude.com/claude-code)