### PR TITLE
chore: refresh upstream backend stages in develop workflow

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -1,12 +1,6 @@
 name: Orb Agent - develop
 on:
   workflow_dispatch:
-    inputs:
-      docker_tag:
-        description: 'Docker tag to use for the image'
-        required: false
-        default: 'develop'
-        type: string
   push:
     branches: [ develop ]
     paths:
@@ -67,7 +61,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,scope=${{ matrix.platform }},mode=max
-          no-cache-filters: python-builder
+          no-cache-filters: python-builder,network-discovery,snmp-discovery,pktvisor,otlpinf
+          pull: true
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
@@ -114,5 +109,5 @@ jobs:
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
-            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.docker_tag || 'develop' }} \
+            --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:develop \
             $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)


### PR DESCRIPTION
## Summary
- Extend `no-cache-filters` in the develop workflow to cover the `network-discovery`, `snmp-discovery`, `pktvisor`, and `otlpinf` stages, and enable `pull: true` so buildx re-resolves their `:latest` tags on every build instead of reusing cached layers.
- Drop the manual `docker_tag` workflow_dispatch input; `develop` is now the only tag produced, so the manifest step hardcodes it.

## Context
The GHA cache was holding onto the layers produced by the `FROM netboxlabs/snmp-discovery:latest` (and similar) stages. Because the tag string in the Dockerfile never changed, buildx had no reason to re-pull the upstream image even when its digest was updated, which meant backend bumps (snmp, device-discovery via the python-builder stage already worked) required manually purging the cache.

`python-builder` stays in `no-cache-filters` as before, which keeps the pip install of `netboxlabs-device-discovery` / `netboxlabs-orb-worker` resolving the latest from PyPI every build. The Go `builder` stage still benefits from the GHA cache, so incremental builds stay fast.

## Test plan
- [ ] Trigger the workflow from `workflow_dispatch` and confirm the build succeeds without the custom tag input.
- [ ] Verify the produced multi-arch image at `docker.io/netboxlabs/orb-agent:develop` contains the current `snmp-discovery` / `network-discovery` / `pktvisor` / `otlpinf` binaries.
- [ ] Confirm the Go builder stage still benefits from the GHA cache on subsequent runs (fast incremental builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)