### PR TITLE
chore: bump pip to 26.0 in python-builder stage

### DIFF
--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -35,8 +35,8 @@ FROM orbcommunity/pktvisor:${PKTVISOR_TAG} AS pktvisor
 ########################################################################
 FROM python:3.14-slim-trixie AS python-builder
 
-# Upgrade pip to latest version (25.3) with fewer vulnerabilities
-RUN python -m pip install --upgrade --no-cache-dir pip==25.3 && \
+# Upgrade pip to latest version (26.0) with fewer vulnerabilities
+RUN python -m pip install --upgrade --no-cache-dir pip==26.0 && \
     rm -rf /usr/local/lib/python3.14/ensurepip/_bundled/pip-*.whl
 
 # Install Python packages


### PR DESCRIPTION
## Summary
- Upgrade the bundled pip in the `python-builder` Docker stage from 25.3 to 26.0.

## Test plan
- [x] Build the agent image (`make agent`) and confirm the python-builder stage installs pip 26.0.
- [x] Verify `netboxlabs-device-discovery` and `netboxlabs-orb-worker` still resolve and install cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)