### PR TITLE
docs(device-discovery): list mellanox_mlnxos in supported platforms (OBS-2776)

### DIFF
--- a/docs/backends/device_discovery/supported_platforms.md
+++ b/docs/backends/device_discovery/supported_platforms.md
@@ -61,6 +61,7 @@ These drivers are bundled with device-discovery. They are **not** tried during a
 | `hp_procurve` | HPE | ProCurve (legacy) |
 | `huawei_smartax` | Huawei | SmartAX (OLT) |
 | `huawei_vrp` | Huawei | VRP |
+| `mellanox_mlnxos` | NVIDIA / Mellanox | MLNX-OS |
 | `mikrotik_routeros` | MikroTik | RouterOS |
 | `nokia_srl` | Nokia | SR Linux |
 | `nokia_sros` | Nokia | SR OS (gNMI/NETCONF) |


### PR DESCRIPTION
## Summary

- Adds `mellanox_mlnxos` to the custom NAPALM drivers table on the device-discovery supported-platforms page.
- Mirrors the new driver added in netboxlabs/orb-discovery#377.

Issue: [OBS-2776](https://linear.app/netboxlabs/issue/OBS-2776/device-discovery-add-napalm-driver-support-for-mellanox-mlnx-os)

## Test plan

- [x] Render `docs/backends/device_discovery/supported_platforms.md` and confirm the new row appears alphabetically between `huawei_vrp` and `mikrotik_routeros`.
- [x] Hold for merge until netboxlabs/orb-discovery#377 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)