### PR TITLE
feat(OBS-2820): propagate resolved NAPALM driver on discovery runs

### DIFF
--- a/agent/backend/backend.go
+++ b/agent/backend/backend.go
@@ -19,6 +19,7 @@ type PolicyStatusRun struct {
 	CreatedAt   int64             `json:"created_at"` // nanoseconds since epoch
 	UpdatedAt   int64             `json:"updated_at"` // nanoseconds since epoch
 	Targets     []string          `json:"targets,omitempty"`
+	Driver      string            `json:"driver,omitempty"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
 }
 

--- a/agent/backend/backend_state.go
+++ b/agent/backend/backend_state.go
@@ -187,6 +187,7 @@ func convertToRunData(statusRuns []PolicyStatusRun) []policies.RunData {
 			CreatedAt:   nsToTime(sr.CreatedAt),
 			UpdatedAt:   nsToTime(sr.UpdatedAt),
 			Targets:     targets,
+			Driver:      sr.Driver,
 		}
 	}
 	return runs

--- a/agent/backend/convert_to_run_data_test.go
+++ b/agent/backend/convert_to_run_data_test.go
@@ -31,6 +31,7 @@ func TestConvertToRunData_MapsAllFields(t *testing.T) {
 			EntityCount: entityCount,
 			CreatedAt:   ts1Ns,
 			UpdatedAt:   ts2Ns,
+			Driver:      "ios",
 		},
 		{
 			ID:        "run-failed",
@@ -58,6 +59,7 @@ func TestConvertToRunData_MapsAllFields(t *testing.T) {
 	assert.Equal(t, int64(42), r0.EntityCount)
 	assert.Equal(t, ts1, r0.CreatedAt)
 	assert.Equal(t, ts2, r0.UpdatedAt)
+	assert.Equal(t, "ios", r0.Driver)
 
 	// Failed run: no entity count
 	r1 := runs[1]
@@ -67,6 +69,7 @@ func TestConvertToRunData_MapsAllFields(t *testing.T) {
 	assert.Zero(t, r1.EntityCount)
 	assert.Equal(t, ts3, r1.CreatedAt)
 	assert.Equal(t, ts4, r1.UpdatedAt)
+	assert.Empty(t, r1.Driver)
 
 	// Running run: zero int64 timestamps (omitted/missing) become zero time.Time
 	// so that UpdateRuns' IsZero() fallback fires correctly.
@@ -77,6 +80,7 @@ func TestConvertToRunData_MapsAllFields(t *testing.T) {
 	assert.Zero(t, r2.EntityCount)
 	assert.True(t, r2.CreatedAt.IsZero(), "zero int64 should map to zero time.Time, not Unix epoch")
 	assert.True(t, r2.UpdatedAt.IsZero(), "zero int64 should map to zero time.Time, not Unix epoch")
+	assert.Empty(t, r2.Driver)
 
 	// PolicyID should never be set by the converter (repo owns that)
 	for _, r := range runs {
@@ -166,6 +170,26 @@ func TestConvertToRunData_FallsBackToMetadataTargets(t *testing.T) {
 	assert.Equal(t, []string{"192.168.1.0/24", "10.0.0.0/8"}, runs[0].Targets)
 }
 
+func TestConvertToRunData_CopiesDriver(t *testing.T) {
+	statusRuns := []PolicyStatusRun{
+		{
+			ID:     "run-1",
+			Status: "completed",
+			Driver: "eos",
+		},
+		{
+			ID:     "run-2",
+			Status: "running",
+		},
+	}
+
+	runs := convertToRunData(statusRuns)
+
+	require.Len(t, runs, 2)
+	assert.Equal(t, "eos", runs[0].Driver)
+	assert.Empty(t, runs[1].Driver)
+}
+
 func TestConvertToRunData_TopLevelTargetsTakePrecedenceOverMetadata(t *testing.T) {
 	statusRuns := []PolicyStatusRun{
 		{
@@ -211,4 +235,31 @@ func TestTargetsFromMetadata_MissingKey(t *testing.T) {
 
 func TestTargetsFromMetadata_Nil(t *testing.T) {
 	assert.Nil(t, targetsFromMetadata(nil))
+}
+
+func TestPolicyStatusRun_DriverOmittedWhenEmptyOnWire(t *testing.T) {
+	payload := []byte(`{"id":"run-1","status":"running","created_at":0,"updated_at":0}`)
+
+	var r PolicyStatusRun
+	require.NoError(t, json.Unmarshal(payload, &r))
+
+	assert.Empty(t, r.Driver)
+}
+
+func TestPolicyStatusRun_DriverUnmarshaledWhenPresent(t *testing.T) {
+	payload := []byte(`{"id":"run-1","status":"completed","driver":"junos","created_at":0,"updated_at":0}`)
+
+	var r PolicyStatusRun
+	require.NoError(t, json.Unmarshal(payload, &r))
+
+	assert.Equal(t, "junos", r.Driver)
+}
+
+func TestPolicyStatusRun_DriverMarshaledAsOmitempty(t *testing.T) {
+	r := PolicyStatusRun{ID: "run-1", Status: "running"}
+
+	body, err := json.Marshal(r)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(body), "driver")
 }

--- a/agent/configmgr/fleet/heartbeats.go
+++ b/agent/configmgr/fleet/heartbeats.go
@@ -181,6 +181,7 @@ func convertRunsToStateInfo(runs []policies.RunData) []messages.RunStateInfo {
 			CreatedAt:   run.CreatedAt,
 			UpdatedAt:   run.UpdatedAt,
 			Targets:     run.Targets,
+			Driver:      run.Driver,
 		}
 	}
 	return runInfos

--- a/agent/configmgr/fleet/heartbeats_test.go
+++ b/agent/configmgr/fleet/heartbeats_test.go
@@ -1807,6 +1807,7 @@ func TestHeartbeater_GetPolicyState_PropagatesTargetsFromRunData(t *testing.T) {
 					CreatedAt: testTime,
 					UpdatedAt: testTime.Add(5 * time.Minute),
 					Targets:   []string{"10.0.0.5", "10.0.0.6"},
+					Driver:    "ios",
 				},
 				{
 					ID:        "run-c",
@@ -1827,6 +1828,9 @@ func TestHeartbeater_GetPolicyState_PropagatesTargetsFromRunData(t *testing.T) {
 	assert.Equal(t, []string{"192.168.1.1"}, ps["policy-1"].Runs[0].Targets)
 	assert.Equal(t, []string{"10.0.0.5", "10.0.0.6"}, ps["policy-1"].Runs[1].Targets)
 	assert.Nil(t, ps["policy-1"].Runs[2].Targets)
+	assert.Equal(t, "ios", ps["policy-1"].Runs[1].Driver)
+	assert.Empty(t, ps["policy-1"].Runs[0].Driver)
+	assert.Empty(t, ps["policy-1"].Runs[2].Driver)
 
 	mockPMgr.AssertExpectations(t)
 }
@@ -1848,6 +1852,7 @@ func TestHeartbeater_SendSingleHeartbeat_SerializesPerRunTargets(t *testing.T) {
 					CreatedAt: testTime,
 					UpdatedAt: testTime,
 					Targets:   []string{"10.0.0.1"},
+					Driver:    "ios",
 				},
 			},
 		},
@@ -1871,7 +1876,9 @@ func TestHeartbeater_SendSingleHeartbeat_SerializesPerRunTargets(t *testing.T) {
 	assert.Equal(t, "1.1", hb2.SchemaVersion)
 	require.Len(t, hb2.PolicyState["policy-1"].Runs, 1)
 	assert.Equal(t, []string{"10.0.0.1"}, hb2.PolicyState["policy-1"].Runs[0].Targets)
+	assert.Equal(t, "ios", hb2.PolicyState["policy-1"].Runs[0].Driver)
 	assert.Contains(t, string(capturedPayload), `"targets":["10.0.0.1"]`)
+	assert.Contains(t, string(capturedPayload), `"driver":"ios"`)
 
 	mockPMgr.AssertExpectations(t)
 }

--- a/agent/configmgr/fleet/messages/fleet_messages.go
+++ b/agent/configmgr/fleet/messages/fleet_messages.go
@@ -40,6 +40,7 @@ type RunStateInfo struct {
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
 	Targets     []string  `json:"targets,omitempty"`
+	Driver      string    `json:"driver,omitempty"`
 }
 
 // PolicyStateInfo contains state information for a policy

--- a/agent/configmgr/fleet/messages/fleet_messages_test.go
+++ b/agent/configmgr/fleet/messages/fleet_messages_test.go
@@ -51,3 +51,26 @@ func TestRunStateInfo_TargetsIncludedWhenPresent(t *testing.T) {
 	assert.Equal(t, "10.0.0.1", targets[0])
 	assert.Equal(t, "10.0.0.2", targets[1])
 }
+
+func TestRunStateInfo_DriverOmittedWhenEmpty(t *testing.T) {
+	r := RunStateInfo{ID: "run-1", PolicyID: "policy-1", Status: "running"}
+
+	body, err := json.Marshal(r)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(body), "driver")
+}
+
+func TestRunStateInfo_DriverIncludedWhenPresent(t *testing.T) {
+	r := RunStateInfo{
+		ID:       "run-1",
+		PolicyID: "policy-1",
+		Status:   "completed",
+		Driver:   "junos",
+	}
+
+	body, err := json.Marshal(r)
+	require.NoError(t, err)
+
+	assert.Contains(t, string(body), `"driver":"junos"`)
+}

--- a/agent/policies/repo.go
+++ b/agent/policies/repo.go
@@ -192,6 +192,10 @@ func (p *policyMemRepo) UpdateRuns(policyName string, runs []RunData) error {
 			if len(runs[i].Targets) == 0 {
 				runs[i].Targets = existing.Targets
 			}
+			// Same semantics for resolved NAPALM driver on device-discovery runs.
+			if runs[i].Driver == "" {
+				runs[i].Driver = existing.Driver
+			}
 		} else {
 			// New run: use the backend's timestamps if provided; fall back to now.
 			if runs[i].CreatedAt.IsZero() {

--- a/agent/policies/repo_test.go
+++ b/agent/policies/repo_test.go
@@ -890,8 +890,85 @@ func TestUpdateRuns_UpdatesTargetsWhenBackendReportsNewNonEmptyList(t *testing.T
 	assert.Equal(t, []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}, got.Runs[0].Targets, "non-empty update should replace existing")
 }
 
+func TestUpdateRuns_NewRunStoresDriver(t *testing.T) {
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	pd := policies.PolicyData{
+		ID:      "test-id",
+		Name:    "test-policy",
+		Backend: "test-backend",
+		Version: 1,
+		State:   policies.Unknown,
+	}
+	require.NoError(t, repo.Update(pd))
+
+	err = repo.UpdateRuns("test-policy", []policies.RunData{
+		{ID: "run-1", Status: "running", Driver: "ios"},
+	})
+	require.NoError(t, err)
+
+	got, err := repo.Get("test-id")
+	require.NoError(t, err)
+	require.Len(t, got.Runs, 1)
+	assert.Equal(t, "ios", got.Runs[0].Driver)
+}
+
+func TestUpdateRuns_PreservesDriverWhenBackendOmitsIt(t *testing.T) {
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	pd := policies.PolicyData{
+		ID:      "test-id",
+		Name:    "test-policy",
+		Backend: "test-backend",
+		Version: 1,
+		State:   policies.Unknown,
+	}
+	require.NoError(t, repo.Update(pd))
+
+	require.NoError(t, repo.UpdateRuns("test-policy", []policies.RunData{
+		{ID: "run-1", Status: "running", Driver: "ios"},
+	}))
+
+	require.NoError(t, repo.UpdateRuns("test-policy", []policies.RunData{
+		{ID: "run-1", Status: "completed"},
+	}))
+
+	got, err := repo.Get("test-id")
+	require.NoError(t, err)
+	require.Len(t, got.Runs, 1)
+	assert.Equal(t, "completed", got.Runs[0].Status)
+	assert.Equal(t, "ios", got.Runs[0].Driver, "driver should be preserved when backend omits the field")
+}
+
+func TestUpdateRuns_UpdatesDriverWhenBackendReportsNewNonEmptyValue(t *testing.T) {
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	pd := policies.PolicyData{
+		ID:      "test-id",
+		Name:    "test-policy",
+		Backend: "test-backend",
+		Version: 1,
+		State:   policies.Unknown,
+	}
+	require.NoError(t, repo.Update(pd))
+
+	require.NoError(t, repo.UpdateRuns("test-policy", []policies.RunData{
+		{ID: "run-1", Status: "running", Driver: "ios"},
+	}))
+
+	require.NoError(t, repo.UpdateRuns("test-policy", []policies.RunData{
+		{ID: "run-1", Status: "running", Driver: "eos"},
+	}))
+
+	got, err := repo.Get("test-id")
+	require.NoError(t, err)
+	assert.Equal(t, "eos", got.Runs[0].Driver, "non-empty update should replace existing driver")
+}
+
 func TestIsTerminalRunStatus(t *testing.T) {
-	t.Parallel()
 	assert.True(t, policies.IsTerminalRunStatus("completed"))
 	assert.True(t, policies.IsTerminalRunStatus("failed"))
 	assert.False(t, policies.IsTerminalRunStatus("running"))

--- a/agent/policies/types.go
+++ b/agent/policies/types.go
@@ -15,6 +15,7 @@ type RunData struct {
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
 	Targets     []string  `json:"targets,omitempty"`
+	Driver      string    `json:"driver,omitempty"`
 }
 
 // PolicyData represents a policy


### PR DESCRIPTION
## Summary
Threads optional per-run `driver` from discovery backends `/api/v1/status` through the in-memory policy repo into fleet heartbeats, matching the device-discovery wire field introduced in the companion PR.

## What changed
- `PolicyStatusRun`, `RunData`, `RunStateInfo`: `driver` with `json:"driver,omitempty"`.
- `convertToRunData` / `convertRunsToStateInfo` copy through.
- `UpdateRuns`: preserve last non-empty `driver` when the backend sends an empty value (same pattern as `targets`).

## How tested
- `make fix-lint`
- `go test -race ./agent/backend/... ./agent/policies/... ./agent/configmgr/fleet/...`

## Companion
- **orb-discovery:** https://github.com/netboxlabs/orb-discovery/pull/381

Made with [Cursor](https://cursor.com)