### PR TITLE
feat(OBS-1946): Batch fleet secret resolution in one MQTT request

### DIFF
--- a/agent/secretsmgr/fleet.go
+++ b/agent/secretsmgr/fleet.go
@@ -340,10 +340,11 @@ func (f *FleetSecretsManager) SolveConfigSecrets(backends map[string]any, config
 func collectFleetPaths(v any, set map[string]struct{}) {
 	switch val := v.(type) {
 	case string:
-		for _, idx := range fleetRefRegex.FindAllStringSubmatchIndex(val, -1) {
-			if len(idx) >= 4 {
-				set[val[idx[2]:idx[3]]] = struct{}{}
-			}
+		// Align with processString: only the first ${fleet://...} is resolved; the rest
+		// of the string is discarded when substituting (legacy single-token behavior).
+		idx := fleetRefRegex.FindStringSubmatchIndex(val)
+		if len(idx) >= 4 {
+			set[val[idx[2]:idx[3]]] = struct{}{}
 		}
 	case map[string]any:
 		for _, vv := range val {

--- a/agent/secretsmgr/fleet.go
+++ b/agent/secretsmgr/fleet.go
@@ -187,12 +187,14 @@ func (f *FleetSecretsManager) handleUpdateNotification(payload []byte) error {
 		// Release the lock before performing the potentially long-running network request
 		f.mu.Unlock()
 
-		// Request updated secret
 		ctx := f.ctx
 		if ctx == nil {
 			ctx = context.Background()
 		}
-		secret, err := f.requestSecret(ctx, path, policyIDsCopy)
+
+		// Request updated secret (do not merge into usedVars here: this handler must
+		// compare versions and update the cache so the policy callback runs).
+		byPath, err := f.requestSecrets(ctx, []string{path}, policyIDsCopy, false)
 
 		// Re-acquire the lock before accessing or mutating shared state
 		f.mu.Lock()
@@ -205,6 +207,16 @@ func (f *FleetSecretsManager) handleUpdateNotification(payload []byte) error {
 			f.mu.Unlock()
 			continue
 		}
+		sv, ok := byPath[path]
+		if !ok {
+			f.logger.Error("failed to request updated secret", "path", path, "error", "missing in response")
+			for id := range policyIDsCopy {
+				changedPolicyIDs[id] = false
+			}
+			f.mu.Unlock()
+			continue
+		}
+		secret := &sv
 
 		// Re-fetch the cached entry in case it changed while the lock was released
 		cached, exists = f.usedVars[path]
@@ -403,7 +415,7 @@ func (f *FleetSecretsManager) ensureSecrets(ctx context.Context, paths []string,
 		return nil
 	}
 
-	_, err := f.requestSecrets(ctx, missing, policyIDs)
+	_, err := f.requestSecrets(ctx, missing, policyIDs, true)
 	return err
 }
 
@@ -491,7 +503,7 @@ func (f *FleetSecretsManager) processSlice(s []any, id string) ([]any, error) {
 
 // requestSecret requests a single secret from the control plane via MQTT.
 func (f *FleetSecretsManager) requestSecret(ctx context.Context, path string, policyIDs map[string]bool) (*messages.SecretValue, error) {
-	byPath, err := f.requestSecrets(ctx, []string{path}, policyIDs)
+	byPath, err := f.requestSecrets(ctx, []string{path}, policyIDs, true)
 	if err != nil {
 		return nil, err
 	}
@@ -502,8 +514,9 @@ func (f *FleetSecretsManager) requestSecret(ctx context.Context, path string, po
 	return &sv, nil
 }
 
-// requestSecrets requests one or more secrets in a single MQTT round-trip and updates the cache on full success.
-func (f *FleetSecretsManager) requestSecrets(ctx context.Context, paths []string, policyIDs map[string]bool) (map[string]messages.SecretValue, error) {
+// requestSecrets requests one or more secrets in a single MQTT round-trip.
+// When writeCache is true, results are merged into usedVars on success.
+func (f *FleetSecretsManager) requestSecrets(ctx context.Context, paths []string, policyIDs map[string]bool, writeCache bool) (map[string]messages.SecretValue, error) {
 	paths = dedupeSortedStrings(paths)
 	if len(paths) == 0 {
 		return map[string]messages.SecretValue{}, nil
@@ -608,21 +621,23 @@ func (f *FleetSecretsManager) requestSecrets(ctx context.Context, paths []string
 			}
 		}
 
-		f.mu.Lock()
-		for _, p := range paths {
-			sv := byPath[p]
-			cached := f.usedVars[p]
-			cached.Value = sv.Value
-			cached.Version = sv.Version
-			if cached.policyIDs == nil {
-				cached.policyIDs = make(map[string]bool)
+		if writeCache {
+			f.mu.Lock()
+			for _, p := range paths {
+				sv := byPath[p]
+				cached := f.usedVars[p]
+				cached.Value = sv.Value
+				cached.Version = sv.Version
+				if cached.policyIDs == nil {
+					cached.policyIDs = make(map[string]bool)
+				}
+				for id := range policyIDs {
+					cached.policyIDs[id] = true
+				}
+				f.usedVars[p] = cached
 			}
-			for id := range policyIDs {
-				cached.policyIDs[id] = true
-			}
-			f.usedVars[p] = cached
+			f.mu.Unlock()
 		}
-		f.mu.Unlock()
 
 		return byPath, nil
 

--- a/agent/secretsmgr/fleet.go
+++ b/agent/secretsmgr/fleet.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"regexp"
+	"sort"
 	"sync"
 	"time"
 
@@ -253,11 +254,18 @@ func (f *FleetSecretsManager) RegisterUpdatePoliciesCallback(callback func(map[s
 
 // SolvePolicySecrets resolves fleet secret references in a policy payload
 func (f *FleetSecretsManager) SolvePolicySecrets(payload config.PolicyPayload) (config.PolicyPayload, error) {
-	// Create a copy of the payload
 	newPayload := payload
 
-	// Process the Data field
-	// TODO: currently this will solve secrets sequentially - we should find all the secrets and then request them all at once
+	pathSet := make(map[string]struct{})
+	collectFleetPaths(payload.Data, pathSet)
+	ctx := f.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := f.ensureSecrets(ctx, setToSortedSlice(pathSet), payload.ID); err != nil {
+		return payload, err
+	}
+
 	processedData, err := f.processValue(payload.Data, payload.ID)
 	if err != nil {
 		return payload, err
@@ -269,7 +277,27 @@ func (f *FleetSecretsManager) SolvePolicySecrets(payload config.PolicyPayload) (
 
 // SolveConfigSecrets resolves fleet secret references in backend and config manager configurations
 func (f *FleetSecretsManager) SolveConfigSecrets(backends map[string]any, configManager config.ManagerConfig) (map[string]any, config.ManagerConfig, error) {
-	// Create a copy of the backends
+	configManagerMap, err := structToMap(configManager)
+	if err != nil {
+		return backends, configManager, fmt.Errorf("failed to convert config manager to map: %w", err)
+	}
+
+	backPaths := make(map[string]struct{})
+	collectFleetPaths(backends, backPaths)
+	cfgPaths := make(map[string]struct{})
+	collectFleetPaths(configManagerMap, cfgPaths)
+
+	ctx := f.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := f.ensureSecrets(ctx, setToSortedSlice(backPaths), "_backends"); err != nil {
+		return backends, configManager, fmt.Errorf("failed to process backends: %w", err)
+	}
+	if err := f.ensureSecrets(ctx, setToSortedSlice(cfgPaths), "_config_manager"); err != nil {
+		return backends, configManager, fmt.Errorf("failed to process config manager: %w", err)
+	}
+
 	newBackends := backends
 	processedBackends, err := f.processValue(newBackends, "_backends")
 	if err != nil {
@@ -280,12 +308,6 @@ func (f *FleetSecretsManager) SolveConfigSecrets(backends map[string]any, config
 		return backends, configManager, fmt.Errorf("failed to cast processed backends to map[string]any")
 	}
 
-	// Convert configManager to map[string]any
-	configManagerMap, err := structToMap(configManager)
-	if err != nil {
-		return backends, configManager, fmt.Errorf("failed to convert config manager to map: %w", err)
-	}
-	// Process the config manager map
 	processedConfigManagerMap, err := f.processValue(configManagerMap, "_config_manager")
 	if err != nil {
 		return backends, configManager, fmt.Errorf("failed to process config manager: %w", err)
@@ -300,8 +322,89 @@ func (f *FleetSecretsManager) SolveConfigSecrets(backends map[string]any, config
 	f.usedVars = make(map[string]fleetCachedSecret)
 	f.mu.Unlock()
 
-	// Process the backends and config manager
 	return newBackends, newConfigManager, nil
+}
+
+func collectFleetPaths(v any, set map[string]struct{}) {
+	switch val := v.(type) {
+	case string:
+		for _, idx := range fleetRefRegex.FindAllStringSubmatchIndex(val, -1) {
+			if len(idx) >= 4 {
+				set[val[idx[2]:idx[3]]] = struct{}{}
+			}
+		}
+	case map[string]any:
+		for _, vv := range val {
+			collectFleetPaths(vv, set)
+		}
+	case []any:
+		for _, vv := range val {
+			collectFleetPaths(vv, set)
+		}
+	default:
+		return
+	}
+}
+
+func setToSortedSlice(set map[string]struct{}) []string {
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for p := range set {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func dedupeSortedStrings(paths []string) []string {
+	if len(paths) <= 1 {
+		return paths
+	}
+	seen := make(map[string]struct{}, len(paths))
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ensureSecrets fetches any uncached fleet paths in one MQTT request (or skip if all cached).
+func (f *FleetSecretsManager) ensureSecrets(ctx context.Context, paths []string, id string) error {
+	paths = dedupeSortedStrings(paths)
+	if len(paths) == 0 {
+		return nil
+	}
+	policyIDs := map[string]bool{id: true}
+
+	f.mu.Lock()
+	var missing []string
+	for _, path := range paths {
+		cached, exists := f.usedVars[path]
+		if exists {
+			if cached.policyIDs == nil {
+				cached.policyIDs = make(map[string]bool)
+			}
+			cached.policyIDs[id] = true
+			f.usedVars[path] = cached
+			continue
+		}
+		missing = append(missing, path)
+	}
+	f.mu.Unlock()
+
+	if len(missing) == 0 {
+		return nil
+	}
+
+	_, err := f.requestSecrets(ctx, missing, policyIDs)
+	return err
 }
 
 func (f *FleetSecretsManager) processValue(value any, id string) (any, error) {
@@ -357,16 +460,6 @@ func (f *FleetSecretsManager) processString(s string, id string) (string, error)
 	}
 
 	f.logger.Info("got secret", "secret_path", fleetPath)
-
-	// Cache the secret
-	f.mu.Lock()
-	f.usedVars[fleetPath] = fleetCachedSecret{
-		Value:     secret.Value,
-		Version:   secret.Version,
-		policyIDs: policyIDs,
-	}
-	f.mu.Unlock()
-
 	return secret.Value, nil
 }
 
@@ -396,24 +489,45 @@ func (f *FleetSecretsManager) processSlice(s []any, id string) ([]any, error) {
 	return result, nil
 }
 
-// requestSecret requests a secret from the control plane via MQTT
+// requestSecret requests a single secret from the control plane via MQTT.
 func (f *FleetSecretsManager) requestSecret(ctx context.Context, path string, policyIDs map[string]bool) (*messages.SecretValue, error) {
-	f.logger.Info("requesting secret", "path", path, "policy_ids", policyIDs)
+	byPath, err := f.requestSecrets(ctx, []string{path}, policyIDs)
+	if err != nil {
+		return nil, err
+	}
+	sv, ok := byPath[path]
+	if !ok {
+		return nil, fmt.Errorf("no secret in response for path %s", path)
+	}
+	return &sv, nil
+}
+
+// requestSecrets requests one or more secrets in a single MQTT round-trip and updates the cache on full success.
+func (f *FleetSecretsManager) requestSecrets(ctx context.Context, paths []string, policyIDs map[string]bool) (map[string]messages.SecretValue, error) {
+	paths = dedupeSortedStrings(paths)
+	if len(paths) == 0 {
+		return map[string]messages.SecretValue{}, nil
+	}
+
+	f.logger.Info("requesting secrets", "paths", paths, "policy_ids", policyIDs)
 	if f.publisher == nil {
 		return nil, fmt.Errorf("MQTT publisher not bound")
 	}
 
 	requestID := uuid.New().String()
+	reqItems := make([]messages.SecretRequest, len(paths))
+	ctxStr := getContextFromPolicyIDs(policyIDs)
+	for i, path := range paths {
+		reqItems[i] = messages.SecretRequest{
+			Path:    path,
+			Context: ctxStr,
+		}
+	}
 	request := messages.SecretRequestMsg{
 		SchemaVersion: messages.CurrentSecretsSchemaVersion,
 		RequestID:     requestID,
 		Timestamp:     time.Now(),
-		Secrets: []messages.SecretRequest{
-			{
-				Path:    path,
-				Context: getContextFromPolicyIDs(policyIDs),
-			},
-		},
+		Secrets:       reqItems,
 	}
 
 	payload, err := json.Marshal(request)
@@ -421,45 +535,70 @@ func (f *FleetSecretsManager) requestSecret(ctx context.Context, path string, po
 		return nil, fmt.Errorf("failed to marshal secret request: %w", err)
 	}
 
-	// Create response channel with buffer size 1 to prevent blocking handleResponse
 	responseCh := make(chan *messages.SecretResponseMsg, 1)
 	f.mu.Lock()
 	f.pendingReqs[requestID] = responseCh
 	f.mu.Unlock()
 
-	// Cleanup pending request on exit
-	// Note: The channel is intentionally not closed here to avoid a race condition where
-	// handleResponse might already have a reference to the channel and attempt to send after
-	// it's closed (which would panic). By removing the channel from pendingReqs, we ensure
-	// no new sends will be attempted, and the buffered channel prevents blocking. The channel
-	// will be garbage collected once this function returns and any in-flight sends complete.
 	defer func() {
 		f.mu.Lock()
 		delete(f.pendingReqs, requestID)
 		f.mu.Unlock()
 	}()
 
-	// Publish request
 	if err := f.publisher.Publish(ctx, f.requestTopic, payload); err != nil {
 		return nil, fmt.Errorf("failed to publish secret request: %w", err)
 	}
 
-	// Wait for response with timeout
 	select {
 	case response := <-responseCh:
 		if response.Status == "error" {
 			if len(response.Errors) > 0 {
-				err := response.Errors[0]
-				return nil, fmt.Errorf("secret request failed: %s (code: %s)", err.Error, err.Code)
+				err0 := response.Errors[0]
+				return nil, fmt.Errorf("secret request failed: %s (code: %s)", err0.Error, err0.Code)
 			}
 			return nil, fmt.Errorf("secret request failed with status: %s", response.Status)
 		}
 
-		if len(response.Secrets) == 0 {
+		if len(response.Secrets) == 0 && len(paths) > 0 {
 			return nil, fmt.Errorf("no secrets in response")
 		}
 
-		// Log warning for partial responses (some secrets succeeded, some failed)
+		want := make(map[string]struct{}, len(paths))
+		for _, p := range paths {
+			want[p] = struct{}{}
+		}
+
+		byPath := make(map[string]messages.SecretValue, len(response.Secrets))
+		for _, sv := range response.Secrets {
+			if _, ok := want[sv.Path]; ok {
+				byPath[sv.Path] = sv
+			}
+		}
+
+		failed := make([]messages.SecretError, 0, len(response.Errors))
+		for _, secretErr := range response.Errors {
+			if _, ok := want[secretErr.Path]; ok {
+				failed = append(failed, secretErr)
+			}
+		}
+
+		for _, p := range paths {
+			if _, ok := byPath[p]; !ok {
+				var combinedErr error
+				for _, fe := range failed {
+					if fe.Path == p {
+						combinedErr = fmt.Errorf("secret request failed for path %s: %s (code: %s)", fe.Path, fe.Error, fe.Code)
+						break
+					}
+				}
+				if combinedErr != nil {
+					return nil, combinedErr
+				}
+				return nil, fmt.Errorf("secret missing in response for path %s", p)
+			}
+		}
+
 		if response.Status == "partial" && len(response.Errors) > 0 {
 			for _, secretErr := range response.Errors {
 				f.logger.Warn("partial secret response: some secrets failed",
@@ -469,7 +608,23 @@ func (f *FleetSecretsManager) requestSecret(ctx context.Context, path string, po
 			}
 		}
 
-		return &response.Secrets[0], nil
+		f.mu.Lock()
+		for _, p := range paths {
+			sv := byPath[p]
+			cached := f.usedVars[p]
+			cached.Value = sv.Value
+			cached.Version = sv.Version
+			if cached.policyIDs == nil {
+				cached.policyIDs = make(map[string]bool)
+			}
+			for id := range policyIDs {
+				cached.policyIDs[id] = true
+			}
+			f.usedVars[p] = cached
+		}
+		f.mu.Unlock()
+
+		return byPath, nil
 
 	case <-ctx.Done():
 		return nil, fmt.Errorf("context canceled while waiting for secret response")

--- a/agent/secretsmgr/fleet_test.go
+++ b/agent/secretsmgr/fleet_test.go
@@ -312,6 +312,51 @@ func TestFleetSecretsManager_SolvePolicySecrets_batchesUncachedPaths(t *testing.
 	assert.Equal(t, "secretvalue", nested["c"])
 }
 
+// Multi-token strings use legacy first-match resolution in processString; prefetch must not
+// request later tokens (they would be ignored and could spuriously fail the solve).
+func TestFleetSecretsManager_SolvePolicySecrets_multiTokenStringPrefetchesFirstRefOnly(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fm := NewFleetSecretsManager(logger, config.FleetSecretsManager{Timeout: intPtr(5)})
+	fm.ctx = ctx
+	fm.requestTopic = "test/request"
+	fm.responseTopic = "test/response"
+	fm.updatedTopic = "test/updated"
+
+	fm.publisher = &asyncMockPublisher{
+		fm: fm,
+		customResponse: func(req messages.SecretRequestMsg) *messages.SecretResponseMsg {
+			require.Len(t, req.Secrets, 1, "only first fleet ref in the string should be prefetched")
+			assert.Equal(t, "path/first", req.Secrets[0].Path)
+			return &messages.SecretResponseMsg{
+				SchemaVersion: messages.CurrentSecretsSchemaVersion,
+				RequestID:     req.RequestID,
+				Timestamp:     time.Now(),
+				Status:        "success",
+				Secrets: []messages.SecretValue{
+					{Path: "path/first", Value: "firstval", Version: 1},
+				},
+			}
+		},
+	}
+	fm.subscriber = &mockSubscriber{}
+
+	payload := config.PolicyPayload{
+		ID: "policy-multi",
+		Data: map[string]any{
+			"k": "${fleet://path/first} ${fleet://path/second}",
+		},
+	}
+
+	out, err := fm.SolvePolicySecrets(payload)
+	require.NoError(t, err)
+	data, ok := out.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "firstval", data["k"])
+}
+
 func TestFleetSecretsManager_SolvePolicySecrets_batchPartialDoesNotCache(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	ctx, cancel := context.WithCancel(context.Background())

--- a/agent/secretsmgr/fleet_test.go
+++ b/agent/secretsmgr/fleet_test.go
@@ -146,16 +146,76 @@ func TestFleetSecretsManager_handleUpdateNotification(t *testing.T) {
 	payload, err := json.Marshal(notification)
 	require.NoError(t, err)
 
-	// Note: This test doesn't fully test the update flow since requestSecret
-	// requires a real MQTT connection. But we can test the notification parsing.
-	// handleUpdateNotification logs errors from requestSecret but returns nil
+	// handleUpdateNotification has no publisher: fetch fails, callback marks policies as failed.
 	err = fm.handleUpdateNotification(payload)
-	assert.NoError(t, err) // Function returns nil even when requestSecret fails (it logs the error)
+	assert.NoError(t, err)
 
-	// Verify the callback was called with the policy marked as failed (false)
 	assert.True(t, callbackCalled)
 	assert.Contains(t, callbackPolicyIDs, "policy1")
-	assert.False(t, callbackPolicyIDs["policy1"]) // false because requestSecret failed
+	assert.False(t, callbackPolicyIDs["policy1"])
+}
+
+func TestFleetSecretsManager_handleUpdateNotification_successUpdatesCacheAndCallbacks(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fm := NewFleetSecretsManager(logger, config.FleetSecretsManager{Timeout: intPtr(5)})
+	fm.ctx = ctx
+	fm.requestTopic = "test/request"
+	fm.responseTopic = "test/response"
+	fm.updatedTopic = "test/updated"
+	fm.usedVars = map[string]fleetCachedSecret{
+		"test/path": {
+			Value:     "oldvalue",
+			Version:   1,
+			policyIDs: map[string]bool{"policy1": true},
+		},
+	}
+
+	var callbackPolicyIDs map[string]bool
+	var callbackCalled bool
+	fm.callback = func(ids map[string]bool) {
+		callbackCalled = true
+		callbackPolicyIDs = ids
+	}
+
+	fm.publisher = &asyncMockPublisher{
+		fm: fm,
+		customResponse: func(req messages.SecretRequestMsg) *messages.SecretResponseMsg {
+			return &messages.SecretResponseMsg{
+				SchemaVersion: messages.CurrentSecretsSchemaVersion,
+				RequestID:     req.RequestID,
+				Timestamp:     time.Now(),
+				Status:        "success",
+				Secrets: []messages.SecretValue{
+					{Path: "test/path", Value: "newvalue", Version: 2},
+				},
+			}
+		},
+	}
+	fm.subscriber = &mockSubscriber{}
+
+	notification := messages.SecretUpdateNotificationMsg{
+		SchemaVersion: messages.CurrentSecretsSchemaVersion,
+		Timestamp:     time.Now(),
+		Updates: []messages.SecretUpdate{
+			{Path: "test/path", Version: 2, Contexts: []string{"policy1"}},
+		},
+	}
+	payload, err := json.Marshal(notification)
+	require.NoError(t, err)
+
+	err = fm.handleUpdateNotification(payload)
+	assert.NoError(t, err)
+
+	assert.True(t, callbackCalled)
+	require.Contains(t, callbackPolicyIDs, "policy1")
+	assert.True(t, callbackPolicyIDs["policy1"], "policy callback should signal success after version bump")
+
+	got := fm.usedVars["test/path"]
+	assert.Equal(t, 2, got.Version)
+	assert.Equal(t, "newvalue", got.Value)
 }
 
 func TestNewFleetSecretsManager(t *testing.T) {

--- a/agent/secretsmgr/fleet_test.go
+++ b/agent/secretsmgr/fleet_test.go
@@ -39,17 +39,7 @@ func TestFleetSecretsManager_processString(t *testing.T) {
 		fm.responseTopic = "test/response"
 		fm.updatedTopic = "test/updated"
 
-		// Create a mock publisher that simulates async responses
-		mockPub := &asyncMockPublisher{
-			fm: fm,
-			responseSecrets: []messages.SecretValue{
-				{
-					Path:    "orb/agents/database/password",
-					Value:   "secretvalue",
-					Version: 1,
-				},
-			},
-		}
+		mockPub := &asyncMockPublisher{fm: fm}
 		fm.publisher = mockPub
 		fm.subscriber = &mockSubscriber{}
 
@@ -216,31 +206,149 @@ func TestFleetSecretsManager_RegisterUpdatePoliciesCallback(t *testing.T) {
 	assert.True(t, called)
 }
 
+func TestFleetSecretsManager_SolvePolicySecrets_batchesUncachedPaths(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fm := NewFleetSecretsManager(logger, config.FleetSecretsManager{Timeout: intPtr(5)})
+	fm.ctx = ctx
+	fm.requestTopic = "test/request"
+	fm.responseTopic = "test/response"
+	fm.updatedTopic = "test/updated"
+
+	var publishCount int
+	mockPub := &asyncMockPublisher{
+		fm: fm,
+		onPublish: func() {
+			publishCount++
+		},
+	}
+	fm.publisher = mockPub
+	fm.subscriber = &mockSubscriber{}
+
+	payload := config.PolicyPayload{
+		ID: "policy-batch",
+		Data: map[string]any{
+			"a":    "${fleet://path/one}",
+			"b":    []any{"${fleet://path/two}", map[string]any{"c": "${fleet://path/three}"}},
+			"same": "${fleet://path/one}",
+		},
+	}
+
+	out, err := fm.SolvePolicySecrets(payload)
+	require.NoError(t, err)
+	assert.Equal(t, 1, publishCount, "expected one batched MQTT request for multiple uncached paths")
+
+	data, ok := out.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "secretvalue", data["a"])
+	assert.Equal(t, "secretvalue", data["same"])
+	slc, ok := data["b"].([]any)
+	require.True(t, ok)
+	assert.Equal(t, "secretvalue", slc[0])
+	nested, ok := slc[1].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "secretvalue", nested["c"])
+}
+
+func TestFleetSecretsManager_SolvePolicySecrets_batchPartialDoesNotCache(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fm := NewFleetSecretsManager(logger, config.FleetSecretsManager{Timeout: intPtr(5)})
+	fm.ctx = ctx
+	fm.requestTopic = "test/request"
+	fm.responseTopic = "test/response"
+	fm.updatedTopic = "test/updated"
+
+	mockPub := &asyncMockPublisher{
+		fm: fm,
+		customResponse: func(req messages.SecretRequestMsg) *messages.SecretResponseMsg {
+			require.Len(t, req.Secrets, 2)
+			var goodPath, badPath string
+			for _, s := range req.Secrets {
+				switch s.Path {
+				case "path/good":
+					goodPath = s.Path
+				case "path/bad":
+					badPath = s.Path
+				}
+			}
+			require.NotEmpty(t, goodPath)
+			require.NotEmpty(t, badPath)
+			return &messages.SecretResponseMsg{
+				SchemaVersion: messages.CurrentSecretsSchemaVersion,
+				RequestID:     req.RequestID,
+				Timestamp:     time.Now(),
+				Status:        "partial",
+				Secrets: []messages.SecretValue{
+					{Path: goodPath, Value: "ok", Version: 1},
+				},
+				Errors: []messages.SecretError{
+					{Path: badPath, Error: "not found", Code: messages.ErrorCodeNotFound},
+				},
+			}
+		},
+	}
+	fm.publisher = mockPub
+	fm.subscriber = &mockSubscriber{}
+
+	payload := config.PolicyPayload{
+		ID: "policy-partial",
+		Data: map[string]any{
+			"x": "${fleet://path/good}",
+			"y": "${fleet://path/bad}",
+		},
+	}
+
+	_, err := fm.SolvePolicySecrets(payload)
+	require.Error(t, err)
+	assert.Empty(t, fm.usedVars, "failed batch must not populate cache")
+}
+
 // Helper functions and mocks
 
 // asyncMockPublisher simulates async MQTT responses for testing
 type asyncMockPublisher struct {
-	fm              *FleetSecretsManager
-	responseSecrets []messages.SecretValue
+	fm             *FleetSecretsManager
+	customResponse func(req messages.SecretRequestMsg) *messages.SecretResponseMsg
+	onPublish      func()
 }
 
 func (m *asyncMockPublisher) Publish(_ context.Context, _ string, payload []byte) error {
-	// Parse the request to get the request ID
 	var req messages.SecretRequestMsg
 	if err := json.Unmarshal(payload, &req); err != nil {
 		return err
 	}
 
-	// Simulate async response in a goroutine
-	go func() {
-		time.Sleep(10 * time.Millisecond) // Small delay to simulate network
+	if m.onPublish != nil {
+		m.onPublish()
+	}
 
-		response := messages.SecretResponseMsg{
-			SchemaVersion: messages.CurrentSecretsSchemaVersion,
-			RequestID:     req.RequestID,
-			Timestamp:     time.Now(),
-			Status:        "success",
-			Secrets:       m.responseSecrets,
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+
+		var response messages.SecretResponseMsg
+		if m.customResponse != nil {
+			response = *m.customResponse(req)
+		} else {
+			secrets := make([]messages.SecretValue, len(req.Secrets))
+			for i, sr := range req.Secrets {
+				secrets[i] = messages.SecretValue{
+					Path:    sr.Path,
+					Value:   "secretvalue",
+					Version: 1,
+				}
+			}
+			response = messages.SecretResponseMsg{
+				SchemaVersion: messages.CurrentSecretsSchemaVersion,
+				RequestID:     req.RequestID,
+				Timestamp:     time.Now(),
+				Status:        "success",
+				Secrets:       secrets,
+			}
 		}
 
 		responsePayload, _ := json.Marshal(response)


### PR DESCRIPTION
## Summary

Batch-resolve uncached `\${fleet://}` secret paths in one MQTT `SecretRequestMsg` round-trip per policy/config solve, instead of sequential requests. `requestSecret` remains a thin path for update notifications.

## What changed

- Collect all fleet secret paths during a solve; resolve missing cache entries in one publish.
- Tests: async mock extended; asserts single publish for multiple paths and no cache population on partial failure.

## How tested

- `make fix-lint`
- `go test -race ./agent/secretsmgr/... -run FleetSecrets`

## Linear

https://linear.app/netboxlabs/issue/OBS-1946/gafeatfleet-solve-secrets-in-single-request-rather-than-sequentially

Made with [Cursor](https://cursor.com)