### PR TITLE
chore(docker): bump pip to 26.1 in agent image

### DIFF
--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -36,7 +36,7 @@ FROM orbcommunity/pktvisor:${PKTVISOR_TAG} AS pktvisor
 FROM python:3.14-slim-trixie AS python-builder
 
 # Upgrade pip to latest version (26.0) with fewer vulnerabilities
-RUN python -m pip install --upgrade --no-cache-dir pip==26.0 && \
+RUN python -m pip install --upgrade --no-cache-dir pip==26.1 && \
     rm -rf /usr/local/lib/python3.14/ensurepip/_bundled/pip-*.whl
 
 # Install Python packages

--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -35,7 +35,7 @@ FROM orbcommunity/pktvisor:${PKTVISOR_TAG} AS pktvisor
 ########################################################################
 FROM python:3.14-slim-trixie AS python-builder
 
-# Upgrade pip to latest version (26.0) with fewer vulnerabilities
+# Upgrade pip to latest version with fewer vulnerabilities
 RUN python -m pip install --upgrade --no-cache-dir pip==26.1 && \
     rm -rf /usr/local/lib/python3.14/ensurepip/_bundled/pip-*.whl
 
@@ -53,7 +53,7 @@ RUN \
 
 RUN mkdir -p /opt/orb
 
-# Copy Python site-packages and binaries from builder (includes pip 25.3 and package executables)
+# Copy Python site-packages and binaries from builder (includes pip and package executables)
 COPY --from=python-builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
 COPY --from=python-builder /usr/local/bin /usr/local/bin
 


### PR DESCRIPTION
## Summary

Bump the pinned `pip` version in the agent Docker image from 26.0 to 26.1.

## What changed

- `agent/docker/Dockerfile`: `pip==26.0` → `pip==26.1` in the Python upgrade step.

## How tested

- Not run (Dockerfile-only change). Recommend `make agent_fast` or CI image build if you want a build smoke check.


Made with [Cursor](https://cursor.com)