### PR TITLE
fix(OBS-2566): log diode ingest OTLP request at debug

### DIFF
--- a/agent/otlpbridge/handlers.go
+++ b/agent/otlpbridge/handlers.go
@@ -91,7 +91,7 @@ func (s *logsServer) Export(ctx context.Context, req *collectorlogs.ExportLogsSe
 	if isIngest {
 		repo := s.bridge.GetPolicyRepo()
 		enrichLogsWithDatasets(req, repo)
-		s.bridge.logger.Info("ingesting enriched logs with dataset_ids", "request", req)
+		s.bridge.logger.Debug("ingesting enriched logs with dataset_ids", "request", req)
 	}
 
 	payload, err := s.bridge.enc.Marshal(req)


### PR DESCRIPTION
## Summary
Downgrades the OTLP logs export path log line that dumps the full `ExportLogsServiceRequest` when enriching Diode ingest payloads with `dataset_ids`. It now uses **debug** instead of **info**, reducing noisy and potentially large payload logs at default log levels.

## What changed
- `agent/otlpbridge/handlers.go`: `logger.Info(...)` → `logger.Debug(...)` for the post-enrichment ingest message.

## How tested
- `make fix-lint`
- `go test ./agent/otlpbridge/...`

## Linear
OBS-2566 — https://linear.app/netboxlabs/issue/OBS-2566/downgrade-diode-ingestion-payload-logs-from-info-to-debug

Made with [Cursor](https://cursor.com)