### PR TITLE
chore(security): bump Go to 1.26.3, go-git to v5.19.0, drop bundled pip wheel

### DIFF
--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -2,7 +2,7 @@ ARG PKTVISOR_TAG=develop
 ARG OTEL_TAG=develop
 ARG NETWORK_DISCOVERY_TAG=latest
 ARG SNMP_DISCOVERY_TAG=latest
-ARG GO_VERSION=1.26
+ARG GO_VERSION=1.26.3
 
 ########################################################################
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-trixie AS builder
@@ -49,7 +49,8 @@ RUN \
     apt update && \
     apt install --yes --no-install-recommends ca-certificates git nmap openssh-client tini && \
     update-ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /usr/local/lib/python3.14/ensurepip/_bundled/pip-*.whl
 
 RUN mkdir -p /opt/orb
 

--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -50,7 +50,9 @@ RUN \
     apt install --yes --no-install-recommends ca-certificates git nmap openssh-client tini && \
     update-ca-certificates && \
     rm -rf /var/lib/apt/lists/* && \
-    rm -rf /usr/local/lib/python3.14/ensurepip/_bundled/pip-*.whl
+    sed -i 's/_PIP_VERSION = "26.0.1"/_PIP_VERSION = "26.1"/' /usr/local/lib/python3.14/ensurepip/__init__.py && \
+    rm -f /usr/local/lib/python3.14/ensurepip/_bundled/pip-*.whl && \
+    python -m pip download pip==26.1 --no-deps --no-cache-dir -d /usr/local/lib/python3.14/ensurepip/_bundled/
 
 RUN mkdir -p /opt/orb
 

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/netboxlabs/orb-agent
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/eclipse/paho.golang v0.23.0
 	github.com/go-cmd/cmd v1.4.3
 	github.com/go-co-op/gocron/v2 v2.20.0
-	github.com/go-git/go-git/v5 v5.18.0
+	github.com/go-git/go-git/v5 v5.19.0
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/vault/api v1.23.0
@@ -50,7 +50,7 @@ require (
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
-	github.com/go-git/go-billy/v5 v5.8.0 // indirect
+	github.com/go-git/go-billy/v5 v5.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -93,7 +93,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
-	github.com/pjbgf/sha1cd v0.5.0 // indirect
+	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,10 +65,14 @@ github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 h1:+zs/tPmkDkHx3U66D
 github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376/go.mod h1:an3vInlBmSxCcxctByoQdvwPiA7DTK7jaaFDBTtu0ic=
 github.com/go-git/go-billy/v5 v5.8.0 h1:I8hjc3LbBlXTtVuFNJuwYuMiHvQJDq1AT6u4DwDzZG0=
 github.com/go-git/go-billy/v5 v5.8.0/go.mod h1:RpvI/rw4Vr5QA+Z60c6d6LXH0rYJo0uD5SqfmrrheCY=
+github.com/go-git/go-billy/v5 v5.9.0 h1:jItGXszUDRtR/AlferWPTMN4j38BQ88XnXKbilmmBPA=
+github.com/go-git/go-billy/v5 v5.9.0/go.mod h1:jCnQMLj9eUgGU7+ludSTYoZL/GGmii14RxKFj7ROgHw=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
 github.com/go-git/go-git/v5 v5.18.0 h1:O831KI+0PR51hM2kep6T8k+w0/LIAD490gvqMCvL5hM=
 github.com/go-git/go-git/v5 v5.18.0/go.mod h1:pW/VmeqkanRFqR6AljLcs7EA7FbZaN5MQqO7oZADXpo=
+github.com/go-git/go-git/v5 v5.19.0 h1:+WkVUQZSy/F1Gb13udrMKjIM2PrzsNfDKFSfo5tkMtc=
+github.com/go-git/go-git/v5 v5.19.0/go.mod h1:Pb1v0c7/g8aGQJwx9Us09W85yGoyvSwuhEGMH7zjDKQ=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -192,6 +196,8 @@ github.com/pierrec/lz4 v2.6.1+incompatible h1:9UY3+iC23yxF0UfGaYrGplQ+79Rg+h/q9F
 github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pjbgf/sha1cd v0.5.0 h1:a+UkboSi1znleCDUNT3M5YxjOnN1fz2FhN48FlwCxs0=
 github.com/pjbgf/sha1cd v0.5.0/go.mod h1:lhpGlyHLpQZoxMv8HcgXvZEhcGs0PG/vsZnEJ7H0iCM=
+github.com/pjbgf/sha1cd v0.6.0 h1:3WJ8Wz8gvDz29quX1OcEmkAlUg9diU4GxJHqs0/XiwU=
+github.com/pjbgf/sha1cd v0.6.0/go.mod h1:lhpGlyHLpQZoxMv8HcgXvZEhcGs0PG/vsZnEJ7H0iCM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
## Summary
Clear the vulnerability-scan failures that are currently blocking other PRs (`Vulnerability Scan: Failed — blocking vulnerabilities detected` on `orb-agent:scan`).

- **Go stdlib (orb-agent binary)**: bump the Dockerfile builder + the `go.mod` `go` directive from `1.26.2` → `1.26.3`.
- **`github.com/go-git/go-git/v5`**: `5.18.0` → `5.19.0`.
- **pip bundled wheel**: delete `/usr/local/lib/python3.14/ensurepip/_bundled/pip-*.whl` in the final image stage so the scanner stops finding the pip 26.0.1 wheel inherited from `python:3.14-slim-trixie` (`pip` itself is already pinned to 26.1 in `python-builder`).

The `network-discovery` / `snmp-discovery` stdlib findings are addressed in the matching orb-discovery PR (netboxlabs/orb-discovery#406) — that PR rebuilds those binaries on Go 1.26.3 and the new images become available via `FROM netboxlabs/network-discovery:latest` / `FROM netboxlabs/snmp-discovery:latest` here.

## CVEs cleared by this PR

| Source | CVE | Severity |
|---|---|---|
| Go stdlib (orb-agent binary) | CVE-2026-33811 | HIGH |
| Go stdlib (orb-agent binary) | CVE-2026-33814 | HIGH |
| Go stdlib (orb-agent binary) | CVE-2026-39820 | HIGH |
| Go stdlib (orb-agent binary) | CVE-2026-39836 | HIGH |
| Go stdlib (orb-agent binary) | CVE-2026-42499 | HIGH |
| Go stdlib (orb-agent binary) | CVE-2026-39823 | MEDIUM |
| Go stdlib (orb-agent binary) | CVE-2026-39825 | MEDIUM |
| Go stdlib (orb-agent binary) | CVE-2026-39826 | MEDIUM |
| go-git/go-git/v5 | CVE-2026-45022 | HIGH |
| pip | CVE-2026-6357 | MEDIUM |

## Test plan
- [x] `go build ./...` passes under 1.26.3 + go-git v5.19.0
- [x] `go test ./agent/configmgr/...` (the go-git consumer) passes
- [ ] CI image build succeeds and the next vulnerability scan shows no remaining `orb-agent` / `pip` rows
- [ ] After netboxlabs/orb-discovery#406 lands and republishes the discovery images, re-running the scan on this branch also clears the `network-discovery` / `snmp-discovery` rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)