### PR TITLE
fix: updates the list of algorithms used to parse JWT

### DIFF
--- a/agent/configmgr/fleet/auth.go
+++ b/agent/configmgr/fleet/auth.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 
 	"github.com/netboxlabs/orb-agent/agent/redact"
@@ -278,7 +277,7 @@ func parseJWTExpiry(tokenString string) (time.Time, error) {
 	}
 
 	// Parse the JWT token without verification
-	token, err := jwt.ParseSigned(tokenString, []jose.SignatureAlgorithm{jose.HS256, jose.HS384, jose.HS512, jose.RS256, jose.RS384, jose.RS512, jose.ES256, jose.ES384, jose.ES512})
+	token, err := jwt.ParseSigned(tokenString, jwtParseSignatureAlgorithms)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("failed to parse JWT token: %w", err)
 	}

--- a/agent/configmgr/fleet/jwt_claims.go
+++ b/agent/configmgr/fleet/jwt_claims.go
@@ -7,6 +7,15 @@ import (
 	"github.com/go-jose/go-jose/v4/jwt"
 )
 
+// jwtParseSignatureAlgorithms lists algorithms allowed when parsing tokens from the
+// OAuth token endpoint. EdDSA matches orb-auth (Ed25519 / isc-jwt); others cover common IdPs.
+var jwtParseSignatureAlgorithms = []jose.SignatureAlgorithm{
+	jose.HS256, jose.HS384, jose.HS512,
+	jose.RS256, jose.RS384, jose.RS512,
+	jose.ES256, jose.ES384, jose.ES512,
+	jose.EdDSA,
+}
+
 // JWTClaims represents the JWT claims we extract for topic templating
 type JWTClaims struct {
 	AgentID  string
@@ -23,8 +32,7 @@ func ParseJWTClaims(tokenString string) (*JWTClaims, error) {
 	}
 
 	// Parse the JWT token without verification (since we already trust it from the token endpoint)
-	// We accept common signature algorithms used in JWTs
-	token, err := jwt.ParseSigned(tokenString, []jose.SignatureAlgorithm{jose.HS256, jose.HS384, jose.HS512, jose.RS256, jose.RS384, jose.RS512, jose.ES256, jose.ES384, jose.ES512})
+	token, err := jwt.ParseSigned(tokenString, jwtParseSignatureAlgorithms)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse JWT token: %w", err)
 	}

--- a/agent/configmgr/fleet/jwt_claims_test.go
+++ b/agent/configmgr/fleet/jwt_claims_test.go
@@ -98,6 +98,22 @@ func TestParseJWTClaims(t *testing.T) {
 			},
 		},
 		{
+			name: "EdDSA header (orb-auth style)",
+			tokenString: RawJWTWithClaimsAlg(map[string]any{
+				"orb:org_id":   "test-org",
+				"orb:zone":     "default",
+				"orb:agent_id": "test-agent",
+				"client_id":    "test-client",
+				"iat":          1516239022,
+			}, "EdDSA"),
+			expected: &JWTClaims{
+				OrgID:    "test-org",
+				Zone:     "default",
+				ClientID: "test-client",
+				AgentID:  "test-agent",
+			},
+		},
+		{
 			name: "JWT missing org_id",
 			tokenString: RawJWTWithClaims(map[string]any{
 				"client_id":    "test-client",

--- a/agent/configmgr/fleet/mocks.go
+++ b/agent/configmgr/fleet/mocks.go
@@ -19,8 +19,13 @@ import (
 // RawJWTWithClaims builds a raw JWT string with the given claims.
 // Signature is a dummy value; ParseUnverified only inspects header/payload.
 func RawJWTWithClaims(claims map[string]any) string {
+	return RawJWTWithClaimsAlg(claims, "RS256")
+}
+
+// RawJWTWithClaimsAlg is like RawJWTWithClaims but sets the JWS "alg" header (for tests).
+func RawJWTWithClaimsAlg(claims map[string]any, alg string) string {
 	header := map[string]any{
-		"alg": "RS256",
+		"alg": alg,
 		"kid": "test-key",
 		"typ": "JWT",
 	}


### PR DESCRIPTION
This change extends the shared parse allowlist with jose.EdDSA and uses it for both topic-related claims (ParseJWTClaims) and exp-based refresh timing (parseJWTExpiry). Behavior is unchanged for existing algorithms; we still decode claims without signature verification, as before (token is obtained from the trusted token endpoint).

Tests add RawJWTWithClaimsAlg and a case that uses an EdDSA header so regressions are caught.

[] go test -race ./agent/configmgr/fleet/...
[] make fix-lint