### PR TITLE
docs(snmp_discovery): describe Virtual Chassis (switch-stack) support

### DIFF
--- a/docs/backends/snmp_discovery/README.md
+++ b/docs/backends/snmp_discovery/README.md
@@ -14,10 +14,37 @@ The SNMP discovery backend uses [Diode Go SDK](https://github.com/netboxlabs/dio
 * [Manufacturer](https://github.com/netboxlabs/diode-sdk-go/blob/develop/docs/examples/manufacturer/main.go)
 * [Site](https://github.com/netboxlabs/diode-sdk-go/blob/develop/docs/examples/site/main.go)
 * [VLAN](https://github.com/netboxlabs/diode-sdk-go/blob/develop/docs/examples/vlan/main.go)
+* [VirtualChassis](https://github.com/netboxlabs/diode-sdk-go/blob/develop/docs/examples/virtual_chassis/main.go)
+
+When a target is a switch stack / Virtual Chassis (NetBox `VirtualChassis`), snmp-discovery emits one `VirtualChassis` entity plus one `Device` per stack member, and routes each interface/IP to the member that physically owns it — see [Switch stacks / Virtual Chassis](#switch-stacks--virtual-chassis) below. Standalone switches and devices not in stack mode fall through to the existing single-`Device` path with no change in behaviour.
 
 When a device exposes the relevant MIBs, interfaces also carry their switching configuration: `mode` (`access` / `tagged` / `tagged-all` / unset for routed), the untagged (access/native) VLAN, and the list of tagged VLANs. VLANs referenced on an interface but not present in the device's VLAN database are auto-emitted as VLAN entities so the association is complete in NetBox; this behavior can be disabled via the `create_unknown_vlans` option (see below). Auto-emitted stubs use the placeholder name `VLAN<vid>` (e.g. `VLAN42`) because NetBox's `ipam.vlan.name` is required — operators or sibling switches can later overwrite the placeholder via the same vid+group matcher. VLAN discovery uses Q-BRIDGE-MIB (RFC 4363) as the generic source and a Cisco-specific overlay (CISCO-VLAN-MEMBERSHIP-MIB, CISCO-VOICE-VLAN-MIB) on Cisco devices that don't fully implement Q-BRIDGE — see [SNMP Discovery — Supported Platforms](./supported_platforms.md#interface--vlan-associations) for which device classes are covered.
 
 Note: when a switchport is converted to a routed (L3) interface between discovery cycles, prior `mode`/untagged-VLAN/tagged-VLAN associations are NOT automatically cleared in NetBox; operators must clear them manually. This is a current limitation of the Diode plugin's PATCH semantics and is tracked separately. The same caveat applies on device-discovery.
+
+## Switch stacks / Virtual Chassis
+
+When the target reports 2+ chassis rows in `ENTITY-MIB` (`entPhysicalTable`) with non-empty serials, snmp-discovery emits a NetBox `VirtualChassis` plus one `Device` per stack member, and routes each interface and IP address to the correct member. Detection is vendor-neutral and driven entirely by `entPhysicalClass`, `entPhysicalContainedIn`, and `entPhysicalSerialNum`; no vendor-specific MIB is required. Standalone switches, devices not in stack mode, and members without a serial fall back to the existing single-`Device` path with no change in behaviour.
+
+**Topology patterns detected.** Two valid `ENTITY-MIB` shapes are supported:
+
+| Pattern | Chassis row's `entPhysicalContainedIn` | Used by |
+|---|---|---|
+| Flat | `0` (chassis rows at the ENTITY-MIB root) | Catalyst 9300/3850 stacks, Aruba CX VSF, Juniper EX/QFX Virtual Chassis, HP/H3C IRF, Huawei iStack, Brocade ICX |
+| Wrapped | non-zero, pointing at a `entPhysicalClass = 11` (stack) container | Cisco StackWise Virtual on 9400/9500/9600/etc. |
+
+**Emission shape** (in order):
+
+1. **Master `Device`** — plain (no `vc_position`, no `virtual_chassis` ref). Named `<sysName>` from the SNMP walk; serial taken from the lowest-id chassis row.
+2. **`VirtualChassis`** — named `<sysName>`, with `master` set to the inline matcher block of the master Device.
+3. **N − 1 member `Device` entities** — each named `<sysName>-<memberID>` (matching the format `device_discovery` emits, so the same physical stack discovered by both services lands on the same NetBox rows), carrying `vc_position = <memberID>` and an inline `virtual_chassis` ref pointing to the same matcher block. Per-member serial comes from `entPhysicalSerialNum` on the member's chassis row; per-member model comes from `entPhysicalModelName` when populated.
+4. **Interface / IPAddress entities** — routed to the member that physically owns them. Routing uses `entAliasMappingTable` (RFC 6933) when present, then falls back to ifName parsing: Cisco IOS/IOS-XE/NX-OS 3-tuple (`Gi1/0/1`, `Te2/1/0/3`, etc., including short forms `Te`/`Fo`/`Hu`/`Tw`/`Fi`/`Twe`), Junos FPC, Aruba CX numeric, H3C dashed. Subinterface unit suffixes (`Gi2/0/1.100`) strip to the parent before parsing.
+
+**Member ID derivation.** When `entPhysicalParentRelPos` is populated (`> 0`) it provides the member id directly; otherwise the trailing integer of `entPhysicalName` (`Switch 2`) is used; the final fallback is the ordinal position of the chassis row in the inventory. Master identity is pinned to the **lowest member id present**, regardless of live role — this is required because the Diode plugin resolves an existing `VirtualChassis` via its `unique_master` matcher, and pinning to the lowest id keeps the master Device stable across live stack-role failovers so re-runs upsert the existing VC instead of creating a new one. The other matcher fields used for VC re-identification (asset_tag, primary_ip4/6, name+site+tenant, and `metadata.source_match`) are carried consistently on both the rich master Device and the inline VC `master` ref.
+
+**Member AssetTag is cleared.** Diode's highest-precedence matcher for `dcim.device` is `asset_tag` (unique). The master Device carries the policy `defaults.asset_tag` value if configured; member Devices have it explicitly cleared so multiple members do not collapse onto one NetBox row through a shared asset tag. Master / standalone AssetTag behaviour from `defaults.asset_tag` is unchanged.
+
+**Orphaned member ports.** If a chassis row is dropped from the validated payload (empty serial, duplicate serial collapsed against a lower-id row, etc.) but the device still reports ports owned by that member, those interfaces are **skipped with a WARNING** rather than routed to master. Routing them to master would silently misattribute member-N ports to a different device — operators see the warning in logs and the missing port in NetBox, not a corrupted port→device mapping.
 
 ## Configuration
 The `snmp_discovery` backend does not require any special configuration in the backends section. The backend will use the `diode` settings specified in the `common` subsection to forward discovery results.


### PR DESCRIPTION
## Summary

Documents the Virtual Chassis (switch-stack) support landing in [netboxlabs/orb-discovery#404](https://github.com/netboxlabs/orb-discovery/pull/404). Drafted alongside it so we can land both together.

- Adds `VirtualChassis` to the SNMP discovery Diode entity list.
- New top-of-README mention that snmp-discovery routes interfaces/IPs to the owning stack member when a stack is detected.
- New **Switch stacks / Virtual Chassis** section covering:
  - The two ENTITY-MIB topology patterns we detect (flat root chassis, vs. wrapped under a `entPhysicalClass = 11` stack container — the latter is required for Cisco StackWise Virtual on the 9400/9500/9600 series).
  - The Diode emission shape: master Device plain, top-level `VirtualChassis`, N-1 member Devices with `vc_position` and inline `virtual_chassis` ref.
  - Member naming convention `<sysName>-<memberID>` — explicitly aligned with `device_discovery.translate_chassis._one`'s format so the same physical stack discovered by both backends lands on the same NetBox rows instead of duplicating.
  - Member id derivation (`entPhysicalParentRelPos` → `entPhysicalName` trailing-int → ordinal fallback) and lowest-id master pinning rationale.
  - The "member AssetTag is cleared" rule that prevents matcher collisions when `defaults.asset_tag` is configured.
  - Interface routing precedence: `entAliasMappingTable` first (RFC 6933), then ifName parsing across Cisco IOS/IOS-XE/NX-OS 3-tuple (incl. short forms `Te`/`Fo`/`Hu`/`Tw`/`Fi`/`Twe`), Junos FPC, Aruba CX numeric, H3C dashed.
  - Dropped-member skip-with-warn behaviour (orphaned ports never silently route to master).

Mirrors the structure of the existing `device_discovery` Virtual Chassis documentation for consistency.

## Test plan

- [ ] Render the README locally / on the docs preview and verify the new section reads cleanly.
- [ ] Cross-reference against [orb-discovery#404](https://github.com/netboxlabs/orb-discovery/pull/404) — once that PR lands, un-draft and merge this.

Draft because it depends on orb-discovery#404 merging first.