### PR TITLE
fix(fleet): correct policy-count log; split RPC trace from active count (OBS-1727)

### DIFF
--- a/agent/configmgr/fleet/from_rpc.go
+++ b/agent/configmgr/fleet/from_rpc.go
@@ -159,30 +159,39 @@ func (messaging *Messaging) handleAgentPolicies(rpc []messages.AgentPolicyRPCPay
 		}
 	}
 
+	applied := 0
+	skipped := 0
 	for _, payload := range rpc {
-		if payload.Action != "sanitize" {
-			// If the policy data is a string and Format is "yaml" (or empty), try to unmarshal it as YAML
-			// This handles cases where Format="yaml" or where the backend sends YAML without setting Format
-			if dataStr, ok := payload.Data.(string); ok && dataStr != "" && (payload.Format == "yaml" || payload.Format == "") {
-				var structuredData map[string]any
-				if err := yaml.Unmarshal([]byte(dataStr), &structuredData); err != nil {
-					// If unmarshaling fails, log a warning only if Format was explicitly set to yaml
-					if payload.Format == "yaml" {
-						messaging.logger.Warn("failed to unmarshal YAML policy data",
-							"policy_id", payload.ID,
-							"policy_name", payload.Name,
-							"error", err)
-					}
-					// Continue with original string data - let the backend handle it
-				} else {
-					// Successfully unmarshaled - use the structured data
-					payload.Data = structuredData
-				}
-			}
-			messaging.policyManager.ManagePolicy(config.PolicyPayload(payload))
+		if payload.Action == "sanitize" {
+			skipped++
+			continue
 		}
+		// If the policy data is a string and Format is "yaml" (or empty), try to unmarshal it as YAML
+		// This handles cases where Format="yaml" or where the backend sends YAML without setting Format
+		if dataStr, ok := payload.Data.(string); ok && dataStr != "" && (payload.Format == "yaml" || payload.Format == "") {
+			var structuredData map[string]any
+			if err := yaml.Unmarshal([]byte(dataStr), &structuredData); err != nil {
+				// If unmarshaling fails, log a warning only if Format was explicitly set to yaml
+				if payload.Format == "yaml" {
+					messaging.logger.Warn("failed to unmarshal YAML policy data",
+						"policy_id", payload.ID,
+						"policy_name", payload.Name,
+						"error", err)
+				}
+				// Continue with original string data - let the backend handle it
+			} else {
+				// Successfully unmarshaled - use the structured data
+				payload.Data = structuredData
+			}
+		}
+		messaging.policyManager.ManagePolicy(config.PolicyPayload(payload))
+		applied++
 	}
-	messaging.logger.Info("successfully processed agent policies", "count", len(rpc))
+	fields := []any{"applied", applied}
+	if skipped > 0 {
+		fields = append(fields, "skipped", skipped)
+	}
+	messaging.logger.Info("successfully processed agent policies", fields...)
 }
 
 func (messaging *Messaging) handleAgentGroupRemoval(rpc messages.GroupRemovedRPCPayload, unsubscribeFromTopic func(topic string) error) {

--- a/agent/configmgr/fleet/from_rpc.go
+++ b/agent/configmgr/fleet/from_rpc.go
@@ -185,6 +185,7 @@ func (messaging *Messaging) handleAgentPolicies(rpc []messages.AgentPolicyRPCPay
 			}
 		}
 		messaging.policyManager.ManagePolicy(config.PolicyPayload(payload))
+		// counts payloads submitted to ManagePolicy; not backend-confirmed applies
 		applied++
 	}
 	fields := []any{"applied", applied}

--- a/agent/configmgr/fleet/from_rpc.go
+++ b/agent/configmgr/fleet/from_rpc.go
@@ -185,14 +185,20 @@ func (messaging *Messaging) handleAgentPolicies(rpc []messages.AgentPolicyRPCPay
 			}
 		}
 		messaging.policyManager.ManagePolicy(config.PolicyPayload(payload))
-		// counts payloads submitted to ManagePolicy; not backend-confirmed applies
 		applied++
 	}
-	fields := []any{"applied", applied}
+	debugFields := []any{"applied", applied}
 	if skipped > 0 {
-		fields = append(fields, "skipped", skipped)
+		debugFields = append(debugFields, "skipped", skipped)
 	}
-	messaging.logger.Info("successfully processed agent policies", fields...)
+	messaging.logger.Debug("agent_policy RPC handled", debugFields...)
+
+	active, err := messaging.policyManager.GetPolicyState()
+	if err != nil {
+		messaging.logger.Warn("failed to read active policy count after RPC", "error", err)
+		return
+	}
+	messaging.logger.Info("agent policies active", "count", len(active))
 }
 
 func (messaging *Messaging) handleAgentGroupRemoval(rpc messages.GroupRemovedRPCPayload, unsubscribeFromTopic func(topic string) error) {

--- a/agent/configmgr/fleet/from_rpc.go
+++ b/agent/configmgr/fleet/from_rpc.go
@@ -191,10 +191,10 @@ func (messaging *Messaging) handleAgentPolicies(rpc []messages.AgentPolicyRPCPay
 
 	managed, err := messaging.policyManager.GetPolicyState()
 	if err != nil {
-		messaging.logger.Warn("failed to read managed policy count after RPC", "error", err)
+		messaging.logger.Warn("failed to read agent managed policy count after RPC", "error", err)
 		return
 	}
-	messaging.logger.Info("managed policies", "count", len(managed))
+	messaging.logger.Info("agent managed policies", "count", len(managed))
 }
 
 func (messaging *Messaging) handleAgentGroupRemoval(rpc messages.GroupRemovedRPCPayload, unsubscribeFromTopic func(topic string) error) {

--- a/agent/configmgr/fleet/from_rpc.go
+++ b/agent/configmgr/fleet/from_rpc.go
@@ -187,18 +187,14 @@ func (messaging *Messaging) handleAgentPolicies(rpc []messages.AgentPolicyRPCPay
 		messaging.policyManager.ManagePolicy(config.PolicyPayload(payload))
 		applied++
 	}
-	debugFields := []any{"applied", applied}
-	if skipped > 0 {
-		debugFields = append(debugFields, "skipped", skipped)
-	}
-	messaging.logger.Debug("agent_policy RPC handled", debugFields...)
+	messaging.logger.Debug("agent_policy RPC handled", "applied", applied, "skipped", skipped)
 
-	active, err := messaging.policyManager.GetPolicyState()
+	managed, err := messaging.policyManager.GetPolicyState()
 	if err != nil {
-		messaging.logger.Warn("failed to read active policy count after RPC", "error", err)
+		messaging.logger.Warn("failed to read managed policy count after RPC", "error", err)
 		return
 	}
-	messaging.logger.Info("agent policies active", "count", len(active))
+	messaging.logger.Info("managed policies", "count", len(managed))
 }
 
 func (messaging *Messaging) handleAgentGroupRemoval(rpc messages.GroupRemovedRPCPayload, unsubscribeFromTopic func(topic string) error) {

--- a/agent/configmgr/fleet/from_rpc_test.go
+++ b/agent/configmgr/fleet/from_rpc_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
 	"testing"
@@ -783,16 +784,18 @@ func TestMessageHandlers_handleAgentPolicies_SkipsSanitizeAction(t *testing.T) {
 // correct applied/skipped counters and omits skipped when zero.
 func TestMessageHandlers_handleAgentPolicies_LogCounters(t *testing.T) {
 	tests := []struct {
-		name        string
-		payloads    []messages.AgentPolicyRPCPayload
-		wantApplied float64
-		wantSkipped float64 // 0 means the key must be absent
+		name            string
+		payloads        []messages.AgentPolicyRPCPayload
+		wantApplied     float64
+		wantSkipped     float64 // 0 means the key must be absent
+		wantManageCalls int
 	}{
 		{
-			name:        "sanitize-only payload reports applied=0 and skipped=1",
-			payloads:    []messages.AgentPolicyRPCPayload{{Action: "sanitize", ID: "p1", Name: "n1", Backend: "pktvisor"}},
-			wantApplied: 0,
-			wantSkipped: 1,
+			name:            "sanitize-only payload reports applied=0 and skipped=1",
+			payloads:        []messages.AgentPolicyRPCPayload{{Action: "sanitize", ID: "p1", Name: "n1", Backend: "pktvisor"}},
+			wantApplied:     0,
+			wantSkipped:     1,
+			wantManageCalls: 0,
 		},
 		{
 			name: "apply-only payloads omit the skipped key",
@@ -800,8 +803,9 @@ func TestMessageHandlers_handleAgentPolicies_LogCounters(t *testing.T) {
 				{Action: "apply", ID: "p1", Name: "n1", Backend: "pktvisor", Data: map[string]any{}},
 				{Action: "apply", ID: "p2", Name: "n2", Backend: "pktvisor", Data: map[string]any{}},
 			},
-			wantApplied: 2,
-			wantSkipped: 0,
+			wantApplied:     2,
+			wantSkipped:     0,
+			wantManageCalls: 2,
 		},
 		{
 			name: "mixed payloads report both counters",
@@ -810,8 +814,9 @@ func TestMessageHandlers_handleAgentPolicies_LogCounters(t *testing.T) {
 				{Action: "sanitize", ID: "p2", Name: "n2", Backend: "pktvisor"},
 				{Action: "sanitize", ID: "p3", Name: "n3", Backend: "pktvisor"},
 			},
-			wantApplied: 1,
-			wantSkipped: 2,
+			wantApplied:     1,
+			wantSkipped:     2,
+			wantManageCalls: 1,
 		},
 	}
 
@@ -836,8 +841,24 @@ func TestMessageHandlers_handleAgentPolicies_LogCounters(t *testing.T) {
 			} else {
 				assert.Equal(t, tc.wantSkipped, record["skipped"], "skipped counter mismatch")
 			}
+			// the old "count" field must not be re-introduced
+			_, hasCount := record["count"]
+			assert.False(t, hasCount, "legacy 'count' key must not be present")
+			assert.Equal(t, tc.wantManageCalls, mockCallCount(mockPMgr, "ManagePolicy"), "ManagePolicy call count mismatch")
 		})
 	}
+}
+
+// mockCallCount returns the number of times the given method was invoked on a
+// testify mock.
+func mockCallCount(m *mockPolicyManager, method string) int {
+	n := 0
+	for _, call := range m.Calls {
+		if call.Method == method {
+			n++
+		}
+	}
+	return n
 }
 
 // findLogRecord scans newline-delimited JSON slog output and returns the first
@@ -856,7 +877,7 @@ func findLogRecord(out []byte, msg string, dst *map[string]any) error {
 			return nil
 		}
 	}
-	return assert.AnError
+	return fmt.Errorf("no log record matching message %q", msg)
 }
 
 // Test handleAgentPolicies with fullList=true but GetAll fails

--- a/agent/configmgr/fleet/from_rpc_test.go
+++ b/agent/configmgr/fleet/from_rpc_test.go
@@ -187,6 +187,7 @@ func TestMessageHandlers_DispatchToHandlers(t *testing.T) {
 			expectedTopics: []string{},
 			setupMocks: func(m *mockPolicyManager) {
 				m.On("ManagePolicy", mock.Anything).Return()
+				m.On("GetPolicyState").Return([]policies.PolicyData{}, nil)
 			},
 			expectedError:         false,
 			expectedPolicyMgrCall: true,
@@ -660,6 +661,7 @@ func TestMessageHandlers_handleAgentPolicies_NotFullList(t *testing.T) {
 	mockPMgr.On("ManagePolicy", mock.MatchedBy(func(p config.PolicyPayload) bool {
 		return p.ID == "policy1" && p.Action == "apply"
 	})).Return()
+	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{}, nil)
 
 	// Create policy payload
 	policies := []messages.AgentPolicyRPCPayload{
@@ -725,6 +727,7 @@ func TestMessageHandlers_handleAgentPolicies_FullList_RemovesOldPolicies(t *test
 	mockPMgr.On("ManagePolicy", mock.MatchedBy(func(p config.PolicyPayload) bool {
 		return p.ID == "policy1" && p.Action == "apply"
 	})).Return()
+	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{{ID: "policy1"}}, nil)
 
 	// Create new policy list (only policy1, so policy2 should be removed)
 	newPolicies := []messages.AgentPolicyRPCPayload{
@@ -754,6 +757,7 @@ func TestMessageHandlers_handleAgentPolicies_SkipsSanitizeAction(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManager{}
+	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{}, nil)
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
 	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
@@ -780,8 +784,9 @@ func TestMessageHandlers_handleAgentPolicies_SkipsSanitizeAction(t *testing.T) {
 	mockPMgr.AssertNotCalled(t, "ManagePolicy", mock.Anything)
 }
 
-// Test that the "successfully processed agent policies" log records the
-// correct applied/skipped counters and omits skipped when zero.
+// Test that handleAgentPolicies emits the DEBUG RPC-shape line with
+// applied/skipped counters (omitting skipped when zero) and the INFO
+// "agent policies active" line reflecting the repo state after handling.
 func TestMessageHandlers_handleAgentPolicies_LogCounters(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -789,16 +794,20 @@ func TestMessageHandlers_handleAgentPolicies_LogCounters(t *testing.T) {
 		wantApplied     float64
 		wantSkipped     float64 // 0 means the key must be absent
 		wantManageCalls int
+		repoState       []policies.PolicyData
+		wantActiveCount float64
 	}{
 		{
-			name:            "sanitize-only payload reports applied=0 and skipped=1",
+			name:            "sanitize-only payload: applied=0, skipped=1, no policies active",
 			payloads:        []messages.AgentPolicyRPCPayload{{Action: "sanitize", ID: "p1", Name: "n1", Backend: "pktvisor"}},
 			wantApplied:     0,
 			wantSkipped:     1,
 			wantManageCalls: 0,
+			repoState:       []policies.PolicyData{},
+			wantActiveCount: 0,
 		},
 		{
-			name: "apply-only payloads omit the skipped key",
+			name: "apply-only payloads: skipped key absent, repo reflects applied policies",
 			payloads: []messages.AgentPolicyRPCPayload{
 				{Action: "apply", ID: "p1", Name: "n1", Backend: "pktvisor", Data: map[string]any{}},
 				{Action: "apply", ID: "p2", Name: "n2", Backend: "pktvisor", Data: map[string]any{}},
@@ -806,9 +815,11 @@ func TestMessageHandlers_handleAgentPolicies_LogCounters(t *testing.T) {
 			wantApplied:     2,
 			wantSkipped:     0,
 			wantManageCalls: 2,
+			repoState:       []policies.PolicyData{{ID: "p1"}, {ID: "p2"}},
+			wantActiveCount: 2,
 		},
 		{
-			name: "mixed payloads report both counters",
+			name: "mixed payloads: both counters present, repo reflects only applied",
 			payloads: []messages.AgentPolicyRPCPayload{
 				{Action: "apply", ID: "p1", Name: "n1", Backend: "pktvisor", Data: map[string]any{}},
 				{Action: "sanitize", ID: "p2", Name: "n2", Backend: "pktvisor"},
@@ -817,33 +828,47 @@ func TestMessageHandlers_handleAgentPolicies_LogCounters(t *testing.T) {
 			wantApplied:     1,
 			wantSkipped:     2,
 			wantManageCalls: 1,
+			repoState:       []policies.PolicyData{{ID: "p1"}},
+			wantActiveCount: 1,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+			logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 			mockPMgr := &mockPolicyManager{}
 			mockPMgr.On("ManagePolicy", mock.Anything).Return()
+			mockPMgr.On("GetPolicyState").Return(tc.repoState, nil)
 			resetChan := make(chan struct{}, 1)
 			groupManager := newGroupManager()
 			handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
 
 			handlers.handleAgentPolicies(tc.payloads, false)
 
-			var record map[string]any
-			require.NoError(t, findLogRecord(buf.Bytes(), "successfully processed agent policies", &record))
-			assert.Equal(t, tc.wantApplied, record["applied"], "applied counter mismatch")
+			// DEBUG line: RPC shape.
+			var debugRec map[string]any
+			require.NoError(t, findLogRecord(buf.Bytes(), "agent_policy RPC handled", &debugRec))
+			assert.Equal(t, "DEBUG", debugRec["level"], "RPC line must be DEBUG")
+			assert.Equal(t, tc.wantApplied, debugRec["applied"], "applied counter mismatch")
 			if tc.wantSkipped == 0 {
-				_, present := record["skipped"]
+				_, present := debugRec["skipped"]
 				assert.False(t, present, "skipped key should be absent when zero")
 			} else {
-				assert.Equal(t, tc.wantSkipped, record["skipped"], "skipped counter mismatch")
+				assert.Equal(t, tc.wantSkipped, debugRec["skipped"], "skipped counter mismatch")
 			}
-			// the old "count" field must not be re-introduced
-			_, hasCount := record["count"]
-			assert.False(t, hasCount, "legacy 'count' key must not be present")
+
+			// INFO line: active count from repo state.
+			var infoRec map[string]any
+			require.NoError(t, findLogRecord(buf.Bytes(), "agent policies active", &infoRec))
+			assert.Equal(t, "INFO", infoRec["level"], "active-count line must be INFO")
+			assert.Equal(t, tc.wantActiveCount, infoRec["count"], "active count mismatch")
+
+			// Legacy combined log message must not be re-introduced.
+			var legacy map[string]any
+			assert.Error(t, findLogRecord(buf.Bytes(), "successfully processed agent policies", &legacy),
+				"legacy combined log message must not be emitted")
+
 			assert.Equal(t, tc.wantManageCalls, mockCallCount(mockPMgr, "ManagePolicy"), "ManagePolicy call count mismatch")
 		})
 	}
@@ -1482,6 +1507,7 @@ func TestMessageHandlers_handleAgentPolicies_YAMLStringData(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManager{}
+	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{}, nil)
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
 	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
@@ -1533,6 +1559,7 @@ func TestMessageHandlers_handleAgentPolicies_StructuredData(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManager{}
+	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{}, nil)
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
 	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
@@ -1587,6 +1614,7 @@ func TestMessageHandlers_handleAgentPolicies_EmptyYAMLString(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManager{}
+	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{}, nil)
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
 	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
@@ -1628,6 +1656,7 @@ func TestMessageHandlers_handleAgentPolicies_InvalidYAMLString(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManager{}
+	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{}, nil)
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
 	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
@@ -1670,6 +1699,7 @@ func TestMessageHandlers_handleAgentPolicies_NonYAMLFormat(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManager{}
+	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{}, nil)
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
 	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)

--- a/agent/configmgr/fleet/from_rpc_test.go
+++ b/agent/configmgr/fleet/from_rpc_test.go
@@ -785,7 +785,7 @@ func TestMessageHandlers_handleAgentPolicies_SkipsSanitizeAction(t *testing.T) {
 }
 
 // Test that handleAgentPolicies emits the DEBUG RPC-shape line with
-// applied/skipped counters and the INFO "managed policies" line reflecting
+// applied/skipped counters and the INFO "agent managed policies" line reflecting
 // the repo state after handling.
 func TestMessageHandlers_handleAgentPolicies_LogCounters(t *testing.T) {
 	tests := []struct {
@@ -855,7 +855,7 @@ func TestMessageHandlers_handleAgentPolicies_LogCounters(t *testing.T) {
 
 			// INFO line: managed policy count from repo state.
 			var infoRec map[string]any
-			require.NoError(t, findLogRecord(buf.Bytes(), "managed policies", &infoRec))
+			require.NoError(t, findLogRecord(buf.Bytes(), "agent managed policies", &infoRec))
 			assert.Equal(t, "INFO", infoRec["level"], "managed-policies line must be INFO")
 			assert.Equal(t, tc.wantManagedCount, infoRec["count"], "managed policy count mismatch")
 

--- a/agent/configmgr/fleet/from_rpc_test.go
+++ b/agent/configmgr/fleet/from_rpc_test.go
@@ -1,6 +1,7 @@
 package fleet
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"log/slog"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/config"
@@ -775,6 +777,86 @@ func TestMessageHandlers_handleAgentPolicies_SkipsSanitizeAction(t *testing.T) {
 
 	// Assert - ManagePolicy should NOT be called for sanitize action
 	mockPMgr.AssertNotCalled(t, "ManagePolicy", mock.Anything)
+}
+
+// Test that the "successfully processed agent policies" log records the
+// correct applied/skipped counters and omits skipped when zero.
+func TestMessageHandlers_handleAgentPolicies_LogCounters(t *testing.T) {
+	tests := []struct {
+		name        string
+		payloads    []messages.AgentPolicyRPCPayload
+		wantApplied float64
+		wantSkipped float64 // 0 means the key must be absent
+	}{
+		{
+			name:        "sanitize-only payload reports applied=0 and skipped=1",
+			payloads:    []messages.AgentPolicyRPCPayload{{Action: "sanitize", ID: "p1", Name: "n1", Backend: "pktvisor"}},
+			wantApplied: 0,
+			wantSkipped: 1,
+		},
+		{
+			name: "apply-only payloads omit the skipped key",
+			payloads: []messages.AgentPolicyRPCPayload{
+				{Action: "apply", ID: "p1", Name: "n1", Backend: "pktvisor", Data: map[string]any{}},
+				{Action: "apply", ID: "p2", Name: "n2", Backend: "pktvisor", Data: map[string]any{}},
+			},
+			wantApplied: 2,
+			wantSkipped: 0,
+		},
+		{
+			name: "mixed payloads report both counters",
+			payloads: []messages.AgentPolicyRPCPayload{
+				{Action: "apply", ID: "p1", Name: "n1", Backend: "pktvisor", Data: map[string]any{}},
+				{Action: "sanitize", ID: "p2", Name: "n2", Backend: "pktvisor"},
+				{Action: "sanitize", ID: "p3", Name: "n3", Backend: "pktvisor"},
+			},
+			wantApplied: 1,
+			wantSkipped: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+			mockPMgr := &mockPolicyManager{}
+			mockPMgr.On("ManagePolicy", mock.Anything).Return()
+			resetChan := make(chan struct{}, 1)
+			groupManager := newGroupManager()
+			handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+
+			handlers.handleAgentPolicies(tc.payloads, false)
+
+			var record map[string]any
+			require.NoError(t, findLogRecord(buf.Bytes(), "successfully processed agent policies", &record))
+			assert.Equal(t, tc.wantApplied, record["applied"], "applied counter mismatch")
+			if tc.wantSkipped == 0 {
+				_, present := record["skipped"]
+				assert.False(t, present, "skipped key should be absent when zero")
+			} else {
+				assert.Equal(t, tc.wantSkipped, record["skipped"], "skipped counter mismatch")
+			}
+		})
+	}
+}
+
+// findLogRecord scans newline-delimited JSON slog output and returns the first
+// record whose msg matches the given message.
+func findLogRecord(out []byte, msg string, dst *map[string]any) error {
+	for _, line := range bytes.Split(bytes.TrimRight(out, "\n"), []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		rec := map[string]any{}
+		if err := json.Unmarshal(line, &rec); err != nil {
+			return err
+		}
+		if rec["msg"] == msg {
+			*dst = rec
+			return nil
+		}
+	}
+	return assert.AnError
 }
 
 // Test handleAgentPolicies with fullList=true but GetAll fails

--- a/agent/configmgr/fleet/from_rpc_test.go
+++ b/agent/configmgr/fleet/from_rpc_test.go
@@ -785,38 +785,38 @@ func TestMessageHandlers_handleAgentPolicies_SkipsSanitizeAction(t *testing.T) {
 }
 
 // Test that handleAgentPolicies emits the DEBUG RPC-shape line with
-// applied/skipped counters (omitting skipped when zero) and the INFO
-// "agent policies active" line reflecting the repo state after handling.
+// applied/skipped counters and the INFO "managed policies" line reflecting
+// the repo state after handling.
 func TestMessageHandlers_handleAgentPolicies_LogCounters(t *testing.T) {
 	tests := []struct {
-		name            string
-		payloads        []messages.AgentPolicyRPCPayload
-		wantApplied     float64
-		wantSkipped     float64 // 0 means the key must be absent
-		wantManageCalls int
-		repoState       []policies.PolicyData
-		wantActiveCount float64
+		name             string
+		payloads         []messages.AgentPolicyRPCPayload
+		wantApplied      float64
+		wantSkipped      float64
+		wantManageCalls  int
+		repoState        []policies.PolicyData
+		wantManagedCount float64
 	}{
 		{
-			name:            "sanitize-only payload: applied=0, skipped=1, no policies active",
-			payloads:        []messages.AgentPolicyRPCPayload{{Action: "sanitize", ID: "p1", Name: "n1", Backend: "pktvisor"}},
-			wantApplied:     0,
-			wantSkipped:     1,
-			wantManageCalls: 0,
-			repoState:       []policies.PolicyData{},
-			wantActiveCount: 0,
+			name:             "sanitize-only payload: applied=0, skipped=1, no managed policies",
+			payloads:         []messages.AgentPolicyRPCPayload{{Action: "sanitize", ID: "p1", Name: "n1", Backend: "pktvisor"}},
+			wantApplied:      0,
+			wantSkipped:      1,
+			wantManageCalls:  0,
+			repoState:        []policies.PolicyData{},
+			wantManagedCount: 0,
 		},
 		{
-			name: "apply-only payloads: skipped key absent, repo reflects applied policies",
+			name: "apply-only payloads: skipped=0, repo reflects applied policies",
 			payloads: []messages.AgentPolicyRPCPayload{
 				{Action: "apply", ID: "p1", Name: "n1", Backend: "pktvisor", Data: map[string]any{}},
 				{Action: "apply", ID: "p2", Name: "n2", Backend: "pktvisor", Data: map[string]any{}},
 			},
-			wantApplied:     2,
-			wantSkipped:     0,
-			wantManageCalls: 2,
-			repoState:       []policies.PolicyData{{ID: "p1"}, {ID: "p2"}},
-			wantActiveCount: 2,
+			wantApplied:      2,
+			wantSkipped:      0,
+			wantManageCalls:  2,
+			repoState:        []policies.PolicyData{{ID: "p1"}, {ID: "p2"}},
+			wantManagedCount: 2,
 		},
 		{
 			name: "mixed payloads: both counters present, repo reflects only applied",
@@ -825,11 +825,11 @@ func TestMessageHandlers_handleAgentPolicies_LogCounters(t *testing.T) {
 				{Action: "sanitize", ID: "p2", Name: "n2", Backend: "pktvisor"},
 				{Action: "sanitize", ID: "p3", Name: "n3", Backend: "pktvisor"},
 			},
-			wantApplied:     1,
-			wantSkipped:     2,
-			wantManageCalls: 1,
-			repoState:       []policies.PolicyData{{ID: "p1"}},
-			wantActiveCount: 1,
+			wantApplied:      1,
+			wantSkipped:      2,
+			wantManageCalls:  1,
+			repoState:        []policies.PolicyData{{ID: "p1"}},
+			wantManagedCount: 1,
 		},
 	}
 
@@ -846,23 +846,18 @@ func TestMessageHandlers_handleAgentPolicies_LogCounters(t *testing.T) {
 
 			handlers.handleAgentPolicies(tc.payloads, false)
 
-			// DEBUG line: RPC shape.
+			// DEBUG line: RPC shape, applied + skipped always emitted.
 			var debugRec map[string]any
 			require.NoError(t, findLogRecord(buf.Bytes(), "agent_policy RPC handled", &debugRec))
 			assert.Equal(t, "DEBUG", debugRec["level"], "RPC line must be DEBUG")
 			assert.Equal(t, tc.wantApplied, debugRec["applied"], "applied counter mismatch")
-			if tc.wantSkipped == 0 {
-				_, present := debugRec["skipped"]
-				assert.False(t, present, "skipped key should be absent when zero")
-			} else {
-				assert.Equal(t, tc.wantSkipped, debugRec["skipped"], "skipped counter mismatch")
-			}
+			assert.Equal(t, tc.wantSkipped, debugRec["skipped"], "skipped counter mismatch")
 
-			// INFO line: active count from repo state.
+			// INFO line: managed policy count from repo state.
 			var infoRec map[string]any
-			require.NoError(t, findLogRecord(buf.Bytes(), "agent policies active", &infoRec))
-			assert.Equal(t, "INFO", infoRec["level"], "active-count line must be INFO")
-			assert.Equal(t, tc.wantActiveCount, infoRec["count"], "active count mismatch")
+			require.NoError(t, findLogRecord(buf.Bytes(), "managed policies", &infoRec))
+			assert.Equal(t, "INFO", infoRec["level"], "managed-policies line must be INFO")
+			assert.Equal(t, tc.wantManagedCount, infoRec["count"], "managed policy count mismatch")
 
 			// Legacy combined log message must not be re-introduced.
 			var legacy map[string]any


### PR DESCRIPTION
## Summary

Fixes [OBS-1727](https://linear.app/netboxlabs/issue/OBS-1727). The fleet-mode `"successfully processed agent policies"` log line reported `count: 1` even when zero policies were attached to the agent. Root cause: it logged `len(rpc)`, which includes payloads with `Action == "sanitize"` that the loop explicitly skips. A single sanitize payload from the control plane was enough to make it look like a policy had been applied.

The fix splits one overloaded log line into two with cleaner semantics:

- **DEBUG `agent_policy RPC handled`** — protocol-shape diagnostic. Reports `applied` (payloads handed to `ManagePolicy`) and `skipped` (sanitize-action payloads), both always emitted. For operators tracing the fleet protocol.
- **INFO `agent managed policies`** — steady-state signal. Reports `count`, read from `PolicyManager.GetPolicyState()` *after* handling the RPC. This is what the reporter wanted: when no policies are attached, `count: 0`, regardless of any sanitize traffic on the wire.

"Managed" matches the codebase's own terminology (`ManagePolicy`, `policyManager`) and accurately describes what `GetPolicyState()` returns — every policy held in the repo, regardless of running/failed state. The "agent" qualifier makes the subject explicit when the log is read across many agents in a fleet, matching this file's existing vocabulary (`handling agent reset`, `handling agent stop`, `agent_policy RPC handled`).

### Behavior

Before (no policies attached, 1 sanitize payload received):
```
INFO  msg="successfully processed agent policies" count=1
```

After (same scenario):
```
DEBUG msg="agent_policy RPC handled"  applied=0 skipped=1
INFO  msg="agent managed policies"    count=0
```

After (one policy attached, no sanitize traffic):
```
DEBUG msg="agent_policy RPC handled"  applied=1 skipped=0
INFO  msg="agent managed policies"    count=1
```

### Notes on the log change

The previous message `"successfully processed agent policies"` and its `count` field are gone. The new INFO message answers the same operator question (how many policies does this agent have?) more accurately. External dashboards or alerts keyed on the old message text will need updating.

## Test plan

- [x] `go test -race ./agent/configmgr/...` (passes)
- [x] `make fix-lint` (0 issues)
- [x] New `TestMessageHandlers_handleAgentPolicies_LogCounters` covers sanitize-only, apply-only, and mixed payloads — asserts DEBUG-level `applied`/`skipped`, INFO-level managed `count` against repo state, absence of the legacy combined log message, and `ManagePolicy` invocation counts
- [x] Pre-existing handleAgentPolicies tests updated to mock `GetPolicyState`
- [x] Existing `TestMessageHandlers_handleAgentPolicies_SkipsSanitizeAction` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)