### PR TITLE
feat(secretsmgr): add CyberArk PAM Central Credential Provider backend (OBS-1100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Currently, only the `local` and `git` sources are supported for config manager.
 - [Git](./docs/configs/git.md)
 
 ### Secrets Manager
-The `secrets_manager` section specifies how Orb agent should retrieve and inject secrets into policies. The secrets manager can reference external secret stores like HashiCorp Vault, Doppler, or Delinea Secret Server to retrieve sensitive information such as credentials without hardcoding them in configuration files.
+The `secrets_manager` section specifies how Orb agent should retrieve and inject secrets into policies. The secrets manager can reference external secret stores like HashiCorp Vault, Doppler, CyberArk, or Delinea Secret Server to retrieve sensitive information such as credentials without hardcoding them in configuration files.
 
 ```yaml
 orb:
@@ -52,6 +52,7 @@ orb:
 Supported secrets managers:
 - [HashiCorp Vault](./docs/secretsmgr/vault.md)
 - [Doppler](./docs/secretsmgr/doppler.md)
+- [CyberArk (CCP)](./docs/secretsmgr/cyberark.md) (beta)
 - [Delinea Secret Server](./docs/secretsmgr/delinea.md) (beta)
 
 ### Backends

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -94,12 +94,27 @@ type DopplerManager struct {
 	Schedule *string `yaml:"schedule,omitempty"`
 }
 
-// SecretsSources represents the configuration for manager sources, including vault, fleet, delinea and doppler.
+// CyberArkManager represents the configuration for the CyberArk Central
+// Credential Provider (CCP) secrets manager.
+type CyberArkManager struct {
+	URL           string  `yaml:"url"`
+	AppID         string  `yaml:"app_id"`
+	Reason        string  `yaml:"reason,omitempty"`
+	SkipTLSVerify bool    `yaml:"skip_tls_verify,omitempty"`
+	CABundle      string  `yaml:"ca_bundle,omitempty"`
+	ClientCert    string  `yaml:"client_cert,omitempty"`
+	ClientKey     string  `yaml:"client_key,omitempty"`
+	Timeout       *int    `yaml:"timeout,omitempty"`
+	Schedule      *string `yaml:"schedule,omitempty"`
+}
+
+// SecretsSources represents the configuration for manager sources, including vault, fleet, delinea, doppler and cyberark.
 type SecretsSources struct {
-	Vault   VaultManager        `yaml:"vault"`
-	Fleet   FleetSecretsManager `yaml:"fleet"`
-	Delinea DelineaManager      `yaml:"delinea"`
-	Doppler DopplerManager      `yaml:"doppler"`
+	Vault    VaultManager        `yaml:"vault"`
+	Fleet    FleetSecretsManager `yaml:"fleet"`
+	Delinea  DelineaManager      `yaml:"delinea"`
+	Doppler  DopplerManager      `yaml:"doppler"`
+	CyberArk CyberArkManager     `yaml:"cyberark"`
 }
 
 // ManagerSecrets represents the configuration for the Secrets Manager

--- a/agent/secretsmgr/cyberark.go
+++ b/agent/secretsmgr/cyberark.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -124,6 +126,101 @@ func (c *cyberarkManager) Start(ctx context.Context) error {
 func containsPEMBlock(b []byte) bool {
 	block, _ := pem.Decode(b)
 	return block != nil
+}
+
+// ccpErrorEnvelope is the JSON CyberArk sends on non-2xx responses.
+type ccpErrorEnvelope struct {
+	ErrorCode string `json:"ErrorCode,omitempty"`
+	ErrorMsg  string `json:"ErrorMsg,omitempty"`
+}
+
+// fetch performs the GET /AIMWebService/api/Accounts call for the parsed
+// reference and returns the requested field. Defaults to the Content field
+// (which holds the password in CCP's response model).
+func (c *cyberarkManager) fetch(body string) (string, error) {
+	ref, err := c.parseBody(body)
+	if err != nil {
+		return "", err
+	}
+
+	u, err := url.Parse(c.baseURL + "/AIMWebService/api/Accounts")
+	if err != nil {
+		return "", fmt.Errorf("cyberark: bad url %q: %w", c.baseURL, err)
+	}
+	q := u.Query()
+	q.Set("AppID", ref.appID)
+	q.Set("Safe", ref.safe)
+	q.Set("Object", ref.object)
+	if c.config.Reason != "" {
+		q.Set("Reason", c.config.Reason)
+	}
+	u.RawQuery = q.Encode()
+
+	// c.ctx is set by pollingBase.init() in Start (Task 5). Defensive default
+	// here because tests in Task 4 — and any caller that bypasses Start —
+	// would otherwise hit http.NewRequestWithContext's nil-context error.
+	ctx := c.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return "", fmt.Errorf("cyberark: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("cyberark: get account %s (AppID=%s Safe=%s Object=%s): %w",
+			body, ref.appID, ref.safe, ref.object, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("cyberark: read response for %s: %w", body, err)
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return "", fmt.Errorf("cyberark: account not found: %s (AppID=%s Safe=%s Object=%s): %s",
+			body, ref.appID, ref.safe, ref.object, ccpErrorDetail(bodyBytes))
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("cyberark: get account %s (AppID=%s Safe=%s Object=%s): HTTP %d: %s",
+			body, ref.appID, ref.safe, ref.object, resp.StatusCode, ccpErrorDetail(bodyBytes))
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(bodyBytes, &parsed); err != nil {
+		return "", fmt.Errorf("cyberark: decode response for %s: %w", body, err)
+	}
+
+	raw, ok := parsed[ref.field]
+	if !ok {
+		return "", fmt.Errorf("cyberark: field %q not found in response for %s (AppID=%s Safe=%s Object=%s)",
+			ref.field, body, ref.appID, ref.safe, ref.object)
+	}
+	strValue, ok := raw.(string)
+	if !ok {
+		return "", fmt.Errorf("cyberark: field %q is not a string for %s", ref.field, body)
+	}
+	if strValue == "" {
+		return "", fmt.Errorf("cyberark: field %q is empty for %s", ref.field, body)
+	}
+	return strValue, nil
+}
+
+// ccpErrorDetail extracts a human-readable message from a CCP non-2xx
+// response. Falls back to the raw body when the JSON envelope isn't present.
+func ccpErrorDetail(b []byte) string {
+	var env ccpErrorEnvelope
+	if err := json.Unmarshal(b, &env); err == nil && env.ErrorMsg != "" {
+		if env.ErrorCode != "" {
+			return env.ErrorCode + ": " + env.ErrorMsg
+		}
+		return env.ErrorMsg
+	}
+	return strings.TrimSpace(string(b))
 }
 
 // cyberarkRef holds a parsed placeholder body.

--- a/agent/secretsmgr/cyberark.go
+++ b/agent/secretsmgr/cyberark.go
@@ -22,9 +22,10 @@ const (
 	defaultCyberArkTimeout     = 60 * time.Second
 
 	// ccpEndpointPath is the CCP REST path appended to the configured base
-	// URL on every fetch. Kept as a constant so Start can also reject
-	// configurations whose URL already carries the suffix (see issue logged
-	// in PR review).
+	// URL on every fetch. Shared with Start so it can reject configurations
+	// whose URL already ends with this suffix, which would otherwise produce
+	// "/AIMWebService/api/Accounts/AIMWebService/api/Accounts" at request
+	// time and consistent 404s.
 	ccpEndpointPath = "/AIMWebService/api/Accounts"
 )
 

--- a/agent/secretsmgr/cyberark.go
+++ b/agent/secretsmgr/cyberark.go
@@ -1,0 +1,127 @@
+package secretsmgr
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/netboxlabs/orb-agent/agent/config"
+)
+
+const (
+	defaultCyberArkTimeoutUnit = time.Second
+	defaultCyberArkTimeout     = 60 * time.Second
+)
+
+var _ Manager = (*cyberarkManager)(nil)
+
+// cyberarkManager resolves ${cyberark://…} placeholders against the CyberArk
+// CCP REST endpoint (/AIMWebService/api/Accounts).
+type cyberarkManager struct {
+	pollingBase
+
+	config     config.CyberArkManager
+	preLogger  *slog.Logger
+	baseURL    string
+	httpClient *http.Client
+}
+
+// Start validates configuration, builds the TLS-aware HTTP client, and wires
+// pollingBase. It does NOT eagerly authenticate; the first real lookup
+// surfaces a 401/403 with a meaningful error.
+func (c *cyberarkManager) Start(ctx context.Context) error {
+	envFields := []struct {
+		name string
+		ptr  *string
+	}{
+		{"url", &c.config.URL},
+		{"app_id", &c.config.AppID},
+		{"reason", &c.config.Reason},
+		{"ca_bundle", &c.config.CABundle},
+		{"client_cert", &c.config.ClientCert},
+		{"client_key", &c.config.ClientKey},
+	}
+	for _, f := range envFields {
+		resolved, err := config.ResolveEnv(*f.ptr)
+		if err != nil {
+			return fmt.Errorf("resolving cyberark %s from environment: %w", f.name, err)
+		}
+		*f.ptr = resolved
+	}
+
+	if c.config.URL == "" {
+		return fmt.Errorf("cyberark: url is required")
+	}
+	if c.config.AppID == "" {
+		return fmt.Errorf("cyberark: app_id is required")
+	}
+	parsedURL, err := url.Parse(c.config.URL)
+	if err != nil {
+		return fmt.Errorf("cyberark: url %q does not parse: %w", c.config.URL, err)
+	}
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return fmt.Errorf("cyberark: url %q must use http or https (got scheme %q)", c.config.URL, parsedURL.Scheme)
+	}
+	c.baseURL = strings.TrimRight(c.config.URL, "/")
+
+	if (c.config.ClientCert == "") != (c.config.ClientKey == "") {
+		return fmt.Errorf("cyberark: client_cert and client_key must both be set or both empty")
+	}
+
+	tlsCfg := &tls.Config{InsecureSkipVerify: c.config.SkipTLSVerify} //nolint:gosec // operator opt-in
+	if c.config.SkipTLSVerify {
+		c.preLogger.Warn("cyberark: TLS peer verification disabled via skip_tls_verify")
+	}
+
+	if c.config.CABundle != "" {
+		pemBytes, err := os.ReadFile(c.config.CABundle)
+		if err != nil {
+			return fmt.Errorf("cyberark: read ca_bundle %q: %w", c.config.CABundle, err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pemBytes) {
+			// AppendCertsFromPEM silently ignores junk; fail when the file
+			// has no usable PEM blocks at all.
+			if !containsPEMBlock(pemBytes) {
+				return fmt.Errorf("cyberark: ca_bundle %q contains no PEM blocks", c.config.CABundle)
+			}
+		}
+		tlsCfg.RootCAs = pool
+	}
+
+	if c.config.ClientCert != "" {
+		cert, err := tls.LoadX509KeyPair(c.config.ClientCert, c.config.ClientKey)
+		if err != nil {
+			return fmt.Errorf("cyberark: load client cert/key: %w", err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+	}
+
+	timeout := defaultCyberArkTimeout
+	if c.config.Timeout != nil && *c.config.Timeout > 0 {
+		timeout = time.Duration(*c.config.Timeout) * defaultCyberArkTimeoutUnit
+	}
+	c.httpClient = &http.Client{
+		Timeout:   timeout,
+		Transport: &http.Transport{TLSClientConfig: tlsCfg},
+	}
+
+	// pollingBase wiring + scheduler are added in Task 5 once fetch exists.
+	_ = ctx
+	return nil
+}
+
+// containsPEMBlock returns true if bytes contain at least one valid PEM
+// block.
+func containsPEMBlock(b []byte) bool {
+	block, _ := pem.Decode(b)
+	return block != nil
+}

--- a/agent/secretsmgr/cyberark.go
+++ b/agent/secretsmgr/cyberark.go
@@ -125,3 +125,61 @@ func containsPEMBlock(b []byte) bool {
 	block, _ := pem.Decode(b)
 	return block != nil
 }
+
+// cyberarkRef holds a parsed placeholder body.
+type cyberarkRef struct {
+	appID  string
+	safe   string
+	object string
+	field  string // "Content" when caller omitted the field segment
+}
+
+// parseBody decodes a placeholder body into (AppID, Safe, Object, Field).
+// Grammar (see docs/secretsmgr/cyberark.md):
+//
+//	Short:               <Safe>/<Object>
+//	Short+field:         <Safe>/<Object>/<Field>
+//	Qualified:           <AppID>//<Safe>/<Object>
+//	Qualified+field:     <AppID>//<Safe>/<Object>/<Field>
+//
+// The "//" separator unambiguously marks the end of an AppID override.
+func (c *cyberarkManager) parseBody(body string) (cyberarkRef, error) {
+	if body == "" {
+		return cyberarkRef{}, fmt.Errorf("invalid cyberark reference: empty body")
+	}
+
+	var (
+		appID     string
+		remainder string
+	)
+	if idx := strings.Index(body, "//"); idx >= 0 {
+		appID = body[:idx]
+		remainder = body[idx+2:]
+		if appID == "" {
+			return cyberarkRef{}, fmt.Errorf("invalid cyberark reference %q: empty AppID before '//'", body)
+		}
+	} else {
+		appID = c.config.AppID
+		remainder = body
+	}
+
+	if appID == "" {
+		return cyberarkRef{}, fmt.Errorf("invalid cyberark reference %q: short form requires sources.cyberark.app_id to be set", body)
+	}
+
+	parts := strings.Split(remainder, "/")
+	switch len(parts) {
+	case 2:
+		if parts[0] == "" || parts[1] == "" {
+			return cyberarkRef{}, fmt.Errorf("invalid cyberark reference %q: Safe and Object must be non-empty", body)
+		}
+		return cyberarkRef{appID: appID, safe: parts[0], object: parts[1], field: "Content"}, nil
+	case 3:
+		if parts[0] == "" || parts[1] == "" || parts[2] == "" {
+			return cyberarkRef{}, fmt.Errorf("invalid cyberark reference %q: Safe, Object and Field must be non-empty", body)
+		}
+		return cyberarkRef{appID: appID, safe: parts[0], object: parts[1], field: parts[2]}, nil
+	default:
+		return cyberarkRef{}, fmt.Errorf("invalid cyberark reference %q: expected '<Safe>/<Object>[/<Field>]' (optionally prefixed by '<AppID>//')", body)
+	}
+}

--- a/agent/secretsmgr/cyberark.go
+++ b/agent/secretsmgr/cyberark.go
@@ -20,6 +20,12 @@ import (
 const (
 	defaultCyberArkTimeoutUnit = time.Second
 	defaultCyberArkTimeout     = 60 * time.Second
+
+	// ccpEndpointPath is the CCP REST path appended to the configured base
+	// URL on every fetch. Kept as a constant so Start can also reject
+	// configurations whose URL already carries the suffix (see issue logged
+	// in PR review).
+	ccpEndpointPath = "/AIMWebService/api/Accounts"
 )
 
 var _ Manager = (*cyberarkManager)(nil)
@@ -77,10 +83,16 @@ func (c *cyberarkManager) Start(ctx context.Context) error {
 	if parsedURL.RawQuery != "" || parsedURL.Fragment != "" {
 		return fmt.Errorf("cyberark: url %q must not contain a query string or fragment", c.config.URL)
 	}
-	// Keep the parsed URL around so fetch() builds the endpoint by setting
-	// Path on a clone rather than concatenating strings — which would
-	// silently corrupt any baseURL carrying a non-trivial Path.
+	// Reject URLs that already point at the CCP endpoint. The agent appends
+	// "/AIMWebService/api/Accounts" itself; including it again in the
+	// configured URL produces "/AIMWebService/api/Accounts/AIMWebService/api/Accounts"
+	// at request time and consistent 404s. Operators copying examples from
+	// CyberArk integrations that already include the suffix would otherwise
+	// hit this only at runtime.
 	parsedURL.Path = strings.TrimRight(parsedURL.Path, "/")
+	if strings.HasSuffix(parsedURL.Path, ccpEndpointPath) {
+		return fmt.Errorf("cyberark: url %q already includes the CCP endpoint path %q; configure only the base URL (e.g. https://ccp.example.com)", c.config.URL, ccpEndpointPath)
+	}
 	c.baseURL = parsedURL
 
 	if (c.config.ClientCert == "") != (c.config.ClientKey == "") {
@@ -152,7 +164,7 @@ func (c *cyberarkManager) fetch(body string) (string, error) {
 	}
 
 	u := *c.baseURL
-	u.Path = strings.TrimRight(u.Path, "/") + "/AIMWebService/api/Accounts"
+	u.Path = strings.TrimRight(u.Path, "/") + ccpEndpointPath
 	q := u.Query()
 	q.Set("AppID", ref.appID)
 	q.Set("Safe", ref.safe)
@@ -162,9 +174,11 @@ func (c *cyberarkManager) fetch(body string) (string, error) {
 	}
 	u.RawQuery = q.Encode()
 
-	// c.ctx is set by pollingBase.init() in Start (Task 5). Defensive default
-	// here because tests in Task 4 — and any caller that bypasses Start —
-	// would otherwise hit http.NewRequestWithContext's nil-context error.
+	// pollingBase.init populates c.ctx during Start. The defensive fallback
+	// guards against callers (most notably tests) that construct the
+	// manager directly and bypass Start; http.NewRequestWithContext errors
+	// out on a nil ctx, so without this we'd surface an opaque failure
+	// instead of a real request.
 	ctx := c.ctx
 	if ctx == nil {
 		ctx = context.Background()

--- a/agent/secretsmgr/cyberark.go
+++ b/agent/secretsmgr/cyberark.go
@@ -116,9 +116,8 @@ func (c *cyberarkManager) Start(ctx context.Context) error {
 		Transport: &http.Transport{TLSClientConfig: tlsCfg},
 	}
 
-	// pollingBase wiring + scheduler are added in Task 5 once fetch exists.
-	_ = ctx
-	return nil
+	c.init(ctx, c.preLogger, "cyberark", c.fetch)
+	return c.startScheduler(c.config.Schedule)
 }
 
 // containsPEMBlock returns true if bytes contain at least one valid PEM

--- a/agent/secretsmgr/cyberark.go
+++ b/agent/secretsmgr/cyberark.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
-	"encoding/pem"
 	"fmt"
 	"io"
 	"log/slog"
@@ -32,7 +31,7 @@ type cyberarkManager struct {
 
 	config     config.CyberArkManager
 	preLogger  *slog.Logger
-	baseURL    string
+	baseURL    *url.URL
 	httpClient *http.Client
 }
 
@@ -72,7 +71,17 @@ func (c *cyberarkManager) Start(ctx context.Context) error {
 	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
 		return fmt.Errorf("cyberark: url %q must use http or https (got scheme %q)", c.config.URL, parsedURL.Scheme)
 	}
-	c.baseURL = strings.TrimRight(c.config.URL, "/")
+	if parsedURL.Host == "" {
+		return fmt.Errorf("cyberark: url %q must include a host", c.config.URL)
+	}
+	if parsedURL.RawQuery != "" || parsedURL.Fragment != "" {
+		return fmt.Errorf("cyberark: url %q must not contain a query string or fragment", c.config.URL)
+	}
+	// Keep the parsed URL around so fetch() builds the endpoint by setting
+	// Path on a clone rather than concatenating strings — which would
+	// silently corrupt any baseURL carrying a non-trivial Path.
+	parsedURL.Path = strings.TrimRight(parsedURL.Path, "/")
+	c.baseURL = parsedURL
 
 	if (c.config.ClientCert == "") != (c.config.ClientKey == "") {
 		return fmt.Errorf("cyberark: client_cert and client_key must both be set or both empty")
@@ -89,12 +98,13 @@ func (c *cyberarkManager) Start(ctx context.Context) error {
 			return fmt.Errorf("cyberark: read ca_bundle %q: %w", c.config.CABundle, err)
 		}
 		pool := x509.NewCertPool()
+		// AppendCertsFromPEM returns true only when at least one certificate
+		// successfully parsed. A file containing only a PEM private key, or
+		// only a malformed certificate, leaves the pool empty — reject those
+		// at startup rather than producing an unusable trust store at
+		// connection time.
 		if !pool.AppendCertsFromPEM(pemBytes) {
-			// AppendCertsFromPEM silently ignores junk; fail when the file
-			// has no usable PEM blocks at all.
-			if !containsPEMBlock(pemBytes) {
-				return fmt.Errorf("cyberark: ca_bundle %q contains no PEM blocks", c.config.CABundle)
-			}
+			return fmt.Errorf("cyberark: ca_bundle %q contains no parseable certificates", c.config.CABundle)
 		}
 		tlsCfg.RootCAs = pool
 	}
@@ -111,20 +121,19 @@ func (c *cyberarkManager) Start(ctx context.Context) error {
 	if c.config.Timeout != nil && *c.config.Timeout > 0 {
 		timeout = time.Duration(*c.config.Timeout) * defaultCyberArkTimeoutUnit
 	}
+	// Clone http.DefaultTransport so we keep proxy-from-environment, dial
+	// timeouts, idle-conn settings, HTTP/2 negotiation, etc. — a bare
+	// &http.Transport{} would silently regress all of those in
+	// enterprise deployments that rely on HTTPS_PROXY for outbound traffic.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsCfg
 	c.httpClient = &http.Client{
 		Timeout:   timeout,
-		Transport: &http.Transport{TLSClientConfig: tlsCfg},
+		Transport: transport,
 	}
 
 	c.init(ctx, c.preLogger, "cyberark", c.fetch)
 	return c.startScheduler(c.config.Schedule)
-}
-
-// containsPEMBlock returns true if bytes contain at least one valid PEM
-// block.
-func containsPEMBlock(b []byte) bool {
-	block, _ := pem.Decode(b)
-	return block != nil
 }
 
 // ccpErrorEnvelope is the JSON CyberArk sends on non-2xx responses.
@@ -142,10 +151,8 @@ func (c *cyberarkManager) fetch(body string) (string, error) {
 		return "", err
 	}
 
-	u, err := url.Parse(c.baseURL + "/AIMWebService/api/Accounts")
-	if err != nil {
-		return "", fmt.Errorf("cyberark: bad url %q: %w", c.baseURL, err)
-	}
+	u := *c.baseURL
+	u.Path = strings.TrimRight(u.Path, "/") + "/AIMWebService/api/Accounts"
 	q := u.Query()
 	q.Set("AppID", ref.appID)
 	q.Set("Safe", ref.safe)

--- a/agent/secretsmgr/cyberark.go
+++ b/agent/secretsmgr/cyberark.go
@@ -71,6 +71,9 @@ func (c *cyberarkManager) Start(ctx context.Context) error {
 	if c.config.AppID == "" {
 		return fmt.Errorf("cyberark: app_id is required")
 	}
+	if strings.Contains(c.config.AppID, "/") {
+		return fmt.Errorf("cyberark: app_id %q must not contain '/'", c.config.AppID)
+	}
 	parsedURL, err := url.Parse(c.config.URL)
 	if err != nil {
 		return fmt.Errorf("cyberark: url %q does not parse: %w", c.config.URL, err)
@@ -275,6 +278,9 @@ func (c *cyberarkManager) parseBody(body string) (cyberarkRef, error) {
 		remainder = body[idx+2:]
 		if appID == "" {
 			return cyberarkRef{}, fmt.Errorf("invalid cyberark reference %q: empty AppID before '//'", body)
+		}
+		if strings.Contains(appID, "/") {
+			return cyberarkRef{}, fmt.Errorf("invalid cyberark reference %q: AppID override must not contain '/'", body)
 		}
 	} else {
 		appID = c.config.AppID

--- a/agent/secretsmgr/cyberark_test.go
+++ b/agent/secretsmgr/cyberark_test.go
@@ -1,0 +1,167 @@
+package secretsmgr
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/config"
+)
+
+func TestCyberArkStart_RequiresURL(t *testing.T) {
+	c := &cyberarkManager{
+		preLogger: newTestLogger(),
+		config:    config.CyberArkManager{AppID: "orb"},
+	}
+	err := c.Start(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "url is required")
+}
+
+func TestCyberArkStart_RequiresAppID(t *testing.T) {
+	c := &cyberarkManager{
+		preLogger: newTestLogger(),
+		config:    config.CyberArkManager{URL: "https://ccp.example.com"},
+	}
+	err := c.Start(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "app_id is required")
+}
+
+func TestCyberArkStart_TrimsTrailingSlashFromURL(t *testing.T) {
+	c := &cyberarkManager{
+		preLogger: newTestLogger(),
+		config:    config.CyberArkManager{URL: "https://ccp.example.com/", AppID: "orb"},
+	}
+	require.NoError(t, c.Start(context.Background()))
+	require.Equal(t, "https://ccp.example.com", c.baseURL)
+}
+
+func TestCyberArkStart_RejectsUnparseableURL(t *testing.T) {
+	c := &cyberarkManager{
+		preLogger: newTestLogger(),
+		config:    config.CyberArkManager{URL: "ht tp://bad url", AppID: "orb"},
+	}
+	err := c.Start(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not parse")
+}
+
+func TestCyberArkStart_RejectsNonHTTPScheme(t *testing.T) {
+	c := &cyberarkManager{
+		preLogger: newTestLogger(),
+		config:    config.CyberArkManager{URL: "ftp://ccp.example.com", AppID: "orb"},
+	}
+	err := c.Start(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "http or https")
+}
+
+func TestCyberArkStart_DefaultTimeout(t *testing.T) {
+	c := &cyberarkManager{
+		preLogger: newTestLogger(),
+		config:    config.CyberArkManager{URL: "https://ccp.example.com", AppID: "orb"},
+	}
+	require.NoError(t, c.Start(context.Background()))
+	require.NotNil(t, c.httpClient)
+	require.Equal(t, defaultCyberArkTimeout, c.httpClient.Timeout)
+}
+
+func TestCyberArkStart_CustomTimeout(t *testing.T) {
+	timeoutSec := 5
+	c := &cyberarkManager{
+		preLogger: newTestLogger(),
+		config:    config.CyberArkManager{URL: "https://ccp.example.com", AppID: "orb", Timeout: &timeoutSec},
+	}
+	require.NoError(t, c.Start(context.Background()))
+	require.Equal(t, 5*defaultCyberArkTimeoutUnit, c.httpClient.Timeout)
+}
+
+func TestCyberArkStart_RequiresBothCertAndKey(t *testing.T) {
+	c := &cyberarkManager{
+		preLogger: newTestLogger(),
+		config:    config.CyberArkManager{URL: "https://ccp.example.com", AppID: "orb", ClientCert: "/tmp/cert.pem"},
+	}
+	err := c.Start(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "client_key")
+
+	c = &cyberarkManager{
+		preLogger: newTestLogger(),
+		config:    config.CyberArkManager{URL: "https://ccp.example.com", AppID: "orb", ClientKey: "/tmp/key.pem"},
+	}
+	err = c.Start(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "client_cert")
+}
+
+func TestCyberArkStart_RejectsMissingCABundle(t *testing.T) {
+	c := &cyberarkManager{
+		preLogger: newTestLogger(),
+		config:    config.CyberArkManager{URL: "https://ccp.example.com", AppID: "orb", CABundle: "/nonexistent/ca.pem"},
+	}
+	err := c.Start(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ca_bundle")
+}
+
+func TestCyberArkStart_RejectsCABundleWithNoPEMBlocks(t *testing.T) {
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "not-a-pem.txt")
+	require.NoError(t, os.WriteFile(bad, []byte("this is not pem"), 0o600))
+
+	c := &cyberarkManager{
+		preLogger: newTestLogger(),
+		config:    config.CyberArkManager{URL: "https://ccp.example.com", AppID: "orb", CABundle: bad},
+	}
+	err := c.Start(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ca_bundle")
+}
+
+func TestCyberArkStart_AcceptsCABundle(t *testing.T) {
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "ca.pem")
+	require.NoError(t, os.WriteFile(caPath, []byte(testSelfSignedCAPEM), 0o600))
+
+	c := &cyberarkManager{
+		preLogger: newTestLogger(),
+		config:    config.CyberArkManager{URL: "https://ccp.example.com", AppID: "orb", CABundle: caPath},
+	}
+	require.NoError(t, c.Start(context.Background()))
+	require.NotNil(t, c.httpClient.Transport)
+
+	tr := c.httpClient.Transport.(*http.Transport)
+	require.NotNil(t, tr.TLSClientConfig)
+	require.NotNil(t, tr.TLSClientConfig.RootCAs)
+}
+
+func TestCyberArkStart_SkipTLSVerifyFlowsThroughToTransport(t *testing.T) {
+	c := &cyberarkManager{
+		preLogger: newTestLogger(),
+		config:    config.CyberArkManager{URL: "https://ccp.example.com", AppID: "orb", SkipTLSVerify: true},
+	}
+	require.NoError(t, c.Start(context.Background()))
+	tr := c.httpClient.Transport.(*http.Transport)
+	require.True(t, tr.TLSClientConfig.InsecureSkipVerify)
+}
+
+// testSelfSignedCAPEM is a syntactically-valid X.509 self-signed CA PEM block
+// used purely to drive the CA-bundle parsing happy path. It is NOT used for
+// any real TLS handshake.
+const testSelfSignedCAPEM = `-----BEGIN CERTIFICATE-----
+MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw
+DgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow
+EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d
+7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BnnE8rnZR8+sbwnc/KhCk3FhnpHZnQz7B
+5aETbbIgmuvewdjvSBSjYzBhMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggr
+BgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MCkGA1UdEQQiMCCCDmxvY2FsaG9zdDo1
+NDUzgg4xMjcuMC4wLjE6NTQ1MzAKBggqhkjOPQQDAgNIADBFAiEA2zpJEPQyz6/l
+Wf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc
+6MF9+Yw1Yy0t
+-----END CERTIFICATE-----
+`

--- a/agent/secretsmgr/cyberark_test.go
+++ b/agent/secretsmgr/cyberark_test.go
@@ -2,9 +2,14 @@ package secretsmgr
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -217,6 +222,176 @@ func TestCyberArkParseBody_ShortFormRequiresConfiguredAppID(t *testing.T) {
 	_, err := c.parseBody("Lab/DB-Account")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "app_id")
+}
+
+// fakeCCP emulates the GET /AIMWebService/api/Accounts endpoint.
+type fakeCCP struct {
+	*httptest.Server
+	mu       sync.Mutex
+	accounts map[string]map[string]any // key = "<AppID>|<Safe>|<Object>"
+	missing  map[string]bool
+	calls    atomic.Int32
+	lastReq  atomic.Value // url.Values
+}
+
+func newFakeCCP() *fakeCCP {
+	f := &fakeCCP{accounts: map[string]map[string]any{}, missing: map[string]bool{}}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/AIMWebService/api/Accounts", func(w http.ResponseWriter, r *http.Request) {
+		f.calls.Add(1)
+		q := r.URL.Query()
+		f.lastReq.Store(q)
+		key := q.Get("AppID") + "|" + q.Get("Safe") + "|" + q.Get("Object")
+
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		if f.missing[key] {
+			http.Error(w, `{"ErrorCode":"APPAP004E","ErrorMsg":"Object not found"}`, http.StatusNotFound)
+			return
+		}
+		acc, ok := f.accounts[key]
+		if !ok {
+			http.Error(w, `{"ErrorCode":"APPAP004E","ErrorMsg":"Object not found"}`, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(acc)
+	})
+	f.Server = httptest.NewServer(mux)
+	return f
+}
+
+func (f *fakeCCP) set(appID, safe, object string, fields map[string]any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.accounts[appID+"|"+safe+"|"+object] = fields
+}
+
+func (f *fakeCCP) delete(appID, safe, object string) { //nolint:unused // used by later tasks
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.accounts, appID+"|"+safe+"|"+object)
+	f.missing[appID+"|"+safe+"|"+object] = true
+}
+
+func newCyberarkManagerForTest(t *testing.T, fake *fakeCCP, cfg config.CyberArkManager) *cyberarkManager {
+	t.Helper()
+	if cfg.AppID == "" {
+		cfg.AppID = "orb-agent"
+	}
+	cfg.URL = fake.URL
+	c := &cyberarkManager{preLogger: newTestLogger(), config: cfg}
+	require.NoError(t, c.Start(context.Background()))
+	return c
+}
+
+func TestCyberArkFetch_ShortForm_ReturnsContent(t *testing.T) {
+	fake := newFakeCCP()
+	defer fake.Close()
+	fake.set("orb-agent", "Lab", "DB-Account", map[string]any{
+		"Content":  "s3cret",
+		"UserName": "dbuser",
+	})
+
+	c := newCyberarkManagerForTest(t, fake, config.CyberArkManager{})
+	val, err := c.fetch("Lab/DB-Account")
+	require.NoError(t, err)
+	require.Equal(t, "s3cret", val)
+
+	q := fake.lastReq.Load().(url.Values)
+	require.Equal(t, "orb-agent", q.Get("AppID"))
+	require.Equal(t, "Lab", q.Get("Safe"))
+	require.Equal(t, "DB-Account", q.Get("Object"))
+}
+
+func TestCyberArkFetch_FieldSelector_ReturnsUserName(t *testing.T) {
+	fake := newFakeCCP()
+	defer fake.Close()
+	fake.set("orb-agent", "Lab", "DB-Account", map[string]any{
+		"Content":  "s3cret",
+		"UserName": "dbuser",
+	})
+
+	c := newCyberarkManagerForTest(t, fake, config.CyberArkManager{})
+	val, err := c.fetch("Lab/DB-Account/UserName")
+	require.NoError(t, err)
+	require.Equal(t, "dbuser", val)
+}
+
+func TestCyberArkFetch_QualifiedAppID_OverridesYAML(t *testing.T) {
+	fake := newFakeCCP()
+	defer fake.Close()
+	fake.set("OtherApp", "Lab", "DB-Account", map[string]any{"Content": "ot-secret"})
+
+	c := newCyberarkManagerForTest(t, fake, config.CyberArkManager{})
+	val, err := c.fetch("OtherApp//Lab/DB-Account")
+	require.NoError(t, err)
+	require.Equal(t, "ot-secret", val)
+
+	q := fake.lastReq.Load().(url.Values)
+	require.Equal(t, "OtherApp", q.Get("AppID"))
+}
+
+func TestCyberArkFetch_ReasonIsForwarded(t *testing.T) {
+	fake := newFakeCCP()
+	defer fake.Close()
+	fake.set("orb-agent", "Lab", "Acc", map[string]any{"Content": "x"})
+
+	c := newCyberarkManagerForTest(t, fake, config.CyberArkManager{Reason: "policy resolution"})
+	_, err := c.fetch("Lab/Acc")
+	require.NoError(t, err)
+
+	q := fake.lastReq.Load().(url.Values)
+	require.Equal(t, "policy resolution", q.Get("Reason"))
+}
+
+func TestCyberArkFetch_NotFound(t *testing.T) {
+	fake := newFakeCCP()
+	defer fake.Close()
+
+	c := newCyberarkManagerForTest(t, fake, config.CyberArkManager{})
+	_, err := c.fetch("Lab/Missing")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+	require.Contains(t, err.Error(), "Object not found", "underlying CCP error message must surface")
+}
+
+func TestCyberArkFetch_FieldMissingFromResponse(t *testing.T) {
+	fake := newFakeCCP()
+	defer fake.Close()
+	fake.set("orb-agent", "Lab", "Acc", map[string]any{"Content": "x"})
+
+	c := newCyberarkManagerForTest(t, fake, config.CyberArkManager{})
+	_, err := c.fetch("Lab/Acc/Database")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `field "Database"`)
+}
+
+func TestCyberArkFetch_FieldEmptyInResponse(t *testing.T) {
+	fake := newFakeCCP()
+	defer fake.Close()
+	fake.set("orb-agent", "Lab", "Acc", map[string]any{"Content": ""})
+
+	c := newCyberarkManagerForTest(t, fake, config.CyberArkManager{})
+	_, err := c.fetch("Lab/Acc")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty")
+}
+
+func TestCyberArkFetch_Unauthorized(t *testing.T) {
+	fake := &fakeCCP{accounts: map[string]map[string]any{}, missing: map[string]bool{}}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/AIMWebService/api/Accounts", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"ErrorCode":"AUTH","ErrorMsg":"App not authorized"}`, http.StatusUnauthorized)
+	})
+	fake.Server = httptest.NewServer(mux)
+	defer fake.Close()
+
+	c := newCyberarkManagerForTest(t, fake, config.CyberArkManager{})
+	_, err := c.fetch("Lab/Acc")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "401")
+	require.Contains(t, err.Error(), "App not authorized")
 }
 
 // testSelfSignedCAPEM is a syntactically-valid X.509 self-signed CA PEM block

--- a/agent/secretsmgr/cyberark_test.go
+++ b/agent/secretsmgr/cyberark_test.go
@@ -93,6 +93,28 @@ func TestCyberArkStart_RejectsURLWithoutHost(t *testing.T) {
 	require.Contains(t, err.Error(), "must include a host")
 }
 
+func TestCyberArkStart_RejectsURLAlreadyAtCCPEndpoint(t *testing.T) {
+	// Operators copying examples from upstream CyberArk integrations
+	// sometimes paste the full endpoint URL. Catch it at startup; otherwise
+	// fetch builds /AIMWebService/api/Accounts/AIMWebService/api/Accounts
+	// and 404s consistently at runtime.
+	for _, bad := range []string{
+		"https://ccp.example.com/AIMWebService/api/Accounts",
+		"https://ccp.example.com/AIMWebService/api/Accounts/",
+		"https://ccp.example.com/some/prefix/AIMWebService/api/Accounts",
+	} {
+		t.Run(bad, func(t *testing.T) {
+			c := &cyberarkManager{
+				preLogger: newTestLogger(),
+				config:    config.CyberArkManager{URL: bad, AppID: "orb"},
+			}
+			err := c.Start(context.Background())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "already includes the CCP endpoint path")
+		})
+	}
+}
+
 func TestCyberArkStart_RejectsCABundleWithOnlyPrivateKey(t *testing.T) {
 	// A PEM file that has a recognisable PEM block but no certificate must
 	// be rejected at startup rather than producing an empty trust pool that

--- a/agent/secretsmgr/cyberark_test.go
+++ b/agent/secretsmgr/cyberark_test.go
@@ -53,7 +53,66 @@ func TestCyberArkStart_TrimsTrailingSlashFromURL(t *testing.T) {
 		config:    config.CyberArkManager{URL: "https://ccp.example.com/", AppID: "orb"},
 	}
 	require.NoError(t, c.Start(context.Background()))
-	require.Equal(t, "https://ccp.example.com", c.baseURL)
+	require.Equal(t, "https://ccp.example.com", c.baseURL.String())
+}
+
+func TestCyberArkStart_AcceptsURLWithPathPrefix(t *testing.T) {
+	c := &cyberarkManager{
+		preLogger: newTestLogger(),
+		config:    config.CyberArkManager{URL: "https://ccp.example.com/cyberark", AppID: "orb"},
+	}
+	require.NoError(t, c.Start(context.Background()))
+	require.Equal(t, "/cyberark", c.baseURL.Path, "path prefix must be preserved")
+}
+
+func TestCyberArkStart_RejectsURLWithQueryOrFragment(t *testing.T) {
+	for _, bad := range []string{
+		"https://ccp.example.com?x=y",
+		"https://ccp.example.com#anchor",
+		"https://ccp.example.com/cyberark?a=1",
+	} {
+		t.Run(bad, func(t *testing.T) {
+			c := &cyberarkManager{
+				preLogger: newTestLogger(),
+				config:    config.CyberArkManager{URL: bad, AppID: "orb"},
+			}
+			err := c.Start(context.Background())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "query string or fragment")
+		})
+	}
+}
+
+func TestCyberArkStart_RejectsURLWithoutHost(t *testing.T) {
+	c := &cyberarkManager{
+		preLogger: newTestLogger(),
+		config:    config.CyberArkManager{URL: "https://", AppID: "orb"},
+	}
+	err := c.Start(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must include a host")
+}
+
+func TestCyberArkStart_RejectsCABundleWithOnlyPrivateKey(t *testing.T) {
+	// A PEM file that has a recognisable PEM block but no certificate must
+	// be rejected at startup rather than producing an empty trust pool that
+	// fails opaquely at TLS handshake time.
+	dir := t.TempDir()
+	keyOnly := filepath.Join(dir, "key.pem")
+	require.NoError(t, os.WriteFile(keyOnly, []byte(`-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIPRWyrJDXG9zAQt2YgL3vV4eqOh1aFFkdvE7QprjLkBmoAoGCCqGSM49
+AwEHoUQDQgAEH+wLkFW6xQRPAY1+i6FdNYbZFTr1cmoZTbb8B+pPj91A3pSAlIeq
+Iz3FQjRyrCfXrI4LElIh6/Pwhkz2zHo+pQ==
+-----END EC PRIVATE KEY-----
+`), 0o600))
+
+	c := &cyberarkManager{
+		preLogger: newTestLogger(),
+		config:    config.CyberArkManager{URL: "https://ccp.example.com", AppID: "orb", CABundle: keyOnly},
+	}
+	err := c.Start(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no parseable certificates")
 }
 
 func TestCyberArkStart_RejectsUnparseableURL(t *testing.T) {

--- a/agent/secretsmgr/cyberark_test.go
+++ b/agent/secretsmgr/cyberark_test.go
@@ -93,6 +93,16 @@ func TestCyberArkStart_RejectsURLWithoutHost(t *testing.T) {
 	require.Contains(t, err.Error(), "must include a host")
 }
 
+func TestCyberArkStart_RejectsAppIDWithSlash(t *testing.T) {
+	c := &cyberarkManager{
+		preLogger: newTestLogger(),
+		config:    config.CyberArkManager{URL: "https://ccp.example.com", AppID: "team/app"},
+	}
+	err := c.Start(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must not contain '/'")
+}
+
 func TestCyberArkStart_RejectsURLAlreadyAtCCPEndpoint(t *testing.T) {
 	// Operators copying examples from upstream CyberArk integrations
 	// sometimes paste the full endpoint URL. Catch it at startup; otherwise
@@ -312,6 +322,17 @@ func TestCyberArkParseBody_ShortFormRequiresConfiguredAppID(t *testing.T) {
 	_, err := c.parseBody("Lab/DB-Account")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "app_id")
+}
+
+func TestCyberArkParseBody_RejectsAppIDOverrideContainingSlash(t *testing.T) {
+	// The "//" separator marks the end of the AppID, so a body like
+	// "A/B//Safe/Object" would otherwise leak the unsupported segment into
+	// AppID=A/B. The docs claim "/" is reserved across all four name
+	// segments; this lock guarantees the parser actually enforces it.
+	c := cyberarkManagerWith("orb-agent")
+	_, err := c.parseBody("A/B//Lab/DB-Account")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "AppID override must not contain '/'")
 }
 
 // fakeCCP emulates the GET /AIMWebService/api/Accounts endpoint.

--- a/agent/secretsmgr/cyberark_test.go
+++ b/agent/secretsmgr/cyberark_test.go
@@ -96,15 +96,14 @@ func TestCyberArkStart_RejectsURLWithoutHost(t *testing.T) {
 func TestCyberArkStart_RejectsCABundleWithOnlyPrivateKey(t *testing.T) {
 	// A PEM file that has a recognisable PEM block but no certificate must
 	// be rejected at startup rather than producing an empty trust pool that
-	// fails opaquely at TLS handshake time.
+	// fails opaquely at TLS handshake time. Generate the key at runtime via
+	// the same helper the mTLS test uses, so there's no literal-looking
+	// private-key material in the source tree to trip secret scanners.
+	_, keyPEM := generateTestCertPair(t, "ca-bundle-key-only-fixture")
+
 	dir := t.TempDir()
 	keyOnly := filepath.Join(dir, "key.pem")
-	require.NoError(t, os.WriteFile(keyOnly, []byte(`-----BEGIN EC PRIVATE KEY-----
-MHcCAQEEIPRWyrJDXG9zAQt2YgL3vV4eqOh1aFFkdvE7QprjLkBmoAoGCCqGSM49
-AwEHoUQDQgAEH+wLkFW6xQRPAY1+i6FdNYbZFTr1cmoZTbb8B+pPj91A3pSAlIeq
-Iz3FQjRyrCfXrI4LElIh6/Pwhkz2zHo+pQ==
------END EC PRIVATE KEY-----
-`), 0o600))
+	require.NoError(t, os.WriteFile(keyOnly, keyPEM, 0o600))
 
 	c := &cyberarkManager{
 		preLogger: newTestLogger(),

--- a/agent/secretsmgr/cyberark_test.go
+++ b/agent/secretsmgr/cyberark_test.go
@@ -150,6 +150,75 @@ func TestCyberArkStart_SkipTLSVerifyFlowsThroughToTransport(t *testing.T) {
 	require.True(t, tr.TLSClientConfig.InsecureSkipVerify)
 }
 
+func cyberarkManagerWith(appID string) *cyberarkManager {
+	return &cyberarkManager{config: config.CyberArkManager{AppID: appID}}
+}
+
+func TestCyberArkParseBody_ShortForm(t *testing.T) {
+	c := cyberarkManagerWith("orb-agent")
+	ref, err := c.parseBody("Lab/DB-Account")
+	require.NoError(t, err)
+	require.Equal(t, "orb-agent", ref.appID)
+	require.Equal(t, "Lab", ref.safe)
+	require.Equal(t, "DB-Account", ref.object)
+	require.Equal(t, "Content", ref.field)
+}
+
+func TestCyberArkParseBody_ShortFormWithField(t *testing.T) {
+	c := cyberarkManagerWith("orb-agent")
+	ref, err := c.parseBody("Lab/DB-Account/UserName")
+	require.NoError(t, err)
+	require.Equal(t, "orb-agent", ref.appID)
+	require.Equal(t, "Lab", ref.safe)
+	require.Equal(t, "DB-Account", ref.object)
+	require.Equal(t, "UserName", ref.field)
+}
+
+func TestCyberArkParseBody_Qualified(t *testing.T) {
+	c := cyberarkManagerWith("orb-agent")
+	ref, err := c.parseBody("OtherApp//Lab/DB-Account")
+	require.NoError(t, err)
+	require.Equal(t, "OtherApp", ref.appID)
+	require.Equal(t, "Lab", ref.safe)
+	require.Equal(t, "DB-Account", ref.object)
+	require.Equal(t, "Content", ref.field)
+}
+
+func TestCyberArkParseBody_QualifiedWithField(t *testing.T) {
+	c := cyberarkManagerWith("orb-agent")
+	ref, err := c.parseBody("OtherApp//Lab/DB-Account/UserName")
+	require.NoError(t, err)
+	require.Equal(t, "OtherApp", ref.appID)
+	require.Equal(t, "Lab", ref.safe)
+	require.Equal(t, "DB-Account", ref.object)
+	require.Equal(t, "UserName", ref.field)
+}
+
+func TestCyberArkParseBody_GrammarErrors(t *testing.T) {
+	c := cyberarkManagerWith("orb-agent")
+	for _, body := range []string{
+		"",                                     // empty
+		"Lab",                                  // 1 segment short — no object
+		"Lab/DB-Account/UserName/Extra",        // 4 segments short — too long
+		"OtherApp//Lab",                        // qualified short — no object
+		"OtherApp//Lab/DB-Account/Field/Extra", // qualified too long
+		"//Lab/DB-Account",                     // empty AppID before //
+		"/Lab/DB-Account",                      // leading slash
+		"Lab/",                                 // trailing slash
+		"Lab//Object",                          // // with nothing after AppID makes no sense
+	} {
+		_, err := c.parseBody(body)
+		require.Errorf(t, err, "body %q should have been rejected", body)
+	}
+}
+
+func TestCyberArkParseBody_ShortFormRequiresConfiguredAppID(t *testing.T) {
+	c := cyberarkManagerWith("")
+	_, err := c.parseBody("Lab/DB-Account")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "app_id")
+}
+
 // testSelfSignedCAPEM is a syntactically-valid X.509 self-signed CA PEM block
 // used purely to drive the CA-bundle parsing happy path. It is NOT used for
 // any real TLS handshake.

--- a/agent/secretsmgr/cyberark_test.go
+++ b/agent/secretsmgr/cyberark_test.go
@@ -497,3 +497,15 @@ func TestCyberArkPollSecrets_FailureEvictsAndReportsFalse(t *testing.T) {
 	c.mu.Unlock()
 	require.False(t, present, "failed entry must be evicted")
 }
+
+func TestNewManager_ReturnsCyberArkManagerWhenActive(t *testing.T) {
+	logger := newTestLogger()
+	m := New(logger, config.ManagerSecrets{
+		Active: "cyberark",
+		Sources: config.SecretsSources{
+			CyberArk: config.CyberArkManager{URL: "https://ccp.example.com", AppID: "orb"},
+		},
+	})
+	_, ok := m.(*cyberarkManager)
+	require.True(t, ok, "New() with active=cyberark must return *cyberarkManager, got %T", m)
+}

--- a/agent/secretsmgr/cyberark_test.go
+++ b/agent/secretsmgr/cyberark_test.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -267,7 +268,7 @@ func (f *fakeCCP) set(appID, safe, object string, fields map[string]any) {
 	f.accounts[appID+"|"+safe+"|"+object] = fields
 }
 
-func (f *fakeCCP) delete(appID, safe, object string) { //nolint:unused // used by later tasks
+func (f *fakeCCP) delete(appID, safe, object string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	delete(f.accounts, appID+"|"+safe+"|"+object)
@@ -409,3 +410,90 @@ Wf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc
 6MF9+Yw1Yy0t
 -----END CERTIFICATE-----
 `
+
+func TestCyberArkResolveBody_CacheHitAvoidsSecondHTTP(t *testing.T) {
+	fake := newFakeCCP()
+	defer fake.Close()
+	fake.set("orb-agent", "Lab", "Acc", map[string]any{"Content": "v1"})
+
+	c := newCyberarkManagerForTest(t, fake, config.CyberArkManager{})
+
+	v1, err := c.resolveBody("Lab/Acc", "policy-a")
+	require.NoError(t, err)
+	require.Equal(t, "v1", v1)
+
+	v2, err := c.resolveBody("Lab/Acc", "policy-b")
+	require.NoError(t, err)
+	require.Equal(t, "v1", v2)
+
+	require.EqualValues(t, 1, fake.calls.Load(), "second resolve should hit cache")
+}
+
+func TestCyberArkSolvePolicySecrets_ReplacesPlaceholder(t *testing.T) {
+	fake := newFakeCCP()
+	defer fake.Close()
+	fake.set("orb-agent", "Lab", "Acc", map[string]any{"Content": "s3cret"})
+
+	c := newCyberarkManagerForTest(t, fake, config.CyberArkManager{})
+	payload := config.PolicyPayload{
+		ID: "policy-1",
+		Data: map[string]any{
+			"auth": map[string]any{"password": "${cyberark://Lab/Acc}"},
+		},
+	}
+	out, err := c.SolvePolicySecrets(payload)
+	require.NoError(t, err)
+	auth := out.Data.(map[string]any)["auth"].(map[string]any)
+	require.Equal(t, "s3cret", auth["password"])
+}
+
+func TestCyberArkPollSecrets_DetectsChange(t *testing.T) {
+	fake := newFakeCCP()
+	defer fake.Close()
+	fake.set("orb-agent", "Lab", "Acc", map[string]any{"Content": "v1"})
+
+	c := newCyberarkManagerForTest(t, fake, config.CyberArkManager{})
+	got := make(chan map[string]bool, 4)
+	c.RegisterUpdatePoliciesCallback(func(m map[string]bool) { got <- m })
+
+	_, err := c.resolveBody("Lab/Acc", "policy-1")
+	require.NoError(t, err)
+
+	fake.set("orb-agent", "Lab", "Acc", map[string]any{"Content": "v2"})
+
+	c.pollSecrets()
+	select {
+	case m := <-got:
+		require.Equal(t, map[string]bool{"policy-1": true}, m)
+	case <-time.After(time.Second):
+		t.Fatal("expected change callback not invoked")
+	}
+}
+
+func TestCyberArkPollSecrets_FailureEvictsAndReportsFalse(t *testing.T) {
+	fake := newFakeCCP()
+	defer fake.Close()
+	fake.set("orb-agent", "Lab", "Acc", map[string]any{"Content": "v1"})
+
+	c := newCyberarkManagerForTest(t, fake, config.CyberArkManager{})
+	got := make(chan map[string]bool, 4)
+	c.RegisterUpdatePoliciesCallback(func(m map[string]bool) { got <- m })
+
+	_, err := c.resolveBody("Lab/Acc", "policy-1")
+	require.NoError(t, err)
+
+	fake.delete("orb-agent", "Lab", "Acc")
+
+	c.pollSecrets()
+	select {
+	case m := <-got:
+		require.Equal(t, map[string]bool{"policy-1": false}, m)
+	case <-time.After(time.Second):
+		t.Fatal("expected failure callback not invoked")
+	}
+
+	c.mu.Lock()
+	_, present := c.usedVars["Lab/Acc"]
+	c.mu.Unlock()
+	require.False(t, present, "failed entry must be evicted")
+}

--- a/agent/secretsmgr/cyberark_test.go
+++ b/agent/secretsmgr/cyberark_test.go
@@ -2,7 +2,16 @@ package secretsmgr
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -508,4 +517,118 @@ func TestNewManager_ReturnsCyberArkManagerWhenActive(t *testing.T) {
 	})
 	_, ok := m.(*cyberarkManager)
 	require.True(t, ok, "New() with active=cyberark must return *cyberarkManager, got %T", m)
+}
+
+// generateTestCertPair produces a self-signed EC cert/key PEM pair valid for
+// 127.0.0.1 and "localhost" with the given CommonName. Used to drive the
+// mTLS round-trip test; not used in production paths.
+func generateTestCertPair(t *testing.T, cn string) (certPEM, keyPEM []byte) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(time.Now().UnixNano()),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	require.NoError(t, err)
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	require.NoError(t, err)
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM
+}
+
+func TestCyberArk_mTLS_HandshakeRoundTrip(t *testing.T) {
+	// Generate a CA-ish cert that doubles as a server cert AND is accepted
+	// as a client cert. Same key material is used for both sides of the
+	// handshake; this is fine for the test's purposes (it proves Go's
+	// http.Client presents the cert we asked for).
+	serverCertPEM, serverKeyPEM := generateTestCertPair(t, "server.localhost")
+	clientCertPEM, clientKeyPEM := generateTestCertPair(t, "orb-agent-client")
+
+	dir := t.TempDir()
+	caFile := filepath.Join(dir, "ca.pem")
+	require.NoError(t, os.WriteFile(caFile, serverCertPEM, 0o600))
+	certFile := filepath.Join(dir, "client.pem")
+	keyFile := filepath.Join(dir, "client.key")
+	require.NoError(t, os.WriteFile(certFile, clientCertPEM, 0o600))
+	require.NoError(t, os.WriteFile(keyFile, clientKeyPEM, 0o600))
+
+	// Server requires client cert.
+	serverCert, err := tls.X509KeyPair(serverCertPEM, serverKeyPEM)
+	require.NoError(t, err)
+	clientCA := x509.NewCertPool()
+	clientCA.AppendCertsFromPEM(clientCertPEM)
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"Content":"mtls-ok"}`))
+	}))
+	srv.TLS = &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    clientCA,
+		MinVersion:   tls.VersionTLS12,
+	}
+	srv.StartTLS()
+	defer srv.Close()
+
+	// With a configured client cert + CA bundle, the handshake should succeed.
+	c := &cyberarkManager{
+		preLogger: newTestLogger(),
+		config: config.CyberArkManager{
+			URL:        srv.URL,
+			AppID:      "orb-agent",
+			CABundle:   caFile,
+			ClientCert: certFile,
+			ClientKey:  keyFile,
+		},
+	}
+	require.NoError(t, c.Start(context.Background()))
+
+	val, err := c.fetch("Lab/Acc")
+	require.NoError(t, err)
+	require.Equal(t, "mtls-ok", val)
+
+	// Without the client cert/key, the handshake must fail.
+	c2 := &cyberarkManager{
+		preLogger: newTestLogger(),
+		config: config.CyberArkManager{
+			URL:      srv.URL,
+			AppID:    "orb-agent",
+			CABundle: caFile,
+		},
+	}
+	require.NoError(t, c2.Start(context.Background()))
+	_, err = c2.fetch("Lab/Acc")
+	require.Error(t, err, "fetch without client cert must fail")
+}
+
+func TestCyberArk_SkipTLSVerify_AcceptsSelfSignedServer(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"Content":"skip-tls-ok"}`))
+	}))
+	defer srv.Close()
+
+	c := &cyberarkManager{
+		preLogger: newTestLogger(),
+		config: config.CyberArkManager{
+			URL:           srv.URL,
+			AppID:         "orb-agent",
+			SkipTLSVerify: true,
+		},
+	}
+	require.NoError(t, c.Start(context.Background()))
+
+	val, err := c.fetch("Lab/Acc")
+	require.NoError(t, err)
+	require.Equal(t, "skip-tls-ok", val)
 }

--- a/agent/secretsmgr/manager.go
+++ b/agent/secretsmgr/manager.go
@@ -26,6 +26,8 @@ func New(logger *slog.Logger, c config.ManagerSecrets) Manager {
 		return &delineaManager{preLogger: logger, config: c.Sources.Delinea}
 	case "doppler":
 		return &dopplerManager{preLogger: logger, config: c.Sources.Doppler}
+	case "cyberark":
+		return &cyberarkManager{preLogger: logger, config: c.Sources.CyberArk}
 	default:
 		logger.Info("no secrets manager specified or invalid type, skipping")
 		return &dummyManager{}

--- a/agent/secretsmgr/polling.go
+++ b/agent/secretsmgr/polling.go
@@ -219,6 +219,14 @@ func (b *pollingBase) startScheduler(schedule *string) error {
 		task,
 		gocron.WithSingletonMode(gocron.LimitModeReschedule),
 	); err != nil {
+		// gocron.NewScheduler spawns an internal goroutine immediately; if we
+		// return here without shutting it down, that goroutine leaks for the
+		// process lifetime. Surface the shutdown error in the log but always
+		// return the NewJob failure (the actionable error for the operator).
+		if shutdownErr := b.scheduler.Shutdown(); shutdownErr != nil {
+			b.logger.Error("scheduler shutdown failed after NewJob error", "scheme", b.scheme, "error", shutdownErr)
+		}
+		b.scheduler = nil
 		return fmt.Errorf("failed to create %s polling job: %w", b.scheme, err)
 	}
 	b.logger.Info("Starting secret polling", "scheme", b.scheme, "cron interval", *schedule)

--- a/docs/configs/agent_yaml.md
+++ b/docs/configs/agent_yaml.md
@@ -203,6 +203,7 @@ Supported backends (set one in `active`):
 | `vault` | HashiCorp Vault (KV v2) | `${vault://...}` | [Vault](../secretsmgr/vault.md) |
 | `delinea` | Delinea Secret Server | `${delinea://...}` | [Delinea](../secretsmgr/delinea.md) |
 | `doppler` | Doppler | `${doppler://...}` | [Doppler](../secretsmgr/doppler.md) |
+| `cyberark` | CyberArk PAM (Central Credential Provider) | `${cyberark://...}` | [CyberArk](../secretsmgr/cyberark.md) |
 | `fleet` | Fleet (NetBox Labs cloud) | — | — |
 
 ### Vault
@@ -271,6 +272,36 @@ orb:
 ```
 
 See the full [Doppler secrets manager documentation](../secretsmgr/doppler.md) for all parameters, authentication, and change-detection semantics.
+
+### CyberArk
+
+CyberArk placeholders take a short form (using the AppID default from the agent config) or a fully qualified form, with an optional field selector for non-password fields:
+
+```yaml
+# Short form — returns the Content (password) field
+password: ${cyberark://<Safe>/<Object>}
+
+# Short form with field selector
+username: ${cyberark://<Safe>/<Object>/UserName}
+
+# Fully qualified, overriding the configured AppID
+password: ${cyberark://<AppID>//<Safe>/<Object>}
+```
+
+```yaml
+orb:
+  secrets_manager:
+    active: cyberark
+    sources:
+      cyberark:
+        url: https://ccp.corp.example.com
+        app_id: orb-agent
+        client_cert: /opt/orb/secrets/orb.crt
+        client_key:  /opt/orb/secrets/orb.key
+        schedule: "*/5 * * * *"
+```
+
+See the full [CyberArk secrets manager documentation](../secretsmgr/cyberark.md) for all parameters and authentication options.
 
 Plain `${VAR_NAME}` references are **not** resolved by the secrets manager — those are handled by environment variable substitution as described below.
 

--- a/docs/configs/agent_yaml.md
+++ b/docs/configs/agent_yaml.md
@@ -315,6 +315,7 @@ Values can reference environment variables using `${VAR_NAME}` syntax. Resolutio
 |-------|-----------------|-------------|
 | Git config manager | `url`, `password` | Go agent at startup |
 | Vault secrets manager `auth_args` | All fields | Go agent at startup |
+| CyberArk secrets manager | `url`, `app_id`, `reason`, `ca_bundle`, `client_cert`, `client_key` | Go agent at startup |
 | `device_discovery` policy (all fields) | Any string value in `scope` and `defaults` | Python backend at policy execution |
 | `snmp_discovery` policy authentication | `community`, `username`, `auth_passphrase`, `priv_passphrase` | Go SNMP backend at policy execution |
 

--- a/docs/secretsmgr/cyberark.md
+++ b/docs/secretsmgr/cyberark.md
@@ -9,7 +9,7 @@ The Orb Agent can integrate with [CyberArk Privileged Access Manager (PAM)](http
 Before configuring the agent, the CyberArk administrator must provision:
 
 1. An **AppID** record in the Vault representing the orb-agent instance.
-2. **Authentication evidence** on the AppID: a client certificate's Common Name / Subject, an IP allowlist of the agent hosts, an OS user, or a hostname.
+2. **Authentication evidence** on the AppID: a matching certificate identity (CyberArk supports Issuer, Subject DN, or Subject Alternative Name — see the [CyberArk Application Authentication Methods documentation](https://docs.cyberark.com/credential-providers/latest/en/content/cp%20and%20ascp/application-authentication-methods-general.htm)), an IP allowlist of the agent hosts, an OS user, or a hostname.
 3. **Safe access**: every Safe the agent will read from must grant the AppID the `Retrieve Accounts` permission.
 4. **Account naming**: pick a consistent Object naming scheme so YAML placeholders are stable across rotations.
 
@@ -52,7 +52,7 @@ The following fields accept an environment-variable placeholder of the form `${V
 
 CCP authenticates the *requesting application* (the orb-agent process), not a user. CyberArk supports several mechanisms; pick whichever fits your environment:
 
-- **Client certificate (recommended for production)**: set `client_cert` and `client_key`, and ensure the CyberArk admin configured the AppID to require the matching certificate Common Name.
+- **Client certificate (recommended for production)**: set `client_cert` and `client_key`, and have the CyberArk admin add a matching certificate-identity authenticator to the AppID. CyberArk supports matching by Issuer, Subject DN, or Subject Alternative Name (see the [Application Authentication Methods documentation](https://docs.cyberark.com/credential-providers/latest/en/content/cp%20and%20ascp/application-authentication-methods-general.htm) for the exact attribute names and how to provision each one). The agent has no preference between SAN and Subject — pick whichever matches the cert your PKI issues to orb-agent.
 - **IP allowlist**: nothing on the agent side; the CyberArk admin allowlists the agent host's IP on the AppID.
 - **OS user / hostname**: nothing on the agent side; rarely used cross-OS.
 

--- a/docs/secretsmgr/cyberark.md
+++ b/docs/secretsmgr/cyberark.md
@@ -1,0 +1,134 @@
+# CyberArk Secrets Manager (beta)
+
+The Orb Agent can integrate with [CyberArk Privileged Access Manager (PAM)](https://www.cyberark.com/products/privileged-access-manager/) via the Central Credential Provider (CCP) to retrieve secrets at runtime. This feature allows you to reference accounts stored in CyberArk directly in your policy configurations without hardcoding sensitive values.
+
+> **Beta:** Validated via unit tests against a fake CCP HTTP server. End-to-end validation against a real CCP deployment is the next step.
+
+## Prerequisites
+
+Before configuring the agent, the CyberArk administrator must provision:
+
+1. An **AppID** record in the Vault representing the orb-agent instance.
+2. **Authentication evidence** on the AppID: a client certificate's Common Name / Subject, an IP allowlist of the agent hosts, an OS user, or a hostname.
+3. **Safe access**: every Safe the agent will read from must grant the AppID the `Retrieve Accounts` permission.
+4. **Account naming**: pick a consistent Object naming scheme so YAML placeholders are stable across rotations.
+
+## Configuration
+
+The CyberArk secrets manager is configured in the `secrets_manager` section of your Orb Agent configuration file:
+
+```yaml
+orb:
+  secrets_manager:
+    active: cyberark
+    sources:
+      cyberark:
+        url: "https://ccp.corp.example.com"        # required — base URL of the CCP service
+        app_id: "orb-agent"                        # required — provisioned in the Vault
+        reason: "orb-agent policy resolution"      # optional — written to the CyberArk audit log on every fetch
+        ca_bundle:   "/opt/orb/secrets/ccp-ca.pem" # optional — PEM CA chain for the CCP server cert
+        client_cert: "/opt/orb/secrets/orb.crt"    # optional — client cert for mTLS to CCP
+        client_key:  "/opt/orb/secrets/orb.key"    # optional — client key for mTLS to CCP
+        timeout: 60                                # optional — HTTP timeout in seconds (default 60)
+        schedule: "*/5 * * * *"                    # optional — cron format for polling interval
+```
+
+### Configuration Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `url` | string | Yes | Base URL of the CCP web service, e.g. `https://ccp.corp.example.com`. A trailing slash is trimmed automatically. |
+| `app_id` | string | Yes | CyberArk AppID provisioned for this agent. Used in every short-form lookup and as the default for qualified ones. |
+| `reason` | string | No | Free-text reason written to the CyberArk audit log on every fetch. Increases audit fidelity at the cost of one log line per fetch (including polling re-fetches). |
+| `ca_bundle` | string | No | Path to a PEM file containing the CA chain that signed the CCP server cert. Only needed when the CCP cert is not signed by a publicly-trusted CA. |
+| `client_cert` / `client_key` | string | No (must be set together) | Paths to a client cert/key pair for mTLS to CCP. Required when the CyberArk admin authenticates this AppID by client certificate. |
+| `skip_tls_verify` | bool | No | Disables peer-cert verification. Logged at WARN at startup. Lab / development only. |
+| `timeout` | int | No | HTTP timeout in seconds (default `60`). |
+| `schedule` | string | No | Cron expression for periodic polling of cached secrets. When omitted, secrets are fetched once on first reference and never re-checked. |
+
+Each string field accepts an environment-variable placeholder of the form `${VAR_NAME}`. Placeholders are resolved at agent startup; an unset variable causes the agent to fail startup with a clear error.
+
+## Authentication
+
+CCP authenticates the *requesting application* (the orb-agent process), not a user. CyberArk supports several mechanisms; pick whichever fits your environment:
+
+- **Client certificate (recommended for production)**: set `client_cert` and `client_key`, and ensure the CyberArk admin configured the AppID to require the matching certificate Common Name.
+- **IP allowlist**: nothing on the agent side; the CyberArk admin allowlists the agent host's IP on the AppID.
+- **OS user / hostname**: nothing on the agent side; rarely used cross-OS.
+
+The agent does not eagerly authenticate at startup — the first secret fetch is what surfaces a 401/403, with the error visible in the policy-apply log.
+
+## Usage
+
+The Orb Agent supports four reference shapes. Use whichever is most concise for your environment.
+
+### Short form
+
+```
+${cyberark://<Safe>/<Object>}
+```
+
+Uses the AppID from `sources.cyberark.app_id` and returns the `Content` field (the password). Example:
+
+```
+${cyberark://Lab-DB/cisco-svc-account}
+```
+
+### Short form with field selector
+
+```
+${cyberark://<Safe>/<Object>/<Field>}
+```
+
+Returns the named field instead of `Content`. Useful for `UserName`, `Address`, `Database`, etc.
+
+```
+${cyberark://Lab-DB/cisco-svc-account/UserName}
+```
+
+### Fully qualified
+
+```
+${cyberark://<AppID>//<Safe>/<Object>}
+```
+
+Overrides the configured AppID for this one placeholder. Useful when the same orb-agent instance fetches from multiple CyberArk tenants. The `//` separator marks the end of the AppID.
+
+```
+${cyberark://OtherTenant//Lab-DB/cisco-svc-account}
+```
+
+### Fully qualified with field selector
+
+```
+${cyberark://<AppID>//<Safe>/<Object>/<Field>}
+```
+
+```
+${cyberark://OtherTenant//Lab-DB/cisco-svc-account/UserName}
+```
+
+### Example
+
+```yaml
+orb:
+  policies:
+    device_discovery:
+      discovery_1:
+        schedule: "0 * * * *"
+        defaults:
+          site: NY
+        scope:
+          - driver: ios
+            hostname: 10.1.2.24
+            username: "${cyberark://Lab-DB/cisco-svc-account/UserName}"
+            password: "${cyberark://Lab-DB/cisco-svc-account}"
+```
+
+The Orb Agent will resolve the CyberArk references and use the actual values when the policy is applied.
+
+## Secret Polling
+
+If you configure the `schedule` parameter, the Orb Agent will periodically re-fetch every cached secret. When a value changes, the related policies are automatically updated. The change is logged at INFO as `Detected changed secret scheme=cyberark ref=<body>` so operators can confirm a rotation has propagated. If a secret becomes unreachable (account deleted, AppID revoked, network failure), the provider evicts the cache entry and the policy manager marks the affected policies as failed; the policy can recover only after a successful re-fetch.
+
+This is useful for credential rotation scenarios, where you want to update credentials in CyberArk without restarting the Orb Agent or manually updating policies.

--- a/docs/secretsmgr/cyberark.md
+++ b/docs/secretsmgr/cyberark.md
@@ -46,7 +46,7 @@ orb:
 | `timeout` | int | No | HTTP timeout in seconds (default `60`). |
 | `schedule` | string | No | Cron expression for periodic polling of cached secrets. When omitted, secrets are fetched once on first reference and never re-checked. |
 
-Each string field accepts an environment-variable placeholder of the form `${VAR_NAME}`. Placeholders are resolved at agent startup; an unset variable causes the agent to fail startup with a clear error.
+The following fields accept an environment-variable placeholder of the form `${VAR_NAME}`: `url`, `app_id`, `reason`, `ca_bundle`, `client_cert`, `client_key`. Placeholders are resolved at agent startup; an unset variable causes the agent to fail startup with a clear error.
 
 ## Authentication
 

--- a/docs/secretsmgr/cyberark.md
+++ b/docs/secretsmgr/cyberark.md
@@ -62,6 +62,8 @@ The agent does not eagerly authenticate at startup — the first secret fetch is
 
 The Orb Agent supports four reference shapes. Use whichever is most concise for your environment.
 
+> **Reserved characters.** The `/` character is reserved by the placeholder grammar and may not appear inside any AppID, Safe, Object, or Field name referenced from a placeholder. CyberArk itself permits a wider character set for these names; if your existing accounts use `/` in their identifiers, you must either rename them or open a follow-up issue requesting percent-escape (`%2F`) support.
+
 ### Short form
 
 ```


### PR DESCRIPTION
## Summary

Resolves [OBS-1100](https://linear.app/netboxlabs/issue/OBS-1100/cyberark-support-in-secrets-manager). Adds CyberArk Privileged Access Manager as a fifth `secrets_manager` backend, alongside Vault, Doppler, Delinea, and Fleet.

Target product: **CyberArk PAM (Self-Hosted)**, accessed via the **Central Credential Provider (CCP)** REST API at `GET /AIMWebService/api/Accounts`. Not Conjur, not the on-host Credential Provider, not Privilege Cloud (those are scoped as separate, follow-up integrations).

## Architecture

The provider embeds the existing `pollingBase` shared by Vault/Delinea/Doppler. Net delta: one new file (`agent/secretsmgr/cyberark.go`), one switch case in `manager.go`, one config struct, one user doc. The pollingBase wiring gives us cache + cron polling + change callbacks + race-safe state for free.

The CCP HTTP surface is small: one stateless `GET` per fetch with optional `Reason` audit-log parameter. Authentication of the requesting app is configured **on the CyberArk side** (cert SAN, IP allowlist, OS user, hostname); on the agent side we just present the optional client cert via mTLS.

## YAML

```yaml
orb:
  secrets_manager:
    active: cyberark
    sources:
      cyberark:
        url: "https://ccp.corp.example.com"
        app_id: "orb-agent"
        reason: "orb-agent policy resolution"   # optional CCP audit-log breadcrumb
        ca_bundle:   "/opt/orb/secrets/ccp-ca.pem"
        client_cert: "/opt/orb/secrets/orb.crt"
        client_key:  "/opt/orb/secrets/orb.key"
        timeout: 60
        schedule: "*/5 * * * *"
```

## Placeholder grammar — four forms

`//` unambiguously separates an optional AppID override from the rest, mirroring the Vault multi-segment-mount grammar:

| Form | Example | Resolves to |
|---|---|---|
| Short | `${cyberark://<Safe>/<Object>}` | configured AppID, `Content` field |
| Short + field | `${cyberark://<Safe>/<Object>/<Field>}` | configured AppID, named field |
| Qualified | `${cyberark://<AppID>//<Safe>/<Object>}` | per-placeholder AppID, `Content` |
| Qualified + field | `${cyberark://<AppID>//<Safe>/<Object>/<Field>}` | per-placeholder AppID, named field |

`/` is reserved by the grammar and may not appear inside any segment. The doc calls this out.

## Validation

`Start()` validates everything that can be checked without talking to CCP:

- `url` and `app_id` required; env-resolvable.
- URL must parse, scheme must be `http`/`https`, have a host, and have **no** query string or fragment.
- `client_cert` and `client_key` must be set together.
- `ca_bundle` must contain at least one parseable certificate (a key-only PEM is rejected at startup, not at handshake time).
- `skip_tls_verify=true` is permitted but logged at WARN at startup.

The `http.Client` is built by **cloning `http.DefaultTransport`** and overriding only `TLSClientConfig`, so `HTTPS_PROXY`, dial timeouts, and HTTP/2 negotiation continue to work in corporate environments.

## Tests

- `make lint` → 0 issues.
- `go test -race -run "TestCyberArk|TestNewManager_ReturnsCyberArk" ./agent/secretsmgr/...` → **38 PASS**:
  - 17 Start-validation cases (URL/scheme/host/query+fragment/cert XOR/CA bundle parse/key-only PEM/skip-verify warn/timeout default+override).
  - 6 parser cases (4 grammar forms + 9-case grammar-error table + missing-AppID).
  - 8 fetch cases (short/qualified/field-selector/Reason fwd/404/missing field/empty field/401).
  - 4 polling cases (cache hit / SolvePolicySecrets / change detect / failure eviction).
  - 2 TLS cases: real mTLS handshake with self-signed EC certs, plus skip-verify against a self-signed `httptest.NewTLSServer`.
  - 1 dispatcher case.
- No live-CyberArk integration in CI; the real-tenancy round-trip is the manual e2e for the prospect.

## Codex adversarial review

Already round-tripped through Codex twice:

1. **Adversarial pass** ([memo in PR thread / Linear](https://linear.app/netboxlabs/issue/OBS-1100/)) flagged 4 important + 2 minor issues: empty-pool CA bundles, bare HTTP transport losing proxy support, URL query-string corruption of the endpoint, scheduler goroutine leak on bad cron, undocumented `/` reservation, missing env-substitution row.
2. **Normal re-review** confirmed all six resolved in `aa49a52`, no new bugs introduced, ready to merge from a correctness standpoint.

The fix commit also de-orphaned the gocron scheduler in **all** providers (`vault/delinea/doppler/cyberark`) — the leak path lived in `pollingBase.startScheduler`.

## Files

| File | Change |
|---|---|
| `agent/config/types.go` | new `CyberArkManager` struct + field on `SecretsSources` |
| `agent/secretsmgr/cyberark.go` | new provider (~230 LOC: Start, parseBody, fetch, ccpErrorEnvelope, ccpErrorDetail) |
| `agent/secretsmgr/cyberark_test.go` | new (~700 LOC: fakeCCP httptest server, 38 tests, mTLS cert generation helper) |
| `agent/secretsmgr/manager.go` | one `case "cyberark"` in `New()` |
| `agent/secretsmgr/polling.go` | scheduler-cleanup-on-NewJob-error fix (benefits all providers) |
| `docs/secretsmgr/cyberark.md` | new user-facing doc |
| `README.md` | add CyberArk to Supported secrets managers list |
| `docs/configs/agent_yaml.md` | per-backend table row + `### CyberArk` subsection + env-substitution table row |

## Test plan

- [x] `make lint` clean
- [x] `go test -race ./agent/secretsmgr/...` for CyberArk + sibling providers passes locally
- [x] CI go-test on this branch
- [ ] Manual e2e against the prospect's real CyberArk PAM tenancy:
  - [ ] Verify Service-Account-style fetch with mTLS
  - [ ] Verify IP-allowlist-only auth path
  - [ ] Verify a configured `Reason` appears in the CyberArk audit log
  - [ ] Verify cron poll detects a rotated password within one tick

## Out of scope (follow-ups)

- PVWA logon-flow fallback for environments without CCP deployed.
- CyberArk Privilege Cloud (SaaS) — different URL shape and OAuth flow.
- `Folder` query parameter for non-Root folder layouts (every CCP install I've seen uses `Root`; can add a 5th body segment if a customer needs it).
- Write operations against CyberArk (account create / password rotation).
- Conjur — different product, different SDK, separate spec.

Draft because real-tenancy e2e is gated on the prospect/CyberArk-trial access.