### PR TITLE
feat(fleet): handle inbox.packages MQTT message to install bundles…

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -121,7 +121,7 @@ func New(logger *slog.Logger, c config.Config, debug bool) (Agent, error) {
 	// Pass a background context to the config manager at construction time. The
 	// manager keeps its own copy and later derives child contexts from the
 	// runtime context supplied in Agent.Start.
-	cm := configmgr.New(logger, pm, c.OrbAgent.ConfigManager.Active, backendStateManager)
+	cm := configmgr.New(logger, pm, c.OrbAgent.ConfigManager.Active, backendStateManager, fm)
 
 	return &orbAgent{
 		logger:              logger,

--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/filesmgr"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/configmgr/fleet"
 	"github.com/netboxlabs/orb-agent/agent/otlpbridge"
@@ -54,12 +55,12 @@ type FleetConfigManager struct {
 	goroutinesWg sync.WaitGroup // tracks goroutines started in Start(); Wait()ed in Stop() before Disconnect
 }
 
-func newFleetConfigManager(logger *slog.Logger, pMgr policymgr.PolicyManager, backendState backend.StateRetriever) *FleetConfigManager {
+func newFleetConfigManager(logger *slog.Logger, pMgr policymgr.PolicyManager, backendState backend.StateRetriever, fm filesmgr.Manager) *FleetConfigManager {
 	resetChan := make(chan struct{}, 1)
 	reconnectChan := make(chan struct{}, 1)
 	return &FleetConfigManager{
 		logger:           logger,
-		connection:       fleet.NewMQTTConnection(logger, pMgr, resetChan, reconnectChan, backendState),
+		connection:       fleet.NewMQTTConnection(logger, pMgr, resetChan, reconnectChan, backendState, fm),
 		authTokenManager: fleet.NewAuthTokenManager(logger),
 		resetChan:        resetChan,
 		reconnectChan:    reconnectChan,

--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -13,9 +13,9 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
-	"github.com/netboxlabs/orb-agent/agent/filesmgr"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/configmgr/fleet"
+	"github.com/netboxlabs/orb-agent/agent/filesmgr"
 	"github.com/netboxlabs/orb-agent/agent/otlpbridge"
 	"github.com/netboxlabs/orb-agent/agent/policymgr"
 	"github.com/netboxlabs/orb-agent/agent/redact"

--- a/agent/configmgr/fleet/connection.go
+++ b/agent/configmgr/fleet/connection.go
@@ -13,6 +13,7 @@ import (
 	"github.com/eclipse/paho.golang/paho"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/filesmgr"
 	"github.com/netboxlabs/orb-agent/agent/policymgr"
 )
 
@@ -49,13 +50,13 @@ type MQTTConnection struct {
 }
 
 // NewMQTTConnection creates a new MQTTConnection
-func NewMQTTConnection(logger *slog.Logger, pMgr policymgr.PolicyManager, resetChan chan struct{}, reconnectChan chan struct{}, backendState backend.StateRetriever) *MQTTConnection {
+func NewMQTTConnection(logger *slog.Logger, pMgr policymgr.PolicyManager, resetChan chan struct{}, reconnectChan chan struct{}, backendState backend.StateRetriever, filesManager filesmgr.Manager) *MQTTConnection {
 	groupManager := newGroupManager()
 	return &MQTTConnection{
 		connectionManager:  nil,
 		logger:             logger,
 		heartbeater:        newHeartbeater(logger, backendState, pMgr, &groupManager),
-		messaging:          NewMessaging(logger, pMgr, resetChan, &groupManager),
+		messaging:          NewMessaging(logger, pMgr, resetChan, &groupManager, filesManager),
 		resetChan:          resetChan,
 		onReadyHooks:       make([]func(cm *autopaho.ConnectionManager, topics TokenResponseTopics), 0),
 		topicHandlers:      make(map[string]TopicMessageHandler),

--- a/agent/configmgr/fleet/connection_hooks_test.go
+++ b/agent/configmgr/fleet/connection_hooks_test.go
@@ -33,7 +33,7 @@ func TestAddOnReadyHook_RegistersHook(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	reset := make(chan struct{}, 1)
 	reconnect := make(chan struct{}, 1)
-	conn := NewMQTTConnection(logger, noopPM{}, reset, reconnect, noopBackendState{})
+	conn := NewMQTTConnection(logger, noopPM{}, reset, reconnect, noopBackendState{}, nil)
 
 	if len(conn.onReadyHooks) != 0 {
 		t.Fatalf("expected 0 hooks initially, got %d", len(conn.onReadyHooks))
@@ -50,7 +50,7 @@ func TestConnect_StoresTopicsBeforeConnecting(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	reset := make(chan struct{}, 1)
 	reconnect := make(chan struct{}, 1)
-	conn := NewMQTTConnection(logger, noopPM{}, reset, reconnect, noopBackendState{})
+	conn := NewMQTTConnection(logger, noopPM{}, reset, reconnect, noopBackendState{}, nil)
 
 	details := ConnectionDetails{
 		MQTTURL:  "mqtt://localhost:1883",

--- a/agent/configmgr/fleet/connection_test.go
+++ b/agent/configmgr/fleet/connection_test.go
@@ -73,7 +73,7 @@ func TestFleetConfigManager_Connect_InvalidURL(t *testing.T) {
 	mockPMgr := &mockPolicyManagerForFleet{}
 	resetChan := make(chan struct{}, 1)
 	reconnectChan := make(chan struct{}, 1)
-	connection := NewMQTTConnection(logger, mockPMgr, resetChan, reconnectChan, &mockBackendState{})
+	connection := NewMQTTConnection(logger, mockPMgr, resetChan, reconnectChan, &mockBackendState{}, nil)
 
 	// Act with invalid URL
 	backends := make(map[string]backend.Backend)
@@ -98,7 +98,7 @@ func TestFleetConfigManager_Connect_ValidURL(t *testing.T) {
 	mockPMgr := &mockPolicyManagerForFleet{}
 	resetChan := make(chan struct{}, 1)
 	reconnectChan := make(chan struct{}, 1)
-	connection := NewMQTTConnection(logger, mockPMgr, resetChan, reconnectChan, &mockBackendState{})
+	connection := NewMQTTConnection(logger, mockPMgr, resetChan, reconnectChan, &mockBackendState{}, nil)
 
 	// Act with valid URL but don't expect successful connection
 	// since we don't have a real MQTT server
@@ -133,7 +133,7 @@ func TestDispatchQueue_ProcessesJobsSequentially(t *testing.T) {
 	mockPMgr := &mockPolicyManagerForFleet{}
 	resetChan := make(chan struct{}, 1)
 	reconnectChan := make(chan struct{}, 1)
-	connection := NewMQTTConnection(logger, mockPMgr, resetChan, reconnectChan, &mockBackendState{})
+	connection := NewMQTTConnection(logger, mockPMgr, resetChan, reconnectChan, &mockBackendState{}, nil)
 
 	// Track the order of job processing using a channel
 	processedOrder := make([]int, 0, 10)
@@ -197,7 +197,7 @@ func TestDispatchQueue_HandlesQueueFull(t *testing.T) {
 	mockPMgr := &mockPolicyManagerForFleet{}
 	resetChan := make(chan struct{}, 1)
 	reconnectChan := make(chan struct{}, 1)
-	connection := NewMQTTConnection(logger, mockPMgr, resetChan, reconnectChan, &mockBackendState{})
+	connection := NewMQTTConnection(logger, mockPMgr, resetChan, reconnectChan, &mockBackendState{}, nil)
 
 	// Don't start the worker so the queue fills up
 	// Just verify we can enqueue up to the buffer size
@@ -230,7 +230,7 @@ func TestDispatchQueue_NoPanicOnConcurrentShutdown(t *testing.T) {
 	mockPMgr := &mockPolicyManagerForFleet{}
 	resetChan := make(chan struct{}, 1)
 	reconnectChan := make(chan struct{}, 1)
-	connection := NewMQTTConnection(logger, mockPMgr, resetChan, reconnectChan, &mockBackendState{})
+	connection := NewMQTTConnection(logger, mockPMgr, resetChan, reconnectChan, &mockBackendState{}, nil)
 
 	connection.startDispatchWorker()
 
@@ -293,7 +293,7 @@ func TestDispatchQueue_DrainsOnShutdown(t *testing.T) {
 	mockPMgr := &mockPolicyManagerForFleet{}
 	resetChan := make(chan struct{}, 1)
 	reconnectChan := make(chan struct{}, 1)
-	connection := NewMQTTConnection(logger, mockPMgr, resetChan, reconnectChan, &mockBackendState{})
+	connection := NewMQTTConnection(logger, mockPMgr, resetChan, reconnectChan, &mockBackendState{}, nil)
 
 	var processed atomic.Int32
 	const numJobs = 50
@@ -337,7 +337,7 @@ func TestDispatchQueue_LateEnqueueAfterWorkerExit_IsNotOrphaned(t *testing.T) {
 	mockPMgr := &mockPolicyManagerForFleet{}
 	resetChan := make(chan struct{}, 1)
 	reconnectChan := make(chan struct{}, 1)
-	connection := NewMQTTConnection(logger, mockPMgr, resetChan, reconnectChan, &mockBackendState{})
+	connection := NewMQTTConnection(logger, mockPMgr, resetChan, reconnectChan, &mockBackendState{}, nil)
 
 	payload := []byte(`{"schema_version":"1.0","func":"group_membership","payload":{"full_list":false,"groups":[{"group_id":"late-send","name":"Late"}]}}`)
 	var processed atomic.Int32
@@ -423,7 +423,7 @@ func TestDispatchQueue_ConcurrentStopDispatchWorker_NoPanic(t *testing.T) {
 	mockPMgr := &mockPolicyManagerForFleet{}
 	resetChan := make(chan struct{}, 1)
 	reconnectChan := make(chan struct{}, 1)
-	connection := NewMQTTConnection(logger, mockPMgr, resetChan, reconnectChan, &mockBackendState{})
+	connection := NewMQTTConnection(logger, mockPMgr, resetChan, reconnectChan, &mockBackendState{}, nil)
 
 	payload := []byte(`{"schema_version":"1.0","func":"group_membership","payload":{"full_list":false,"groups":[{"group_id":"stop-race","name":"StopRace"}]}}`)
 	jobStarted := make(chan struct{})

--- a/agent/configmgr/fleet/from_rpc.go
+++ b/agent/configmgr/fleet/from_rpc.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"os"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -22,17 +23,27 @@ type Messaging struct {
 	groupManager  *GroupManager
 	resetChan     chan struct{}
 	filesManager  filesmgr.Manager
+	stopCtx       context.Context
+	stopCancel    context.CancelFunc
 }
 
 // NewMessaging creates a new Messaging
 func NewMessaging(logger *slog.Logger, policyManager policymgr.PolicyManager, resetChan chan struct{}, groupManager *GroupManager, filesManager filesmgr.Manager) *Messaging {
+	stopCtx, stopCancel := context.WithCancel(context.Background())
 	return &Messaging{
 		logger:        logger,
 		policyManager: policyManager,
 		groupManager:  groupManager,
 		resetChan:     resetChan,
 		filesManager:  filesManager,
+		stopCtx:       stopCtx,
+		stopCancel:    stopCancel,
 	}
+}
+
+// Stop cancels any in-flight bundle installations.
+func (messaging *Messaging) Stop() {
+	messaging.stopCancel()
 }
 
 // DispatchToHandlers dispatches the message to the appropriate handler
@@ -109,7 +120,7 @@ func (messaging *Messaging) DispatchToHandlers(ctx context.Context, payload []by
 // handlePackages installs each bundle delivered by filesmanager.
 // Failures are non-fatal: a failed bundle is logged and skipped so that
 // other bundles in the same delivery are still installed.
-func (messaging *Messaging) handlePackages(ctx context.Context, payload messages.PackagesCredentialsRPCPayload) {
+func (messaging *Messaging) handlePackages(_ context.Context, payload messages.PackagesCredentialsRPCPayload) {
 	if messaging.filesManager == nil {
 		messaging.logger.Error("filesManager is nil, cannot install bundles")
 		return
@@ -122,14 +133,18 @@ func (messaging *Messaging) handlePackages(ctx context.Context, payload messages
 	for _, bundle := range payload.Bundles {
 		// TODO: check bundle.ExpiresAt before calling Ensure to avoid
 		// unnecessary download attempts with expired presigned URLs.
+		installCtx, cancel := context.WithTimeout(messaging.stopCtx, 10*time.Minute)
 		spec := filesmgr.FileSpec{
-			Name:    bundle.Name,
-			Version: bundle.Version,
-			URL:     bundle.URL,
-			SHA256:  bundle.SHA256,
-			Extract: true,
+			Name:       bundle.Name,
+			Version:    bundle.Version,
+			URL:        bundle.URL,
+			SHA256:     bundle.SHA256,
+			Extract:    bundle.Extract,
+			TargetPath: bundle.TargetPath,
+			Mode:       bundle.Mode,
 		}
-		path, err := messaging.filesManager.Ensure(ctx, spec)
+		path, err := messaging.filesManager.Ensure(installCtx, spec)
+		cancel()
 		if err != nil {
 			messaging.logger.Error("failed to install bundle",
 				"name", bundle.Name,

--- a/agent/configmgr/fleet/from_rpc.go
+++ b/agent/configmgr/fleet/from_rpc.go
@@ -6,12 +6,13 @@ import (
 	"log/slog"
 	"os"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/configmgr/fleet/messages"
 	"github.com/netboxlabs/orb-agent/agent/filesmgr"
 	"github.com/netboxlabs/orb-agent/agent/policymgr"
-	"gopkg.in/yaml.v3"
 )
 
 // Messaging handles the messages from the MQTT broker

--- a/agent/configmgr/fleet/from_rpc.go
+++ b/agent/configmgr/fleet/from_rpc.go
@@ -11,6 +11,7 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/configmgr/fleet/messages"
+	"github.com/netboxlabs/orb-agent/agent/filesmgr"
 	"github.com/netboxlabs/orb-agent/agent/policymgr"
 )
 
@@ -20,15 +21,17 @@ type Messaging struct {
 	policyManager policymgr.PolicyManager
 	groupManager  *GroupManager
 	resetChan     chan struct{}
+	filesManager  filesmgr.Manager
 }
 
 // NewMessaging creates a new Messaging
-func NewMessaging(logger *slog.Logger, policyManager policymgr.PolicyManager, resetChan chan struct{}, groupManager *GroupManager) *Messaging {
+func NewMessaging(logger *slog.Logger, policyManager policymgr.PolicyManager, resetChan chan struct{}, groupManager *GroupManager, filesManager filesmgr.Manager) *Messaging {
 	return &Messaging{
 		logger:        logger,
 		policyManager: policyManager,
 		groupManager:  groupManager,
 		resetChan:     resetChan,
+		filesManager:  filesManager,
 	}
 }
 
@@ -69,7 +72,6 @@ func (messaging *Messaging) DispatchToHandlers(ctx context.Context, payload []by
 			return err
 		}
 		messaging.handleAgentGroupRemoval(groupRemoved.Payload, topicActions.Unsubscribe)
-
 	case messages.DatasetRemovedRPCFunc:
 		var r messages.DatasetRemovedRPC
 		if err := json.Unmarshal(payload, &r); err != nil {
@@ -91,10 +93,49 @@ func (messaging *Messaging) DispatchToHandlers(ctx context.Context, payload []by
 			return err
 		}
 		messaging.handleAgentReset(ctx, r.Payload)
+	case messages.PackagesCredentialsRPCFunc:
+		var r messages.PackagesCredentialsRPC
+		if err := json.Unmarshal(payload, &r); err != nil {
+			messaging.logger.Error("error decoding packages credentials message from core", "error", messages.ErrSchemaMalformed)
+			return err
+		}
+		messaging.handlePackages(ctx, r.Payload)
 	default:
 		messaging.logger.Debug("unknown rpc function", "func", rpc.Func)
 	}
 	return nil
+}
+
+// handlePackages installs each bundle delivered by filesmanager.
+// Failures are non-fatal: a failed bundle is logged and skipped so that
+// other bundles in the same delivery are still installed.
+func (messaging *Messaging) handlePackages(ctx context.Context, payload messages.PackagesCredentialsRPCPayload) {
+	if len(payload.Bundles) == 0 {
+		messaging.logger.Debug("packages_credentials received with empty bundle list, nothing to do")
+		return
+	}
+	messaging.logger.Info("installing bundles", "count", len(payload.Bundles))
+	for _, bundle := range payload.Bundles {
+		spec := filesmgr.FileSpec{
+			Name:    bundle.Name,
+			Version: bundle.Version,
+			URL:     bundle.URL,
+			SHA256:  bundle.SHA256,
+			Extract: true,
+		}
+		path, err := messaging.filesManager.Ensure(ctx, spec)
+		if err != nil {
+			messaging.logger.Error("failed to install bundle",
+				"name", bundle.Name,
+				"version", bundle.Version,
+				"error", err)
+			continue
+		}
+		messaging.logger.Info("bundle installed",
+			"name", bundle.Name,
+			"version", bundle.Version,
+			"path", path)
+	}
 }
 
 func (messaging *Messaging) handleGroupMemberships(ctx context.Context, groupMemberships messages.GroupMembershipRPCPayload, orgID string, agentID string, topicActions TopicActions) {

--- a/agent/configmgr/fleet/from_rpc.go
+++ b/agent/configmgr/fleet/from_rpc.go
@@ -116,6 +116,8 @@ func (messaging *Messaging) handlePackages(ctx context.Context, payload messages
 	}
 	messaging.logger.Info("installing bundles", "count", len(payload.Bundles))
 	for _, bundle := range payload.Bundles {
+		// TODO: check bundle.ExpiresAt before calling Ensure to avoid
+		// unnecessary download attempts with expired presigned URLs.
 		spec := filesmgr.FileSpec{
 			Name:    bundle.Name,
 			Version: bundle.Version,

--- a/agent/configmgr/fleet/from_rpc.go
+++ b/agent/configmgr/fleet/from_rpc.go
@@ -117,7 +117,7 @@ func (messaging *Messaging) DispatchToHandlers(ctx context.Context, payload []by
 	return nil
 }
 
-// handlePackages installs each bundle delivered by filesmanager.
+// handlePackages installs each bundle delivered by filesmgr.Manager.
 // Failures are non-fatal: a failed bundle is logged and skipped so that
 // other bundles in the same delivery are still installed.
 func (messaging *Messaging) handlePackages(_ context.Context, payload messages.PackagesCredentialsRPCPayload) {

--- a/agent/configmgr/fleet/from_rpc.go
+++ b/agent/configmgr/fleet/from_rpc.go
@@ -110,6 +110,10 @@ func (messaging *Messaging) DispatchToHandlers(ctx context.Context, payload []by
 // Failures are non-fatal: a failed bundle is logged and skipped so that
 // other bundles in the same delivery are still installed.
 func (messaging *Messaging) handlePackages(ctx context.Context, payload messages.PackagesCredentialsRPCPayload) {
+	if messaging.filesManager == nil {
+		messaging.logger.Error("filesManager is nil, cannot install bundles")
+		return
+	}
 	if len(payload.Bundles) == 0 {
 		messaging.logger.Debug("packages_credentials received with empty bundle list, nothing to do")
 		return

--- a/agent/configmgr/fleet/from_rpc.go
+++ b/agent/configmgr/fleet/from_rpc.go
@@ -6,13 +6,12 @@ import (
 	"log/slog"
 	"os"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/configmgr/fleet/messages"
 	"github.com/netboxlabs/orb-agent/agent/filesmgr"
 	"github.com/netboxlabs/orb-agent/agent/policymgr"
+	"gopkg.in/yaml.v3"
 )
 
 // Messaging handles the messages from the MQTT broker

--- a/agent/configmgr/fleet/from_rpc_test.go
+++ b/agent/configmgr/fleet/from_rpc_test.go
@@ -1737,7 +1737,7 @@ func TestHandleAgentReset_NoFullReset(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, nil, resetChan, &groupManager)
+	handlers := NewMessaging(logger, nil, resetChan, &groupManager, nil)
 
 	// FullReset=false should not send to resetChan
 	handlers.handleAgentReset(context.Background(), messages.AgentResetRPCPayload{
@@ -1754,7 +1754,7 @@ func TestHandleGroupMemberships_UnsubscribeError(_ *testing.T) {
 	// Pre-populate the group manager with a group
 	groupManager.Add(messages.GroupMembershipData{GroupID: "group1", Name: "Group 1"})
 
-	handlers := NewMessaging(logger, &mockPolicyManager{}, resetChan, &groupManager)
+	handlers := NewMessaging(logger, &mockPolicyManager{}, resetChan, &groupManager, nil)
 
 	mockRepo := &mockPolicyRepo{}
 	mockRepo.On("GetAll").Return([]policies.PolicyData{}, nil)
@@ -1781,7 +1781,7 @@ func TestHandleGroupMemberships_SubscribeError(_ *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, nil, resetChan, &groupManager)
+	handlers := NewMessaging(logger, nil, resetChan, &groupManager, nil)
 
 	mockRepo := &mockPolicyRepo{}
 	mockRepo.On("GetAll").Return([]policies.PolicyData{}, nil)

--- a/agent/configmgr/fleet/from_rpc_test.go
+++ b/agent/configmgr/fleet/from_rpc_test.go
@@ -277,7 +277,7 @@ func TestMessageHandlers_DispatchToHandlers(t *testing.T) {
 			}
 			resetChan := make(chan struct{}, 1)
 			groupManager := newGroupManager()
-			handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+			handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 			agentID := "agent123"
 			mockPublishToTopic := func(_ context.Context, _ string, _ []byte) error {
@@ -318,7 +318,7 @@ func TestMessageHandlers_handleGroupMemberships_Success(t *testing.T) {
 	mockPMgr := &mockPolicyManager{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Mock subscribeToTopic function
 	subscribedTopics := []string{}
@@ -361,7 +361,7 @@ func TestMessageHandlers_handleGroupMemberships_InvalidPayload(t *testing.T) {
 	mockPMgr := &mockPolicyManager{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Mock subscribeToTopic function
 	subscribedTopics := []string{}
@@ -401,7 +401,7 @@ func TestMessageHandlers_handleGroupMemberships_EmptyGroups(t *testing.T) {
 	mockPMgr := &mockPolicyManager{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Mock subscribeToTopic function
 	subscribedTopics := []string{}
@@ -439,7 +439,7 @@ func TestMessageHandlers_handleGroupMemberships_JSONMarshalError(t *testing.T) {
 	mockPMgr := &mockPolicyManager{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Mock subscribeToTopic function
 	subscribedTopics := []string{}
@@ -520,7 +520,7 @@ func TestMessageHandlers_handleGroupMemberships_ComplexPayload(t *testing.T) {
 	mockPMgr := &mockPolicyManager{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Mock subscribeToTopic function
 	subscribedTopics := []string{}
@@ -565,7 +565,7 @@ func TestMessageHandlers_handleGroupMemberships_SendsAgentPoliciesRequest(t *tes
 	mockPMgr := &mockPolicyManager{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Mock subscribeToTopic function
 	subscribedTopics := []string{}
@@ -642,7 +642,7 @@ func TestNewMessageHandlers(t *testing.T) {
 	// Act
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Assert
 	assert.NotNil(t, handlers)
@@ -657,7 +657,7 @@ func TestMessageHandlers_handleAgentPolicies_NotFullList(t *testing.T) {
 	mockPMgr := &mockPolicyManager{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Setup mock expectations
 	mockPMgr.On("ManagePolicy", mock.MatchedBy(func(p config.PolicyPayload) bool {
@@ -695,7 +695,7 @@ func TestMessageHandlers_handleAgentPolicies_FullList_RemovesOldPolicies(t *test
 	mockRepo := &mockPolicyRepo{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Setup existing policies in repo
 	existingPolicies := []policies.PolicyData{
@@ -762,7 +762,7 @@ func TestMessageHandlers_handleAgentPolicies_SkipsSanitizeAction(t *testing.T) {
 	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{}, nil)
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Create policy payload with sanitize action
 	policies := []messages.AgentPolicyRPCPayload{
@@ -844,7 +844,7 @@ func TestMessageHandlers_handleAgentPolicies_LogCounters(t *testing.T) {
 			mockPMgr.On("GetPolicyState").Return(tc.repoState, nil)
 			resetChan := make(chan struct{}, 1)
 			groupManager := newGroupManager()
-			handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+			handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 			handlers.handleAgentPolicies(tc.payloads, false)
 
@@ -910,7 +910,7 @@ func TestMessageHandlers_handleAgentPolicies_FullList_GetAllFails(t *testing.T) 
 	mockRepo := &mockPolicyRepo{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Setup mock expectations - GetAll fails
 	mockPMgr.On("GetRepo").Return(mockRepo)
@@ -947,7 +947,7 @@ func TestMessageHandlers_handleAgentGroupRemoval_RemovesPolicyWhenNoGroupsRemain
 	mockRepo := &mockPolicyRepo{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	unsubscribedTopics := []string{}
 	mockUnsubscribeFromTopic := func(topic string) error {
@@ -992,7 +992,7 @@ func TestMessageHandlers_handleAgentGroupRemoval_RemovesDatasetsWhenGroupsRemain
 	mockRepo := &mockPolicyRepo{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	unsubscribedTopics := []string{}
 	mockUnsubscribeFromTopic := func(topic string) error {
@@ -1045,7 +1045,7 @@ func TestMessageHandlers_handleAgentGroupRemoval_UnsubscribeFails(t *testing.T) 
 	mockPMgr := &mockPolicyManager{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	mockUnsubscribeFromTopic := func(_ string) error {
 		return assert.AnError
@@ -1071,7 +1071,7 @@ func TestMessageHandlers_DispatchToHandlers_InvalidJSON(t *testing.T) {
 	mockPMgr := &mockPolicyManager{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	invalidPayload := []byte("invalid json {")
 
@@ -1094,7 +1094,7 @@ func TestMessageHandlers_DispatchToHandlers_MissingFunc(t *testing.T) {
 	mockPMgr := &mockPolicyManager{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Create RPC with empty Func
 	rpc := messages.RPC{
@@ -1124,7 +1124,7 @@ func TestMessageHandlers_DispatchToHandlers_NilPayload(t *testing.T) {
 	mockPMgr := &mockPolicyManager{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Create RPC with nil Payload
 	rpc := messages.RPC{
@@ -1154,7 +1154,7 @@ func TestMessageHandlers_DispatchToHandlers_MalformedGroupMembershipPayload(t *t
 	mockPMgr := &mockPolicyManager{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Create malformed payload - using string instead of proper structure
 	malformedPayload := []byte(`{"schema_version":"1.0","func":"group_membership","payload":"not_a_valid_structure"}`)
@@ -1178,7 +1178,7 @@ func TestMessageHandlers_DispatchToHandlers_MalformedAgentPolicyPayload(t *testi
 	mockPMgr := &mockPolicyManager{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Create malformed payload
 	malformedPayload := []byte(`{"schema_version":"1.0","func":"agent_policy","payload":"not_an_array"}`)
@@ -1202,7 +1202,7 @@ func TestMessageHandlers_DispatchToHandlers_MalformedGroupRemovedPayload(t *test
 	mockPMgr := &mockPolicyManager{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Create malformed payload
 	malformedPayload := []byte(`{"schema_version":"1.0","func":"group_removed","payload":"not_a_structure"}`)
@@ -1226,7 +1226,7 @@ func TestMessageHandlers_DispatchToHandlers_MalformedDatasetRemovedPayload(t *te
 	mockPMgr := &mockPolicyManager{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Create malformed payload
 	malformedPayload := []byte(`{"schema_version":"1.0","func":"dataset_removed","payload":"not_a_structure"}`)
@@ -1251,7 +1251,7 @@ func TestMessageHandlers_handleDatasetRemoval_Success(t *testing.T) {
 	mockRepo := &mockPolicyRepo{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Register a mock backend for testing
 	mockBe := &mockBackend{}
@@ -1293,7 +1293,7 @@ func TestMessageHandlers_handleDatasetRemoval_PolicyRetrievalFails(t *testing.T)
 	mockRepo := &mockPolicyRepo{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Setup mock expectations - Get fails
 	mockPMgr.On("GetRepo").Return(mockRepo)
@@ -1322,7 +1322,7 @@ func TestMessageHandlers_handleDatasetRemoval_BackendNotFound(t *testing.T) {
 	mockRepo := &mockPolicyRepo{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Setup mock expectations - policy exists but with nonexistent backend
 	mockPMgr.On("GetRepo").Return(mockRepo)
@@ -1354,7 +1354,7 @@ func TestMessageHandlers_handleAgentReset_NoFullReset(t *testing.T) {
 	mockPMgr := &mockPolicyManager{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	ctx := context.Background()
 
@@ -1384,7 +1384,7 @@ func TestMessageHandlers_DispatchToHandlers_AgentReset(t *testing.T) {
 	mockPMgr := &mockPolicyManager{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	ctx := context.Background()
 
@@ -1420,7 +1420,7 @@ func TestMessageHandlers_DispatchToHandlers_MalformedAgentResetPayload(t *testin
 	mockPMgr := &mockPolicyManager{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Create malformed payload
 	malformedPayload := []byte(`{"schema_version":"1.0","func":"agent_reset","payload":"not_a_structure"}`)
@@ -1444,7 +1444,7 @@ func TestMessageHandlers_DispatchToHandlers_AgentStop(t *testing.T) {
 	mockPMgr := &mockPolicyManager{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	_ = NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	_ = NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Create agent_stop RPC message
 	rpc := messages.AgentStopRPC{
@@ -1482,7 +1482,7 @@ func TestMessageHandlers_DispatchToHandlers_MalformedAgentStopPayload(t *testing
 	mockPMgr := &mockPolicyManager{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Create malformed payload
 	malformedPayload := []byte(`{"schema_version":"1.0","func":"agent_stop","payload":"not_a_structure"}`)
@@ -1507,7 +1507,7 @@ func TestMessageHandlers_handleAgentPolicies_YAMLStringData(t *testing.T) {
 	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{}, nil)
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Setup mock expectations - verify that the data is converted to a map
 	mockPMgr.On("ManagePolicy", mock.MatchedBy(func(p config.PolicyPayload) bool {
@@ -1559,7 +1559,7 @@ func TestMessageHandlers_handleAgentPolicies_StructuredData(t *testing.T) {
 	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{}, nil)
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Setup mock expectations - verify that structured data is passed through unchanged
 	mockPMgr.On("ManagePolicy", mock.MatchedBy(func(p config.PolicyPayload) bool {
@@ -1614,7 +1614,7 @@ func TestMessageHandlers_handleAgentPolicies_EmptyYAMLString(t *testing.T) {
 	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{}, nil)
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Setup mock expectations - empty string should be passed through
 	mockPMgr.On("ManagePolicy", mock.MatchedBy(func(p config.PolicyPayload) bool {
@@ -1656,7 +1656,7 @@ func TestMessageHandlers_handleAgentPolicies_InvalidYAMLString(t *testing.T) {
 	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{}, nil)
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Setup mock expectations - invalid YAML should be passed through as-is
 	mockPMgr.On("ManagePolicy", mock.MatchedBy(func(p config.PolicyPayload) bool {
@@ -1699,7 +1699,7 @@ func TestMessageHandlers_handleAgentPolicies_NonYAMLFormat(t *testing.T) {
 	mockPMgr.On("GetPolicyState").Return([]policies.PolicyData{}, nil)
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	handlers := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Setup mock expectations - non-yaml format should pass data through unchanged
 	mockPMgr.On("ManagePolicy", mock.MatchedBy(func(p config.PolicyPayload) bool {

--- a/agent/configmgr/fleet/messages/packages.go
+++ b/agent/configmgr/fleet/messages/packages.go
@@ -1,15 +1,22 @@
 package messages
 
+import "os"
+
 // PackagesCredentialsRPCFunc is the function name for packages credentials RPC calls
 const PackagesCredentialsRPCFunc = "packages_credentials"
 
-// BundleSpec describes a single bundle delivered by filesmanager
+// BundleSpec describes a single bundle delivered by filesmanager.
+// Fields mirror filesmgr.FileSpec so the MQTT payload can fully drive
+// how the bundle is fetched, placed, and permissioned on disk.
 type BundleSpec struct {
-	Name      string `json:"name"`
-	Version   string `json:"version"`
-	URL       string `json:"url"`
-	SHA256    string `json:"sha256"`
-	ExpiresAt int64  `json:"expires_at"`
+	Name       string      `json:"name"`
+	Version    string      `json:"version"`
+	URL        string      `json:"url"`
+	SHA256     string      `json:"sha256"`
+	ExpiresAt  int64       `json:"expires_at"`
+	Extract    bool        `json:"extract"`
+	TargetPath string      `json:"target_path,omitempty"`
+	Mode       os.FileMode `json:"mode,omitempty"`
 }
 
 // PackagesCredentialsRPCPayload is the payload for packages credentials RPC messages

--- a/agent/configmgr/fleet/messages/packages.go
+++ b/agent/configmgr/fleet/messages/packages.go
@@ -5,7 +5,7 @@ import "os"
 // PackagesCredentialsRPCFunc is the function name for packages credentials RPC calls
 const PackagesCredentialsRPCFunc = "packages_credentials"
 
-// BundleSpec describes a single bundle delivered by filesmanager.
+// BundleSpec describes a single bundle delivered by filesmgr.Manager.
 // Fields mirror filesmgr.FileSpec so the MQTT payload can fully drive
 // how the bundle is fetched, placed, and permissioned on disk.
 type BundleSpec struct {

--- a/agent/configmgr/fleet/messages/packages.go
+++ b/agent/configmgr/fleet/messages/packages.go
@@ -5,11 +5,11 @@ const PackagesCredentialsRPCFunc = "packages_credentials"
 
 // BundleSpec describes a single bundle delivered by filesmanager
 type BundleSpec struct {
-	Name      string    `json:"name"`
-	Version   string    `json:"version"`
-	URL       string    `json:"url"`
-	SHA256    string    `json:"sha256"`
-	ExpiresAt int64     `json:"expires_at"`
+	Name      string `json:"name"`
+	Version   string `json:"version"`
+	URL       string `json:"url"`
+	SHA256    string `json:"sha256"`
+	ExpiresAt int64  `json:"expires_at"`
 }
 
 // PackagesCredentialsRPCPayload is the payload for packages credentials RPC messages

--- a/agent/configmgr/fleet/messages/packages.go
+++ b/agent/configmgr/fleet/messages/packages.go
@@ -1,0 +1,27 @@
+package messages
+
+import "time"
+
+// PackagesCredentialsRPCFunc is the function name for packages credentials RPC calls
+const PackagesCredentialsRPCFunc = "packages_credentials"
+
+// BundleSpec describes a single bundle delivered by filesmanager
+type BundleSpec struct {
+	Name      string    `json:"name"`
+	Version   string    `json:"version"`
+	URL       string    `json:"url"`
+	SHA256    string    `json:"sha256"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// PackagesCredentialsRPCPayload is the payload for packages credentials RPC messages
+type PackagesCredentialsRPCPayload struct {
+	Bundles []BundleSpec `json:"bundles"`
+}
+
+// PackagesCredentialsRPC represents an RPC message for bundle delivery
+type PackagesCredentialsRPC struct {
+	SchemaVersion string                        `json:"schema_version"`
+	Func          string                        `json:"func"`
+	Payload       PackagesCredentialsRPCPayload `json:"payload"`
+}

--- a/agent/configmgr/fleet/messages/packages.go
+++ b/agent/configmgr/fleet/messages/packages.go
@@ -1,7 +1,6 @@
 package messages
 
 
-
 // PackagesCredentialsRPCFunc is the function name for packages credentials RPC calls
 const PackagesCredentialsRPCFunc = "packages_credentials"
 
@@ -11,7 +10,7 @@ type BundleSpec struct {
 	Version   string    `json:"version"`
 	URL       string    `json:"url"`
 	SHA256    string    `json:"sha256"`
-	ExpiresAt int64 `json:"expires_at"`
+	ExpiresAt int64     `json:"expires_at"`
 }
 
 // PackagesCredentialsRPCPayload is the payload for packages credentials RPC messages

--- a/agent/configmgr/fleet/messages/packages.go
+++ b/agent/configmgr/fleet/messages/packages.go
@@ -1,6 +1,5 @@
 package messages
 
-
 // PackagesCredentialsRPCFunc is the function name for packages credentials RPC calls
 const PackagesCredentialsRPCFunc = "packages_credentials"
 

--- a/agent/configmgr/fleet/messages/packages.go
+++ b/agent/configmgr/fleet/messages/packages.go
@@ -1,6 +1,6 @@
 package messages
 
-import "time"
+
 
 // PackagesCredentialsRPCFunc is the function name for packages credentials RPC calls
 const PackagesCredentialsRPCFunc = "packages_credentials"
@@ -11,7 +11,7 @@ type BundleSpec struct {
 	Version   string    `json:"version"`
 	URL       string    `json:"url"`
 	SHA256    string    `json:"sha256"`
-	ExpiresAt time.Time `json:"expires_at"`
+	ExpiresAt int64 `json:"expires_at"`
 }
 
 // PackagesCredentialsRPCPayload is the payload for packages credentials RPC messages

--- a/agent/configmgr/fleet/packages_test.go
+++ b/agent/configmgr/fleet/packages_test.go
@@ -1,0 +1,157 @@
+package fleet
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/netboxlabs/orb-agent/agent/configmgr/fleet/messages"
+	"github.com/netboxlabs/orb-agent/agent/filesmgr"
+)
+
+// mockFilesManager implements filesmgr.Manager for testing
+type mockFilesManager struct {
+	mock.Mock
+}
+
+func (m *mockFilesManager) Start(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockFilesManager) Stop(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockFilesManager) Ensure(ctx context.Context, spec filesmgr.FileSpec) (string, error) {
+	args := m.Called(ctx, spec)
+	return args.String(0), args.Error(1)
+}
+
+func (m *mockFilesManager) Get(name string) (filesmgr.FileEntry, bool) {
+	args := m.Called(name)
+	return args.Get(0).(filesmgr.FileEntry), args.Bool(1)
+}
+
+func (m *mockFilesManager) Remove(ctx context.Context, name string) error {
+	args := m.Called(ctx, name)
+	return args.Error(0)
+}
+
+func (m *mockFilesManager) Rollback(ctx context.Context, name string) error {
+	args := m.Called(ctx, name)
+	return args.Error(0)
+}
+
+func (m *mockFilesManager) Subscribe(fn func(filesmgr.FileEvent)) func() {
+	args := m.Called(fn)
+	return args.Get(0).(func())
+}
+
+func newTestMessagingWithFiles(fm filesmgr.Manager) *Messaging {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	resetChan := make(chan struct{}, 1)
+	groupManager := newGroupManager()
+	return NewMessaging(logger, nil, resetChan, &groupManager, fm)
+}
+
+func TestHandlePackages_HappyPath(t *testing.T) {
+	fm := &mockFilesManager{}
+	fm.On("Ensure", mock.Anything, filesmgr.FileSpec{
+		Name:    "nbl_cisco_meraki",
+		Version: "0.2.0",
+		URL:     "https://example.com/bundle.tar.gz",
+		SHA256:  "abc123",
+		Extract: true,
+	}).Return("/opt/orb/files/nbl_cisco_meraki/0.2.0", nil)
+
+	messaging := newTestMessagingWithFiles(fm)
+	payload := messages.PackagesCredentialsRPCPayload{
+		Bundles: []messages.BundleSpec{
+			{
+				Name:      "nbl_cisco_meraki",
+				Version:   "0.2.0",
+				URL:       "https://example.com/bundle.tar.gz",
+				SHA256:    "abc123",
+				ExpiresAt: time.Now().Add(15 * time.Minute),
+			},
+		},
+	}
+	messaging.handlePackages(context.Background(), payload)
+	fm.AssertExpectations(t)
+}
+
+func TestHandlePackages_EmptyBundles(t *testing.T) {
+	fm := &mockFilesManager{}
+	// Ensure should never be called for empty payload
+	messaging := newTestMessagingWithFiles(fm)
+	messaging.handlePackages(context.Background(), messages.PackagesCredentialsRPCPayload{})
+	fm.AssertNotCalled(t, "Ensure")
+}
+
+func TestHandlePackages_PartialFailure(t *testing.T) {
+	fm := &mockFilesManager{}
+	fm.On("Ensure", mock.Anything, filesmgr.FileSpec{
+		Name:    "nbl_cisco_meraki",
+		Version: "0.2.0",
+		URL:     "https://example.com/meraki.tar.gz",
+		SHA256:  "aaa111",
+		Extract: true,
+	}).Return("", assert.AnError)
+	fm.On("Ensure", mock.Anything, filesmgr.FileSpec{
+		Name:    "nbl_cisco_catalyst_center",
+		Version: "0.1.0",
+		URL:     "https://example.com/catalyst.tar.gz",
+		SHA256:  "bbb222",
+		Extract: true,
+	}).Return("/opt/orb/files/nbl_cisco_catalyst_center/0.1.0", nil)
+
+	messaging := newTestMessagingWithFiles(fm)
+	payload := messages.PackagesCredentialsRPCPayload{
+		Bundles: []messages.BundleSpec{
+			{Name: "nbl_cisco_meraki", Version: "0.2.0", URL: "https://example.com/meraki.tar.gz", SHA256: "aaa111"},
+			{Name: "nbl_cisco_catalyst_center", Version: "0.1.0", URL: "https://example.com/catalyst.tar.gz", SHA256: "bbb222"},
+		},
+	}
+	// Should not panic — failure is non-fatal
+	messaging.handlePackages(context.Background(), payload)
+	fm.AssertExpectations(t)
+}
+
+func TestDispatchToHandlers_PackagesCredentials(t *testing.T) {
+	fm := &mockFilesManager{}
+	fm.On("Ensure", mock.Anything, mock.AnythingOfType("filesmgr.FileSpec")).
+		Return("/opt/orb/files/nbl_cisco_meraki/0.2.0", nil)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	resetChan := make(chan struct{}, 1)
+	groupManager := newGroupManager()
+	handlers := NewMessaging(logger, nil, resetChan, &groupManager, fm)
+
+	rpc := messages.PackagesCredentialsRPC{
+		SchemaVersion: "2",
+		Func:          messages.PackagesCredentialsRPCFunc,
+		Payload: messages.PackagesCredentialsRPCPayload{
+			Bundles: []messages.BundleSpec{
+				{Name: "nbl_cisco_meraki", Version: "0.2.0", URL: "https://example.com/bundle.tar.gz", SHA256: "abc123"},
+			},
+		},
+	}
+	payload, err := json.Marshal(rpc)
+	assert.NoError(t, err)
+
+	err = handlers.DispatchToHandlers(context.Background(), payload, "org1", "agent1", TopicActions{
+		Subscribe:   func(string) error { return nil },
+		Publish:     func(_ context.Context, _ string, _ []byte) error { return nil },
+		Unsubscribe: func(string) error { return nil },
+	})
+	assert.NoError(t, err)
+	fm.AssertExpectations(t)
+}

--- a/agent/configmgr/fleet/packages_test.go
+++ b/agent/configmgr/fleet/packages_test.go
@@ -80,7 +80,7 @@ func TestHandlePackages_HappyPath(t *testing.T) {
 				Version:   "0.2.0",
 				URL:       "https://example.com/bundle.tar.gz",
 				SHA256:    "abc123",
-				ExpiresAt: time.Now().Add(15 * time.Minute),
+				ExpiresAt: time.Now().Add(15 * time.Minute).Unix(),
 			},
 		},
 	}
@@ -154,4 +154,15 @@ func TestDispatchToHandlers_PackagesCredentials(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	fm.AssertExpectations(t)
+}
+
+func TestHandlePackages_NilFilesManager(t *testing.T) {
+	messaging := newTestMessagingWithFiles(nil)
+	payload := messages.PackagesCredentialsRPCPayload{
+		Bundles: []messages.BundleSpec{
+			{Name: "nbl_cisco_meraki", Version: "0.2.0", URL: "https://example.com/bundle.tar.gz", SHA256: "abc123"},
+		},
+	}
+	// Should not panic when filesManager is nil
+	messaging.handlePackages(context.Background(), payload)
 }

--- a/agent/configmgr/fleet/packages_test.go
+++ b/agent/configmgr/fleet/packages_test.go
@@ -156,7 +156,7 @@ func TestDispatchToHandlers_PackagesCredentials(t *testing.T) {
 	fm.AssertExpectations(t)
 }
 
-func TestHandlePackages_NilFilesManager(t *testing.T) {
+func TestHandlePackages_NilFilesManager(_ *testing.T) {
 	messaging := newTestMessagingWithFiles(nil)
 	payload := messages.PackagesCredentialsRPCPayload{
 		Bundles: []messages.BundleSpec{

--- a/agent/configmgr/fleet/packages_test.go
+++ b/agent/configmgr/fleet/packages_test.go
@@ -80,6 +80,7 @@ func TestHandlePackages_HappyPath(t *testing.T) {
 				Version:   "0.2.0",
 				URL:       "https://example.com/bundle.tar.gz",
 				SHA256:    "abc123",
+				Extract:   true,
 				ExpiresAt: time.Now().Add(15 * time.Minute).Unix(),
 			},
 		},
@@ -116,8 +117,8 @@ func TestHandlePackages_PartialFailure(t *testing.T) {
 	messaging := newTestMessagingWithFiles(fm)
 	payload := messages.PackagesCredentialsRPCPayload{
 		Bundles: []messages.BundleSpec{
-			{Name: "nbl_cisco_meraki", Version: "0.2.0", URL: "https://example.com/meraki.tar.gz", SHA256: "aaa111"},
-			{Name: "nbl_cisco_catalyst_center", Version: "0.1.0", URL: "https://example.com/catalyst.tar.gz", SHA256: "bbb222"},
+			{Name: "nbl_cisco_meraki", Version: "0.2.0", URL: "https://example.com/meraki.tar.gz", SHA256: "aaa111", Extract: true},
+			{Name: "nbl_cisco_catalyst_center", Version: "0.1.0", URL: "https://example.com/catalyst.tar.gz", SHA256: "bbb222", Extract: true},
 		},
 	}
 	// Should not panic — failure is non-fatal
@@ -140,7 +141,7 @@ func TestDispatchToHandlers_PackagesCredentials(t *testing.T) {
 		Func:          messages.PackagesCredentialsRPCFunc,
 		Payload: messages.PackagesCredentialsRPCPayload{
 			Bundles: []messages.BundleSpec{
-				{Name: "nbl_cisco_meraki", Version: "0.2.0", URL: "https://example.com/bundle.tar.gz", SHA256: "abc123"},
+				{Name: "nbl_cisco_meraki", Version: "0.2.0", URL: "https://example.com/bundle.tar.gz", SHA256: "abc123", Extract: true},
 			},
 		},
 	}
@@ -160,7 +161,7 @@ func TestHandlePackages_NilFilesManager(_ *testing.T) {
 	messaging := newTestMessagingWithFiles(nil)
 	payload := messages.PackagesCredentialsRPCPayload{
 		Bundles: []messages.BundleSpec{
-			{Name: "nbl_cisco_meraki", Version: "0.2.0", URL: "https://example.com/bundle.tar.gz", SHA256: "abc123"},
+			{Name: "nbl_cisco_meraki", Version: "0.2.0", URL: "https://example.com/bundle.tar.gz", SHA256: "abc123", Extract: true},
 		},
 	}
 	// Should not panic when filesManager is nil

--- a/agent/configmgr/fleet/to_rpc_test.go
+++ b/agent/configmgr/fleet/to_rpc_test.go
@@ -63,7 +63,7 @@ func TestMessaging_SendCapabilities_Success(t *testing.T) {
 	mockPMgr := &mockPolicyManagerForToRPC{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	messaging := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	messaging := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Create mock backends
 	mockBackend1 := &mockBackend{}
@@ -151,7 +151,7 @@ func TestMessaging_SendCapabilities_BackendVersionError(t *testing.T) {
 	mockPMgr := &mockPolicyManagerForToRPC{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	messaging := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	messaging := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Create mock backends - one succeeds, one fails on version
 	mockBackend1 := &mockBackend{}
@@ -215,7 +215,7 @@ func TestMessaging_SendCapabilities_BackendCapabilitiesError(t *testing.T) {
 	mockPMgr := &mockPolicyManagerForToRPC{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	messaging := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	messaging := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// Create mock backends - one succeeds, one fails on capabilities
 	mockBackend1 := &mockBackend{}
@@ -279,7 +279,7 @@ func TestMessaging_SendCapabilities_PublishError(t *testing.T) {
 	mockPMgr := &mockPolicyManagerForToRPC{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	messaging := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	messaging := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	mockBackend1 := &mockBackend{}
 	mockBackend1.On("Version").Return("1.0.0", nil)
@@ -325,7 +325,7 @@ func TestMessaging_SendCapabilities_EmptyBackends(t *testing.T) {
 	mockPMgr := &mockPolicyManagerForToRPC{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	messaging := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	messaging := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	backends := map[string]backend.Backend{} // Empty backends
 	labels := map[string]string{}
@@ -371,7 +371,7 @@ func TestMessaging_SendCapabilities_AllBackendsFail(t *testing.T) {
 	mockPMgr := &mockPolicyManagerForToRPC{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	messaging := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	messaging := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	// All backends fail
 	mockBackend1 := &mockBackend{}
@@ -420,7 +420,7 @@ func TestMessaging_SendCapabilities_CapabilitiesStructure(t *testing.T) {
 	mockPMgr := &mockPolicyManagerForToRPC{}
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	messaging := NewMessaging(logger, mockPMgr, resetChan, &groupManager)
+	messaging := NewMessaging(logger, mockPMgr, resetChan, &groupManager, nil)
 
 	mockBackend1 := &mockBackend{}
 	mockBackend1.On("Version").Return("test-version", nil)

--- a/agent/configmgr/fleet/to_rpc_test.go
+++ b/agent/configmgr/fleet/to_rpc_test.go
@@ -480,7 +480,7 @@ func TestSendGroupMembershipsRequest_Success(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	messaging := NewMessaging(logger, nil, resetChan, &groupManager)
+	messaging := NewMessaging(logger, nil, resetChan, &groupManager, nil)
 
 	var published []byte
 	publishFunc := func(_ context.Context, payload []byte) error {
@@ -500,7 +500,7 @@ func TestSendGroupMembershipsRequest_PublishError(_ *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	resetChan := make(chan struct{}, 1)
 	groupManager := newGroupManager()
-	messaging := NewMessaging(logger, nil, resetChan, &groupManager)
+	messaging := NewMessaging(logger, nil, resetChan, &groupManager, nil)
 
 	publishFunc := func(_ context.Context, _ []byte) error {
 		return errors.New("publish failed")

--- a/agent/configmgr/fleet_stop_test.go
+++ b/agent/configmgr/fleet_stop_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestFleetConfigManager_Stop_ShutsDownBridge(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	mgr := newFleetConfigManager(logger, nil, nil)
+	mgr := newFleetConfigManager(logger, nil, nil, nil)
 
 	// Create a real bridge on an ephemeral port
 	bridge, err := otlpbridge.NewBridgeServer(otlpbridge.BridgeConfig{ListenAddr: ":0", Encoding: "protobuf"}, nil, logger)

--- a/agent/configmgr/fleet_test.go
+++ b/agent/configmgr/fleet_test.go
@@ -93,7 +93,7 @@ func TestFleetConfigManager_Start_TokenError(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
 	mockPMgr.On("GetRepo").Return(nil)
-	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{})
+	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{}, nil)
 
 	// Create config with invalid token URL
 	cfg := config.Config{
@@ -190,7 +190,7 @@ func TestFleetConfigManager_GetContext(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{})
+	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{}, nil)
 
 	originalCtx := context.Background()
 	type contextKey string
@@ -292,7 +292,7 @@ func TestFleetConfigManager_Start_WithJWTTopicGeneration(t *testing.T) {
 func TestFleetConfigManager_configToSafeString(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{})
+	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{}, nil)
 
 	tests := []struct {
 		name         string
@@ -371,7 +371,7 @@ func TestFleetConfigManager_configToSafeString(t *testing.T) {
 func TestFleetConfigManager_configToSafeString_DoesNotModifyOriginal(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{})
+	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{}, nil)
 
 	// Arrange
 	originalSecret := "my-secret-password"
@@ -405,7 +405,7 @@ func TestFleetConfigManager_MonitorTokenExpiry_Configuration(t *testing.T) {
 	// Test that monitorTokenExpiry uses default values when config is not set
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{})
+	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{}, nil)
 
 	// Set config with no monitoring settings (should use defaults)
 	cfg := config.Config{
@@ -449,7 +449,7 @@ func TestFleetConfigManager_MonitorTokenExpiry_CustomConfiguration(t *testing.T)
 	// Test that monitorTokenExpiry uses custom config values
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{})
+	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{}, nil)
 
 	// Set config with custom monitoring settings
 	checkInterval := 60
@@ -497,7 +497,7 @@ func TestFleetConfigManager_Stop_CancelsMonitor(t *testing.T) {
 	// Test that Stop() properly cancels the token expiry monitor
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{})
+	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{}, nil)
 
 	// Initialize monitor context
 	fleetManager.monitorCtx, fleetManager.monitorCancel = context.WithCancel(context.Background())
@@ -530,7 +530,7 @@ func TestFleetConfigManager_Stop_HandlesNilMonitorCancel(t *testing.T) {
 	// Test that Stop() handles nil monitorCancel gracefully
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{})
+	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{}, nil)
 
 	// Don't initialize monitorCancel (should be nil)
 	fleetManager.monitorCancel = nil
@@ -547,7 +547,7 @@ func TestFleetConfigManager_MonitorTokenExpiry_DetectsExpiredToken(t *testing.T)
 	// Test that monitor detects expired token and triggers reconnection
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{})
+	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{}, nil)
 
 	// Set up config
 	cfg := config.Config{
@@ -647,7 +647,7 @@ func TestFleetConfigManager_MonitorTokenExpiry_DetectsExpiringSoonToken(t *testi
 	// Test that monitor detects token expiring soon and triggers reconnection
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{})
+	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{}, nil)
 
 	// Set up config
 	cfg := config.Config{
@@ -756,7 +756,7 @@ func TestFleetConfigManager_MonitorTokenExpiry_DetectsExpiringSoonToken(t *testi
 func TestFleetConfigManager_MonitorTokenExpiry_NoSpuriousReconnectForShortLivedToken(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
-	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{})
+	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{}, nil)
 
 	// Use a 1-second check interval so the ticker fires within the test window.
 	// The default is 30 seconds which would never tick during a short test.
@@ -827,7 +827,7 @@ func TestFleetConfigManager_OnReadyHook_InitializesBridgeOnFirstCall(t *testing.
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
 	mockPMgr.On("GetRepo").Return(nil)
-	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{})
+	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{}, nil)
 
 	// Verify bridge is nil initially
 	assert.Nil(t, fleetManager.otlpBridge, "bridge should be nil initially")
@@ -891,7 +891,7 @@ func TestFleetConfigManager_OnReadyHook_SkipsInitializationOnReconnect(t *testin
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
 	mockPMgr.On("GetRepo").Return(nil)
-	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{})
+	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{}, nil)
 
 	// Pre-initialize the bridge (simulating it was already created)
 	bridgeConfig := otlpbridge.BridgeConfig{
@@ -966,7 +966,7 @@ func TestFleetConfigManager_OnReadyHook_UsesConfiguredGRPCPort(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
 	mockPMgr.On("GetRepo").Return(nil)
-	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{})
+	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{}, nil)
 
 	// Create config with custom gRPC port
 	customPort := 9999
@@ -1049,7 +1049,7 @@ func TestFleetConfigManager_OnReadyHook_UsesDefaultGRPCPort(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	mockPMgr := &mockPolicyManagerForFleet{}
 	mockPMgr.On("GetRepo").Return(nil)
-	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{})
+	fleetManager := newFleetConfigManager(logger, mockPMgr, &mockBackendState{}, nil)
 
 	// Create config without gRPC port configured (should use default)
 	cfg := config.Config{

--- a/agent/configmgr/git_test.go
+++ b/agent/configmgr/git_test.go
@@ -126,7 +126,7 @@ backend1:
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	// Instantiate the gitConfigManager.
-	gc := configmgr.New(logger, pMgr, cfg.OrbAgent.ConfigManager.Active, &mockBackendState{})
+	gc := configmgr.New(logger, pMgr, cfg.OrbAgent.ConfigManager.Active, &mockBackendState{}, nil)
 
 	// Call Start
 	backends := map[string]backend.Backend{
@@ -206,7 +206,7 @@ backend1:
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	gc := configmgr.New(logger, pMgr, cfg.OrbAgent.ConfigManager.Active, &mockBackendState{})
+	gc := configmgr.New(logger, pMgr, cfg.OrbAgent.ConfigManager.Active, &mockBackendState{}, nil)
 
 	backends := map[string]backend.Backend{
 		"backend1": &mockBackend{name: "backend1"},
@@ -308,7 +308,7 @@ backend1:
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	gc := configmgr.New(logger, pMgr, "git", &mockBackendState{})
+	gc := configmgr.New(logger, pMgr, "git", &mockBackendState{}, nil)
 
 	backends := map[string]backend.Backend{
 		"backend1": &mockBackend{name: "backend1"},

--- a/agent/configmgr/local_test.go
+++ b/agent/configmgr/local_test.go
@@ -51,7 +51,7 @@ func TestLocalConfigManager(t *testing.T) {
 		})).Return()
 
 		// Create and start the manager
-		mgr := configmgr.New(logger, pMgr, cfg.Active, &mockBackendState{})
+		mgr := configmgr.New(logger, pMgr, cfg.Active, &mockBackendState{}, nil)
 		err := mgr.Start(context.Background(), testConfig, backends)
 
 		// Verify
@@ -70,7 +70,7 @@ func TestLocalConfigManager(t *testing.T) {
 		backends := map[string]backend.Backend{}
 
 		// Create the manager
-		mgr := configmgr.New(logger, pMgr, cfg.Active, &mockBackendState{})
+		mgr := configmgr.New(logger, pMgr, cfg.Active, &mockBackendState{}, nil)
 		err := mgr.Start(context.Background(), testConfig, backends)
 
 		// Should return an error
@@ -99,7 +99,7 @@ func TestLocalConfigManager(t *testing.T) {
 		backends := map[string]backend.Backend{}
 
 		// Create the manager
-		mgr := configmgr.New(logger, pMgr, cfg.Active, &mockBackendState{})
+		mgr := configmgr.New(logger, pMgr, cfg.Active, &mockBackendState{}, nil)
 		err := mgr.Start(context.Background(), testConfig, backends)
 
 		// Should return an error

--- a/agent/configmgr/manager.go
+++ b/agent/configmgr/manager.go
@@ -22,12 +22,12 @@ type Manager interface {
 func New(logger *slog.Logger, pMgr policymgr.PolicyManager, active string, backendState backend.StateRetriever, fm filesmgr.Manager) Manager {
 	switch active {
 	case "local":
-		return &localConfigManager{logger: logger, pMgr: pMgr}
+		return &localConfigManager{logger: logger, pMgr: pMgr} // fm unused: local/git mode has no fleet bundle delivery
 	case "git":
 		return &gitConfigManager{logger: logger, pMgr: pMgr}
 	case "fleet":
 		return newFleetConfigManager(logger, pMgr, backendState, fm)
 	default:
-		return &localConfigManager{logger: logger, pMgr: pMgr}
+		return &localConfigManager{logger: logger, pMgr: pMgr} // fm unused: local/git mode has no fleet bundle delivery
 	}
 }

--- a/agent/configmgr/manager.go
+++ b/agent/configmgr/manager.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/config"
+	"github.com/netboxlabs/orb-agent/agent/filesmgr"
 	"github.com/netboxlabs/orb-agent/agent/policymgr"
 )
 
@@ -18,14 +19,14 @@ type Manager interface {
 
 // New creates a new instance of ConfigManager that is bound to the
 // supplied context.
-func New(logger *slog.Logger, pMgr policymgr.PolicyManager, active string, backendState backend.StateRetriever) Manager {
+func New(logger *slog.Logger, pMgr policymgr.PolicyManager, active string, backendState backend.StateRetriever, fm filesmgr.Manager) Manager {
 	switch active {
 	case "local":
 		return &localConfigManager{logger: logger, pMgr: pMgr}
 	case "git":
 		return &gitConfigManager{logger: logger, pMgr: pMgr}
 	case "fleet":
-		return newFleetConfigManager(logger, pMgr, backendState)
+		return newFleetConfigManager(logger, pMgr, backendState, fm)
 	default:
 		return &localConfigManager{logger: logger, pMgr: pMgr}
 	}

--- a/agent/configmgr/manager_test.go
+++ b/agent/configmgr/manager_test.go
@@ -141,7 +141,7 @@ func TestManagerNew(t *testing.T) {
 			},
 		}
 
-		mgr := configmgr.New(logger, pMgr, cfg.Active, &mockBackendState{})
+		mgr := configmgr.New(logger, pMgr, cfg.Active, &mockBackendState{}, nil)
 		assert.NotNil(t, mgr)
 		// Check we got the expected implementation
 		ctx := context.Background()
@@ -159,7 +159,7 @@ func TestManagerNew(t *testing.T) {
 			},
 		}
 
-		mgr := configmgr.New(logger, pMgr, cfg.Active, &mockBackendState{})
+		mgr := configmgr.New(logger, pMgr, cfg.Active, &mockBackendState{}, nil)
 		assert.NotNil(t, mgr)
 		// Check we got the expected implementation
 		ctx := context.Background()
@@ -180,7 +180,7 @@ func TestManagerNew(t *testing.T) {
 		}
 
 		mockBackendState := &mockBackendState{}
-		mgr := configmgr.New(logger, pMgr, cfg.Active, mockBackendState)
+		mgr := configmgr.New(logger, pMgr, cfg.Active, mockBackendState, nil)
 		assert.NotNil(t, mgr)
 		// Check we got the expected implementation
 		ctx := context.Background()
@@ -193,7 +193,7 @@ func TestManagerNew(t *testing.T) {
 			Active: "unknown",
 		}
 
-		mgr := configmgr.New(logger, pMgr, cfg.Active, &mockBackendState{})
+		mgr := configmgr.New(logger, pMgr, cfg.Active, &mockBackendState{}, nil)
 		assert.NotNil(t, mgr)
 		// Check we got the local implementation
 		ctx := context.Background()


### PR DESCRIPTION
## Context

`filesmgr.Manager` was already implemented in orb-agent with fetch, sha256 verification, extraction, atomic symlink-swap, and crash recovery. This PR adds the **MQTT glue** — the missing piece that routes `inbox.packages` messages from the fleet manager into the existing `filesmgr.Manager`.

---

## What changes

### New: `agent/configmgr/fleet/messages/packages.go`
Defines the `inbox.packages` message types:
- `PackagesCredentialsRPCFunc = "packages_credentials"`
- `BundleSpec` — `{name, version, url, sha256, expires_at}`
- `PackagesCredentialsRPCPayload` — `{bundles: []BundleSpec}`
- `PackagesCredentialsRPC` — full RPC envelope

### Modified: `agent/configmgr/fleet/from_rpc.go`
- Added `filesManager filesmgr.Manager` field to `Messaging` struct
- Added `filesManager` parameter to `NewMessaging` constructor
- Added `case messages.PackagesCredentialsRPCFunc` to `DispatchToHandlers` switch
- Added `handlePackages(ctx, payload)`:
  - Iterates bundles in payload
  - Calls `filesManager.Ensure(ctx, FileSpec{Name, Version, URL, SHA256, Extract: true})` per bundle
  - Non-fatal: a failed bundle is logged and skipped, others continue installing
  - No-ops on empty payload

### Modified: `agent/configmgr/fleet/connection.go`
- Added `filesManager filesmgr.Manager` parameter to `NewMQTTConnection`
- Threads it through to `NewMessaging`

### Modified: `agent/configmgr/fleet.go`
- Added `fm filesmgr.Manager` parameter to `newFleetConfigManager`
- Threads it through to `fleet.NewMQTTConnection`

### Modified: `agent/configmgr/manager.go`
- Added `fm filesmgr.Manager` parameter to `New`
- Passes it to `newFleetConfigManager` for the `fleet` config manager case
- `local` and `git` config managers are unaffected

### Modified: `agent/agent.go`
- Passes the already-constructed `fm` (from `filesmgr.NewManager`) into `configmgr.New`

### New: `agent/configmgr/fleet/packages_test.go`
4 unit tests, no external dependencies required:
- `TestHandlePackages_HappyPath` — single bundle, Ensure called with correct FileSpec
- `TestHandlePackages_EmptyBundles` — empty payload, Ensure never called
- `TestHandlePackages_PartialFailure` — first bundle fails, second still installs (non-fatal)
- `TestDispatchToHandlers_PackagesCredentials` — full dispatch path via JSON-marshalled RPC

---

## Message schema

```json
{
  "schema_version": "2",
  "func": "packages_credentials",
  "payload": {
    "bundles": [
      {
        "name": "nbl_cisco_meraki",
        "version": "0.2.0",
        "url": "https://example.com/bundle.tar.gz?signed-params",
        "sha256": "abc123...",
        "expires_at": 1234567890
      }
    ]
  }
}
```

The `url` is a presigned URL with a short TTL. The `sha256` is of the fat bundle tarball containing the package and all its dependencies pre-installed.

---

## What filesmgr.Ensure does

For each bundle, `Ensure` will:
1. Check if `<root>/<name>/<version>/` already exists and matches sha256 — skip if so
2. Fetch the tarball via `go-getter` using the presigned URL
3. Verify sha256 against the spec
4. Extract into `<root>/<name>/<version>/`
5. Atomically swap the `current` symlink to the new version
6. Persist state to `state.json` for crash recovery

---

## Test results

```
ok   github.com/netboxlabs/orb-agent/agent/configmgr               11.277s
ok   github.com/netboxlabs/orb-agent/agent/configmgr/fleet          3.160s
ok   github.com/netboxlabs/orb-agent/agent/configmgr/fleet/messages  0.357s
```

Note: `agent/secretsmgr` has pre-existing failures requiring a live Docker+Vault — unrelated to this PR.