### PR TITLE
test(filesmgr): add local dev S3 integration test for Manager.Ensure

### DIFF
--- a/agent/filesmgr/filesmgr_integration_test.go
+++ b/agent/filesmgr/filesmgr_integration_test.go
@@ -1,0 +1,99 @@
+//go:build integration
+
+package filesmgr
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestManager_EnsureFromS3 is an integration test that downloads a real bundle
+// from the nbl-orb-bundles-dev S3 bucket via a presigned URL and verifies the
+// full Ensure flow: download, SHA256 verification, extraction, and symlink.
+//
+// Requirements:
+//   - AWS credentials must be active (use: assume observability-dev-netboxlabs-AWSAdministratorAccess)
+//   - Run with: go test -v -tags integration -timeout 120s ./agent/filesmgr/... -run TestManager_EnsureFromS3
+
+const (
+	s3Bucket       = "nbl-orb-bundles-dev"
+	s3Region       = "us-east-2"
+	s3Key          = "nbl_cisco_meraki/2.12.0/bundle.tar.gz"
+	s3BundleSHA256 = "fd4c5fda92bf1ae36d589dcd331db7f2cdbb8807792af7fa85ca8b0105a9f5b1"
+	s3BundleName   = "nbl_cisco_meraki"
+	s3BundleVer    = "2.12.0"
+)
+
+func presignS3URL(t *testing.T) string {
+	t.Helper()
+	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithRegion(s3Region))
+	require.NoError(t, err, "load AWS config")
+
+	client := s3.NewFromConfig(cfg)
+	presignClient := s3.NewPresignClient(client)
+
+	req, err := presignClient.PresignGetObject(context.Background(), &s3.GetObjectInput{
+		Bucket: &[]string{s3Bucket}[0],
+		Key:    &[]string{s3Key}[0],
+	}, s3.WithPresignExpires(15*time.Minute))
+	require.NoError(t, err, "presign S3 URL")
+	return req.URL
+}
+
+func TestManager_EnsureFromS3(t *testing.T) {
+	if os.Getenv("AWS_ACCESS_KEY_ID") == "" && os.Getenv("AWS_SESSION_TOKEN") == "" {
+		t.Skip("skipping S3 integration test: no AWS credentials found")
+	}
+
+	url := presignS3URL(t)
+
+	root := t.TempDir()
+	m := NewManager(slog.Default(), root)
+	require.NoError(t, m.Start(context.Background()))
+
+	var eventCount int
+	m.Subscribe(func(_ FileEvent) {
+		eventCount++
+	})
+
+	// First Ensure — download, verify SHA256, extract, symlink
+	path, err := m.Ensure(context.Background(), FileSpec{
+		Name:    s3BundleName,
+		Version: s3BundleVer,
+		URL:     url,
+		SHA256:  s3BundleSHA256,
+		Extract: true,
+	})
+	require.NoError(t, err)
+
+	expectedPath := filepath.Join(root, s3BundleName, "current")
+	assert.Equal(t, expectedPath, path)
+
+	target, err := os.Readlink(filepath.Join(root, s3BundleName, "current"))
+	require.NoError(t, err)
+	assert.Equal(t, s3BundleVer, target)
+
+	assert.DirExists(t, filepath.Join(root, s3BundleName, s3BundleVer))
+	assert.Equal(t, 1, eventCount, "expected exactly one install event")
+
+	// Second Ensure — must be idempotent
+	path2, err := m.Ensure(context.Background(), FileSpec{
+		Name:    s3BundleName,
+		Version: s3BundleVer,
+		URL:     url,
+		SHA256:  s3BundleSHA256,
+		Extract: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, path, path2)
+	assert.Equal(t, 1, eventCount, "idempotent Ensure must not emit a second event")
+}

--- a/agent/filesmgr/filesmgr_integration_test.go
+++ b/agent/filesmgr/filesmgr_integration_test.go
@@ -17,33 +17,40 @@ import (
 )
 
 // TestManager_EnsureFromS3 is an integration test that downloads a real bundle
-// from the nbl-orb-bundles-dev S3 bucket via a presigned URL and verifies the
+// from a private S3 bucket via a presigned URL and verifies the
 // full Ensure flow: download, SHA256 verification, extraction, and symlink.
 //
 // Requirements:
-//   - AWS credentials must be active (use: assume observability-dev-netboxlabs-AWSAdministratorAccess)
+//   - AWS credentials must be active with read access to the configured S3 bucket
+//   - The following environment variables must be set:
+//     S3_TEST_BUCKET, S3_TEST_REGION, S3_TEST_KEY, S3_TEST_SHA256,
+//     S3_TEST_BUNDLE_NAME, S3_TEST_BUNDLE_VERSION
 //   - Run with: go test -v -tags integration -timeout 120s ./agent/filesmgr/... -run TestManager_EnsureFromS3
 
-const (
-	s3Bucket       = "nbl-orb-bundles-dev"
-	s3Region       = "us-east-2"
-	s3Key          = "nbl_cisco_meraki/2.12.0/bundle.tar.gz"
-	s3BundleSHA256 = "fd4c5fda92bf1ae36d589dcd331db7f2cdbb8807792af7fa85ca8b0105a9f5b1"
-	s3BundleName   = "nbl_cisco_meraki"
-	s3BundleVer    = "2.12.0"
-)
-
-func presignS3URL(t *testing.T) string {
+func s3TestConfig(t *testing.T) (bucket, region, key, sha256, name, version string) {
 	t.Helper()
-	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithRegion(s3Region))
+	get := func(env string) string {
+		v := os.Getenv(env)
+		if v == "" {
+			t.Skipf("skipping S3 integration test: %s not set", env)
+		}
+		return v
+	}
+	return get("S3_TEST_BUCKET"), get("S3_TEST_REGION"), get("S3_TEST_KEY"),
+		get("S3_TEST_SHA256"), get("S3_TEST_BUNDLE_NAME"), get("S3_TEST_BUNDLE_VERSION")
+}
+
+func presignS3URL(t *testing.T, bucket, region, key string) string {
+	t.Helper()
+	cfg, err := config.LoadDefaultConfig(context.Background(), config.WithRegion(region))
 	require.NoError(t, err, "load AWS config")
 
 	client := s3.NewFromConfig(cfg)
 	presignClient := s3.NewPresignClient(client)
 
 	req, err := presignClient.PresignGetObject(context.Background(), &s3.GetObjectInput{
-		Bucket: &[]string{s3Bucket}[0],
-		Key:    &[]string{s3Key}[0],
+		Bucket: &bucket,
+		Key:    &key,
 	}, s3.WithPresignExpires(15*time.Minute))
 	require.NoError(t, err, "presign S3 URL")
 	return req.URL
@@ -54,7 +61,8 @@ func TestManager_EnsureFromS3(t *testing.T) {
 		t.Skip("skipping S3 integration test: no AWS credentials found")
 	}
 
-	url := presignS3URL(t)
+	bucket, region, key, sha256, bundleName, bundleVer := s3TestConfig(t)
+	url := presignS3URL(t, bucket, region, key)
 
 	root := t.TempDir()
 	m := NewManager(slog.Default(), root)
@@ -67,30 +75,30 @@ func TestManager_EnsureFromS3(t *testing.T) {
 
 	// First Ensure — download, verify SHA256, extract, symlink
 	path, err := m.Ensure(context.Background(), FileSpec{
-		Name:    s3BundleName,
-		Version: s3BundleVer,
+		Name:    bundleName,
+		Version: bundleVer,
 		URL:     url,
-		SHA256:  s3BundleSHA256,
+		SHA256:  sha256,
 		Extract: true,
 	})
 	require.NoError(t, err)
 
-	expectedPath := filepath.Join(root, s3BundleName, "current")
+	expectedPath := filepath.Join(root, bundleName, "current")
 	assert.Equal(t, expectedPath, path)
 
-	target, err := os.Readlink(filepath.Join(root, s3BundleName, "current"))
+	target, err := os.Readlink(filepath.Join(root, bundleName, "current"))
 	require.NoError(t, err)
-	assert.Equal(t, s3BundleVer, target)
+	assert.Equal(t, bundleVer, target)
 
-	assert.DirExists(t, filepath.Join(root, s3BundleName, s3BundleVer))
+	assert.DirExists(t, filepath.Join(root, bundleName, bundleVer))
 	assert.Equal(t, 1, eventCount, "expected exactly one install event")
 
 	// Second Ensure — must be idempotent
 	path2, err := m.Ensure(context.Background(), FileSpec{
-		Name:    s3BundleName,
-		Version: s3BundleVer,
+		Name:    bundleName,
+		Version: bundleVer,
 		URL:     url,
-		SHA256:  s3BundleSHA256,
+		SHA256:  sha256,
 		Extract: true,
 	})
 	require.NoError(t, err)

--- a/agent/filesmgr/filesmgr_integration_test.go
+++ b/agent/filesmgr/filesmgr_integration_test.go
@@ -16,16 +16,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestManager_EnsureFromS3 is an integration test that downloads a real bundle
-// from a private S3 bucket via a presigned URL and verifies the
-// full Ensure flow: download, SHA256 verification, extraction, and symlink.
+// TestManager_EnsureFromS3 is a LOCAL DEVELOPER integration test — it is NOT
+// intended for CI/CD pipelines. It validates the full end-to-end Ensure flow
+// against a real S3 bucket: presigned URL generation, download, SHA256
+// verification, extraction, current symlink creation, and idempotency.
 //
-// Requirements:
-//   - AWS credentials must be active with read access to the configured S3 bucket
-//   - The following environment variables must be set:
-//     S3_TEST_BUCKET, S3_TEST_REGION, S3_TEST_KEY, S3_TEST_SHA256,
-//     S3_TEST_BUNDLE_NAME, S3_TEST_BUNDLE_VERSION
-//   - Run with: go test -v -tags integration -timeout 120s ./agent/filesmgr/... -run TestManager_EnsureFromS3
+// This test is guarded by the "integration" build tag and is skipped
+// automatically when any required environment variable is unset, so it will
+// never run accidentally in standard `go test ./...` invocations.
+//
+// To run locally:
+//
+//  1. Obtain AWS credentials with read access to your S3 bucket.
+//  2. Export the following environment variables:
+//       S3_TEST_BUCKET        — bucket name
+//       S3_TEST_REGION        — AWS region (e.g. us-east-2)
+//       S3_TEST_KEY           — object key of the bundle tarball
+//       S3_TEST_SHA256        — expected SHA256 hex digest of the tarball
+//       S3_TEST_BUNDLE_NAME   — logical bundle name
+//       S3_TEST_BUNDLE_VERSION — bundle version string
+//  3. Run:
+//       go test -v -tags integration -timeout 120s ./agent/filesmgr/... -run TestManager_EnsureFromS3
 
 func s3TestConfig(t *testing.T) (bucket, region, key, sha256, name, version string) {
 	t.Helper()

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.26.2
 
 require (
 	github.com/DelineaXPM/tss-sdk-go/v3 v3.0.2
+	github.com/aws/aws-sdk-go-v2/config v1.32.12
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0
 	github.com/eclipse/paho.golang v0.23.0
 	github.com/go-cmd/cmd v1.4.3
 	github.com/go-co-op/gocron/v2 v2.20.0
@@ -48,7 +50,6 @@ require (
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.7 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.32.12 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.12 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.20 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
@@ -59,7 +60,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.23 // indirect
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.101.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.17 // indirect


### PR DESCRIPTION
## What this PR adds

`agent/filesmgr/filesmgr_integration_test.go` — a **local developer integration test** for `Manager.Ensure()` against a real S3 bucket.

> ⚠️ This test is **not intended for CI/CD pipelines**. It is an opt-in local validation tool for developers to verify the full end-to-end bundle delivery flow against real infrastructure.

**Test flow:**
1. Generates a presigned S3 URL via AWS SDK v2 (15 min TTL)
2. Downloads a real bundle tarball from S3
3. Verifies SHA256 integrity
4. Verifies extraction and `current` symlink creation
5. Verifies idempotency — second `Ensure` emits no second event

Guarded by the `integration` build tag — **skipped automatically** when any required env var is unset. Will never run in standard `go test ./...`.

### How to run

```bash
export S3_TEST_BUCKET=<your-bucket>
export S3_TEST_REGION=<region>
export S3_TEST_KEY=<s3-object-key>
export S3_TEST_SHA256=<sha256-of-bundle>
export S3_TEST_BUNDLE_NAME=<bundle-name>
export S3_TEST_BUNDLE_VERSION=<bundle-version>

go test -v -tags integration -timeout 120s ./agent/filesmgr/... -run TestManager_EnsureFromS3
```