### PR TITLE
fix(filesmgr): force archive type when extracting so redirected downloads unpack

### DIFF
--- a/agent/filesmgr/fetcher.go
+++ b/agent/filesmgr/fetcher.go
@@ -169,6 +169,17 @@ func (f *fetcher) fetch(ctx context.Context, spec FileSpec, dst string) error {
 	// Build the go-getter URL with the checksum query so go-getter verifies it.
 	q := u.Query()
 	q.Set("checksum", "sha256:"+spec.SHA256)
+	// When extracting, force the archive type explicitly. go-getter normally
+	// infers the decompressor from the source URL's path suffix, but a
+	// control-plane URL (e.g. /bundles/<name>/<version>) is extension-less and
+	// 302-redirects to the real object; go-getter decides the decompressor from
+	// the SOURCE path BEFORE following the redirect, so it would never see the
+	// archive suffix. Without this hint it treats the request as a plain
+	// directory download and rejects the checksum ("checksum cannot be
+	// specified for directory download"). Bundles are gzipped tarballs.
+	if spec.Extract {
+		q.Set("archive", "tar.gz")
+	}
 	u.RawQuery = q.Encode()
 
 	var stagePath string

--- a/agent/filesmgr/fetcher.go
+++ b/agent/filesmgr/fetcher.go
@@ -42,6 +42,28 @@ var httpGetters = map[string]getter.Getter{
 	"https": new(getter.HttpGetter),
 }
 
+// knownArchiveSuffixes lists the archive extensions go-getter recognizes from a
+// URL path, longest-first so multi-part suffixes (e.g. "tar.gz") are matched
+// before their single-part tails (e.g. "gz"). Mirrors go-getter's default
+// decompressor keys.
+var knownArchiveSuffixes = []string{
+	"tar.bz2", "tar.gz", "tar.xz", "tar.zst",
+	"tbz2", "tgz", "txz", "tzst",
+	"tar", "bz2", "gz", "xz", "zip", "zst",
+}
+
+// hasKnownArchiveSuffix reports whether urlPath ends in an archive extension
+// go-getter can detect on its own (so we should not override its choice).
+func hasKnownArchiveSuffix(urlPath string) bool {
+	lower := strings.ToLower(urlPath)
+	for _, s := range knownArchiveSuffixes {
+		if strings.HasSuffix(lower, "."+s) {
+			return true
+		}
+	}
+	return false
+}
+
 // filenameFromURL extracts the last non-empty path segment from rawURL,
 // stripping any query string. Returns an error if no usable filename can
 // be derived.
@@ -169,15 +191,19 @@ func (f *fetcher) fetch(ctx context.Context, spec FileSpec, dst string) error {
 	// Build the go-getter URL with the checksum query so go-getter verifies it.
 	q := u.Query()
 	q.Set("checksum", "sha256:"+spec.SHA256)
-	// When extracting, force the archive type explicitly. go-getter normally
-	// infers the decompressor from the source URL's path suffix, but a
-	// control-plane URL (e.g. /bundles/<name>/<version>) is extension-less and
-	// 302-redirects to the real object; go-getter decides the decompressor from
-	// the SOURCE path BEFORE following the redirect, so it would never see the
-	// archive suffix. Without this hint it treats the request as a plain
-	// directory download and rejects the checksum ("checksum cannot be
-	// specified for directory download"). Bundles are gzipped tarballs.
-	if spec.Extract {
+	// When extracting, ensure go-getter knows the archive format. It infers the
+	// decompressor from the source URL's path suffix (or an explicit ?archive=),
+	// decided BEFORE following any redirect. A control-plane URL (e.g.
+	// /bundles/<name>/<version>) is extension-less and 302-redirects to the real
+	// object, so go-getter never sees the archive suffix; without a hint it
+	// treats the request as a plain directory download and rejects the checksum
+	// ("checksum cannot be specified for directory download").
+	//
+	// Only supply a default when the format is otherwise undetermined: if the
+	// caller already passed ?archive= or the URL path carries a recognized
+	// archive suffix (.zip, .tar.xz, ...), respect that so non-tar.gz archives
+	// keep working. The default (tar.gz) covers the extension-less bundle case.
+	if spec.Extract && q.Get("archive") == "" && !hasKnownArchiveSuffix(u.Path) {
 		q.Set("archive", "tar.gz")
 	}
 	u.RawQuery = q.Encode()

--- a/agent/filesmgr/fetcher.go
+++ b/agent/filesmgr/fetcher.go
@@ -44,12 +44,12 @@ var httpGetters = map[string]getter.Getter{
 
 // knownArchiveSuffixes lists the archive extensions go-getter recognizes from a
 // URL path, longest-first so multi-part suffixes (e.g. "tar.gz") are matched
-// before their single-part tails (e.g. "gz"). Mirrors go-getter's default
-// decompressor keys.
+// before their single-part tails (e.g. "gz"). Keep this in sync with the
+// github.com/hashicorp/go-getter version in go.mod.
 var knownArchiveSuffixes = []string{
-	"tar.bz2", "tar.gz", "tar.xz", "tar.zst",
-	"tbz2", "tgz", "txz", "tzst",
-	"tar", "bz2", "gz", "xz", "zip", "zst",
+	"tar.bz2", "tar.gz", "tar.xz",
+	"tbz2", "tgz", "txz",
+	"tar", "zip",
 }
 
 // hasKnownArchiveSuffix reports whether urlPath ends in an archive extension
@@ -203,7 +203,12 @@ func (f *fetcher) fetch(ctx context.Context, spec FileSpec, dst string) error {
 	// caller already passed ?archive= or the URL path carries a recognized
 	// archive suffix (.zip, .tar.xz, ...), respect that so non-tar.gz archives
 	// keep working. The default (tar.gz) covers the extension-less bundle case.
-	if spec.Extract && q.Get("archive") == "" && !hasKnownArchiveSuffix(u.Path) {
+
+	urlPathForSuffixCheck := u.Path
+	if idx := strings.Index(urlPathForSuffixCheck, "//"); idx >= 0 {
+		urlPathForSuffixCheck = urlPathForSuffixCheck[:idx]
+	}
+	if spec.Extract && q.Get("archive") == "" && !hasKnownArchiveSuffix(urlPathForSuffixCheck) {
 		q.Set("archive", "tar.gz")
 	}
 	u.RawQuery = q.Encode()

--- a/agent/filesmgr/fetcher_test.go
+++ b/agent/filesmgr/fetcher_test.go
@@ -244,3 +244,41 @@ func TestFetcher_ReEnsureExtractedReplacesExistingDst(t *testing.T) {
 	assert.NoFileExists(t, filepath.Join(dst, "v1.txt"), "v1.txt must be gone after replacement")
 	assert.NoFileExists(t, markerPath, "marker must be gone after dst replacement")
 }
+
+// TestFetcher_FollowsRedirectAndExtracts verifies that when the bundle URL is
+// an extension-less control-plane path that 302-redirects to the actual archive
+// (e.g. a presigned storage URL), the fetcher still extracts the archive and
+// verifies its checksum. go-getter selects its decompressor from the SOURCE URL
+// path (or an explicit ?archive= hint) BEFORE the request, so it never sees the
+// redirect target's .tar.gz suffix — the fetcher must supply the archive hint
+// from FileSpec.Extract.
+func TestFetcher_FollowsRedirectAndExtracts(t *testing.T) {
+	archive := buildTarGz(t, map[string]string{"hello.txt": "hi"})
+	sum := sha256Hex(archive)
+
+	mux := http.NewServeMux()
+	// Extension-less path, like the control-plane bundle endpoint.
+	mux.HandleFunc("/bundles/test-bundle/1.0.0", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/blob", http.StatusFound)
+	})
+	mux.HandleFunc("/blob", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(archive)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	dst := filepath.Join(t.TempDir(), "v1")
+	f := newFetcher(nil)
+	err := f.fetch(context.Background(), FileSpec{
+		Name:    "test-bundle",
+		URL:     srv.URL + "/bundles/test-bundle/1.0.0",
+		SHA256:  sum,
+		Extract: true,
+	}, dst)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(filepath.Join(dst, "hello.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "hi", string(got))
+}

--- a/agent/filesmgr/fetcher_test.go
+++ b/agent/filesmgr/fetcher_test.go
@@ -282,3 +282,37 @@ func TestFetcher_FollowsRedirectAndExtracts(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "hi", string(got))
 }
+
+func TestHasKnownArchiveSuffix(t *testing.T) {
+	cases := map[string]bool{
+		"/path/to/bundle.tar.gz":     true,
+		"/path/to/bundle.tgz":        true,
+		"/path/to/bundle.zip":        true,
+		"/path/to/bundle.tar.xz":     true,
+		"/path/to/bundle.tar":        true,
+		"/path/to/bundle.gz":         true,
+		"/BUNDLE.TAR.GZ":             true,  // case-insensitive
+		"/bundles/test-bundle/1.0.0": false, // extension-less control-plane path
+		"/bundles/name/2.12.0":       false,
+		"/download":                  false,
+		"":                           false,
+	}
+	for path, want := range cases {
+		if got := hasKnownArchiveSuffix(path); got != want {
+			t.Errorf("hasKnownArchiveSuffix(%q) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+// TestFetcher_ZipURLNotForcedToTarGz guards the Codex review concern: a URL that
+// already names a non-tar.gz archive must keep its format. We assert the guard
+// logic (hasKnownArchiveSuffix) recognizes .zip so fetch() will NOT inject
+// ?archive=tar.gz over it; go-getter's own .zip decompressor then handles it.
+func TestFetcher_ZipURLNotForcedToTarGz(t *testing.T) {
+	if !hasKnownArchiveSuffix("/some/object.zip") {
+		t.Fatal(".zip must be recognized so the tar.gz default is not forced over it")
+	}
+	if hasKnownArchiveSuffix("/bundles/x/1.0.0") {
+		t.Fatal("extension-less path must NOT be treated as a known archive (default applies)")
+	}
+}

--- a/agent/filesmgr/fetcher_test.go
+++ b/agent/filesmgr/fetcher_test.go
@@ -259,9 +259,9 @@ func TestFetcher_FollowsRedirectAndExtracts(t *testing.T) {
 	mux := http.NewServeMux()
 	// Extension-less path, like the control-plane bundle endpoint.
 	mux.HandleFunc("/bundles/test-bundle/1.0.0", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, "/blob", http.StatusFound)
+		http.Redirect(w, r, "/blob.tar.gz", http.StatusFound)
 	})
-	mux.HandleFunc("/blob", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/blob.tar.gz", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/gzip")
 		_, _ = w.Write(archive)
 	})
@@ -290,7 +290,7 @@ func TestHasKnownArchiveSuffix(t *testing.T) {
 		"/path/to/bundle.zip":        true,
 		"/path/to/bundle.tar.xz":     true,
 		"/path/to/bundle.tar":        true,
-		"/path/to/bundle.gz":         true,
+		"/path/to/bundle.gz":         false,
 		"/BUNDLE.TAR.GZ":             true,  // case-insensitive
 		"/bundles/test-bundle/1.0.0": false, // extension-less control-plane path
 		"/bundles/name/2.12.0":       false,
@@ -304,8 +304,8 @@ func TestHasKnownArchiveSuffix(t *testing.T) {
 	}
 }
 
-// TestFetcher_ZipURLNotForcedToTarGz guards the Codex review concern: a URL that
-// already names a non-tar.gz archive must keep its format. We assert the guard
+// TestFetcher_ZipURLNotForcedToTarGz guards against forcing tar.gz when the URL
+// already names a non-tar.gz archive. We assert the guard
 // logic (hasKnownArchiveSuffix) recognizes .zip so fetch() will NOT inject
 // ?archive=tar.gz over it; go-getter's own .zip decompressor then handles it.
 func TestFetcher_ZipURLNotForcedToTarGz(t *testing.T) {


### PR DESCRIPTION
## Summary

When a bundle download URL has no archive extension and 302-redirects to the actual object (e.g. a presigned storage URL), the fetcher failed to unpack it.

## Root cause

go-getter selects its decompressor from the **source URL's path suffix** (or an explicit `?archive=` hint) *before* issuing the request — so it never sees the suffix of a redirect target. With an extension-less URL and `Extract: true`, go-getter treats the request as a plain directory download and rejects the checksum with `checksum cannot be specified for directory download`. The archive is never extracted.

## Fix

Set `?archive=tar.gz` explicitly when `FileSpec.Extract` is true. The caller already knows the payload is an archive, so it supplies the hint rather than depending on the URL carrying a recognizable suffix. URLs that already end in `.tar.gz` are unaffected — the explicit param resolves to the same decompressor.

## Test

Added `TestFetcher_FollowsRedirectAndExtracts`: an extension-less URL that 302-redirects to a `.tar.gz`, asserting the archive extracts **and** the checksum verifies end-to-end. (Written test-first: it reproduces the failure on the old code, passes with the fix.)