### PR TITLE
docs(discovery): reorder device-discovery, snmp-discovery, and supported-platforms sections

### DIFF
--- a/docs/backends/device_discovery/README.md
+++ b/docs/backends/device_discovery/README.md
@@ -26,44 +26,6 @@ When a target is a switch stack / Virtual Chassis (NetBox `VirtualChassis`), dev
 
 When a target is a modular chassis and the `discover_modules` policy option is enabled, device-discovery additionally emits `Module` and `ModuleBay` entities for each chassis slot (and, in `full` mode, each transceiver sub-bay) — see [Modules / ModuleBays](#modules--modulebays) below. Defaults to `off`, so existing operators see zero behaviour change.
 
-## Switch stacks / Virtual Chassis
-
-When a driver implements stack-member discovery and the target reports 2+ members with serials, device-discovery emits a NetBox `VirtualChassis` plus one `Device` per member, and routes each interface and IP address to the correct member based on the interface name prefix (e.g. `GigabitEthernet1/0/1` → member 1, `GigabitEthernet2/0/12` → member 2). Standalone switches, devices not in stack mode, and members without a serial (which Diode cannot resolve) fall back to the existing single-`Device` path with no change in behaviour.
-
-**Emission shape** (in order):
-1. **Master `Device`** — plain (no `vc_position`, no `virtual_chassis` ref). Named `<hostname>-<id>` where `<hostname>` is the management hostname and `<id>` is the master's stack-member id.
-2. **`VirtualChassis`** — named `<hostname>`, with `master` set to the inline matcher block of the master Device.
-3. **N − 1 member `Device` entities** — each carries `vc_position = <member id>` and an inline `virtual_chassis` ref pointing to the same matcher block.
-4. **Interface / IPAddress entities** — routed to the member device whose id matches the interface name prefix. Logical interfaces with no parseable member id (`Vlan*`, `Loopback*`, `Port-channel*`, etc.) land on the master.
-
-**Master pinning.** The logical master sent to Diode is always the **lowest stack-member id present**, regardless of live role. This is required because the NetBox Diode plugin resolves an existing `VirtualChassis` via its `unique_master` matcher — pinning to the lowest id keeps the master Device stable across StackWise role failovers so re-runs upsert the existing VC instead of creating a new one. The other matcher fields used for VC re-identification (asset_tag, primary_ip4/6, name+site+tenant, and `metadata.source_match`) are carried consistently on both the rich master Device and the inline VC `master` ref so the plugin's matcher cascade resolves through the same record on every cycle.
-
-**Orphaned member ports.** If a member is dropped from the validated payload (missing serial, duplicate id, etc.) but the device still reports its ports via `show interfaces`, those interfaces are **skipped with a WARNING** rather than routed to master. Routing them to master would silently misattribute member-N ports to a different device — operators see the warning in logs and the missing port in NetBox, not a corrupted port→device mapping.
-
-**Supported drivers.** Stack discovery is opt-in per driver (analogous to interface↔VLAN associations). See the [supported platforms page](./supported_platforms.md#switch-stacks--virtual-chassis-vc) for the current list; vendors land as follow-up PRs as the underlying drivers gain stack-discovery support.
-
-When a driver supports it, interfaces also carry their switching configuration: `mode` (`access` / `tagged` / `tagged-all` / unset for routed), the untagged (access/native) VLAN, and the list of tagged VLANs. Trunks that allow every VLAN (e.g. Cisco IOS `Trunking VLANs Enabled: ALL` or `1-4094`) are emitted as `tagged-all` so NetBox sees the proper 802.1Q semantics rather than a `tagged` interface with an empty allowed-VLAN list. VLANs referenced on an interface but not present in the device's VLAN database are auto-emitted as VLAN entities so the association is complete in NetBox; this behavior can be disabled via the `create_unknown_vlans` option (see below). Auto-emitted stubs use the placeholder name `VLAN<vid>` (e.g. `VLAN42`) because NetBox's `ipam.vlan.name` is required — operators or sibling switches can later overwrite the placeholder via the same vid+group matcher. Malformed CLI rows that the driver cannot parse fail closed (plain `tagged` mode with no tagged VLANs and a logged warning) — they never silently widen an interface to all VLANs. Note: when a switchport is converted to a routed (L3) interface between discovery cycles, prior `mode`/untagged-VLAN/tagged-VLAN associations are NOT automatically cleared in NetBox; operators must clear them manually. This is a current limitation of the Diode plugin's PATCH semantics and is tracked separately.
-
-## Modules / ModuleBays
-
-When a driver implements module discovery and the `discover_modules` policy option is enabled, device-discovery emits NetBox `Module` and `ModuleBay` entities for each chassis slot (e.g. a Catalyst 9404R supervisor + line cards in slots 1–4) and, in `full` mode, for each transceiver sub-bay reported by the device. Standalone non-modular switches (e.g. a Cat 3850 / 9300 with no removable line cards) and devices whose driver does not implement module discovery fall back to the existing emission with no change in behaviour. The option defaults to `off` so existing operators see zero behaviour change unless they explicitly opt in.
-
-**Three modes:**
-
-| `discover_modules` | What gets emitted |
-|---|---|
-| `off` *(default)* | No module / module-bay entities. Existing behaviour. |
-| `linecards` | One `ModuleBay` + `Module` per chassis slot (line cards, supervisors, PSU / fan modules a driver classifies explicitly). Transceiver sub-bays are skipped — useful when operators care about the slot inventory but not per-port optics. |
-| `full` | `linecards` plus one extra `ModuleBay` + `Module` for every transceiver sub-bay reported by the device. Interfaces backed by a transceiver carry a `module=` reference to the transceiver module so NetBox shows which port is populated by which optic. |
-
-**Emission order** (standalone modular chassis): `Device` → all `ModuleBay` + `Module` entries → `Interface` / `IPAddress` entries. The order matters because each interface entity may reference the module installed in its bay; emitting modules first lets the Diode reconciler resolve `Interface.module` against the just-created module.
-
-**Virtual-chassis-of-modular** (e.g. Catalyst 9300 stack with FRU uplinks, Catalyst 9400 / 9500 in StackWise Virtual mode). When a VC member is itself a modular chassis, modules and bays are dispatched per member: each `Module` / `ModuleBay` carries `device=` set to the member that physically owns the slot, and the `Module.module_bay` reference points at that member's bay. The emission order becomes: `Device(master)` → `VirtualChassis` → `Device(non-master members)` → all `ModuleBay` + `Module` per member → `Interface` / `IPAddress` per member. Stack members that are non-modular emit no module entries; the VC stack envelope is unchanged.
-
-**Current sub-bay rendering trade-off (transient).** In `full` mode the transceiver sub-bay is emitted device-rooted — i.e. without a `module=parent_linecard` link. As a result, NetBox renders the transceiver sub-bay at chassis level (alongside the line-card slot bays) instead of visually nested under its parent line card. The transceiver `Module` itself is still installed in the sub-bay correctly via `Module.module_bay`, so per-port optic visibility works as expected; only the bay-under-linecard hierarchy is lost. The link is dropped because, in the current per-entity reconciler, attaching `module=parent_linecard` on a sub-bay causes the parent Module to be re-created from inside the sub-bay's changeset and conflicts at apply with the line card already created by the prior top-level Module entity. The link will be restored once the reconciler resolves nested parent-module refs against committed sibling entities in a single ingest call.
-
-**Supported drivers.** Module discovery is opt-in per driver (analogous to interface↔VLAN associations and stack discovery). See the [supported platforms page](./supported_platforms.md#modules--modulebays) for the current list; vendors land as follow-up PRs as the underlying drivers gain module-discovery support.
-
 ## Configuration
 The `device_discovery` backend does not require any special configuration, though overriding `host` and `port` values can be specified. The backend will use the `diode` settings specified in the `common` subsection to forward discovery results.
 
@@ -336,6 +298,44 @@ orb:
 In this example:
 - The `credentials` section defines reusable credentials using the anchor `&ios_credentials`.
 - The `<<: *ios_credentials` alias is used to include the credentials in multiple devices within the `scope` section.
+
+## Switch stacks / Virtual Chassis
+
+When a driver implements stack-member discovery and the target reports 2+ members with serials, device-discovery emits a NetBox `VirtualChassis` plus one `Device` per member, and routes each interface and IP address to the correct member based on the interface name prefix (e.g. `GigabitEthernet1/0/1` → member 1, `GigabitEthernet2/0/12` → member 2). Standalone switches, devices not in stack mode, and members without a serial (which Diode cannot resolve) fall back to the existing single-`Device` path with no change in behaviour.
+
+**Emission shape** (in order):
+1. **Master `Device`** — plain (no `vc_position`, no `virtual_chassis` ref). Named `<hostname>-<id>` where `<hostname>` is the management hostname and `<id>` is the master's stack-member id.
+2. **`VirtualChassis`** — named `<hostname>`, with `master` set to the inline matcher block of the master Device.
+3. **N − 1 member `Device` entities** — each carries `vc_position = <member id>` and an inline `virtual_chassis` ref pointing to the same matcher block.
+4. **Interface / IPAddress entities** — routed to the member device whose id matches the interface name prefix. Logical interfaces with no parseable member id (`Vlan*`, `Loopback*`, `Port-channel*`, etc.) land on the master.
+
+**Master pinning.** The logical master sent to Diode is always the **lowest stack-member id present**, regardless of live role. This is required because the NetBox Diode plugin resolves an existing `VirtualChassis` via its `unique_master` matcher — pinning to the lowest id keeps the master Device stable across StackWise role failovers so re-runs upsert the existing VC instead of creating a new one. The other matcher fields used for VC re-identification (asset_tag, primary_ip4/6, name+site+tenant, and `metadata.source_match`) are carried consistently on both the rich master Device and the inline VC `master` ref so the plugin's matcher cascade resolves through the same record on every cycle.
+
+**Orphaned member ports.** If a member is dropped from the validated payload (missing serial, duplicate id, etc.) but the device still reports its ports via `show interfaces`, those interfaces are **skipped with a WARNING** rather than routed to master. Routing them to master would silently misattribute member-N ports to a different device — operators see the warning in logs and the missing port in NetBox, not a corrupted port→device mapping.
+
+**Supported drivers.** Stack discovery is opt-in per driver (analogous to interface↔VLAN associations). See the [supported platforms page](./supported_platforms.md#switch-stacks--virtual-chassis-vc) for the current list; vendors land as follow-up PRs as the underlying drivers gain stack-discovery support.
+
+When a driver supports it, interfaces also carry their switching configuration: `mode` (`access` / `tagged` / `tagged-all` / unset for routed), the untagged (access/native) VLAN, and the list of tagged VLANs. Trunks that allow every VLAN (e.g. Cisco IOS `Trunking VLANs Enabled: ALL` or `1-4094`) are emitted as `tagged-all` so NetBox sees the proper 802.1Q semantics rather than a `tagged` interface with an empty allowed-VLAN list. VLANs referenced on an interface but not present in the device's VLAN database are auto-emitted as VLAN entities so the association is complete in NetBox; this behavior can be disabled via the `create_unknown_vlans` option (see below). Auto-emitted stubs use the placeholder name `VLAN<vid>` (e.g. `VLAN42`) because NetBox's `ipam.vlan.name` is required — operators or sibling switches can later overwrite the placeholder via the same vid+group matcher. Malformed CLI rows that the driver cannot parse fail closed (plain `tagged` mode with no tagged VLANs and a logged warning) — they never silently widen an interface to all VLANs. Note: when a switchport is converted to a routed (L3) interface between discovery cycles, prior `mode`/untagged-VLAN/tagged-VLAN associations are NOT automatically cleared in NetBox; operators must clear them manually. This is a current limitation of the Diode plugin's PATCH semantics and is tracked separately.
+
+## Modules / ModuleBays
+
+When a driver implements module discovery and the `discover_modules` policy option is enabled, device-discovery emits NetBox `Module` and `ModuleBay` entities for each chassis slot (e.g. a Catalyst 9404R supervisor + line cards in slots 1–4) and, in `full` mode, for each transceiver sub-bay reported by the device. Standalone non-modular switches (e.g. a Cat 3850 / 9300 with no removable line cards) and devices whose driver does not implement module discovery fall back to the existing emission with no change in behaviour. The option defaults to `off` so existing operators see zero behaviour change unless they explicitly opt in.
+
+**Three modes:**
+
+| `discover_modules` | What gets emitted |
+|---|---|
+| `off` *(default)* | No module / module-bay entities. Existing behaviour. |
+| `linecards` | One `ModuleBay` + `Module` per chassis slot (line cards, supervisors, PSU / fan modules a driver classifies explicitly). Transceiver sub-bays are skipped — useful when operators care about the slot inventory but not per-port optics. |
+| `full` | `linecards` plus one extra `ModuleBay` + `Module` for every transceiver sub-bay reported by the device. Interfaces backed by a transceiver carry a `module=` reference to the transceiver module so NetBox shows which port is populated by which optic. |
+
+**Emission order** (standalone modular chassis): `Device` → all `ModuleBay` + `Module` entries → `Interface` / `IPAddress` entries. The order matters because each interface entity may reference the module installed in its bay; emitting modules first lets the Diode reconciler resolve `Interface.module` against the just-created module.
+
+**Virtual-chassis-of-modular** (e.g. Catalyst 9300 stack with FRU uplinks, Catalyst 9400 / 9500 in StackWise Virtual mode). When a VC member is itself a modular chassis, modules and bays are dispatched per member: each `Module` / `ModuleBay` carries `device=` set to the member that physically owns the slot, and the `Module.module_bay` reference points at that member's bay. The emission order becomes: `Device(master)` → `VirtualChassis` → `Device(non-master members)` → all `ModuleBay` + `Module` per member → `Interface` / `IPAddress` per member. Stack members that are non-modular emit no module entries; the VC stack envelope is unchanged.
+
+**Current sub-bay rendering trade-off (transient).** In `full` mode the transceiver sub-bay is emitted device-rooted — i.e. without a `module=parent_linecard` link. As a result, NetBox renders the transceiver sub-bay at chassis level (alongside the line-card slot bays) instead of visually nested under its parent line card. The transceiver `Module` itself is still installed in the sub-bay correctly via `Module.module_bay`, so per-port optic visibility works as expected; only the bay-under-linecard hierarchy is lost. The link is dropped because, in the current per-entity reconciler, attaching `module=parent_linecard` on a sub-bay causes the parent Module to be re-created from inside the sub-bay's changeset and conflicts at apply with the line card already created by the prior top-level Module entity. The link will be restored once the reconciler resolves nested parent-module refs against committed sibling entities in a single ingest call.
+
+**Supported drivers.** Module discovery is opt-in per driver (analogous to interface↔VLAN associations and stack discovery). See the [supported platforms page](./supported_platforms.md#modules--modulebays) for the current list; vendors land as follow-up PRs as the underlying drivers gain module-discovery support.
 
 ## What NAPALM Collects Automatically
 

--- a/docs/backends/device_discovery/supported_platforms.md
+++ b/docs/backends/device_discovery/supported_platforms.md
@@ -10,6 +10,70 @@ The backend connects to network devices over SSH / NETCONF / vendor APIs via [NA
 
 When a scope entry does not specify a `driver`, device-discovery attempts driver detection automatically. Only the **standard NAPALM drivers** below are tried during auto-discovery. Custom drivers must be used explicitly by either setting `driver:` on the scope entry, or by listing them in the `discovery_drivers` option (see [Custom Driver Discovery Example](./README.md#custom-driver-discovery-example)).
 
+## Standard NAPALM drivers
+
+These drivers ship with the [NAPALM](https://napalm.readthedocs.io/en/latest/support/) library and are eligible for auto-discovery.
+
+| Driver | Vendor | Platform / OS |
+|--------|--------|---------------|
+| `eos` | Arista | EOS |
+| `ios` | Cisco | IOS / IOS-XE |
+| `iosxr` | Cisco | IOS-XR (XML agent) |
+| `iosxr_netconf` | Cisco | IOS-XR (NETCONF) |
+| `junos` | Juniper | Junos |
+| `nxos` | Cisco | NX-OS (NX-API) |
+| `nxos_ssh` | Cisco | NX-OS (SSH) |
+
+## Custom NAPALM drivers
+
+These drivers are bundled with device-discovery. They are **not** tried during auto-discovery unless explicitly listed in `discovery_drivers`; otherwise set `driver:` on the scope entry.
+
+| Driver | Vendor | Platform / OS |
+|--------|--------|---------------|
+| `alcatel_aos` | Nokia / Alcatel-Lucent Enterprise | AOS |
+| `aruba_aoscx` | HPE Aruba Networking | AOS-CX (REST) |
+| `aruba_aoscx_ssh` | HPE Aruba Networking | AOS-CX (SSH) |
+| `aruba_os` | HPE Aruba Networking | ArubaOS (controllers) |
+| `aruba_osswitch` | HPE Aruba Networking | ArubaOS-Switch (ex-ProCurve) |
+| `avaya_ers` | Extreme Networks (ex-Avaya) | Ethernet Routing Switch (ERS) |
+| `brocade_fastiron` | Ruckus / CommScope (ex-Brocade) | FastIron (ICX) |
+| `brocade_netiron` | Extreme Networks (ex-Brocade) | NetIron (MLX / CES / CER) |
+| `checkpoint_gaia` | Check Point | Gaia |
+| `ciena_saos` | Ciena | SAOS |
+| `cisco_apic` | Cisco | ACI APIC |
+| `cisco_asa` | Cisco | ASA |
+| `cisco_asa_ssh` | Cisco | ASA (SSH) |
+| `cisco_ftd_ssh` | Cisco | Firepower Threat Defense (FTD) |
+| `cisco_fxos` | Cisco | FXOS |
+| `cisco_s300` | Cisco | Small Business 300/350/550 series |
+| `cisco_viptela_ssh` | Cisco | Viptela / SD-WAN |
+| `cisco_wlc` | Cisco | Wireless LAN Controller (AireOS) |
+| `cumulus_linux` | NVIDIA (ex-Cumulus) | Cumulus Linux |
+| `dell_ftos` | Dell | Force10 / FTOS |
+| `dell_powerconnect` | Dell | PowerConnect |
+| `dell_sonic` | Dell | Enterprise SONiC |
+| `ericsson_ipos` | Ericsson | IPOS (ex-Redback SmartEdge) |
+| `extreme_exos` | Extreme Networks | EXOS |
+| `extreme_slx` | Extreme Networks | SLX-OS |
+| `extreme_vsp` | Extreme Networks | VSP / VOSS |
+| `fortinet_fortios_ssh` | Fortinet | FortiOS |
+| `hp_comware` | HPE / H3C | Comware |
+| `hp_procurve` | HPE | ProCurve (legacy) |
+| `huawei_smartax` | Huawei | SmartAX (OLT) |
+| `huawei_vrp` | Huawei | VRP |
+| `mellanox_mlnxos` | NVIDIA / Mellanox | MLNX-OS |
+| `mikrotik_routeros` | MikroTik | RouterOS |
+| `nokia_srl` | Nokia | SR Linux |
+| `nokia_sros` | Nokia | SR OS (gNMI/NETCONF) |
+| `nokia_sros_ssh` | Nokia | SR OS (SSH) |
+| `paloalto_panos` | Palo Alto Networks | PAN-OS (XML API) |
+| `paloalto_panos_ssh` | Palo Alto Networks | PAN-OS (SSH) |
+| `ubiquiti_edgerouter` | Ubiquiti | EdgeRouter (EdgeOS) |
+| `ubiquiti_edgeswitch` | Ubiquiti | EdgeSwitch |
+| `ubiquiti_unifiswitch` | Ubiquiti | UniFi Switch |
+
+The source for the custom drivers is maintained at [orb-discovery/device-discovery/custom_napalm](https://github.com/netboxlabs/orb-discovery/tree/develop/device-discovery/custom_napalm).
+
 ## Interface ↔ VLAN associations
 
 Drivers that implement `get_interfaces_vlans()` populate per-interface switching configuration on the emitted `Interface` entities (mode, untagged/access VLAN, tagged VLAN list). Drivers without the method continue to emit interfaces without VLAN associations — this is opt-in per driver.
@@ -170,70 +234,6 @@ Drivers that implement `get_modules()` discover the per-slot module inventory on
 **HP / H3C Comware (`hp_comware`).** Module discovery covers the H3C / HPE modular families S7500E, S10500, S12500 / S12500X-AF, and S12900. Family detection runs against the `display version` model string using substring family tokens (`S75` / `S105` / `S125` / `S129` for the H3C-branded forms `S7503E` / `S10510` / `S12508X-AF` / `S12916-AF`, plus the HPE-rebrand variants `7500` / `10500` / `12500` / `12900` for `HPE FlexFabric 12500` / `HP A10500` / etc.) — these match every chassis variant while cleanly rejecting fixed pizza-box families (`S5500-28C-EI`, `S5800-32F`, `S6800-54QF`) so the non-modular tail incurs no extra command round-trip. For modular families the driver parses the `hp_comware_display_device_manuinfo` ntc-template (filldown `CHASSIS_ID` + `SLOT_TYPE` / `SLOT_ID` / `DEVICE_NAME` / `DEVICE_SERIAL_NUMBER`) and partitions surviving Slot rows by `chassis_id`. Standalone modular chassis emit a single `members[None]` envelope (matching the single-device translate path's `{None: device}` map); IRF-of-modular emits one envelope per IRF member chassis (`members[1]`, `members[2]`, …) for the multi-member `translate_as_stack` path — the same code path covers both deployments without a separate command. **Supervisor identification is by SKU substring, not family prefix**: H3C reuses the same family prefix (`LSQM` / `LSUM` / `LSXM`) for both MPU (supervisor) and interface cards on the same chassis, so the role is encoded in the SKU body — `LSQM1MPUC0` (supervisor) vs `LSQM1FH48EA` (interface card). The classifier looks for `MPU` / `SUP` substrings first → `supervisor`; anything else matching a documented modular-family prefix (LSUM / LSQM / LSXM / LSQS / LSXS / LSQ1 / LSQ2 / LSQK / LSX1 / LSX2 / LSR / LSU) → `linecard` (SFU / fabric cards land here too because NetBox has no fabric module type today). Subslot / Fan / Power rows are dropped — sub-bay discovery (e.g. SFP sub-modules under an LSXM2 daughtercard) is a documented v1 limitation queued for a follow-up batch.
 
 **Extreme EXOS (`extreme_exos`).** Module discovery is scoped to the BlackDiamond X8 modular chassis. Other EXOS hardware in the field — the X670 / X870 fixed pizza-boxes, the BD-X8-X32 stackable variant — share the `X8` family token in their model strings but are not modular and must not produce module entries. Family detection scans the **full `show version` output** (not just `System Type:`, which Extreme's command-reference BD-X8 example omits in favour of `Switch :` / `Chassis :` / `Slot-*` / `FM-*` lines) using a regex with a negative-lookahead anchor (`(?:BD-|BLACKDIAMOND\s+)X8(?![-\w])`) rather than a Python `\b` word-boundary, because `\b` fires between the digit `8` and the dash in `BD-X8-32` and would accept the wrong model. For BD-X8 chassis the driver parses `show slot detail` directly — no `extreme_exos_show_slot_detail` ntc-template exists, so a block-per-slot regex walks each `Slot-N information:` / `MSM-A information:` / `FM-1 information:` block (case-insensitive) and extracts the `Hw Module Type` and `Serial number` fields. The serial capture is whitespace-tolerant: real BD-X8 prints two whitespace-separated tokens (`Serial number: 800432-00-09 1534G-01368` — part-number plus unique serial), and the parser collapses internal whitespace runs to a single space so the persisted value is stable. The classifier maps `BDX-MM` (Management Module) to `supervisor` and the I/O / Fabric Module families (`BDXA-FM` / `BDXA-` / `BDXB-`) to `linecard`; Fabric Modules emit as `linecard` because NetBox has no fabric module type today. Any hypothetical `BDXB-FM*` SKU still classifies as linecard via the generic `BDXB-` fallback. Slot header parsing tolerates both `Slot-N` and `Slot N` (space-separator) layouts that EXOS releases interchangeably emit; space variants are normalised to hyphenated bay names (`Slot 1` → `Slot-1`) so bay identifiers stay consistent across releases. Single-member envelope keyed by `None`; EXOS has no stack-of-modular dispatch in v1.
-
-## Standard NAPALM drivers
-
-These drivers ship with the [NAPALM](https://napalm.readthedocs.io/en/latest/support/) library and are eligible for auto-discovery.
-
-| Driver | Vendor | Platform / OS |
-|--------|--------|---------------|
-| `eos` | Arista | EOS |
-| `ios` | Cisco | IOS / IOS-XE |
-| `iosxr` | Cisco | IOS-XR (XML agent) |
-| `iosxr_netconf` | Cisco | IOS-XR (NETCONF) |
-| `junos` | Juniper | Junos |
-| `nxos` | Cisco | NX-OS (NX-API) |
-| `nxos_ssh` | Cisco | NX-OS (SSH) |
-
-## Custom NAPALM drivers
-
-These drivers are bundled with device-discovery. They are **not** tried during auto-discovery unless explicitly listed in `discovery_drivers`; otherwise set `driver:` on the scope entry.
-
-| Driver | Vendor | Platform / OS |
-|--------|--------|---------------|
-| `alcatel_aos` | Nokia / Alcatel-Lucent Enterprise | AOS |
-| `aruba_aoscx` | HPE Aruba Networking | AOS-CX (REST) |
-| `aruba_aoscx_ssh` | HPE Aruba Networking | AOS-CX (SSH) |
-| `aruba_os` | HPE Aruba Networking | ArubaOS (controllers) |
-| `aruba_osswitch` | HPE Aruba Networking | ArubaOS-Switch (ex-ProCurve) |
-| `avaya_ers` | Extreme Networks (ex-Avaya) | Ethernet Routing Switch (ERS) |
-| `brocade_fastiron` | Ruckus / CommScope (ex-Brocade) | FastIron (ICX) |
-| `brocade_netiron` | Extreme Networks (ex-Brocade) | NetIron (MLX / CES / CER) |
-| `checkpoint_gaia` | Check Point | Gaia |
-| `ciena_saos` | Ciena | SAOS |
-| `cisco_apic` | Cisco | ACI APIC |
-| `cisco_asa` | Cisco | ASA |
-| `cisco_asa_ssh` | Cisco | ASA (SSH) |
-| `cisco_ftd_ssh` | Cisco | Firepower Threat Defense (FTD) |
-| `cisco_fxos` | Cisco | FXOS |
-| `cisco_s300` | Cisco | Small Business 300/350/550 series |
-| `cisco_viptela_ssh` | Cisco | Viptela / SD-WAN |
-| `cisco_wlc` | Cisco | Wireless LAN Controller (AireOS) |
-| `cumulus_linux` | NVIDIA (ex-Cumulus) | Cumulus Linux |
-| `dell_ftos` | Dell | Force10 / FTOS |
-| `dell_powerconnect` | Dell | PowerConnect |
-| `dell_sonic` | Dell | Enterprise SONiC |
-| `ericsson_ipos` | Ericsson | IPOS (ex-Redback SmartEdge) |
-| `extreme_exos` | Extreme Networks | EXOS |
-| `extreme_slx` | Extreme Networks | SLX-OS |
-| `extreme_vsp` | Extreme Networks | VSP / VOSS |
-| `fortinet_fortios_ssh` | Fortinet | FortiOS |
-| `hp_comware` | HPE / H3C | Comware |
-| `hp_procurve` | HPE | ProCurve (legacy) |
-| `huawei_smartax` | Huawei | SmartAX (OLT) |
-| `huawei_vrp` | Huawei | VRP |
-| `mellanox_mlnxos` | NVIDIA / Mellanox | MLNX-OS |
-| `mikrotik_routeros` | MikroTik | RouterOS |
-| `nokia_srl` | Nokia | SR Linux |
-| `nokia_sros` | Nokia | SR OS (gNMI/NETCONF) |
-| `nokia_sros_ssh` | Nokia | SR OS (SSH) |
-| `paloalto_panos` | Palo Alto Networks | PAN-OS (XML API) |
-| `paloalto_panos_ssh` | Palo Alto Networks | PAN-OS (SSH) |
-| `ubiquiti_edgerouter` | Ubiquiti | EdgeRouter (EdgeOS) |
-| `ubiquiti_edgeswitch` | Ubiquiti | EdgeSwitch |
-| `ubiquiti_unifiswitch` | Ubiquiti | UniFi Switch |
-
-The source for the custom drivers is maintained at [orb-discovery/device-discovery/custom_napalm](https://github.com/netboxlabs/orb-discovery/tree/develop/device-discovery/custom_napalm).
 
 ## Querying supported drivers at runtime
 

--- a/docs/backends/snmp_discovery/README.md
+++ b/docs/backends/snmp_discovery/README.md
@@ -26,58 +26,6 @@ When a device exposes the relevant MIBs, interfaces also carry their switching c
 
 Note: when a switchport is converted to a routed (L3) interface between discovery cycles, prior `mode`/untagged-VLAN/tagged-VLAN associations are NOT automatically cleared in NetBox; operators must clear them manually. This is a current limitation of the Diode plugin's PATCH semantics and is tracked separately. The same caveat applies on device-discovery.
 
-## Switch stacks / Virtual Chassis
-
-When the target reports 2+ chassis rows in `ENTITY-MIB` (`entPhysicalTable`) with non-empty serials, snmp-discovery emits a NetBox `VirtualChassis` plus one `Device` per stack member, and routes each interface and IP address to the correct member. Detection is vendor-neutral and driven entirely by `entPhysicalClass`, `entPhysicalContainedIn`, and `entPhysicalSerialNum`; no vendor-specific MIB is required. Standalone switches, devices not in stack mode, and members without a serial fall back to the existing single-`Device` path with no change in behaviour.
-
-**Topology patterns detected.** Two valid `ENTITY-MIB` shapes are supported:
-
-| Pattern | Chassis row's `entPhysicalContainedIn` | Used by |
-|---|---|---|
-| Flat | `0` (chassis rows at the ENTITY-MIB root) | Catalyst 9300/3850 stacks, Aruba CX VSF, Juniper EX/QFX Virtual Chassis, HP/H3C IRF, Huawei iStack, Brocade ICX |
-| Wrapped | non-zero, pointing at a `entPhysicalClass = 11` (stack) container | Cisco StackWise Virtual on 9400/9500/9600/etc. |
-
-**Emission shape** (in order):
-
-1. **Master `Device`** — plain (no `vc_position`, no `virtual_chassis` ref). Named `<sysName>` from the SNMP walk; serial taken from the lowest-id chassis row.
-2. **`VirtualChassis`** — named `<sysName>`, with `master` set to the inline matcher block of the master Device.
-3. **N − 1 member `Device` entities** — each named `<sysName>-<memberID>` (matching the format `device_discovery` emits, so the same physical stack discovered by both services lands on the same NetBox rows), carrying `vc_position = <memberID>` and an inline `virtual_chassis` ref pointing to the same matcher block. Per-member serial comes from `entPhysicalSerialNum` on the member's chassis row; per-member model comes from `entPhysicalModelName` when populated.
-4. **Interface / IPAddress entities** — routed to the member that physically owns them. Routing uses `entAliasMappingTable` (RFC 6933) when present, then falls back to ifName parsing: Cisco IOS/IOS-XE/NX-OS 3-tuple (`Gi1/0/1`, `Te2/1/0/3`, etc., including short forms `Te`/`Fo`/`Hu`/`Tw`/`Fi`/`Twe`), Junos FPC, Aruba CX numeric, H3C dashed. Subinterface unit suffixes (`Gi2/0/1.100`) strip to the parent before parsing.
-
-**Member ID derivation.** When `entPhysicalParentRelPos` is populated (`> 0`) it provides the member id directly; otherwise the trailing integer of `entPhysicalName` (`Switch 2`) is used; the final fallback is the ordinal position of the chassis row in the inventory. Master identity is pinned to the **lowest member id present**, regardless of live role — this is required because the Diode plugin resolves an existing `VirtualChassis` via its `unique_master` matcher, and pinning to the lowest id keeps the master Device stable across live stack-role failovers so re-runs upsert the existing VC instead of creating a new one. The other matcher fields used for VC re-identification (asset_tag, primary_ip4/6, name+site+tenant, and `metadata.source_match`) are carried consistently on both the rich master Device and the inline VC `master` ref.
-
-**Member AssetTag is cleared.** Diode's highest-precedence matcher for `dcim.device` is `asset_tag` (unique). The master Device carries the policy `defaults.asset_tag` value if configured; member Devices have it explicitly cleared so multiple members do not collapse onto one NetBox row through a shared asset tag. Master / standalone AssetTag behaviour from `defaults.asset_tag` is unchanged.
-
-**Orphaned member ports.** If a chassis row is dropped from the validated payload (empty serial, duplicate serial collapsed against a lower-id row, etc.) but the device still reports ports owned by that member, those interfaces are **skipped with a WARNING** rather than routed to master. Routing them to master would silently misattribute member-N ports to a different device — operators see the warning in logs and the missing port in NetBox, not a corrupted port→device mapping.
-
-## Modules / ModuleBays
-
-When the `discover_modules` policy option is enabled, snmp-discovery emits NetBox `Module` and `ModuleBay` entities for each chassis slot reported in `ENTITY-MIB` `entPhysicalTable` (and, in `full` mode, for each transceiver sub-bay). Discovery is **vendor-neutral**: rows are selected by `entPhysicalClass` alone — `chassis(3)` anchors the device, `container(5)` rows become module bays, `module(9)` rows become modules — with PID-prefix classification used only to split modules into `supervisor` / `linecard` / `transceiver` / `psu` / `fan` types. Any vendor that populates `entPhysicalTable` per ENTITY-MIB (RFC 6933) is supported; see the [supported platforms page](./supported_platforms.md#modules--modulebays) for the list known-tested. The option defaults to `off` so existing operators see zero behaviour change unless they explicitly opt in.
-
-**Three modes:**
-
-| `discover_modules` | What gets emitted |
-|---|---|
-| `off` *(default)* | No module / module-bay entities. Existing behaviour. |
-| `linecards` | One `ModuleBay` + `Module` per chassis slot (line cards, supervisors). PSU and fan modules are recognised by the PID classifier so they label correctly in metrics, but are **never** emitted as `Module` entities — useful when operators care about the slot inventory but not power/cooling FRUs. Transceiver sub-bays are skipped. |
-| `full` | `linecards` plus one extra `ModuleBay` + `Module` for every transceiver sub-bay reported by the device. Interfaces backed by a transceiver carry a `module=` reference to the transceiver module so NetBox shows which port is populated by which optic. Per-port linkage uses `entAliasMappingTable` (RFC 6933) when present to map transceiver rows to their owning `ifIndex`. |
-
-**Emission order** (standalone modular chassis): `Device` → all `ModuleBay` + `Module` entries → `Interface` / `IPAddress` entries. The order matters because each interface entity may reference the module installed in its bay; emitting modules first lets the Diode reconciler resolve `Interface.module` against the just-created module.
-
-**Virtual-chassis-of-modular** (e.g. Cisco StackWise Virtual on Catalyst 9500 / 9600, Catalyst 9300 stack with FRU uplink modules). When a VC member is itself a modular chassis, modules and bays are dispatched per member via the `ChassisInventory.Members` map: each `Module` / `ModuleBay` carries `device=` set to the member that physically owns the slot, and the `Module.module_bay` reference points at that member's bay. Master identity follows the same lowest-member-id pinning as the VC envelope itself. The emission order becomes: `Device(master)` → `VirtualChassis` → `Device(non-master members)` → all `ModuleBay` + `Module` per member → `Interface` / `IPAddress` per member.
-
-**Empty bays.** A `container(5)` row with no `module(9)` child (an Aruba CX 8400 pattern, where empty line-card slots still surface as containers) is emitted as a bare `ModuleBay` with no installed Module. This faithfully captures the physical chassis surface so operators see populated *and* empty slots in NetBox.
-
-**Chassis-rooted modules.** On fixed-FRU switches where a `module(9)` row's `entPhysicalContainedIn` chain leads directly to the `chassis(3)` row without an intermediate `container(5)` bay, snmp-discovery synthesises a `ModuleBay` named `Slot <ParentRelPos>` derived from the module's own `entPhysicalParentRelPos`. The module is then installed in the synthesised bay, keeping the `Device → ModuleBay → Module` shape uniform regardless of how the vendor models its inventory tree.
-
-**Interface.Module routing.** The reference from an interface to the transceiver installed on it is populated through a bay matcher (Device + Serial + `ModuleBay{Name, Position, Device}`) so the Diode reconciler resolves to the standalone Module already emitted in the same payload, rather than creating a duplicate inline. When `entAliasMappingTable` is populated, transceiver rows are mapped to their owning `ifIndex` via that table; otherwise transceiver attachment falls back to the row's parent-bay name.
-
-**Current sub-bay rendering trade-off (transient).** In `full` mode the transceiver sub-bay is emitted device-rooted — i.e. without a `module=parent_linecard` link. As a result, NetBox renders the transceiver sub-bay at chassis level (alongside the line-card slot bays) instead of visually nested under its parent line card. The transceiver `Module` itself is still installed in the sub-bay correctly via `Module.module_bay`, so per-port optic visibility works as expected; only the bay-under-linecard hierarchy is lost. The link is dropped because, in the current per-entity reconciler, attaching `module=parent_linecard` on a sub-bay causes the parent Module to be re-created from inside the sub-bay's changeset and conflicts at apply with the line card already created by the prior top-level Module entity. The link will be restored once the reconciler resolves nested parent-module refs against committed sibling entities in a single ingest call.
-
-**Metrics.** Three OTLP counters cover module discovery operationally: `modules_emitted{vendor,type}`, `module_bays_emitted{vendor}`, and `modules_dropped{reason}` (e.g. PSU/fan filtered from `linecards`, malformed row, missing parent). PSU and fan rows count in `modules_dropped` rather than `modules_emitted` even though their PIDs are recognised by the classifier.
-
-**Supported vendors.** Module discovery works on any vendor that populates `entPhysicalTable` per RFC 6933 — see the [supported platforms page](./supported_platforms.md#modules--modulebays) for the platforms known-tested in v1.
-
 ## Configuration
 The `snmp_discovery` backend does not require any special configuration in the backends section. The backend will use the `diode` settings specified in the `common` subsection to forward discovery results.
 
@@ -281,6 +229,58 @@ scope:
     protocol_version: "SNMPv2c"
     community: "public"
 ```
+
+## Switch stacks / Virtual Chassis
+
+When the target reports 2+ chassis rows in `ENTITY-MIB` (`entPhysicalTable`) with non-empty serials, snmp-discovery emits a NetBox `VirtualChassis` plus one `Device` per stack member, and routes each interface and IP address to the correct member. Detection is vendor-neutral and driven entirely by `entPhysicalClass`, `entPhysicalContainedIn`, and `entPhysicalSerialNum`; no vendor-specific MIB is required. Standalone switches, devices not in stack mode, and members without a serial fall back to the existing single-`Device` path with no change in behaviour.
+
+**Topology patterns detected.** Two valid `ENTITY-MIB` shapes are supported:
+
+| Pattern | Chassis row's `entPhysicalContainedIn` | Used by |
+|---|---|---|
+| Flat | `0` (chassis rows at the ENTITY-MIB root) | Catalyst 9300/3850 stacks, Aruba CX VSF, Juniper EX/QFX Virtual Chassis, HP/H3C IRF, Huawei iStack, Brocade ICX |
+| Wrapped | non-zero, pointing at a `entPhysicalClass = 11` (stack) container | Cisco StackWise Virtual on 9400/9500/9600/etc. |
+
+**Emission shape** (in order):
+
+1. **Master `Device`** — plain (no `vc_position`, no `virtual_chassis` ref). Named `<sysName>` from the SNMP walk; serial taken from the lowest-id chassis row.
+2. **`VirtualChassis`** — named `<sysName>`, with `master` set to the inline matcher block of the master Device.
+3. **N − 1 member `Device` entities** — each named `<sysName>-<memberID>` (matching the format `device_discovery` emits, so the same physical stack discovered by both services lands on the same NetBox rows), carrying `vc_position = <memberID>` and an inline `virtual_chassis` ref pointing to the same matcher block. Per-member serial comes from `entPhysicalSerialNum` on the member's chassis row; per-member model comes from `entPhysicalModelName` when populated.
+4. **Interface / IPAddress entities** — routed to the member that physically owns them. Routing uses `entAliasMappingTable` (RFC 6933) when present, then falls back to ifName parsing: Cisco IOS/IOS-XE/NX-OS 3-tuple (`Gi1/0/1`, `Te2/1/0/3`, etc., including short forms `Te`/`Fo`/`Hu`/`Tw`/`Fi`/`Twe`), Junos FPC, Aruba CX numeric, H3C dashed. Subinterface unit suffixes (`Gi2/0/1.100`) strip to the parent before parsing.
+
+**Member ID derivation.** When `entPhysicalParentRelPos` is populated (`> 0`) it provides the member id directly; otherwise the trailing integer of `entPhysicalName` (`Switch 2`) is used; the final fallback is the ordinal position of the chassis row in the inventory. Master identity is pinned to the **lowest member id present**, regardless of live role — this is required because the Diode plugin resolves an existing `VirtualChassis` via its `unique_master` matcher, and pinning to the lowest id keeps the master Device stable across live stack-role failovers so re-runs upsert the existing VC instead of creating a new one. The other matcher fields used for VC re-identification (asset_tag, primary_ip4/6, name+site+tenant, and `metadata.source_match`) are carried consistently on both the rich master Device and the inline VC `master` ref.
+
+**Member AssetTag is cleared.** Diode's highest-precedence matcher for `dcim.device` is `asset_tag` (unique). The master Device carries the policy `defaults.asset_tag` value if configured; member Devices have it explicitly cleared so multiple members do not collapse onto one NetBox row through a shared asset tag. Master / standalone AssetTag behaviour from `defaults.asset_tag` is unchanged.
+
+**Orphaned member ports.** If a chassis row is dropped from the validated payload (empty serial, duplicate serial collapsed against a lower-id row, etc.) but the device still reports ports owned by that member, those interfaces are **skipped with a WARNING** rather than routed to master. Routing them to master would silently misattribute member-N ports to a different device — operators see the warning in logs and the missing port in NetBox, not a corrupted port→device mapping.
+
+## Modules / ModuleBays
+
+When the `discover_modules` policy option is enabled, snmp-discovery emits NetBox `Module` and `ModuleBay` entities for each chassis slot reported in `ENTITY-MIB` `entPhysicalTable` (and, in `full` mode, for each transceiver sub-bay). Discovery is **vendor-neutral**: rows are selected by `entPhysicalClass` alone — `chassis(3)` anchors the device, `container(5)` rows become module bays, `module(9)` rows become modules — with PID-prefix classification used only to split modules into `supervisor` / `linecard` / `transceiver` / `psu` / `fan` types. Any vendor that populates `entPhysicalTable` per ENTITY-MIB (RFC 6933) is supported; see the [supported platforms page](./supported_platforms.md#modules--modulebays) for the list known-tested. The option defaults to `off` so existing operators see zero behaviour change unless they explicitly opt in.
+
+**Three modes:**
+
+| `discover_modules` | What gets emitted |
+|---|---|
+| `off` *(default)* | No module / module-bay entities. Existing behaviour. |
+| `linecards` | One `ModuleBay` + `Module` per chassis slot (line cards, supervisors). PSU and fan modules are recognised by the PID classifier so they label correctly in metrics, but are **never** emitted as `Module` entities — useful when operators care about the slot inventory but not power/cooling FRUs. Transceiver sub-bays are skipped. |
+| `full` | `linecards` plus one extra `ModuleBay` + `Module` for every transceiver sub-bay reported by the device. Interfaces backed by a transceiver carry a `module=` reference to the transceiver module so NetBox shows which port is populated by which optic. Per-port linkage uses `entAliasMappingTable` (RFC 6933) when present to map transceiver rows to their owning `ifIndex`. |
+
+**Emission order** (standalone modular chassis): `Device` → all `ModuleBay` + `Module` entries → `Interface` / `IPAddress` entries. The order matters because each interface entity may reference the module installed in its bay; emitting modules first lets the Diode reconciler resolve `Interface.module` against the just-created module.
+
+**Virtual-chassis-of-modular** (e.g. Cisco StackWise Virtual on Catalyst 9500 / 9600, Catalyst 9300 stack with FRU uplink modules). When a VC member is itself a modular chassis, modules and bays are dispatched per member via the `ChassisInventory.Members` map: each `Module` / `ModuleBay` carries `device=` set to the member that physically owns the slot, and the `Module.module_bay` reference points at that member's bay. Master identity follows the same lowest-member-id pinning as the VC envelope itself. The emission order becomes: `Device(master)` → `VirtualChassis` → `Device(non-master members)` → all `ModuleBay` + `Module` per member → `Interface` / `IPAddress` per member.
+
+**Empty bays.** A `container(5)` row with no `module(9)` child (an Aruba CX 8400 pattern, where empty line-card slots still surface as containers) is emitted as a bare `ModuleBay` with no installed Module. This faithfully captures the physical chassis surface so operators see populated *and* empty slots in NetBox.
+
+**Chassis-rooted modules.** On fixed-FRU switches where a `module(9)` row's `entPhysicalContainedIn` chain leads directly to the `chassis(3)` row without an intermediate `container(5)` bay, snmp-discovery synthesises a `ModuleBay` named `Slot <ParentRelPos>` derived from the module's own `entPhysicalParentRelPos`. The module is then installed in the synthesised bay, keeping the `Device → ModuleBay → Module` shape uniform regardless of how the vendor models its inventory tree.
+
+**Interface.Module routing.** The reference from an interface to the transceiver installed on it is populated through a bay matcher (Device + Serial + `ModuleBay{Name, Position, Device}`) so the Diode reconciler resolves to the standalone Module already emitted in the same payload, rather than creating a duplicate inline. When `entAliasMappingTable` is populated, transceiver rows are mapped to their owning `ifIndex` via that table; otherwise transceiver attachment falls back to the row's parent-bay name.
+
+**Current sub-bay rendering trade-off (transient).** In `full` mode the transceiver sub-bay is emitted device-rooted — i.e. without a `module=parent_linecard` link. As a result, NetBox renders the transceiver sub-bay at chassis level (alongside the line-card slot bays) instead of visually nested under its parent line card. The transceiver `Module` itself is still installed in the sub-bay correctly via `Module.module_bay`, so per-port optic visibility works as expected; only the bay-under-linecard hierarchy is lost. The link is dropped because, in the current per-entity reconciler, attaching `module=parent_linecard` on a sub-bay causes the parent Module to be re-created from inside the sub-bay's changeset and conflicts at apply with the line card already created by the prior top-level Module entity. The link will be restored once the reconciler resolves nested parent-module refs against committed sibling entities in a single ingest call.
+
+**Metrics.** Three OTLP counters cover module discovery operationally: `modules_emitted{vendor,type}`, `module_bays_emitted{vendor}`, and `modules_dropped{reason}` (e.g. PSU/fan filtered from `linecards`, malformed row, missing parent). PSU and fan rows count in `modules_dropped` rather than `modules_emitted` even though their PIDs are recognised by the classifier.
+
+**Supported vendors.** Module discovery works on any vendor that populates `entPhysicalTable` per RFC 6933 — see the [supported platforms page](./supported_platforms.md#modules--modulebays) for the platforms known-tested in v1.
 
 ## Device Model Lookup
 


### PR DESCRIPTION
## Summary

Documentation-only reordering across the discovery docs. No prose, tables, or heading anchors were changed — only section order, so all in-page cross-references still resolve.

### `device_discovery/supported_platforms.md`

Front-loads the driver catalogs. New order:

1. Intro
2. Auto-discovery behavior
3. **Standard NAPALM drivers**
4. **Custom NAPALM drivers**
5. Interface ↔ VLAN associations
6. Switch stacks / Virtual Chassis
7. Modules / ModuleBays
8. Querying supported drivers at runtime

The two driver-catalog tables now sit together right after *Auto-discovery behavior* (which references "the **standard NAPALM drivers** below") instead of being buried beneath the feature tables. The runtime capabilities-query section stays at the bottom.

### `device_discovery/README.md`

Moves **Switch stacks / Virtual Chassis** and **Modules / ModuleBays** from just below *Diode Entities* down to just before *What NAPALM Collects Automatically*.

### `snmp_discovery/README.md`

Mirrors the device-discovery change: moves **Switch stacks / Virtual Chassis** and **Modules / ModuleBays** from just below *Diode Entities* down to just before *Device Model Lookup*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)