### PR TITLE
fix: avoid ERROR-level OTLP export failures during fleet startup

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -483,6 +483,22 @@ func (a *orbAgent) Start(ctx context.Context, cancelFunc context.CancelFunc) err
 		}
 	}
 
+	var fleetCM *configmgr.FleetConfigManager
+	if a.config.OrbAgent.ConfigManager.Active == "fleet" {
+		var ok bool
+		fleetCM, ok = a.configManager.(*configmgr.FleetConfigManager)
+		if ok {
+			if err = fleetCM.StartOTLPBridge(ctx, a.config); err != nil {
+				return err
+			}
+			defer func() {
+				if err != nil {
+					_ = fleetCM.StopOTLPBridge(context.Background())
+				}
+			}()
+		}
+	}
+
 	if err = a.startBackends(agentCtx, a.config.OrbAgent.Backends, a.config.OrbAgent.Labels); err != nil {
 		return err
 	}

--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -84,6 +84,51 @@ func newFleetConfigManagerWithConnection(logger *slog.Logger, pMgr policymgr.Pol
 	}
 }
 
+func fleetOTLPGRPCPort(cfg config.Config) int {
+	grpcPort := 4317
+	if cfg.OrbAgent.ConfigManager.Sources.Fleet.OTLPBridgeGRPCPort != nil {
+		grpcPort = *cfg.OrbAgent.ConfigManager.Sources.Fleet.OTLPBridgeGRPCPort
+	}
+	return grpcPort
+}
+
+// StartOTLPBridge starts the local OTLP gRPC bridge so backends can export
+// telemetry before the MQTT connection is established. Safe to call once;
+// subsequent calls are no-ops when the bridge is already running.
+func (fleetManager *FleetConfigManager) StartOTLPBridge(ctx context.Context, cfg config.Config) error {
+	if fleetManager.otlpBridge != nil {
+		return nil
+	}
+
+	grpcPort := fleetOTLPGRPCPort(cfg)
+	bridgeConfig := otlpbridge.BridgeConfig{
+		ListenAddr: fmt.Sprintf(":%d", grpcPort),
+		Encoding:   "json",
+	}
+
+	var err error
+	fleetManager.otlpBridge, err = otlpbridge.NewBridgeServer(bridgeConfig, fleetManager.policyManager.GetRepo(), fleetManager.logger)
+	if err != nil {
+		return fmt.Errorf("failed to create OTLP bridge: %w", err)
+	}
+	if err := fleetManager.otlpBridge.Start(ctx); err != nil {
+		fleetManager.otlpBridge = nil
+		return fmt.Errorf("failed to start OTLP bridge on port %d: %w", grpcPort, err)
+	}
+	fleetManager.logger.Info("OTLP bridge server started", slog.Int("grpc_port", grpcPort))
+	return nil
+}
+
+// StopOTLPBridge shuts down the OTLP bridge if it was started.
+func (fleetManager *FleetConfigManager) StopOTLPBridge(ctx context.Context) error {
+	if fleetManager.otlpBridge == nil {
+		return nil
+	}
+	err := fleetManager.otlpBridge.Stop(ctx)
+	fleetManager.otlpBridge = nil
+	return err
+}
+
 // Start initializes and starts the Fleet configuration manager
 func (fleetManager *FleetConfigManager) Start(ctx context.Context, cfg config.Config, backends map[string]backend.Backend) error {
 	var err error
@@ -111,22 +156,11 @@ func (fleetManager *FleetConfigManager) Start(ctx context.Context, cfg config.Co
 
 	// Start OTLP bridge server early, before MQTT connection.
 	// Port binding errors are local/permanent so we fail immediately.
-	grpcPort := 4317
-	if cfg.OrbAgent.ConfigManager.Sources.Fleet.OTLPBridgeGRPCPort != nil {
-		grpcPort = *cfg.OrbAgent.ConfigManager.Sources.Fleet.OTLPBridgeGRPCPort
+	// The bridge may already be running when Agent.Start() called StartOTLPBridge
+	// before backends were started.
+	if err := fleetManager.StartOTLPBridge(ctx, cfg); err != nil {
+		return err
 	}
-	bridgeConfig := otlpbridge.BridgeConfig{
-		ListenAddr: fmt.Sprintf(":%d", grpcPort),
-		Encoding:   "json",
-	}
-	fleetManager.otlpBridge, err = otlpbridge.NewBridgeServer(bridgeConfig, fleetManager.policyManager.GetRepo(), fleetManager.logger)
-	if err != nil {
-		return fmt.Errorf("failed to create OTLP bridge: %w", err)
-	}
-	if err := fleetManager.otlpBridge.Start(context.Background()); err != nil {
-		return fmt.Errorf("failed to start OTLP bridge on port %d: %w", grpcPort, err)
-	}
-	fleetManager.logger.Info("OTLP bridge server started", slog.Int("grpc_port", grpcPort))
 
 	// Create a shared cancellable context for the reconnect worker, token expiry
 	// monitor, and reset handler so that Stop() can terminate all goroutines with
@@ -173,12 +207,12 @@ func (fleetManager *FleetConfigManager) Start(ctx context.Context, cfg config.Co
 		// Non-retriable: bad credentials
 		var authErr *fleet.AuthError
 		if errors.As(startupErr, &authErr) {
-			_ = fleetManager.otlpBridge.Stop(context.Background())
+			_ = fleetManager.StopOTLPBridge(context.Background())
 			return fmt.Errorf("startup aborted, credentials rejected: %w", startupErr)
 		}
 
 		if maxStartupRetries > 0 && attempt >= maxStartupRetries {
-			_ = fleetManager.otlpBridge.Stop(context.Background())
+			_ = fleetManager.StopOTLPBridge(context.Background())
 			return fmt.Errorf("startup failed after %d attempts: %w", attempt, startupErr)
 		}
 
@@ -197,7 +231,7 @@ func (fleetManager *FleetConfigManager) Start(ctx context.Context, cfg config.Co
 
 		select {
 		case <-ctx.Done():
-			_ = fleetManager.otlpBridge.Stop(context.Background())
+			_ = fleetManager.StopOTLPBridge(context.Background())
 			return fmt.Errorf("startup cancelled: %w", ctx.Err())
 		case <-time.After(startupBackoff):
 		}
@@ -616,11 +650,9 @@ func (fleetManager *FleetConfigManager) Stop(ctx context.Context) error {
 		fleetManager.connCancel()
 	}
 
-	if fleetManager.otlpBridge != nil {
-		if err := fleetManager.otlpBridge.Stop(ctx); err != nil {
-			fleetManager.logger.Error("error while stopping OTLP bridge", slog.Any("error", err))
-			return err
-		}
+	if err := fleetManager.StopOTLPBridge(ctx); err != nil {
+		fleetManager.logger.Error("error while stopping OTLP bridge", slog.Any("error", err))
+		return err
 	}
 	return nil
 }

--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -112,6 +112,7 @@ func (fleetManager *FleetConfigManager) StartOTLPBridge(ctx context.Context, cfg
 		return fmt.Errorf("failed to create OTLP bridge: %w", err)
 	}
 	if err := fleetManager.otlpBridge.Start(ctx); err != nil {
+		_ = fleetManager.otlpBridge.Stop(ctx)
 		fleetManager.otlpBridge = nil
 		return fmt.Errorf("failed to start OTLP bridge on port %d: %w", grpcPort, err)
 	}

--- a/agent/configmgr/fleet_stop_test.go
+++ b/agent/configmgr/fleet_stop_test.go
@@ -6,9 +6,35 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/configmgr/fleet"
 	"github.com/netboxlabs/orb-agent/agent/otlpbridge"
 )
+
+func TestFleetConfigManager_StartOTLPBridge_Idempotent(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	mockPMgr := &mockPolicyManagerForFleet{}
+	mockPMgr.On("GetRepo").Return(nil)
+	mgr := newFleetConfigManager(logger, mockPMgr, nil, nil)
+
+	port := findAvailablePort(t)
+	cfg := config.Config{}
+	cfg.OrbAgent.ConfigManager.Sources.Fleet.OTLPBridgeGRPCPort = &port
+
+	ctx := context.Background()
+	require.NoError(t, mgr.StartOTLPBridge(ctx, cfg))
+	bridge := mgr.otlpBridge
+	require.NotNil(t, bridge)
+
+	require.NoError(t, mgr.StartOTLPBridge(ctx, cfg))
+	assert.Same(t, bridge, mgr.otlpBridge, "second StartOTLPBridge should reuse existing bridge")
+
+	require.NoError(t, mgr.StopOTLPBridge(ctx))
+	assert.Nil(t, mgr.otlpBridge)
+}
 
 func TestFleetConfigManager_Stop_ShutsDownBridge(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))

--- a/agent/configmgr/fleet_test.go
+++ b/agent/configmgr/fleet_test.go
@@ -1254,18 +1254,11 @@ func TestFleetConfigManager_Start_OTLPBridgeStartsBeforeMQTT(t *testing.T) {
 
 	// Assert
 	// Even though MQTT connection fails, we should verify that:
-	// 1. OTLP bridge was started (it should exist)
-	// 2. Connect() was called (indicating we got past bridge startup)
+	// 1. Connect() was called (indicating we got past OTLP bridge startup)
+	// 2. The bridge is torn down when startup is cancelled by context timeout
 	require.Error(t, err, "Start() should fail due to MQTT connection error")
 	assert.True(t, mockConn.ConnectCalled(), "MQTT Connect() should have been called")
-	// The bridge should have been created and started before Connect() was called
-	// Since Connect() was called, the bridge must have started successfully
-	assert.NotNil(t, fleetManager.otlpBridge, "OTLP bridge should be initialized before MQTT connection")
-
-	// Cleanup
-	if fleetManager.otlpBridge != nil {
-		_ = fleetManager.otlpBridge.Stop(context.Background())
-	}
+	assert.Nil(t, fleetManager.otlpBridge, "OTLP bridge should be stopped when startup is cancelled")
 }
 
 // controlledTokenServer is a test HTTP server whose response can switch from failure to success

--- a/agent/telemetry/logs.go
+++ b/agent/telemetry/logs.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 
 	otelslog "go.opentelemetry.io/contrib/bridges/otelslog"
 	"go.opentelemetry.io/otel/attribute"
@@ -14,10 +15,14 @@ import (
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/version"
 )
+
+const otlpExportStartupGrace = 30 * time.Second
 
 // multiHandler broadcasts log records to multiple handlers.
 type multiHandler struct {
@@ -203,9 +208,10 @@ func normalizeEndpoint(raw string) (string, bool, error) {
 
 // resilientLogExporter wraps an exporter to provide resilience and error logging.
 type resilientLogExporter struct {
-	endpoint string
-	logger   *slog.Logger
-	warnOnce sync.Once
+	endpoint  string
+	logger    *slog.Logger
+	createdAt time.Time
+	logOnce   sync.Once
 
 	mu       sync.RWMutex
 	exporter sdklog.Exporter
@@ -217,10 +223,41 @@ func newResilientLogExporter(exp sdklog.Exporter, logger *slog.Logger, endpoint 
 		return nil
 	}
 	return &resilientLogExporter{
-		endpoint: endpoint,
-		logger:   logger,
-		exporter: exp,
+		endpoint:  endpoint,
+		logger:    logger,
+		createdAt: time.Now(),
+		exporter:  exp,
 	}
+}
+
+func isTransientOTLPErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := err.Error()
+	if strings.Contains(msg, "connection refused") || strings.Contains(msg, "exporter export timeout") {
+		return true
+	}
+
+	if st, ok := status.FromError(err); ok {
+		switch st.Code() {
+		case codes.Unavailable, codes.DeadlineExceeded, codes.Canceled:
+			return true
+		}
+	}
+
+	return false
+}
+
+func (r *resilientLogExporter) exportFailureLogLevel(err error) slog.Level {
+	if isTransientOTLPErr(err) {
+		if time.Since(r.createdAt) < otlpExportStartupGrace {
+			return slog.LevelDebug
+		}
+		return slog.LevelWarn
+	}
+	return slog.LevelError
 }
 
 func (r *resilientLogExporter) Export(ctx context.Context, records []sdklog.Record) error {
@@ -233,9 +270,9 @@ func (r *resilientLogExporter) Export(ctx context.Context, records []sdklog.Reco
 	}
 
 	if err := exp.Export(ctx, records); err != nil {
-		r.warnOnce.Do(func() {
+		r.logOnce.Do(func() {
 			if r.logger != nil {
-				r.logger.Error("OTLP gRPC log export failed",
+				r.logger.Log(ctx, r.exportFailureLogLevel(err), "OTLP gRPC log export failed",
 					"endpoint", r.endpoint,
 					"error", err)
 			}

--- a/agent/telemetry/logs.go
+++ b/agent/telemetry/logs.go
@@ -211,7 +211,9 @@ type resilientLogExporter struct {
 	endpoint  string
 	logger    *slog.Logger
 	createdAt time.Time
-	logOnce   sync.Once
+	debugOnce sync.Once
+	warnOnce  sync.Once
+	errorOnce sync.Once
 
 	mu       sync.RWMutex
 	exporter sdklog.Exporter
@@ -260,6 +262,28 @@ func (r *resilientLogExporter) exportFailureLogLevel(err error) slog.Level {
 	return slog.LevelError
 }
 
+func (r *resilientLogExporter) logExportFailure(ctx context.Context, err error) {
+	if r.logger == nil {
+		return
+	}
+
+	level := r.exportFailureLogLevel(err)
+	log := func() {
+		r.logger.Log(ctx, level, "OTLP gRPC log export failed",
+			"endpoint", r.endpoint,
+			"error", err)
+	}
+
+	switch level {
+	case slog.LevelDebug:
+		r.debugOnce.Do(log)
+	case slog.LevelWarn:
+		r.warnOnce.Do(log)
+	default:
+		r.errorOnce.Do(log)
+	}
+}
+
 func (r *resilientLogExporter) Export(ctx context.Context, records []sdklog.Record) error {
 	r.mu.RLock()
 	exp := r.exporter
@@ -270,13 +294,7 @@ func (r *resilientLogExporter) Export(ctx context.Context, records []sdklog.Reco
 	}
 
 	if err := exp.Export(ctx, records); err != nil {
-		r.logOnce.Do(func() {
-			if r.logger != nil {
-				r.logger.Log(ctx, r.exportFailureLogLevel(err), "OTLP gRPC log export failed",
-					"endpoint", r.endpoint,
-					"error", err)
-			}
-		})
+		r.logExportFailure(ctx, err)
 		return err
 	}
 

--- a/agent/telemetry/logs_test.go
+++ b/agent/telemetry/logs_test.go
@@ -13,6 +13,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/version"
@@ -281,7 +283,7 @@ func TestBuildResource(t *testing.T) {
 	}
 }
 
-func TestResilientLogExporterWarnsOnce(t *testing.T) {
+func TestResilientLogExporterLogsOnce(t *testing.T) {
 	t.Parallel()
 
 	exp := &mockExporter{exportErr: errors.New("boom")}
@@ -303,8 +305,82 @@ func TestResilientLogExporterWarnsOnce(t *testing.T) {
 	if exp.exportCount != 2 {
 		t.Fatalf("expected export to be called twice, got %d", exp.exportCount)
 	}
-	if handler.errorCount != 1 {
-		t.Fatalf("expected error log only once, got %d", handler.errorCount)
+	if handler.logCount != 1 {
+		t.Fatalf("expected failure log only once, got %d", handler.logCount)
+	}
+	if handler.lastLevel != slog.LevelError {
+		t.Fatalf("expected non-transient failure at ERROR, got %v", handler.lastLevel)
+	}
+}
+
+func TestResilientLogExporterTransientStartupLogsDebug(t *testing.T) {
+	t.Parallel()
+
+	exp := &mockExporter{exportErr: errors.New("connection refused")}
+	handler := &levelRecordingHandler{}
+	logger := slog.New(handler)
+	resilient := newResilientLogExporter(exp, logger, "localhost:4317")
+
+	ctx := context.Background()
+	if err := resilient.Export(ctx, nil); err == nil {
+		t.Fatalf("expected export error to propagate")
+	}
+	if handler.logCount != 1 {
+		t.Fatalf("expected failure log only once, got %d", handler.logCount)
+	}
+	if handler.lastLevel != slog.LevelDebug {
+		t.Fatalf("expected transient startup failure at DEBUG, got %v", handler.lastLevel)
+	}
+}
+
+func TestResilientLogExporterTransientAfterGraceLogsWarn(t *testing.T) {
+	t.Parallel()
+
+	exp := &mockExporter{exportErr: status.Error(codes.Unavailable, "transport closing")}
+	handler := &levelRecordingHandler{}
+	logger := slog.New(handler)
+	resilient := newResilientLogExporter(exp, logger, "localhost:4317")
+	r, ok := resilient.(*resilientLogExporter)
+	if !ok {
+		t.Fatalf("expected resilientLogExporter type")
+	}
+	r.createdAt = time.Now().Add(-otlpExportStartupGrace - time.Second)
+
+	ctx := context.Background()
+	if err := resilient.Export(ctx, nil); err == nil {
+		t.Fatalf("expected export error to propagate")
+	}
+	if handler.logCount != 1 {
+		t.Fatalf("expected failure log only once, got %d", handler.logCount)
+	}
+	if handler.lastLevel != slog.LevelWarn {
+		t.Fatalf("expected transient failure after grace at WARN, got %v", handler.lastLevel)
+	}
+}
+
+func TestIsTransientOTLPErr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "connection refused", err: errors.New("dial tcp 127.0.0.1:4337: connect: connection refused"), want: true},
+		{name: "export timeout", err: errors.New("exporter export timeout: unavailable"), want: true},
+		{name: "unavailable", err: status.Error(codes.Unavailable, "server down"), want: true},
+		{name: "other", err: errors.New("permission denied"), want: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isTransientOTLPErr(tt.err); got != tt.want {
+				t.Fatalf("isTransientOTLPErr() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -424,8 +500,9 @@ func (m *mockExporter) Shutdown(context.Context) error {
 }
 
 type levelRecordingHandler struct {
-	mu         sync.Mutex
-	errorCount int
+	mu        sync.Mutex
+	logCount  int
+	lastLevel slog.Level
 }
 
 func (h *levelRecordingHandler) Enabled(context.Context, slog.Level) bool {
@@ -435,9 +512,8 @@ func (h *levelRecordingHandler) Enabled(context.Context, slog.Level) bool {
 func (h *levelRecordingHandler) Handle(_ context.Context, record slog.Record) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	if record.Level == slog.LevelError {
-		h.errorCount++
-	}
+	h.logCount++
+	h.lastLevel = record.Level
 	return nil
 }
 

--- a/agent/telemetry/logs_test.go
+++ b/agent/telemetry/logs_test.go
@@ -333,6 +333,41 @@ func TestResilientLogExporterTransientStartupLogsDebug(t *testing.T) {
 	}
 }
 
+func TestResilientLogExporterEscalatesFromDebugToWarn(t *testing.T) {
+	t.Parallel()
+
+	exp := &mockExporter{exportErr: errors.New("connection refused")}
+	handler := &levelRecordingHandler{}
+	logger := slog.New(handler)
+	resilient := newResilientLogExporter(exp, logger, "localhost:4317")
+	r, ok := resilient.(*resilientLogExporter)
+	if !ok {
+		t.Fatalf("expected resilientLogExporter type")
+	}
+
+	ctx := context.Background()
+	if err := resilient.Export(ctx, nil); err == nil {
+		t.Fatalf("expected export error to propagate")
+	}
+	if handler.logCount != 1 {
+		t.Fatalf("expected one DEBUG failure log during grace, got %d", handler.logCount)
+	}
+	if handler.lastLevel != slog.LevelDebug {
+		t.Fatalf("expected transient startup failure at DEBUG, got %v", handler.lastLevel)
+	}
+
+	r.createdAt = time.Now().Add(-otlpExportStartupGrace - time.Second)
+	if err := resilient.Export(ctx, nil); err == nil {
+		t.Fatalf("expected export error to propagate after grace")
+	}
+	if handler.logCount != 2 {
+		t.Fatalf("expected WARN log after grace period, got %d logs", handler.logCount)
+	}
+	if handler.lastLevel != slog.LevelWarn {
+		t.Fatalf("expected transient failure after grace at WARN, got %v", handler.lastLevel)
+	}
+}
+
 func TestResilientLogExporterTransientAfterGraceLogsWarn(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Start the fleet OTLP bridge before backends so log exporters no longer dial localhost before the listener is up.
- Downgrade transient OTLP log export failures to DEBUG/WARN during startup instead of emitting ERROR on every boot.

## What changed
- Added `StartOTLPBridge` / `StopOTLPBridge` on `FleetConfigManager` and call early startup from `agent.Start()` in fleet mode.
- `FleetConfigManager.Start()` reuses an already-running bridge and tears it down consistently on failure/cancel.
- `resilientLogExporter` now classifies transient export errors and logs DEBUG during a 30s startup grace period, WARN afterward, and ERROR only for non-transient failures.
- Added/updated tests for bridge idempotency, teardown on cancelled startup, and export log severity behavior.

## How tested
- `make fix-lint`
- `go test -race ./agent/telemetry/... ./agent/configmgr/... ./agent/...`
- Built `netboxlabs/orb-agent:develop` locally and verified fleet startup shows `OTLP bridge server started` before backends, with no `OTLP gRPC log export failed` ERROR during initialization (tested on a free OTLP port when host port 4337 was occupied by an SSH forward).

Made with [Cursor](https://cursor.com)