### PR TITLE
docs(network-discovery): document defaults.rd

### DIFF
--- a/docs/backends/network_discovery.md
+++ b/docs/backends/network_discovery.md
@@ -47,6 +47,7 @@ Current supported defaults:
 |  Key  | Type | Description  |
 |:-----:|:----:|:-------------:|
 | vrf | str | VRF name to assign to discovered IP addresses |
+| rd | str | Route Distinguisher (RD) for the VRF (only used when `vrf` is set). Optional — when omitted the VRF is emitted without an RD so NetBox can match an existing VRF whose `rd` is null. |
 | tenant | str | Tenant name to assign to discovered IP addresses |
 | role | str | Role to assign to discovered IP addresses |
 | comments | str | NetBox Comments information to be added to discovered IP |


### PR DESCRIPTION
## Summary

Companion to netboxlabs/orb-discovery#445 (closes orb-agent#389).

Adds the new \`rd\` row to the network-discovery defaults table, explaining that it pairs with \`vrf\` to set the NetBox VRF Route Distinguisher and that leaving it unset lets the agent match an existing VRF whose \`rd\` is null.

### Example
\`\`\`yaml
policies:
  network_discovery:
    my_policy:
      config:
        defaults:
          vrf: production
          rd: \"65000:100\"   # optional
      scope:
        targets: [\"10.0.0.0/24\"]
\`\`\`

## Test plan

- [x] Rendered the defaults table; the new \`rd\` row reads cleanly next to \`vrf\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)