### PR TITLE
docs(snmp-discovery): document vrf polymorphic shape

### DIFF
--- a/docs/backends/snmp_discovery/README.md
+++ b/docs/backends/snmp_discovery/README.md
@@ -88,7 +88,7 @@ SNMP discovery policies are broken down into two subsections: `config` and `scop
 | ├─ if_type       | string | Interface type (e.g. "ethernet", "virtual")  |
 | ipaddress    | map  | IP address-specific defaults  |
 | ├─ role   | string  | IP address role                  |
-| ├─ vrf   | string  | IP address vrf                    |
+| ├─ vrf   | string \| map  | IP address VRF. Accepts either a bare VRF name (`vrf: production`) or a map with `name` plus optional `rd` / `description` / `comments` / `tags` — matches the device-discovery `vrf` shape. The scalar form leaves Route Distinguisher empty so NetBox can match an existing VRF whose `rd` column is null. |
 | ├─ tenant   | string  | IP address tenant              |
 | ├─ description | string  | IP address description      |
 | vlan    | map  | VLAN-specific defaults  |
@@ -179,7 +179,12 @@ config:
       description: "SNMP discovered IP"
       role: "management"
       tenant: "network-ops"
-      vrf: "management"
+      # vrf accepts either a bare name (rd left empty) ...
+      # vrf: "management"
+      # ... or a map with name + optional rd / description / comments / tags:
+      vrf:
+        name: "management"
+        rd: "65000:100"
     interface:
       description: "Auto-discovered interface"
       if_type: "ethernet"

--- a/docs/backends/snmp_discovery/README.md
+++ b/docs/backends/snmp_discovery/README.md
@@ -88,7 +88,12 @@ SNMP discovery policies are broken down into two subsections: `config` and `scop
 | ├─ if_type       | string | Interface type (e.g. "ethernet", "virtual")  |
 | ipaddress    | map  | IP address-specific defaults  |
 | ├─ role   | string  | IP address role                  |
-| ├─ vrf   | string \| map  | IP address VRF. Accepts either a bare VRF name (`vrf: production`) or a map with `name` plus optional `rd` / `description` / `comments` / `tags` — matches the device-discovery `vrf` shape. The scalar form leaves Route Distinguisher empty so NetBox can match an existing VRF whose `rd` column is null. **`name` is required** when using the map form: setting `rd` / `description` / `comments` / `tags` without a `name` (either at the policy level or via `override_defaults`) drops the VRF entirely — the agent logs a warning once per discovery run pointing at the misconfigured field. **`vrf: null` / `vrf: ~`** is accepted as decode safety (prevents creating a phantom VRF named `"null"`); it does NOT clear an inherited VRF default at override-merge time — `MergeDefaults` follows the same non-empty-wins semantic as every other override field, so `vrf: null` and an absent `vrf` key are indistinguishable during merge. |
+| ├─ vrf   | string \| map  | IP address VRF name, or VRF object with route distinguisher |
+| ├──── name | string  | VRF name |
+| ├──── rd | string  | Route distinguisher (e.g. `65000:100`) |
+| ├──── description | string  | VRF description |
+| ├──── comments | string  | VRF comments |
+| ├──── tags | list  | VRF tags |
 | ├─ tenant   | string  | IP address tenant              |
 | ├─ description | string  | IP address description      |
 | vlan    | map  | VLAN-specific defaults  |

--- a/docs/backends/snmp_discovery/README.md
+++ b/docs/backends/snmp_discovery/README.md
@@ -88,7 +88,7 @@ SNMP discovery policies are broken down into two subsections: `config` and `scop
 | ├─ if_type       | string | Interface type (e.g. "ethernet", "virtual")  |
 | ipaddress    | map  | IP address-specific defaults  |
 | ├─ role   | string  | IP address role                  |
-| ├─ vrf   | string \| map  | IP address VRF. Accepts either a bare VRF name (`vrf: production`) or a map with `name` plus optional `rd` / `description` / `comments` / `tags` — matches the device-discovery `vrf` shape. The scalar form leaves Route Distinguisher empty so NetBox can match an existing VRF whose `rd` column is null. |
+| ├─ vrf   | string \| map  | IP address VRF. Accepts either a bare VRF name (`vrf: production`) or a map with `name` plus optional `rd` / `description` / `comments` / `tags` — matches the device-discovery `vrf` shape. The scalar form leaves Route Distinguisher empty so NetBox can match an existing VRF whose `rd` column is null. **`name` is required** when using the map form: setting `rd` / `description` / `comments` / `tags` without a `name` (either at the policy level or via `override_defaults`) drops the VRF entirely — the agent logs a warning once per discovery run pointing at the misconfigured field. **`vrf: null` / `vrf: ~`** is accepted as decode safety (prevents creating a phantom VRF named `"null"`); it does NOT clear an inherited VRF default at override-merge time — `MergeDefaults` follows the same non-empty-wins semantic as every other override field, so `vrf: null` and an absent `vrf` key are indistinguishable during merge. |
 | ├─ tenant   | string  | IP address tenant              |
 | ├─ description | string  | IP address description      |
 | vlan    | map  | VLAN-specific defaults  |


### PR DESCRIPTION
## Summary

Companion to netboxlabs/orb-discovery#446. Documents the new polymorphic shape for \`defaults.ip_address.vrf\` in snmp-discovery — matches what device-discovery already exposes.

### Both shapes now accepted

\`\`\`yaml
defaults:
  ip_address:
    # scalar (Rd left empty so NetBox can match an existing VRF whose rd is null):
    # vrf: production

    # rich (name + optional rd / description / comments / tags):
    vrf:
      name: production
      rd: \"65000:100\"
\`\`\`

The sample policy in the README now shows the rich form so operators see the \`rd\` knob, and the defaults table notes that the scalar form leaves Rd empty for the no-rd-match case.

## Test plan

- [x] Rendered the updated defaults table and sample — both render cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)