### PR TITLE
docs(device-discovery): document per-AF vrf_ipv4 / vrf_ipv6 overrides

### DIFF
--- a/docs/backends/device_discovery/README.md
+++ b/docs/backends/device_discovery/README.md
@@ -112,14 +112,18 @@ Current supported defaults:
 | ipaddress    | map  | IP address-specific defaults  |
 | ├─ role   | str  | IP address role                  |
 | ├─ tenant   | str  | IP address tenant              |
-| ├─ vrf   | str/map  | IP address VRF name, or VRF object with route distinguisher |
+| ├─ vrf   | str/map  | IP address VRF name, or VRF object with route distinguisher. Used for both address families unless an AF-specific override below is set. |
+| ├─ vrf_ipv4   | str/map  | IPv4-specific VRF override (same shape as `vrf`). When set, IPv4 IP addresses are emitted with this VRF; IPv6 still uses `vrf`. |
+| ├─ vrf_ipv6   | str/map  | IPv6-specific VRF override (same shape as `vrf`). When set, IPv6 IP addresses are emitted with this VRF; IPv4 still uses `vrf`. |
 | ├─ description | str  | IP address description      |
 | ├─ comments   | str  | IP address comments          |
 | ├─ tags       | list | IP address tags              |
 | prefix       | map  | Prefix-specific defaults      |
 | ├─ role   | str  | Prefix role                    |
 | ├─ tenant   | str  | Prefix tenant                |
-| ├─ vrf   | str/map  | Prefix VRF name, or VRF object with route distinguisher |
+| ├─ vrf   | str/map  | Prefix VRF name, or VRF object with route distinguisher. Used for both address families unless an AF-specific override below is set. |
+| ├─ vrf_ipv4   | str/map  | IPv4-specific VRF override for prefixes (same shape as `vrf`). When set, IPv4 prefixes use this VRF; IPv6 still uses `vrf`. |
+| ├─ vrf_ipv6   | str/map  | IPv6-specific VRF override for prefixes (same shape as `vrf`). When set, IPv6 prefixes use this VRF; IPv4 still uses `vrf`. |
 | ├─ description | str  | Prefix description        |
 | ├─ comments   | str  | Prefix comments            |
 | ├─ tags       | list | Prefix tags                |


### PR DESCRIPTION
## Summary

Companion to netboxlabs/orb-discovery#448 (closes orb-agent#392).

Adds two rows under both \`defaults.ipaddress\` and \`defaults.prefix\` (\`vrf_ipv4\` and \`vrf_ipv6\`) so dual-stack operators can split discovered IPv4 vs IPv6 entities into different NetBox VRFs from a single discovery policy.

### Example
\`\`\`yaml
defaults:
  ipaddress:
    vrf: fallback-vrf
    vrf_ipv4:
      name: customer-vrf
      rd: \"65000:10\"
    vrf_ipv6:
      name: global-vrf
      rd: \"65000:20\"
\`\`\`

## Test plan

- [x] Rendered the defaults table; the new rows read cleanly next to the existing \`vrf\` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)