### PR TITLE
docs(snmp-discovery): fix ipaddress to ip_address defaults key

### DIFF
--- a/docs/backends/snmp_discovery/README.md
+++ b/docs/backends/snmp_discovery/README.md
@@ -92,7 +92,7 @@ SNMP discovery policies are broken down into two subsections: `config` and `scop
 | ├──── name | string  | VRF name |
 | ├──── rd | string  | Route distinguisher (e.g. `65000:100`) |
 | ├────description | string  | VRF description |
-| ├────comments | string  | VRF comments |
+| ├──── comments | string  | VRF comments |
 | ├──── tags | list  | VRF tags |
 | ├─ tenant   | string  | IP address tenant              |
 | ├─ description | string  | IP address description      |

--- a/docs/backends/snmp_discovery/README.md
+++ b/docs/backends/snmp_discovery/README.md
@@ -91,8 +91,8 @@ SNMP discovery policies are broken down into two subsections: `config` and `scop
 | ├─ vrf   | string \| map  | IP address VRF name, or VRF object with route distinguisher |
 | ├──── name | string  | VRF name |
 | ├──── rd | string  | Route distinguisher (e.g. `65000:100`) |
-| ├──── description | string  | VRF description |
-| ├──── comments | string  | VRF comments |
+| ├────description | string  | VRF description |
+| ├────comments | string  | VRF comments |
 | ├──── tags | list  | VRF tags |
 | ├─ tenant   | string  | IP address tenant              |
 | ├─ description | string  | IP address description      |

--- a/docs/backends/snmp_discovery/README.md
+++ b/docs/backends/snmp_discovery/README.md
@@ -86,7 +86,7 @@ SNMP discovery policies are broken down into two subsections: `config` and `scop
 | interface    | map  | Interface-specific defaults    |
 | ├─ description | string  | Interface description        |
 | ├─ if_type       | string | Interface type (e.g. "ethernet", "virtual")  |
-| ipaddress    | map  | IP address-specific defaults  |
+| ip_address   | map  | IP address-specific defaults  |
 | ├─ role   | string  | IP address role                  |
 | ├─ vrf   | string \| map  | IP address VRF name, or VRF object with route distinguisher |
 | ├──── name | string  | VRF name |
@@ -98,7 +98,7 @@ SNMP discovery policies are broken down into two subsections: `config` and `scop
 | ├─ description | string  | IP address description      |
 | vlan    | map  | VLAN-specific defaults  |
 | ├─ description | string  | VLAN description |
-| ├─ tags | list | Per-VLAN tags. Merged with the top-level `tags` list on each emitted VLAN entity, mirroring the `device`/`interface`/`ipaddress` defaults pattern. |
+| ├─ tags | list | Per-VLAN tags. Merged with the top-level `tags` list on each emitted VLAN entity, mirroring the `device`/`interface`/`ip_address` defaults pattern. |
 | ├─ group | string | VLAN group name. When set, every emitted VLAN is attached to an `ipam.vlangroup` scoped to `defaults.site`: the group's `scope_site` is populated from `defaults.site` |
 | ├─ tenant | string | VLAN tenant |
 | ├─ status | string | VLAN status override (`active`, `reserved`, `deprecated`). When unset, status is derived from `dot1qVlanStaticRowStatus`: `active(1)` → `active`, `notInService(2)` → `reserved`. |


### PR DESCRIPTION
## Summary

The defaults table in `docs/backends/snmp_discovery/README.md` listed the IP-address block under `ipaddress` (no underscore), but the actual config key consumed by snmp-discovery is `ip_address` (with underscore). The sample policy further down in the same README already used the correct key, so the table was the only outlier.

Copy-pasting from the table led to netboxlabs/orb-agent#389 — operator's IPs landed in the default Global VRF instead of the configured one because the entire IP-address defaults block was silently dropped by the YAML decoder.

Fixes the row + the cross-reference under `vlan.tags`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)