### PR TITLE
chore: never cache the runtime stage so apk upgrade stays effective

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,7 +50,7 @@ jobs:
           platforms: linux/amd64
           cache-from: type=gha,scope=linux/amd64
           cache-to: type=gha,scope=linux/amd64,mode=max
-          no-cache-filters: python-builder
+          no-cache-filters: python-builder,final
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
           tags: orb-agent:scan

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -61,7 +61,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,scope=${{ matrix.platform }},mode=max
-          no-cache-filters: python-builder,network-discovery,snmp-discovery,pktvisor,otlpinf
+          no-cache-filters: python-builder,network-discovery,snmp-discovery,pktvisor,otlpinf,final
           pull: true
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -169,6 +169,7 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,scope=${{ matrix.platform }},mode=max
           no-cache-filters: python-builder,network-discovery,snmp-discovery,pktvisor,otlpinf,final
+          pull: true
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -168,6 +168,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,scope=${{ matrix.platform }},mode=max
+          no-cache-filters: python-builder,network-discovery,snmp-discovery,pktvisor,otlpinf,final
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true

--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -43,13 +43,15 @@ RUN python -m pip install --upgrade --no-cache-dir pip==26.1 && \
 RUN pip3 install --no-cache-dir netboxlabs-device-discovery netboxlabs-orb-worker
 
 ########################################################################
-FROM python:3.14-alpine
+# Stage name is referenced by no-cache-filters in the build workflows so
+# the apk upgrade layer below is never served from a stale build cache.
+FROM python:3.14-alpine AS final
 
 ENV TZ=UTC
 
 # apk upgrade pulls the latest patched versions of base/transitive packages
 # (e.g. libssh2, brought in by nmap) so image scans stay clean without
-# per-package version pins. It also busts any stale layer cache.
+# per-package version pins.
 RUN apk upgrade --no-cache && \
     apk add --no-cache \
         bash \


### PR DESCRIPTION
## Summary

The daily container rescan flags the published `orb-agent:develop` image with 30 OpenSSL findings ([code-scanning alerts 153–182](https://github.com/netboxlabs/orb-agent/security/code-scanning/168), incl. HIGH CVE-2026-45447): `libcrypto3`/`libssl3` are at **3.5.6-r0**, fixed in **3.5.7-r0**.

The runtime stage already runs a blanket `apk upgrade --no-cache`, but the GHA layer cache replays that layer verbatim: its cache key is the base-image digest plus the unchanged RUN line, and the OpenSSL fix only exists in the Alpine package repo — no rebuilt `python:3.14-alpine` base image has been published. So the upgrade never re-executes and the image stays on the vulnerable packages until upstream rebuilds the base image, with the same gap recurring on every future CVE batch.

## Changes

- **agent/docker/Dockerfile**: name the runtime stage (`AS final`) and correct the comment that claimed `apk upgrade` busts the layer cache (it doesn't — an unchanged RUN line is exactly what the cache reuses).
- **build.yaml** (PR scan): `no-cache-filters: python-builder,final`
- **develop.yaml**: append `final` to the existing filter list.
- **release.yaml**: add `no-cache-filters` (it previously had no cache bypass at all, so even release images could ship stale layers) matching develop's list plus `final`.

Cost per build: a few seconds of apk downloads and the cheap COPY steps in the final stage; all builder stages stay cached.

## Verification

```
$ docker run --rm python:3.14-alpine sh -c 'cat /etc/alpine-release; apk --no-cache upgrade'
3.23.4
(1/2) Upgrading libcrypto3 (3.5.6-r0 -> 3.5.7-r0)
(2/2) Upgrading libssl3 (3.5.6-r0 -> 3.5.7-r0)
```

After merge, the next develop build re-runs the upgrade and the rescan should close alerts 153–182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)