### PR TITLE
docs(device-discovery): lead with supported driver and vendor counts

### DIFF
--- a/docs/backends/device_discovery/README.md
+++ b/docs/backends/device_discovery/README.md
@@ -1,7 +1,14 @@
 # Device Discovery
 The device discovery backend leverages [NAPALM](https://napalm.readthedocs.io/en/latest/index.html) to connect to network devices and collect network information.
 
-For the full list of vendors and NAPALM drivers supported by this backend (standard and custom), see [Device Discovery — Supported Platforms](./supported_platforms.md).
+## Supported Platforms
+
+Device discovery supports **48 NAPALM drivers covering 17+ network vendors** out of the box:
+
+* **7 standard NAPALM drivers** — Arista EOS, Cisco IOS/IOS-XE, IOS-XR, NX-OS, and Juniper Junos. These are tried automatically during driver auto-discovery.
+* **41 custom drivers bundled with the backend** — extending coverage to Palo Alto Networks, Fortinet, Check Point, Huawei, Nokia, HPE Aruba, Extreme Networks, Dell, NVIDIA (Cumulus/Mellanox), MikroTik, Ubiquiti, Ruckus/Brocade, Ciena, Ericsson, and more. No extra installation is needed — select them with `driver:` on a scope entry or opt them into auto-discovery via the `discovery_drivers` option.
+
+For the full driver list with vendor and platform details — including which drivers support VLAN associations, switch stacks / Virtual Chassis, and module discovery — see [Device Discovery — Supported Platforms](./supported_platforms.md).
 
 ## Diode Entities
 The device discovery backend uses [Diode Python SDK](https://github.com/netboxlabs/diode-sdk-python) to ingest the following entities:

--- a/docs/backends/device_discovery/supported_platforms.md
+++ b/docs/backends/device_discovery/supported_platforms.md
@@ -1,6 +1,6 @@
 # Device Discovery — Supported Platforms
 
-This page lists the vendors, operating systems, and NAPALM drivers supported by the [device discovery](./README.md) backend.
+This page lists the vendors, operating systems, and NAPALM drivers supported by the [device discovery](./README.md) backend — currently **48 drivers (7 standard + 41 custom) covering 17+ network vendors**, all available out of the box.
 
 The backend connects to network devices over SSH / NETCONF / vendor APIs via [NAPALM](https://napalm.readthedocs.io/). Support is driver-bound: a device is supported only if a corresponding NAPALM driver exists.
 


### PR DESCRIPTION
## Summary

Customer feedback: the device discovery README does not convey that we support a large set of custom NAPALM drivers — the only mention was a one-line cross-reference to the supported platforms page.

- Add a **Supported Platforms** section near the top of the README that leads with the totals: **48 NAPALM drivers (7 standard + 41 bundled custom) covering 17+ network vendors**, with a vendor name-drop list and a note that custom drivers require no extra installation.
- Echo the same counts in the `supported_platforms.md` intro so both pages tell the same story.

Counts verified against the driver tables in `supported_platforms.md`.

> Note: the counts are now hardcoded in two places and need a bump when new drivers land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)