### PR TITLE
chore: pin netboxlabs-orb-worker to 1.16.0

### DIFF
--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -40,7 +40,7 @@ RUN python -m pip install --upgrade --no-cache-dir pip==26.1 && \
     rm -rf /usr/local/lib/python3.14/ensurepip/_bundled/pip-*.whl
 
 # Install Python packages
-RUN pip3 install --no-cache-dir netboxlabs-device-discovery netboxlabs-orb-worker
+RUN pip3 install --no-cache-dir netboxlabs-device-discovery netboxlabs-orb-worker==1.16.0
 
 ########################################################################
 # Stage name is referenced by no-cache-filters in the build workflows so


### PR DESCRIPTION
[claude]

## Problem

The agent image installs `netboxlabs-orb-worker` unpinned, so every build floats to whatever is latest on PyPI. With 1.16.0 now published, builds silently pick it up — and 1.16.0 reshaped the worker `Backend` ingest contract, so the version the image ships is no longer incidental and should be explicit.

## Solution

Pin `netboxlabs-orb-worker==1.16.0` in `agent/docker/Dockerfile`.

The sibling `netboxlabs-device-discovery` on the same `pip3 install` line is unpinned and stays that way — bumping it is out of scope here. `pip` itself is already pinned with `==` in the stage just above, so an explicit `==` on the worker matches the one pin style already in the file and makes the image reproducible.

1.16.0 carries the new worker ingest contract: the single `ingest_callback` is replaced by a typed `IngestSink` protocol (`ingest()` / `record_failure()`), alongside `describe()` / `setup()` and transient-failure classification. Backends built on this version receive an `ingest_sink`.

### Caveats for reviewers

- **Minor version number, breaking contract.** 1.16.0 is a semver *minor* bump, but the ingest-contract change is effectively breaking. No `BREAKING CHANGE` footer drove the version, so the version number under-signals the impact. Scheduled `nbl-*` backends remain backward compatible; the change is on the sink path.
- **Deployment ordering.** The controller-integrations `trigger-api-util` consumer must be updated to read `ingest_sink` (separate PR), or API-triggered `/sync` silently degrades to `/health`-only. Shipping orb-agent on 1.16.0 presumes that consumer update lands too.

## Test summary

No code changed — this is a one-line dependency pin. 1.16.0 was verified present on PyPI (current latest release). The existing build and test workflows resolve and install the pinned version as part of the image build.
