### PR TITLE
docs(network-discovery): correct default scan timeout to 5 minutes

### DIFF
--- a/docs/backends/network_discovery.md
+++ b/docs/backends/network_discovery.md
@@ -39,7 +39,7 @@ Config defines data for the whole scope and is optional overall.
 |:---------:|:----:|:--------:|:-----------:|
 | schedule | cron format | no  |  If defined, it will execute scope following cron schedule time. If not defined, it will execute scope only once  |
 | defaults | map | no  |  key value pair that defines default values  |
-| timeout | int | no | Timeout in minutes for the nmap scan operation. The default value is 2 minutes.
+| timeout | int | no | Timeout in minutes for the nmap scan operation. The default value is 5 minutes.
 
 #### Defaults
 Current supported defaults:


### PR DESCRIPTION
## Summary

The network-discovery backend docs state the `timeout` default is **2 minutes**, but the code default is **5 minutes**.

In [`network-discovery/policy/runner.go`](https://github.com/netboxlabs/orb-discovery/blob/develop/network-discovery/policy/runner.go) the policy `timeout` (in minutes) falls back to `defaultTimeout = 5 * time.Minute` when unset:

```go
const defaultTimeout = 5 * time.Minute
...
runner.timeout = time.Duration(policy.Config.Timeout) * time.Minute
if runner.timeout == 0 {
    runner.timeout = defaultTimeout
}
```

There is no manager-level default that changes this, so the effective default is 5 minutes. The unit (minutes) was already documented correctly — only the default value was wrong (likely copied from snmp-discovery, whose default is 2 minutes).

## Change

`docs/backends/network_discovery.md` — "The default value is 2 minutes." → "The default value is 5 minutes."

🤖 Generated with [Claude Code](https://claude.com/claude-code)