### PR TITLE
ci(repo): per-backend lint and test workflows for discovery backends

### DIFF
--- a/.github/workflows/device-discovery-lint-tests.yaml
+++ b/.github/workflows/device-discovery-lint-tests.yaml
@@ -1,0 +1,62 @@
+name: Device Discovery - lint and tests
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "orb-discovery/device-discovery/**"
+  push:
+    branches:
+      - "!release"
+    paths:
+      - "orb-discovery/device-discovery/**"
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  BE_DIR: orb-discovery/device-discovery
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        python: [ "3.11", "3.12", "3.13", "3.14" ]
+    defaults:
+      run:
+        working-directory: ${{ env.BE_DIR }}
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    - name: Setup Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+        pip install .[dev]
+        pip install .[test]
+
+    - name: Run tests with coverage
+      run: |
+        set -o pipefail
+        pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=device_discovery/ | tee pytest-coverage.txt
+
+    - name: Pytest coverage comment
+      uses: MishaKav/pytest-coverage-comment@dd5b80bde6d16941f336518e92929e89069d8451 # v1.7.2
+      if: github.event.pull_request.head.repo.full_name == github.repository
+      with:
+        pytest-coverage-path: ${{ env.BE_DIR }}/pytest-coverage.txt
+        junitxml-path: ${{ env.BE_DIR }}/pytest.xml
+
+    - name: Lint with Ruff
+      run: |
+        ruff check --output-format=github device_discovery/ tests/
+      continue-on-error: true

--- a/.github/workflows/device-discovery-lint-tests.yaml
+++ b/.github/workflows/device-discovery-lint-tests.yaml
@@ -5,8 +5,8 @@ on:
     paths:
       - "orb-discovery/device-discovery/**"
   push:
-    branches:
-      - "!release"
+    branches-ignore:
+      - release
     paths:
       - "orb-discovery/device-discovery/**"
 

--- a/.github/workflows/gnmi-discovery-lint.yaml
+++ b/.github/workflows/gnmi-discovery-lint.yaml
@@ -1,0 +1,34 @@
+name: gNMI Discovery - lint
+on:
+  push:
+    branches-ignore:
+      - release
+    paths:
+      - "orb-discovery/gnmi-discovery/**"
+      - "!orb-discovery/gnmi-discovery/docker/**"
+  pull_request:
+    paths:
+      - "orb-discovery/gnmi-discovery/**"
+      - "!orb-discovery/gnmi-discovery/docker/**"
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    runs-on: ubuntu-latest
+    env:
+      GOWORK: "off"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: 'orb-discovery/gnmi-discovery/go.mod'
+      - name: Lint
+        uses: golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c # v9.2.1
+        with:
+          version: v2.11.3
+          working-directory: orb-discovery/gnmi-discovery
+          args: --config ../.github/golangci.yaml

--- a/.github/workflows/gnmi-discovery-tests.yaml
+++ b/.github/workflows/gnmi-discovery-tests.yaml
@@ -1,0 +1,75 @@
+name: gNMI Discovery - test
+on:
+  push:
+    branches-ignore:
+      - release
+    paths:
+      - "orb-discovery/gnmi-discovery/**"
+      - "!orb-discovery/gnmi-discovery/docker/**"
+  pull_request:
+    paths:
+      - "orb-discovery/gnmi-discovery/**"
+      - "!orb-discovery/gnmi-discovery/docker/**"
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write # peter-evans/create-or-update-comment posts an issue comment on the PR
+  pull-requests: write
+
+jobs:
+  go-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GOWORK: "off"
+    defaults:
+      run:
+        working-directory: orb-discovery/gnmi-discovery
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: 'orb-discovery/gnmi-discovery/go.mod'
+      - name: Run go build
+        run: go build ./...
+      - name: Install additional dependencies
+        run: |
+          make install-dev-tools
+      - name: Run go test
+        id: go-test
+        run: |
+          make test-coverage
+          echo 'coverage-report<<EOF' >> $GITHUB_OUTPUT
+          cat .coverage/test-report.md >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+          echo "coverage-total=$(cat .coverage/coverage.txt)" >> $GITHUB_OUTPUT
+      - name: Output Result
+        if: always()
+        run: cat .coverage/test-report.md
+      - name: Find comment
+        # Only on pull_request: on push runs there is no pull_request.number, and
+        # find-comment v4 coerces the empty input to 0 and fails the job.
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
+        id: existing-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Go test coverage
+      - name: Post comment
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        with:
+          comment-id: ${{ steps.existing-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Go test coverage
+            ${{ steps.go-test.outputs.coverage-report }}
+            Total coverage: ${{ steps.go-test.outputs.coverage-total }}%
+          edit-mode: replace

--- a/.github/workflows/network-discovery-lint.yaml
+++ b/.github/workflows/network-discovery-lint.yaml
@@ -1,8 +1,8 @@
 name: Network Discovery - lint
 on:
   push:
-    branches:
-      - "!release"
+    branches-ignore:
+      - release
     paths:
       - "orb-discovery/network-discovery/**"
       - "!orb-discovery/network-discovery/docker/**"

--- a/.github/workflows/network-discovery-lint.yaml
+++ b/.github/workflows/network-discovery-lint.yaml
@@ -1,0 +1,34 @@
+name: Network Discovery - lint
+on:
+  push:
+    branches:
+      - "!release"
+    paths:
+      - "orb-discovery/network-discovery/**"
+      - "!orb-discovery/network-discovery/docker/**"
+  pull_request:
+    paths:
+      - "orb-discovery/network-discovery/**"
+      - "!orb-discovery/network-discovery/docker/**"
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    runs-on: ubuntu-latest
+    env:
+      GOWORK: "off"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: 'orb-discovery/network-discovery/go.mod'
+      - name: Lint
+        uses: golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c # v9.2.1
+        with:
+          version: v2.11.3
+          working-directory: orb-discovery/network-discovery
+          args: --config ../.github/golangci.yaml

--- a/.github/workflows/network-discovery-tests.yaml
+++ b/.github/workflows/network-discovery-tests.yaml
@@ -1,8 +1,8 @@
 name: Network Discovery - test
 on:
   push:
-    branches:
-      - "!release"
+    branches-ignore:
+      - release
     paths:
       - "orb-discovery/network-discovery/**"
       - "!orb-discovery/network-discovery/docker/**"

--- a/.github/workflows/network-discovery-tests.yaml
+++ b/.github/workflows/network-discovery-tests.yaml
@@ -1,0 +1,73 @@
+name: Network Discovery - test
+on:
+  push:
+    branches:
+      - "!release"
+    paths:
+      - "orb-discovery/network-discovery/**"
+      - "!orb-discovery/network-discovery/docker/**"
+  pull_request:
+    paths:
+      - "orb-discovery/network-discovery/**"
+      - "!orb-discovery/network-discovery/docker/**"
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  go-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GOWORK: "off"
+    defaults:
+      run:
+        working-directory: orb-discovery/network-discovery
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: 'orb-discovery/network-discovery/go.mod'
+      - name: Run go build
+        run: go build ./...
+      - name: Install additional dependencies
+        run: |
+          go install github.com/mfridman/tparse@v0.14.0
+          sudo apt-get -y install nmap
+          sudo setcap cap_net_raw,cap_net_admin=eip $(which nmap)
+      - name: Run go test
+        id: go-test
+        run: |
+          make test-coverage
+          echo 'coverage-report<<EOF' >> $GITHUB_OUTPUT
+          cat .coverage/test-report.md >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+          echo "coverage-total=$(cat .coverage/coverage.txt)" >> $GITHUB_OUTPUT
+      - name: Output Result
+        if: always()
+        run: cat .coverage/test-report.md
+      - name: Find comment
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
+        id: existing-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Go test coverage
+      - name: Post comment
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        with:
+          comment-id: ${{ steps.existing-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Go test coverage
+            ${{ steps.go-test.outputs.coverage-report }}
+            Total coverage: ${{ steps.go-test.outputs.coverage-total }}%
+          edit-mode: replace

--- a/.github/workflows/network-discovery-tests.yaml
+++ b/.github/workflows/network-discovery-tests.yaml
@@ -54,6 +54,9 @@ jobs:
         if: always()
         run: cat .coverage/test-report.md
       - name: Find comment
+        # Only on pull_request: on push runs there is no pull_request.number, and
+        # find-comment v4 coerces the empty input to 0 and fails the job.
+        if: github.event_name == 'pull_request'
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: existing-comment
         with:

--- a/.github/workflows/snmp-discovery-lint.yaml
+++ b/.github/workflows/snmp-discovery-lint.yaml
@@ -1,0 +1,34 @@
+name: SNMP Discovery - lint
+on:
+  push:
+    branches:
+      - "!release"
+    paths:
+      - "orb-discovery/snmp-discovery/**"
+      - "!orb-discovery/snmp-discovery/docker/**"
+  pull_request:
+    paths:
+      - "orb-discovery/snmp-discovery/**"
+      - "!orb-discovery/snmp-discovery/docker/**"
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    runs-on: ubuntu-latest
+    env:
+      GOWORK: "off"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: 'orb-discovery/snmp-discovery/go.mod'
+      - name: Lint
+        uses: golangci/golangci-lint-action@db582008a42febd596419635a5abc9d9815daa9c # v9.2.1
+        with:
+          version: v2.11.3
+          working-directory: orb-discovery/snmp-discovery
+          args: --config ../.github/golangci.yaml

--- a/.github/workflows/snmp-discovery-lint.yaml
+++ b/.github/workflows/snmp-discovery-lint.yaml
@@ -1,8 +1,8 @@
 name: SNMP Discovery - lint
 on:
   push:
-    branches:
-      - "!release"
+    branches-ignore:
+      - release
     paths:
       - "orb-discovery/snmp-discovery/**"
       - "!orb-discovery/snmp-discovery/docker/**"

--- a/.github/workflows/snmp-discovery-tests.yaml
+++ b/.github/workflows/snmp-discovery-tests.yaml
@@ -1,0 +1,71 @@
+name: SNMP Discovery - test
+on:
+  push:
+    branches:
+      - "!release"
+    paths:
+      - "orb-discovery/snmp-discovery/**"
+      - "!orb-discovery/snmp-discovery/docker/**"
+  pull_request:
+    paths:
+      - "orb-discovery/snmp-discovery/**"
+      - "!orb-discovery/snmp-discovery/docker/**"
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  go-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GOWORK: "off"
+    defaults:
+      run:
+        working-directory: orb-discovery/snmp-discovery
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: 'orb-discovery/snmp-discovery/go.mod'
+      - name: Run go build
+        run: go build ./...
+      - name: Install additional dependencies
+        run: |
+          make install-dev-tools
+      - name: Run go test
+        id: go-test
+        run: |
+          make test-coverage
+          echo 'coverage-report<<EOF' >> $GITHUB_OUTPUT
+          cat .coverage/test-report.md >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+          echo "coverage-total=$(cat .coverage/coverage.txt)" >> $GITHUB_OUTPUT
+      - name: Output Result
+        if: always()
+        run: cat .coverage/test-report.md
+      - name: Find comment
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
+        id: existing-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Go test coverage
+      - name: Post comment
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        with:
+          comment-id: ${{ steps.existing-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Go test coverage
+            ${{ steps.go-test.outputs.coverage-report }}
+            Total coverage: ${{ steps.go-test.outputs.coverage-total }}%
+          edit-mode: replace

--- a/.github/workflows/snmp-discovery-tests.yaml
+++ b/.github/workflows/snmp-discovery-tests.yaml
@@ -1,8 +1,8 @@
 name: SNMP Discovery - test
 on:
   push:
-    branches:
-      - "!release"
+    branches-ignore:
+      - release
     paths:
       - "orb-discovery/snmp-discovery/**"
       - "!orb-discovery/snmp-discovery/docker/**"

--- a/.github/workflows/snmp-discovery-tests.yaml
+++ b/.github/workflows/snmp-discovery-tests.yaml
@@ -52,6 +52,9 @@ jobs:
         if: always()
         run: cat .coverage/test-report.md
       - name: Find comment
+        # Only on pull_request: on push runs there is no pull_request.number, and
+        # find-comment v4 coerces the empty input to 0 and fails the job.
+        if: github.event_name == 'pull_request'
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: existing-comment
         with:

--- a/.github/workflows/worker-lint-tests.yaml
+++ b/.github/workflows/worker-lint-tests.yaml
@@ -1,0 +1,62 @@
+name: Worker - lint and tests
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "orb-discovery/worker/**"
+  push:
+    branches:
+      - "!release"
+    paths:
+      - "orb-discovery/worker/**"
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  BE_DIR: orb-discovery/worker
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        python: [ "3.11", "3.12", "3.13", "3.14" ]
+    defaults:
+      run:
+        working-directory: ${{ env.BE_DIR }}
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    - name: Setup Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+        pip install .[dev]
+        pip install .[test]
+
+    - name: Run tests with coverage
+      run: |
+        set -o pipefail
+        pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=worker/ | tee pytest-coverage.txt
+
+    - name: Pytest coverage comment
+      uses: MishaKav/pytest-coverage-comment@dd5b80bde6d16941f336518e92929e89069d8451 # v1.7.2
+      if: github.event.pull_request.head.repo.full_name == github.repository
+      with:
+        pytest-coverage-path: ${{ env.BE_DIR }}/pytest-coverage.txt
+        junitxml-path: ${{ env.BE_DIR }}/pytest.xml
+
+    - name: Lint with Ruff
+      run: |
+        ruff check --output-format=github worker/ tests/
+      continue-on-error: true

--- a/.github/workflows/worker-lint-tests.yaml
+++ b/.github/workflows/worker-lint-tests.yaml
@@ -5,8 +5,8 @@ on:
     paths:
       - "orb-discovery/worker/**"
   push:
-    branches:
-      - "!release"
+    branches-ignore:
+      - release
     paths:
       - "orb-discovery/worker/**"
 

--- a/orb-discovery/gnmi-discovery/cmd/main.go
+++ b/orb-discovery/gnmi-discovery/cmd/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/env"
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/gnmi"

--- a/orb-discovery/gnmi-discovery/mapping/coverage_parity_test.go
+++ b/orb-discovery/gnmi-discovery/mapping/coverage_parity_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
 )
 
 // Device gains an unconditional "active" status. (asset_tag is resolved by the

--- a/orb-discovery/gnmi-discovery/mapping/model_test.go
+++ b/orb-discovery/gnmi-discovery/mapping/model_test.go
@@ -3,8 +3,9 @@ package mapping
 import (
 	"testing"
 
-	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/gnmi"
 	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/gnmi"
 )
 
 func TestApplyUpdateAndSnapshot(t *testing.T) {

--- a/orb-discovery/gnmi-discovery/mapping/prefix.go
+++ b/orb-discovery/gnmi-discovery/mapping/prefix.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
 )
 

--- a/orb-discovery/gnmi-discovery/mapping/prefix_test.go
+++ b/orb-discovery/gnmi-discovery/mapping/prefix_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
 	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
 )
 
 func ipEnt(addr string, vrf *diode.VRF) *diode.IPAddress {

--- a/orb-discovery/gnmi-discovery/mapping/translate.go
+++ b/orb-discovery/gnmi-discovery/mapping/translate.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
 )
 

--- a/orb-discovery/gnmi-discovery/mapping/translate_ip.go
+++ b/orb-discovery/gnmi-discovery/mapping/translate_ip.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
 )
 

--- a/orb-discovery/gnmi-discovery/mapping/translate_test.go
+++ b/orb-discovery/gnmi-discovery/mapping/translate_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
 	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
 )
 
 func TestListKeyAndLeaf(t *testing.T) {

--- a/orb-discovery/gnmi-discovery/mapping/vlan.go
+++ b/orb-discovery/gnmi-discovery/mapping/vlan.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
 )
 

--- a/orb-discovery/gnmi-discovery/mapping/vlan_test.go
+++ b/orb-discovery/gnmi-discovery/mapping/vlan_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
 	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
 )
 
 func TestParseNetworkInstanceVlanPath(t *testing.T) {

--- a/orb-discovery/gnmi-discovery/mapping/vrf.go
+++ b/orb-discovery/gnmi-discovery/mapping/vrf.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
 )
 

--- a/orb-discovery/gnmi-discovery/policy/config_capture_test.go
+++ b/orb-discovery/gnmi-discovery/policy/config_capture_test.go
@@ -8,11 +8,12 @@ import (
 	"time"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/gnmi"
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/mapping"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func boolPtr(b bool) *bool { return &b }

--- a/orb-discovery/gnmi-discovery/policy/coverage_boost_test.go
+++ b/orb-discovery/gnmi-discovery/policy/coverage_boost_test.go
@@ -20,10 +20,11 @@ import (
 	"time"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/stretchr/testify/require"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/gnmi"
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/mapping"
-	"github.com/stretchr/testify/require"
 )
 
 // ─── Manager lifecycle ────────────────────────────────────────────────────────

--- a/orb-discovery/gnmi-discovery/policy/dryrun_test.go
+++ b/orb-discovery/gnmi-discovery/policy/dryrun_test.go
@@ -9,10 +9,11 @@ import (
 	"time"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/stretchr/testify/require"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/gnmi"
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/mapping"
-	"github.com/stretchr/testify/require"
 )
 
 type rawNote struct {

--- a/orb-discovery/gnmi-discovery/policy/manager.go
+++ b/orb-discovery/gnmi-discovery/policy/manager.go
@@ -13,11 +13,12 @@ import (
 	"time"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+	"gopkg.in/yaml.v3"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/env"
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/gnmi"
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/mapping"
-	"gopkg.in/yaml.v3"
 )
 
 // maxIntervalMs is the largest interval (in ms) that can be multiplied by

--- a/orb-discovery/gnmi-discovery/policy/manager_test.go
+++ b/orb-discovery/gnmi-discovery/policy/manager_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/gnmi"
 	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/gnmi"
 )
 
 func newTestManager(t *testing.T) *Manager {

--- a/orb-discovery/gnmi-discovery/policy/runner.go
+++ b/orb-discovery/gnmi-discovery/policy/runner.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/gnmi"
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/mapping"

--- a/orb-discovery/gnmi-discovery/policy/runner_test.go
+++ b/orb-discovery/gnmi-discovery/policy/runner_test.go
@@ -10,10 +10,11 @@ import (
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	diodepb "github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
+	"github.com/stretchr/testify/require"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/gnmi"
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/mapping"
-	"github.com/stretchr/testify/require"
 )
 
 // recordingClient captures Ingest calls.

--- a/orb-discovery/gnmi-discovery/server/server.go
+++ b/orb-discovery/gnmi-discovery/server/server.go
@@ -14,11 +14,12 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/metrics"
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/policy"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
 )
 
 // Response represents the server response

--- a/orb-discovery/gnmi-discovery/server/server_test.go
+++ b/orb-discovery/gnmi-discovery/server/server_test.go
@@ -16,10 +16,11 @@ import (
 	"time"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/stretchr/testify/require"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/gnmi"
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/metrics"
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/policy"
-	"github.com/stretchr/testify/require"
 )
 
 // initTestMetrics initialises the OTel meter to a live (but no-export) provider

--- a/orb-discovery/network-discovery/cmd/main.go
+++ b/orb-discovery/network-discovery/cmd/main.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/metrics"
 	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/policy"

--- a/orb-discovery/network-discovery/config/logger_test.go
+++ b/orb-discovery/network-discovery/config/logger_test.go
@@ -4,9 +4,10 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/config"
 )
 
 func TestNewLogger(t *testing.T) {

--- a/orb-discovery/network-discovery/metrics/metrics_test.go
+++ b/orb-discovery/network-discovery/metrics/metrics_test.go
@@ -6,11 +6,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/metrics"
 )
 
 func TestSetupMetricsExport(t *testing.T) {

--- a/orb-discovery/network-discovery/policy/manager.go
+++ b/orb-discovery/network-discovery/policy/manager.go
@@ -7,8 +7,9 @@ import (
 	"log/slog"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/config"
 	"gopkg.in/yaml.v3"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/config"
 )
 
 // Manager represents the policy manager

--- a/orb-discovery/network-discovery/policy/manager_test.go
+++ b/orb-discovery/network-discovery/policy/manager_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/config"
-	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/policy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/config"
+	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/policy"
 )
 
 // MockRunner mocks the Runner

--- a/orb-discovery/network-discovery/policy/run_test.go
+++ b/orb-discovery/network-discovery/policy/run_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/policy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/policy"
 )
 
 func TestRunStore_CreateRun(t *testing.T) {

--- a/orb-discovery/network-discovery/policy/runner.go
+++ b/orb-discovery/network-discovery/policy/runner.go
@@ -13,10 +13,11 @@ import (
 	"github.com/Ullaakut/nmap/v3"
 	"github.com/go-co-op/gocron/v2"
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/config"
-	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/metrics"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/config"
+	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/metrics"
 )
 
 // Define a custom type for the context key

--- a/orb-discovery/network-discovery/policy/runner_test.go
+++ b/orb-discovery/network-discovery/policy/runner_test.go
@@ -10,11 +10,12 @@ import (
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/metrics"
 	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/policy"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 type MockClient struct {

--- a/orb-discovery/network-discovery/server/server.go
+++ b/orb-discovery/network-discovery/server/server.go
@@ -12,11 +12,12 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/metrics"
 	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/policy"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
 )
 
 // Response represents the server response

--- a/orb-discovery/network-discovery/server/server_test.go
+++ b/orb-discovery/network-discovery/server/server_test.go
@@ -13,11 +13,12 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/metrics"
 	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/policy"
 	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/server"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 type MockClient struct {

--- a/orb-discovery/network-discovery/version/version_test.go
+++ b/orb-discovery/network-discovery/version/version_test.go
@@ -3,8 +3,9 @@ package version_test
 import (
 	"testing"
 
-	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/version"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/version"
 )
 
 func TestVersion(t *testing.T) {

--- a/orb-discovery/snmp-discovery/cmd/main.go
+++ b/orb-discovery/snmp-discovery/cmd/main.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/data"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/env"

--- a/orb-discovery/snmp-discovery/config/logger_test.go
+++ b/orb-discovery/snmp-discovery/config/logger_test.go
@@ -4,9 +4,10 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 )
 
 func TestNewLogger(t *testing.T) {

--- a/orb-discovery/snmp-discovery/env/env_test.go
+++ b/orb-discovery/snmp-discovery/env/env_test.go
@@ -4,9 +4,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/env"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/env"
 )
 
 func TestResolveEnv(t *testing.T) {

--- a/orb-discovery/snmp-discovery/mapping/chassis.go
+++ b/orb-discovery/snmp-discovery/mapping/chassis.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 )
 

--- a/orb-discovery/snmp-discovery/mapping/chassis_test.go
+++ b/orb-discovery/snmp-discovery/mapping/chassis_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v3"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 )
 
 // TestChassisInventoryMapper_IsNoOp confirms the mapper accepts

--- a/orb-discovery/snmp-discovery/mapping/export_test.go
+++ b/orb-discovery/snmp-discovery/mapping/export_test.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 )
 

--- a/orb-discovery/snmp-discovery/mapping/interface_name_source_test.go
+++ b/orb-discovery/snmp-discovery/mapping/interface_name_source_test.go
@@ -3,8 +3,9 @@ package mapping
 import (
 	"testing"
 
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 )
 
 func TestResolveInterfaceName(t *testing.T) {

--- a/orb-discovery/snmp-discovery/mapping/interface_resolver_test.go
+++ b/orb-discovery/snmp-discovery/mapping/interface_resolver_test.go
@@ -5,8 +5,9 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 )
 
 // TestResolveInterfaceType_Priority tests the 5-tier priority system

--- a/orb-discovery/snmp-discovery/mapping/interface_types_test.go
+++ b/orb-discovery/snmp-discovery/mapping/interface_types_test.go
@@ -3,8 +3,9 @@ package mapping_test
 import (
 	"testing"
 
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/mapping"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/mapping"
 )
 
 var tests = []struct {

--- a/orb-discovery/snmp-discovery/mapping/mappers.go
+++ b/orb-discovery/snmp-discovery/mapping/mappers.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/data"
 )

--- a/orb-discovery/snmp-discovery/mapping/mappers_defaults_test.go
+++ b/orb-discovery/snmp-discovery/mapping/mappers_defaults_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 )
 
 func newTestDeviceMapper() *DeviceMapper {

--- a/orb-discovery/snmp-discovery/mapping/mappers_deferred_type_test.go
+++ b/orb-discovery/snmp-discovery/mapping/mappers_deferred_type_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 )
 
 func TestInterfaceMapper_DeferredTypeResolution(t *testing.T) {

--- a/orb-discovery/snmp-discovery/mapping/mappers_test.go
+++ b/orb-discovery/snmp-discovery/mapping/mappers_test.go
@@ -9,12 +9,13 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/mapping"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/mapping"
 )
 
 func TestIPAddressMapper_Map(t *testing.T) {

--- a/orb-discovery/snmp-discovery/mapping/mappers_vrf_af_test.go
+++ b/orb-discovery/snmp-discovery/mapping/mappers_vrf_af_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 )
 
 func newTestIPAddressMapper() *IPAddressMapper {

--- a/orb-discovery/snmp-discovery/mapping/mapping.go
+++ b/orb-discovery/snmp-discovery/mapping/mapping.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/data"
 )

--- a/orb-discovery/snmp-discovery/mapping/mapping_internal_test.go
+++ b/orb-discovery/snmp-discovery/mapping/mapping_internal_test.go
@@ -6,9 +6,10 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 )
 
 // TestResolveMappingEntry_FallsBackThroughPDUs covers the Codex P1 from

--- a/orb-discovery/snmp-discovery/mapping/mapping_test.go
+++ b/orb-discovery/snmp-discovery/mapping/mapping_test.go
@@ -12,10 +12,11 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/mapping"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/mapping"
 )
 
 type FakeManufacturers struct{}

--- a/orb-discovery/snmp-discovery/mapping/module.go
+++ b/orb-discovery/snmp-discovery/mapping/module.go
@@ -13,10 +13,11 @@ import (
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/metrics"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/metrics"
 )
 
 // entPhysical column prefixes specific to module discovery (the rest

--- a/orb-discovery/snmp-discovery/mapping/module_routing.go
+++ b/orb-discovery/snmp-discovery/mapping/module_routing.go
@@ -16,9 +16,10 @@ import (
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/metrics"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/metrics"
 )
 
 // assignMemberID stamps each ModuleEntry in inv with the logical member

--- a/orb-discovery/snmp-discovery/mapping/module_test.go
+++ b/orb-discovery/snmp-discovery/mapping/module_test.go
@@ -5,9 +5,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 )
 
 // TestChassisModuleMapper_MapReturnsNil confirms the mapper accepts

--- a/orb-discovery/snmp-discovery/mapping/module_translate.go
+++ b/orb-discovery/snmp-discovery/mapping/module_translate.go
@@ -22,10 +22,11 @@ import (
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/metrics"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/metrics"
 )
 
 // TranslateModules is a thin wrapper for callers without alias data —

--- a/orb-discovery/snmp-discovery/mapping/module_translate_test.go
+++ b/orb-discovery/snmp-discovery/mapping/module_translate_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 )
 
 // modeOff / modeLinecards / modeFull return *config.Options with the

--- a/orb-discovery/snmp-discovery/mapping/pattern_matcher_test.go
+++ b/orb-discovery/snmp-discovery/mapping/pattern_matcher_test.go
@@ -5,8 +5,9 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 )
 
 func TestNewPatternMatcher(t *testing.T) {

--- a/orb-discovery/snmp-discovery/mapping/post_pass_test.go
+++ b/orb-discovery/snmp-discovery/mapping/post_pass_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 )
 

--- a/orb-discovery/snmp-discovery/mapping/prefix.go
+++ b/orb-discovery/snmp-discovery/mapping/prefix.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 )
 

--- a/orb-discovery/snmp-discovery/mapping/prefix_test.go
+++ b/orb-discovery/snmp-discovery/mapping/prefix_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 )
 
 func ipEntity(addr string) *diode.IPAddress {

--- a/orb-discovery/snmp-discovery/mapping/subinterface_test.go
+++ b/orb-discovery/snmp-discovery/mapping/subinterface_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/mapping"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/mapping"
 )
 
 func TestExtractParentInterfaceName(t *testing.T) {

--- a/orb-discovery/snmp-discovery/mapping/vlan_mapper.go
+++ b/orb-discovery/snmp-discovery/mapping/vlan_mapper.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/mapping/qbridge"
 )

--- a/orb-discovery/snmp-discovery/mapping/vlan_mapper_test.go
+++ b/orb-discovery/snmp-discovery/mapping/vlan_mapper_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 )
 

--- a/orb-discovery/snmp-discovery/mapping/vrf.go
+++ b/orb-discovery/snmp-discovery/mapping/vrf.go
@@ -11,6 +11,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 )
 

--- a/orb-discovery/snmp-discovery/mapping/vrf_test.go
+++ b/orb-discovery/snmp-discovery/mapping/vrf_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 )
 
 // oidIdx encodes a VRF name into its length-prefixed OID index form.

--- a/orb-discovery/snmp-discovery/metrics/metrics_test.go
+++ b/orb-discovery/snmp-discovery/metrics/metrics_test.go
@@ -6,11 +6,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/metrics"
 )
 
 func TestSetupMetricsExport(t *testing.T) {

--- a/orb-discovery/snmp-discovery/policy/manager.go
+++ b/orb-discovery/snmp-discovery/policy/manager.go
@@ -9,11 +9,12 @@ import (
 	"time"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+	"gopkg.in/yaml.v3"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/data"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/env"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/snmp"
-	"gopkg.in/yaml.v3"
 )
 
 //go:embed mapping.yaml

--- a/orb-discovery/snmp-discovery/policy/manager_test.go
+++ b/orb-discovery/snmp-discovery/policy/manager_test.go
@@ -8,13 +8,14 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/data"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/policy"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/snmp"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 // MockRunner mocks the Runner

--- a/orb-discovery/snmp-discovery/policy/run_test.go
+++ b/orb-discovery/snmp-discovery/policy/run_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/policy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/policy"
 )
 
 func TestRunStore_CreateRun(t *testing.T) {

--- a/orb-discovery/snmp-discovery/policy/runner.go
+++ b/orb-discovery/snmp-discovery/policy/runner.go
@@ -11,14 +11,15 @@ import (
 	"github.com/go-co-op/gocron/v2"
 	"github.com/google/uuid"
 	"github.com/netboxlabs/diode-sdk-go/diode"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/data"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/mapping"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/metrics"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/snmp"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/targets"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
 )
 
 // Define a custom type for the context key

--- a/orb-discovery/snmp-discovery/policy/runner_internal_test.go
+++ b/orb-discovery/snmp-discovery/policy/runner_internal_test.go
@@ -13,11 +13,12 @@ import (
 	"github.com/google/uuid"
 	"github.com/gosnmp/gosnmp"
 	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/mapping"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/snmp"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // slowWalker blocks in Connect until done is closed, simulating a long-running SNMP operation.

--- a/orb-discovery/snmp-discovery/policy/runner_test.go
+++ b/orb-discovery/snmp-discovery/policy/runner_test.go
@@ -10,13 +10,14 @@ import (
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/metrics"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/policy"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/snmp"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 type MockDiodeClient struct {

--- a/orb-discovery/snmp-discovery/server/server.go
+++ b/orb-discovery/snmp-discovery/server/server.go
@@ -12,11 +12,12 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/metrics"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/policy"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
 )
 
 // Response represents the server response

--- a/orb-discovery/snmp-discovery/server/server_test.go
+++ b/orb-discovery/snmp-discovery/server/server_test.go
@@ -12,12 +12,13 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/metrics"
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/policy"
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/metrics"
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/policy"
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/server"
 )
 
 type MockClient struct {

--- a/orb-discovery/snmp-discovery/snmp/mocks.go
+++ b/orb-discovery/snmp-discovery/snmp/mocks.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/gosnmp/gosnmp"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 )
 

--- a/orb-discovery/snmp-discovery/snmp/snmp.go
+++ b/orb-discovery/snmp-discovery/snmp/snmp.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gosnmp/gosnmp"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/mapping"
 )

--- a/orb-discovery/snmp-discovery/snmp/snmp_test.go
+++ b/orb-discovery/snmp-discovery/snmp/snmp_test.go
@@ -11,11 +11,12 @@ import (
 	"github.com/gosnmp/gosnmp"
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/mapping"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/snmp"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 // MockSNMP is a mock for Walker

--- a/orb-discovery/snmp-discovery/version/version_test.go
+++ b/orb-discovery/snmp-discovery/version/version_test.go
@@ -3,8 +3,9 @@ package version_test
 import (
 	"testing"
 
-	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/version"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/version"
 )
 
 func TestVersion(t *testing.T) {


### PR DESCRIPTION
## PR 1b — Per-backend lint/test CI

Second step of the orb-discovery monorepo migration. Adds each backend's own lint+test jobs to orb-agent CI, **path-filtered** to `orb-discovery/<backend>/**`, so a backend-only change runs only that backend's jobs (plus the agent's existing `build-and-scan`, which every PR triggers).

> [!NOTE]
> Unlike #411, this is an ordinary PR — **squash-merge is fine** (no history to preserve).

### What's in it
Ported the 8 per-backend lint/test workflows from the imported `orb-discovery/.github/workflows/` (inert reference) to the repo-root `.github/workflows/`, with mechanical path adaptations:
- **Go** (`network`, `snmp`, `gnmi`): `working-directory: orb-discovery/<backend>`, `go-version-file` prefixed, `GOWORK: "off"` (test each module against its own go.mod), golangci `--config ../.github/golangci.yaml` (resolves to `orb-discovery/.github/golangci.yaml`). network-discovery keeps nmap+setcap; snmp/gnmi use `make install-dev-tools`.
- **Python** (`device-discovery`, `worker`): pytest+ruff matrix over Python 3.11–3.14, paths prefixed.
- `actions/checkout`/`setup-go` pinned to the SHAs already used in this repo.

### Verified
- All 8 YAML files parse.
- Go backends: `GOWORK=off go build ./... && make test-coverage` pass for network/snmp/gnmi.
- device-discovery: `pip install .[test]` resolves, pytest collects 1948 tests.
- Fixed a latent bug while porting: network/snmp `find-comment` step now guarded to `pull_request` events (it would otherwise fail on `push`); matches the gnmi + agent `tests.yaml` pattern.

### Not in this PR
- Per-backend releases + PyPI (later PR).
- `orb-discovery/.github/` reference copies are left untouched (ported by the release PR).
- `actions/setup-python` left at `@v6` (repo has no prior pin to reuse; Dependabot can pin it).
