### PR TITLE
fix(repo): local builds ignore backend tags and a local go.work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,10 @@ make work                   # generate a git-ignored go.work for local dev
 
 The discovery backends live in their own modules under `orb-discovery/`. `go.work`
 is a local convenience only — it is git-ignored, and the agent image and CI build
-the agent as a single module.
+the agent as a single module. If your global `go env` sets `GOFLAGS=-mod=mod`, clear
+it (`go env -u GOFLAGS`): `-mod=mod` is invalid in workspace mode and breaks
+gopls/govulncheck while a `go.work` exists. `make` targets are unaffected — they run
+with `GOWORK=off`.
 
 After editing, always run `make fix-lint` — gci (import ordering) and gofumpt (formatting) are enforced in CI.
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BUILD_DIR ?= build
 CGO_ENABLED ?= 0
 GOARCH ?= $(shell go env GOARCH)
 GOOS ?= $(shell go env GOOS)
-ORB_VERSION ?= $(shell echo "$${BUILD_VERSION:-$$(cat agent/version/BUILD_VERSION.txt 2>/dev/null || git describe --tags --always 2>/dev/null || echo dev)}")
+ORB_VERSION ?= $(shell echo "$${BUILD_VERSION:-$$(cat agent/version/BUILD_VERSION.txt 2>/dev/null || git describe --tags --match 'v[0-9]*' --always 2>/dev/null || echo dev)}")
 COMMIT_HASH = $(shell git rev-parse --short HEAD)
 COMMIT_BRANCH = $(shell branch=$$(git rev-parse --abbrev-ref HEAD); if [ "$$branch" = "HEAD" ]; then branch=$${GITHUB_HEAD_REF:-$$GITHUB_REF_NAME}; fi; echo "$${branch:-unknown}")
 VERSION_PKG = github.com/netboxlabs/orb-agent/agent/version
@@ -18,6 +18,11 @@ EXTRA_LDFLAGS ?=
 LDFLAGS ?= -X $(VERSION_PKG).buildVersion=$(ORB_VERSION) -X $(VERSION_PKG).buildBranch=$(COMMIT_BRANCH) $(EXTRA_LDFLAGS)
 OTEL_COLLECTOR_CONTRIB_VERSION ?= 0.91.0
 OTEL_CONTRIB_URL ?= "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$(OTEL_COLLECTOR_CONTRIB_VERSION)/otelcol-contrib_$(OTEL_COLLECTOR_CONTRIB_VERSION)_$(GOOS)_$(GOARCH).tar.gz"
+
+# Make targets operate on the agent (a single module), so never use a local
+# go.work — workspace mode is incompatible with the -mod=mod build flow. The
+# `work` target below re-enables it explicitly for generating the file.
+export GOWORK = off
 
 .PHONY: agent agent_bin
 
@@ -48,7 +53,7 @@ deps:
 .PHONY: work
 work:
 	@rm -f go.work go.work.sum
-	@go work init . ./orb-discovery/network-discovery ./orb-discovery/snmp-discovery ./orb-discovery/gnmi-discovery
+	@GOWORK= go work init . ./orb-discovery/network-discovery ./orb-discovery/snmp-discovery ./orb-discovery/gnmi-discovery
 	@echo "go.work created (git-ignored). Use 'GOWORK=off' for single-module commands."
 
 agent_bin:


### PR DESCRIPTION
## Two local-dev breakages from the monorepo migration

### 1. `make agent` → invalid Docker tag
`ORB_VERSION` falls back to `git describe --tags --always`, which now returns the nearest tag — a **backend** tag like `device-discovery/v1.30.1-2-g47d6b56`. The slash makes an invalid image reference:
```
ERROR: invalid tag "netboxlabs/orb-agent:device-discovery/v1.30.1-2-g47d6b56": invalid reference format
```
Fix: `git describe --tags --match 'v[0-9]*'` — only the agent's `vX.Y.Z` tags (backend `<backend>/v*` excluded). Same class as the develop/build image fix in #416, for local `make`.

### 2. `make agent_bin`/`test` + gopls/govulncheck break with a local `go.work`
A local `go.work` enables workspace mode, which is incompatible with `-mod=mod` (the Makefile's build flag and many devs' global `GOFLAGS`):
```
go: -mod may only be set to readonly or vendor when in workspace mode, but it is set to "mod"
```
Fix: `export GOWORK = off` in the Makefile — its targets operate on the agent (single module), so they ignore a local workspace (CI is unaffected: it has no `go.work`). The `work` target re-enables it (`GOWORK=`) to generate the file. AGENTS.md now also notes that **`go env -u GOFLAGS`** is needed so gopls/govulncheck work while a `go.work` exists (those tools don't go through the Makefile).

### Verified
- `make -n agent` → `netboxlabs/orb-agent:develop`, `:<sha>` (valid, no slash).
- `make agent_bin` builds with a local `go.work` present.
- `make work` still regenerates `go.work`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)