### PR TITLE
fix(repo): inject real backend versions in from-source image builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,11 +42,20 @@ jobs:
           # pattern; ls-remote avoids release-API pagination and works at any clone depth.
           LATEST_RELEASE=$(git ls-remote --tags --refs origin 'refs/tags/v*' | sed 's#.*refs/tags/##' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
           echo "${LATEST_RELEASE:-develop}" > ./agent/version/BUILD_VERSION.txt
-          # Backend versions (latest <backend>/v* tag) — stamped into the from-source build.
-          nd=$(git ls-remote --tags --refs origin 'refs/tags/network-discovery/v*' | sed 's#.*/v##' | sort -V | tail -1)
-          sd=$(git ls-remote --tags --refs origin 'refs/tags/snmp-discovery/v*' | sed 's#.*/v##' | sort -V | tail -1)
-          dd=$(git ls-remote --tags --refs origin 'refs/tags/device-discovery/v*' | sed 's#.*/v##' | sort -V | tail -1)
-          wk=$(git ls-remote --tags --refs origin 'refs/tags/worker/v*' | sed 's#.*/v##' | sort -V | tail -1)
+          # Latest RELEASED version per backend (highest <backend>/vX.Y.Z tag;
+          # pre-releases excluded, mirroring the agent's own version filter above)
+          # — stamped into the from-source build. ls-remote runs on its own line
+          # so a transport failure aborts the step (errexit) instead of silently
+          # falling back to 0.0.0 and reintroducing the regression this fixes.
+          backend_version() {
+            local refs
+            refs=$(git ls-remote --tags --refs origin "refs/tags/$1/v*") || return 1
+            printf '%s\n' "$refs" | sed 's#.*/v##' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1
+          }
+          nd=$(backend_version network-discovery)
+          sd=$(backend_version snmp-discovery)
+          dd=$(backend_version device-discovery)
+          wk=$(backend_version worker)
           {
             echo "BUILD_COMMIT_SHORT=${GITHUB_SHA::7}"
             echo "ND_VERSION=${nd:-0.0.0}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,6 +42,18 @@ jobs:
           # pattern; ls-remote avoids release-API pagination and works at any clone depth.
           LATEST_RELEASE=$(git ls-remote --tags --refs origin 'refs/tags/v*' | sed 's#.*refs/tags/##' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
           echo "${LATEST_RELEASE:-develop}" > ./agent/version/BUILD_VERSION.txt
+          # Backend versions (latest <backend>/v* tag) — stamped into the from-source build.
+          nd=$(git ls-remote --tags --refs origin 'refs/tags/network-discovery/v*' | sed 's#.*/v##' | sort -V | tail -1)
+          sd=$(git ls-remote --tags --refs origin 'refs/tags/snmp-discovery/v*' | sed 's#.*/v##' | sort -V | tail -1)
+          dd=$(git ls-remote --tags --refs origin 'refs/tags/device-discovery/v*' | sed 's#.*/v##' | sort -V | tail -1)
+          wk=$(git ls-remote --tags --refs origin 'refs/tags/worker/v*' | sed 's#.*/v##' | sort -V | tail -1)
+          {
+            echo "BUILD_COMMIT_SHORT=${GITHUB_SHA::7}"
+            echo "ND_VERSION=${nd:-0.0.0}"
+            echo "SD_VERSION=${sd:-0.0.0}"
+            echo "DD_VERSION=${dd:-0.0.0}"
+            echo "WK_VERSION=${wk:-0.0.0}"
+          } >> "$GITHUB_ENV"
 
       - name: Build image
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
@@ -56,6 +68,12 @@ jobs:
           no-cache-filters: python-builder,final
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
+            BUILD_COMMIT=${{ env.BUILD_COMMIT_SHORT }}
+            BUILD_TRACK=develop
+            NETWORK_DISCOVERY_VERSION=${{ env.ND_VERSION }}
+            SNMP_DISCOVERY_VERSION=${{ env.SD_VERSION }}
+            DEVICE_DISCOVERY_VERSION=${{ env.DD_VERSION }}
+            WORKER_VERSION=${{ env.WK_VERSION }}
           tags: orb-agent:scan
 
       - name: Scan image for vulnerabilities

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -58,6 +58,18 @@ jobs:
           # pattern; ls-remote avoids release-API pagination and works at any clone depth.
           LATEST_RELEASE=$(git ls-remote --tags --refs origin 'refs/tags/v*' | sed 's#.*refs/tags/##' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
           echo "${LATEST_RELEASE:-develop}" > ./agent/version/BUILD_VERSION.txt
+          # Backend versions (latest <backend>/v* tag) — stamped into the from-source build.
+          nd=$(git ls-remote --tags --refs origin 'refs/tags/network-discovery/v*' | sed 's#.*/v##' | sort -V | tail -1)
+          sd=$(git ls-remote --tags --refs origin 'refs/tags/snmp-discovery/v*' | sed 's#.*/v##' | sort -V | tail -1)
+          dd=$(git ls-remote --tags --refs origin 'refs/tags/device-discovery/v*' | sed 's#.*/v##' | sort -V | tail -1)
+          wk=$(git ls-remote --tags --refs origin 'refs/tags/worker/v*' | sed 's#.*/v##' | sort -V | tail -1)
+          {
+            echo "BUILD_COMMIT_SHORT=${GITHUB_SHA::7}"
+            echo "ND_VERSION=${nd:-0.0.0}"
+            echo "SD_VERSION=${sd:-0.0.0}"
+            echo "DD_VERSION=${dd:-0.0.0}"
+            echo "WK_VERSION=${wk:-0.0.0}"
+          } >> "$GITHUB_ENV"
 
       - name: Build image and push by digest
         id: build
@@ -72,6 +84,12 @@ jobs:
           pull: true
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
+            BUILD_COMMIT=${{ env.BUILD_COMMIT_SHORT }}
+            BUILD_TRACK=develop
+            NETWORK_DISCOVERY_VERSION=${{ env.ND_VERSION }}
+            SNMP_DISCOVERY_VERSION=${{ env.SD_VERSION }}
+            DEVICE_DISCOVERY_VERSION=${{ env.DD_VERSION }}
+            WORKER_VERSION=${{ env.WK_VERSION }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -58,11 +58,20 @@ jobs:
           # pattern; ls-remote avoids release-API pagination and works at any clone depth.
           LATEST_RELEASE=$(git ls-remote --tags --refs origin 'refs/tags/v*' | sed 's#.*refs/tags/##' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
           echo "${LATEST_RELEASE:-develop}" > ./agent/version/BUILD_VERSION.txt
-          # Backend versions (latest <backend>/v* tag) — stamped into the from-source build.
-          nd=$(git ls-remote --tags --refs origin 'refs/tags/network-discovery/v*' | sed 's#.*/v##' | sort -V | tail -1)
-          sd=$(git ls-remote --tags --refs origin 'refs/tags/snmp-discovery/v*' | sed 's#.*/v##' | sort -V | tail -1)
-          dd=$(git ls-remote --tags --refs origin 'refs/tags/device-discovery/v*' | sed 's#.*/v##' | sort -V | tail -1)
-          wk=$(git ls-remote --tags --refs origin 'refs/tags/worker/v*' | sed 's#.*/v##' | sort -V | tail -1)
+          # Latest RELEASED version per backend (highest <backend>/vX.Y.Z tag;
+          # pre-releases excluded, mirroring the agent's own version filter above)
+          # — stamped into the from-source build. ls-remote runs on its own line
+          # so a transport failure aborts the step (errexit) instead of silently
+          # falling back to 0.0.0 and reintroducing the regression this fixes.
+          backend_version() {
+            local refs
+            refs=$(git ls-remote --tags --refs origin "refs/tags/$1/v*") || return 1
+            printf '%s\n' "$refs" | sed 's#.*/v##' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1
+          }
+          nd=$(backend_version network-discovery)
+          sd=$(backend_version snmp-discovery)
+          dd=$(backend_version device-discovery)
+          wk=$(backend_version worker)
           {
             echo "BUILD_COMMIT_SHORT=${GITHUB_SHA::7}"
             echo "ND_VERSION=${nd:-0.0.0}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -173,6 +173,17 @@ jobs:
         run: |
           echo $BUILD_COMMIT > ./agent/version/BUILD_COMMIT.txt
           echo $BUILD_VERSION > ./agent/version/BUILD_VERSION.txt
+          # Backend versions (latest <backend>/v* tag) — stamped into the from-source build.
+          nd=$(git ls-remote --tags --refs origin 'refs/tags/network-discovery/v*' | sed 's#.*/v##' | sort -V | tail -1)
+          sd=$(git ls-remote --tags --refs origin 'refs/tags/snmp-discovery/v*' | sed 's#.*/v##' | sort -V | tail -1)
+          dd=$(git ls-remote --tags --refs origin 'refs/tags/device-discovery/v*' | sed 's#.*/v##' | sort -V | tail -1)
+          wk=$(git ls-remote --tags --refs origin 'refs/tags/worker/v*' | sed 's#.*/v##' | sort -V | tail -1)
+          {
+            echo "ND_VERSION=${nd:-0.0.0}"
+            echo "SD_VERSION=${sd:-0.0.0}"
+            echo "DD_VERSION=${dd:-0.0.0}"
+            echo "WK_VERSION=${wk:-0.0.0}"
+          } >> "$GITHUB_ENV"
 
       - name: Build image and push by digest
         id: build
@@ -187,6 +198,12 @@ jobs:
           pull: true
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
+            BUILD_COMMIT=${{ env.BUILD_COMMIT }}
+            BUILD_TRACK=release
+            NETWORK_DISCOVERY_VERSION=${{ env.ND_VERSION }}
+            SNMP_DISCOVERY_VERSION=${{ env.SD_VERSION }}
+            DEVICE_DISCOVERY_VERSION=${{ env.DD_VERSION }}
+            WORKER_VERSION=${{ env.WK_VERSION }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -173,11 +173,20 @@ jobs:
         run: |
           echo $BUILD_COMMIT > ./agent/version/BUILD_COMMIT.txt
           echo $BUILD_VERSION > ./agent/version/BUILD_VERSION.txt
-          # Backend versions (latest <backend>/v* tag) — stamped into the from-source build.
-          nd=$(git ls-remote --tags --refs origin 'refs/tags/network-discovery/v*' | sed 's#.*/v##' | sort -V | tail -1)
-          sd=$(git ls-remote --tags --refs origin 'refs/tags/snmp-discovery/v*' | sed 's#.*/v##' | sort -V | tail -1)
-          dd=$(git ls-remote --tags --refs origin 'refs/tags/device-discovery/v*' | sed 's#.*/v##' | sort -V | tail -1)
-          wk=$(git ls-remote --tags --refs origin 'refs/tags/worker/v*' | sed 's#.*/v##' | sort -V | tail -1)
+          # Latest RELEASED version per backend (highest <backend>/vX.Y.Z tag;
+          # pre-releases excluded) — stamped into the from-source build. ls-remote
+          # runs on its own line so a transport failure aborts the step (errexit)
+          # instead of silently falling back to 0.0.0 and reintroducing the
+          # regression this fixes.
+          backend_version() {
+            local refs
+            refs=$(git ls-remote --tags --refs origin "refs/tags/$1/v*") || return 1
+            printf '%s\n' "$refs" | sed 's#.*/v##' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1
+          }
+          nd=$(backend_version network-discovery)
+          sd=$(backend_version snmp-discovery)
+          dd=$(backend_version device-discovery)
+          wk=$(backend_version worker)
           {
             echo "ND_VERSION=${nd:-0.0.0}"
             echo "SD_VERSION=${sd:-0.0.0}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,10 @@ make work                   # generate a git-ignored go.work for local dev
 
 The discovery backends live in their own modules under `orb-discovery/`. `go.work`
 is a local convenience only — it is git-ignored, and the agent image and CI build
-the agent as a single module.
+the agent as a single module. If your global `go env` sets `GOFLAGS=-mod=mod`, clear
+it (`go env -u GOFLAGS`): `-mod=mod` is invalid in workspace mode and breaks
+gopls/govulncheck while a `go.work` exists. `make` targets are unaffected — they run
+with `GOWORK=off`.
 
 After editing, always run `make fix-lint` — gci (import ordering) and gofumpt (formatting) are enforced in CI.
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BUILD_DIR ?= build
 CGO_ENABLED ?= 0
 GOARCH ?= $(shell go env GOARCH)
 GOOS ?= $(shell go env GOOS)
-ORB_VERSION ?= $(shell echo "$${BUILD_VERSION:-$$(cat agent/version/BUILD_VERSION.txt 2>/dev/null || git describe --tags --always 2>/dev/null || echo dev)}")
+ORB_VERSION ?= $(shell echo "$${BUILD_VERSION:-$$(cat agent/version/BUILD_VERSION.txt 2>/dev/null || git describe --tags --match 'v[0-9]*' --always 2>/dev/null || echo dev)}")
 COMMIT_HASH = $(shell git rev-parse --short HEAD)
 COMMIT_BRANCH = $(shell branch=$$(git rev-parse --abbrev-ref HEAD); if [ "$$branch" = "HEAD" ]; then branch=$${GITHUB_HEAD_REF:-$$GITHUB_REF_NAME}; fi; echo "$${branch:-unknown}")
 VERSION_PKG = github.com/netboxlabs/orb-agent/agent/version
@@ -18,6 +18,11 @@ EXTRA_LDFLAGS ?=
 LDFLAGS ?= -X $(VERSION_PKG).buildVersion=$(ORB_VERSION) -X $(VERSION_PKG).buildBranch=$(COMMIT_BRANCH) $(EXTRA_LDFLAGS)
 OTEL_COLLECTOR_CONTRIB_VERSION ?= 0.91.0
 OTEL_CONTRIB_URL ?= "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$(OTEL_COLLECTOR_CONTRIB_VERSION)/otelcol-contrib_$(OTEL_COLLECTOR_CONTRIB_VERSION)_$(GOOS)_$(GOARCH).tar.gz"
+
+# Make targets operate on the agent (a single module), so never use a local
+# go.work — workspace mode is incompatible with the -mod=mod build flow. The
+# `work` target below re-enables it explicitly for generating the file.
+export GOWORK = off
 
 .PHONY: agent agent_bin
 
@@ -48,7 +53,7 @@ deps:
 .PHONY: work
 work:
 	@rm -f go.work go.work.sum
-	@go work init . ./orb-discovery/network-discovery ./orb-discovery/snmp-discovery ./orb-discovery/gnmi-discovery
+	@GOWORK= go work init . ./orb-discovery/network-discovery ./orb-discovery/snmp-discovery ./orb-discovery/gnmi-discovery
 	@echo "go.work created (git-ignored). Use 'GOWORK=off' for single-module commands."
 
 agent_bin:

--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,14 @@ LDFLAGS ?= -X $(VERSION_PKG).buildVersion=$(ORB_VERSION) -X $(VERSION_PKG).build
 OTEL_COLLECTOR_CONTRIB_VERSION ?= 0.91.0
 OTEL_CONTRIB_URL ?= "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$(OTEL_COLLECTOR_CONTRIB_VERSION)/otelcol-contrib_$(OTEL_COLLECTOR_CONTRIB_VERSION)_$(GOOS)_$(GOARCH).tar.gz"
 # Backend versions stamped into the from-source image (latest <backend>/v* tag);
-# without these the from-source backends report 0.0.0.
-ND_VERSION ?= $(shell v=$$(git describe --tags --match 'network-discovery/v[0-9]*' --abbrev=0 2>/dev/null | sed 's|.*/v||'); echo $${v:-0.0.0})
-SD_VERSION ?= $(shell v=$$(git describe --tags --match 'snmp-discovery/v[0-9]*' --abbrev=0 2>/dev/null | sed 's|.*/v||'); echo $${v:-0.0.0})
-DD_VERSION ?= $(shell v=$$(git describe --tags --match 'device-discovery/v[0-9]*' --abbrev=0 2>/dev/null | sed 's|.*/v||'); echo $${v:-0.0.0})
-WK_VERSION ?= $(shell v=$$(git describe --tags --match 'worker/v[0-9]*' --abbrev=0 2>/dev/null | sed 's|.*/v||'); echo $${v:-0.0.0})
+# without these the from-source backends report 0.0.0. List + version-sort the
+# tags rather than `git describe` so the result does not depend on the tag being
+# reachable from HEAD (backend tags are cut on the `release` branch), matching
+# how the CI workflows resolve versions via `git ls-remote`.
+ND_VERSION ?= $(shell v=$$(git tag -l 'network-discovery/v[0-9]*' | sed 's|.*/v||' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' | sort -V | tail -1); echo $${v:-0.0.0})
+SD_VERSION ?= $(shell v=$$(git tag -l 'snmp-discovery/v[0-9]*' | sed 's|.*/v||' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' | sort -V | tail -1); echo $${v:-0.0.0})
+DD_VERSION ?= $(shell v=$$(git tag -l 'device-discovery/v[0-9]*' | sed 's|.*/v||' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' | sort -V | tail -1); echo $${v:-0.0.0})
+WK_VERSION ?= $(shell v=$$(git tag -l 'worker/v[0-9]*' | sed 's|.*/v||' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' | sort -V | tail -1); echo $${v:-0.0.0})
 BACKEND_VERSION_ARGS = --build-arg NETWORK_DISCOVERY_VERSION=$(ND_VERSION) --build-arg SNMP_DISCOVERY_VERSION=$(SD_VERSION) --build-arg DEVICE_DISCOVERY_VERSION=$(DD_VERSION) --build-arg WORKER_VERSION=$(WK_VERSION) --build-arg BUILD_COMMIT=$(COMMIT_HASH) --build-arg BUILD_TRACK=$(COMMIT_BRANCH)
 
 # Make targets operate on the agent (a single module), so never use a local

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,13 @@ EXTRA_LDFLAGS ?=
 LDFLAGS ?= -X $(VERSION_PKG).buildVersion=$(ORB_VERSION) -X $(VERSION_PKG).buildBranch=$(COMMIT_BRANCH) $(EXTRA_LDFLAGS)
 OTEL_COLLECTOR_CONTRIB_VERSION ?= 0.91.0
 OTEL_CONTRIB_URL ?= "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$(OTEL_COLLECTOR_CONTRIB_VERSION)/otelcol-contrib_$(OTEL_COLLECTOR_CONTRIB_VERSION)_$(GOOS)_$(GOARCH).tar.gz"
+# Backend versions stamped into the from-source image (latest <backend>/v* tag);
+# without these the from-source backends report 0.0.0.
+ND_VERSION ?= $(shell v=$$(git describe --tags --match 'network-discovery/v[0-9]*' --abbrev=0 2>/dev/null | sed 's|.*/v||'); echo $${v:-0.0.0})
+SD_VERSION ?= $(shell v=$$(git describe --tags --match 'snmp-discovery/v[0-9]*' --abbrev=0 2>/dev/null | sed 's|.*/v||'); echo $${v:-0.0.0})
+DD_VERSION ?= $(shell v=$$(git describe --tags --match 'device-discovery/v[0-9]*' --abbrev=0 2>/dev/null | sed 's|.*/v||'); echo $${v:-0.0.0})
+WK_VERSION ?= $(shell v=$$(git describe --tags --match 'worker/v[0-9]*' --abbrev=0 2>/dev/null | sed 's|.*/v||'); echo $${v:-0.0.0})
+BACKEND_VERSION_ARGS = --build-arg NETWORK_DISCOVERY_VERSION=$(ND_VERSION) --build-arg SNMP_DISCOVERY_VERSION=$(SD_VERSION) --build-arg DEVICE_DISCOVERY_VERSION=$(DD_VERSION) --build-arg WORKER_VERSION=$(WK_VERSION) --build-arg BUILD_COMMIT=$(COMMIT_HASH) --build-arg BUILD_TRACK=$(COMMIT_BRANCH)
 
 # Make targets operate on the agent (a single module), so never use a local
 # go.work — workspace mode is incompatible with the -mod=mod build flow. The
@@ -99,6 +106,7 @@ agent:
 	  --tag=$(ORB_DOCKERHUB_REPO)/orb-agent:$(REF_TAG) \
 	  --tag=$(ORB_DOCKERHUB_REPO)/orb-agent:$(ORB_VERSION) \
 	  --tag=$(ORB_DOCKERHUB_REPO)/orb-agent:$(ORB_VERSION)-$(COMMIT_HASH) \
+	  $(BACKEND_VERSION_ARGS) \
 	  -f agent/docker/Dockerfile .
 
 agent_fast:
@@ -108,6 +116,7 @@ agent_fast:
 	  --tag=$(ORB_DOCKERHUB_REPO)/orb-agent:$(REF_TAG) \
 	  --tag=$(ORB_DOCKERHUB_REPO)/orb-agent:$(ORB_VERSION) \
 	  --tag=$(ORB_DOCKERHUB_REPO)/orb-agent:$(ORB_VERSION)-$(COMMIT_HASH) \
+	  $(BACKEND_VERSION_ARGS) \
 	  -f agent/docker/Dockerfile .
 
 agent_debug:
@@ -115,6 +124,7 @@ agent_debug:
 	  --build-arg PKTVISOR_TAG=$(PKTVISOR_DEBUG_TAG) \
 	  --tag=$(DOCKERHUB_REPO)/orb-agent:$(DEBUG_REF_TAG) \
 	  --tag=$(ORB_DOCKERHUB_REPO)/orb-agent:$(DEBUG_REF_TAG) \
+	  $(BACKEND_VERSION_ARGS) \
 	  -f agent/docker/Dockerfile .
 
 agent_production:
@@ -123,12 +133,14 @@ agent_production:
 	  --tag=$(ORB_DOCKERHUB_REPO)/orb-agent:$(PRODUCTION_AGENT_REF_TAG) \
 	  --tag=$(ORB_DOCKERHUB_REPO)/orb-agent:$(ORB_VERSION) \
 	  --tag=$(ORB_DOCKERHUB_REPO)/orb-agent:$(ORB_VERSION)-$(COMMIT_HASH) \
+	  $(BACKEND_VERSION_ARGS) \
 	  -f agent/docker/Dockerfile .
 
 agent_debug_production:
 	docker build \
 	  --build-arg PKTVISOR_TAG=$(PKTVISOR_DEBUG_TAG) \
 	  --tag=$(ORB_DOCKERHUB_REPO)/orb-agent:$(PRODUCTION_AGENT_DEBUG_REF_TAG) \
+	  $(BACKEND_VERSION_ARGS) \
 	  -f agent/docker/Dockerfile .
 
 pull-latest-otel-collector-contrib:

--- a/Makefile
+++ b/Makefile
@@ -19,14 +19,16 @@ LDFLAGS ?= -X $(VERSION_PKG).buildVersion=$(ORB_VERSION) -X $(VERSION_PKG).build
 OTEL_COLLECTOR_CONTRIB_VERSION ?= 0.91.0
 OTEL_CONTRIB_URL ?= "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$(OTEL_COLLECTOR_CONTRIB_VERSION)/otelcol-contrib_$(OTEL_COLLECTOR_CONTRIB_VERSION)_$(GOOS)_$(GOARCH).tar.gz"
 # Backend versions stamped into the from-source image (latest <backend>/v* tag);
-# without these the from-source backends report 0.0.0. List + version-sort the
-# tags rather than `git describe` so the result does not depend on the tag being
-# reachable from HEAD (backend tags are cut on the `release` branch), matching
-# how the CI workflows resolve versions via `git ls-remote`.
-ND_VERSION ?= $(shell v=$$(git tag -l 'network-discovery/v[0-9]*' | sed 's|.*/v||' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' | sort -V | tail -1); echo $${v:-0.0.0})
-SD_VERSION ?= $(shell v=$$(git tag -l 'snmp-discovery/v[0-9]*' | sed 's|.*/v||' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' | sort -V | tail -1); echo $${v:-0.0.0})
-DD_VERSION ?= $(shell v=$$(git tag -l 'device-discovery/v[0-9]*' | sed 's|.*/v||' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' | sort -V | tail -1); echo $${v:-0.0.0})
-WK_VERSION ?= $(shell v=$$(git tag -l 'worker/v[0-9]*' | sed 's|.*/v||' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' | sort -V | tail -1); echo $${v:-0.0.0})
+# without these the from-source backends report 0.0.0. List the tags rather than
+# `git describe` so the result does not depend on the tag being reachable from
+# HEAD (backend tags are cut on the `release` branch), matching how the CI
+# workflows resolve versions. The grep keeps only released X.Y.Z tags, so the
+# dot-field numeric sort below is equivalent to `sort -V` but portable to the
+# BSD `sort` on contributor macOS machines (which lacks GNU's -V).
+ND_VERSION ?= $(shell v=$$(git tag -l 'network-discovery/v[0-9]*' | sed 's|.*/v||' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1); echo $${v:-0.0.0})
+SD_VERSION ?= $(shell v=$$(git tag -l 'snmp-discovery/v[0-9]*' | sed 's|.*/v||' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1); echo $${v:-0.0.0})
+DD_VERSION ?= $(shell v=$$(git tag -l 'device-discovery/v[0-9]*' | sed 's|.*/v||' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1); echo $${v:-0.0.0})
+WK_VERSION ?= $(shell v=$$(git tag -l 'worker/v[0-9]*' | sed 's|.*/v||' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1); echo $${v:-0.0.0})
 BACKEND_VERSION_ARGS = --build-arg NETWORK_DISCOVERY_VERSION=$(ND_VERSION) --build-arg SNMP_DISCOVERY_VERSION=$(SD_VERSION) --build-arg DEVICE_DISCOVERY_VERSION=$(DD_VERSION) --build-arg WORKER_VERSION=$(WK_VERSION) --build-arg BUILD_COMMIT=$(COMMIT_HASH) --build-arg BUILD_TRACK=$(COMMIT_BRANCH)
 
 # Make targets operate on the agent (a single module), so never use a local

--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -33,9 +33,14 @@ WORKDIR /src/network-discovery
 COPY orb-discovery/network-discovery/ .
 
 ARG TARGETOS TARGETARCH
+# Stamp the backend version: its version package go:embeds version/BUILD_*.txt.
+ARG NETWORK_DISCOVERY_VERSION=0.0.0
+ARG BUILD_COMMIT=unknown
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
+    echo "${NETWORK_DISCOVERY_VERSION}" > version/BUILD_VERSION.txt && \
+    echo "${BUILD_COMMIT}" > version/BUILD_COMMIT.txt && \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -ldflags="-s -w" -trimpath -o /usr/local/bin/network-discovery ./cmd/main.go
 
@@ -47,9 +52,14 @@ WORKDIR /src/snmp-discovery
 COPY orb-discovery/snmp-discovery/ .
 
 ARG TARGETOS TARGETARCH
+# Stamp the backend version: its version package go:embeds version/BUILD_*.txt.
+ARG SNMP_DISCOVERY_VERSION=0.0.0
+ARG BUILD_COMMIT=unknown
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
+    echo "${SNMP_DISCOVERY_VERSION}" > version/BUILD_VERSION.txt && \
+    echo "${BUILD_COMMIT}" > version/BUILD_COMMIT.txt && \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -ldflags="-s -w" -trimpath -o /usr/local/bin/snmp-discovery ./cmd/main.go
 
@@ -66,8 +76,20 @@ RUN python -m pip install --upgrade --no-cache-dir pip==26.1 && \
 # Install the Python backends from in-repo source (was: published PyPI packages
 # netboxlabs-device-discovery / netboxlabs-orb-worker). Console scripts
 # device-discovery and orb-worker land in /usr/local/bin.
+# Stamp backend versions into version.py (the release pipeline does this via sed;
+# mirror it so the from-source build reports real versions, not 0.0.0).
+ARG DEVICE_DISCOVERY_VERSION=0.0.0
+ARG WORKER_VERSION=0.0.0
+ARG BUILD_COMMIT=unknown
+ARG BUILD_TRACK=dev
+
 COPY orb-discovery/device-discovery/ /src/device-discovery/
 COPY orb-discovery/worker/ /src/worker/
+COPY agent/docker/stamp_version.py /tmp/stamp_version.py
+RUN BUILD_COMMIT="${BUILD_COMMIT}" BUILD_TRACK="${BUILD_TRACK}" \
+      python /tmp/stamp_version.py "${DEVICE_DISCOVERY_VERSION}" /src/device-discovery/device_discovery/version.py && \
+    BUILD_COMMIT="${BUILD_COMMIT}" BUILD_TRACK="${BUILD_TRACK}" \
+      python /tmp/stamp_version.py "${WORKER_VERSION}" /src/worker/worker/version.py
 RUN pip3 install --no-cache-dir /src/device-discovery /src/worker
 
 ########################################################################

--- a/agent/docker/stamp_version.py
+++ b/agent/docker/stamp_version.py
@@ -13,6 +13,9 @@ import os
 import re
 import sys
 
+if len(sys.argv) != 3:
+    sys.exit(f"usage: {sys.argv[0]} <version> <path/to/version.py>")
+
 version, path = sys.argv[1], sys.argv[2]
 fields = {
     "__version__": version,
@@ -22,12 +25,16 @@ fields = {
 
 with open(path) as f:
     text = f.read()
+# Fail fast if an expected assignment isn't found: a silent no-op would let the
+# image ship with the 0.0.0/unknown defaults this script exists to replace.
 for name, value in fields.items():
-    text = re.sub(
+    text, replaced = re.subn(
         rf"(?m)^{name} = .*$",
-        lambda m, v=value, n=name: f"{n} = {v!r}",
+        lambda m, v=value, key=name: f"{key} = {v!r}",
         text,
         count=1,
     )
+    if replaced != 1:
+        sys.exit(f"{path}: expected to stamp '{name}' exactly once, matched {replaced}")
 with open(path, "w") as f:
     f.write(text)

--- a/agent/docker/stamp_version.py
+++ b/agent/docker/stamp_version.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+"""Stamp build metadata into a backend's version.py.
+
+Usage: stamp_version.py <version> <path/to/version.py>
+
+Reads BUILD_COMMIT and BUILD_TRACK from the environment and the version from the
+first argument, then rewrites the __version__/__commit_hash__/__track__ module
+assignments in the target file. Done in Python rather than sed so that a value
+containing characters significant to sed (e.g. a '/' in a local branch-name
+track) cannot corrupt the substitution.
+"""
+import os
+import re
+import sys
+
+version, path = sys.argv[1], sys.argv[2]
+fields = {
+    "__version__": version,
+    "__commit_hash__": os.environ.get("BUILD_COMMIT", "unknown"),
+    "__track__": os.environ.get("BUILD_TRACK", "dev"),
+}
+
+with open(path) as f:
+    text = f.read()
+for name, value in fields.items():
+    text = re.sub(
+        rf"(?m)^{name} = .*$",
+        lambda m, v=value, n=name: f"{n} = {v!r}",
+        text,
+        count=1,
+    )
+with open(path, "w") as f:
+    f.write(text)

--- a/agent/docker/stamp_version.py
+++ b/agent/docker/stamp_version.py
@@ -25,14 +25,15 @@ fields = {
 
 with open(path) as f:
     text = f.read()
-# Fail fast if an expected assignment isn't found: a silent no-op would let the
-# image ship with the 0.0.0/unknown defaults this script exists to replace.
+# Enforce exactly one matching assignment per field: a no-op (0) would let the
+# image ship with the 0.0.0/unknown defaults this script exists to replace, and
+# duplicates (2+) are ambiguous about which value wins — fail fast on either.
+# (No count limit, so duplicates are actually counted rather than capped at 1.)
 for name, value in fields.items():
     text, replaced = re.subn(
-        rf"(?m)^{name} = .*$",
+        rf"(?m)^{re.escape(name)} = .*$",
         lambda m, v=value, key=name: f"{key} = {v!r}",
         text,
-        count=1,
     )
     if replaced != 1:
         sys.exit(f"{path}: expected to stamp '{name}' exactly once, matched {replaced}")


### PR DESCRIPTION
## Problem

The from-source agent image rebuilds each discovery backend from `orb-discovery/` source, but nothing stamped their build metadata — so every backend reported `version: 0.0.0`. This is a **regression** vs. the previous published-image builds, and it shows up both in the CI pipeline and in local `make agent*` builds.

## Fix

Resolve the latest **released** version per backend (highest `<backend>/vX.Y.Z` tag, pre-releases excluded) at the top of **every** image-build entry point and pass them as Docker build-args:

| Entry point | Version source | `BUILD_TRACK` |
|---|---|---|
| `develop.yaml` / `build.yaml` | `git ls-remote --tags` → `grep '^X.Y.Z$'` → `sort -V` (reachability-independent, no release-API pagination) | `develop` |
| `release.yaml` | same as above | `release` |
| `Makefile` (`make agent*`) | `git tag -l '<backend>/v[0-9]*'` → `grep '^X.Y.Z$'` → portable `sort -t. -k1,1n -k2,2n -k3,3n` | current branch |

Notes on the resolution logic:
- In the workflows, `git ls-remote` runs on its own line so a transient transport/auth failure aborts the step (errexit) instead of being masked by the trailing `tail -1` and silently falling back to `0.0.0`. A genuine zero-match (no tags yet) still falls back gracefully.
- The `grep '^[0-9]+\.[0-9]+\.[0-9]+$'` filter keeps only released versions, mirroring the agent's own version line (`sort -V` would otherwise rank `1.18.0-rc1` above `1.18.0`).
- The Makefile lists tags (rather than `git describe`) so resolution does not depend on the tag being reachable from `HEAD` — backend tags are cut on the `release` branch. Because the `grep` guarantees pure `X.Y.Z`, the dot-field numeric sort is equivalent to `sort -V` but portable to the BSD `sort` on contributor macOS machines.

**Dockerfile** consumes the args:
- **Go backends** (network/snmp): write `version/BUILD_{VERSION,COMMIT}.txt` before `go build` so the `//go:embed` picks them up.
- **Python backends** (device-discovery/worker): stamp `version.py` via a small Python helper (`agent/docker/stamp_version.py`) instead of `sed`. The helper validates its arguments and fails the build if any expected assignment is not matched exactly once, so format drift cannot silently re-ship the `0.0.0`/`unknown` defaults it exists to replace.

### Why a Python helper instead of `sed`

A track containing `/` (e.g. a local branch name like `fix/backend-version-injection`) collided with `sed`'s `/` delimiter — `sed: bad option in substitution expression` — **failing the build entirely**, which is worse than reporting `0.0.0`. The helper passes values through the environment and rewrites the assignments in Python, so any character significant to `sed` (`/`, `&`, `\`, …) is handled safely. It lives only in the `python-builder` stage and never reaches the final image.

## Verification

End-to-end via `make agent_fast`, inspecting the built image:

- `orb-worker -V` → **1.16.0**
- `device-discovery --version` → **1.30.1**
- `network-discovery` embedded → **1.18.0**
- `snmp-discovery` embedded → **1.33.0**

Other checks:
- All 3 workflows validate as YAML and their "Set build info" scripts pass `bash -n`; running `develop.yaml`'s script against the repo under `bash -e` resolves the four versions above.
- `make -n agent` resolves the same versions, including with a stock `/usr/bin:/bin` `PATH` (no GNU coreutils), confirming the portable sort.
- `stamp_version.py` was exercised manually during development for the positive, format-drift (exits non-zero), and bad-argv (exits non-zero) cases. In the build its contract is enforced by the fail-fast guard — a failed substitution fails the build. There is no standalone unit-test suite for this build helper in the repo, and no CI job currently runs Python tests for `agent/docker/`.
- The Go backends' `version_test.go` still asserts `0.0.0` against unchanged source (the source defaults are only overwritten inside the image build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
