### PR TITLE
feat(snmp-discovery): serialize diode ingest via queued client

### DIFF
--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -76,6 +77,36 @@ func Register() bool {
 	return true
 }
 
+func parseIngestBufferSize(v any) (int, error) {
+	var n int
+
+	switch val := v.(type) {
+	case int:
+		n = val
+	case int64:
+		n = int(val)
+	case float64:
+		if val != float64(int64(val)) {
+			return 0, fmt.Errorf("ingest_buffer_size must be a whole number, got %v", val)
+		}
+		n = int(val)
+	case string:
+		parsed, err := strconv.Atoi(val)
+		if err != nil {
+			return 0, fmt.Errorf("ingest_buffer_size: invalid integer %q: %w", val, err)
+		}
+		n = parsed
+	default:
+		return 0, fmt.Errorf("ingest_buffer_size must be an integer, got %T", v)
+	}
+
+	if n < 1 {
+		return 0, fmt.Errorf("ingest_buffer_size must be >= 1, got %d", n)
+	}
+
+	return n, nil
+}
+
 func (d *snmpDiscoveryBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	config map[string]any, common config.BackendCommons, _ filesmgr.Manager,
 ) error {
@@ -95,12 +126,11 @@ func (d *snmpDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Poli
 
 	d.ingestBufferSize = defaultIngestBufferSize
 	if v, prs := config["ingest_buffer_size"]; prs {
-		switch n := v.(type) {
-		case int:
-			d.ingestBufferSize = n
-		case float64:
-			d.ingestBufferSize = int(n)
+		size, err := parseIngestBufferSize(v)
+		if err != nil {
+			return fmt.Errorf("snmp_discovery: %w", err)
 		}
+		d.ingestBufferSize = size
 	}
 
 	d.diodeTarget = common.Diode.Target

--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -33,7 +33,7 @@ const (
 	defaultExec             = "snmp-discovery"
 	defaultAPIHost          = "localhost"
 	defaultAPIPort          = "8070"
-	defaultIngestBufferSize = 256
+	defaultIngestBufferSize = 512
 )
 
 type snmpDiscoveryBackend struct {

--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -23,16 +23,16 @@ import (
 var _ backend.Backend = (*snmpDiscoveryBackend)(nil)
 
 const (
-	versionTimeout      = 2
-	capabilitiesTimeout = 5
-	readinessBackoff    = 10
-	applyPolicyTimeout  = 10
-	removePolicyTimeout = 20
-	statusTimeout       = 5
-	defaultExec              = "snmp-discovery"
-	defaultAPIHost           = "localhost"
-	defaultAPIPort           = "8070"
-	defaultIngestBufferSize  = 256
+	versionTimeout          = 2
+	capabilitiesTimeout     = 5
+	readinessBackoff        = 10
+	applyPolicyTimeout      = 10
+	removePolicyTimeout     = 20
+	statusTimeout           = 5
+	defaultExec             = "snmp-discovery"
+	defaultAPIHost          = "localhost"
+	defaultAPIPort          = "8070"
+	defaultIngestBufferSize = 256
 )
 
 type snmpDiscoveryBackend struct {

--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -29,9 +29,10 @@ const (
 	applyPolicyTimeout  = 10
 	removePolicyTimeout = 20
 	statusTimeout       = 5
-	defaultExec         = "snmp-discovery"
-	defaultAPIHost      = "localhost"
-	defaultAPIPort      = "8070"
+	defaultExec              = "snmp-discovery"
+	defaultAPIHost           = "localhost"
+	defaultAPIPort           = "8070"
+	defaultIngestBufferSize  = 256
 )
 
 type snmpDiscoveryBackend struct {
@@ -52,6 +53,7 @@ type snmpDiscoveryBackend struct {
 	diodeDryRun          bool
 	diodeDryRunOutputDir string
 	diodeLogLevel        string
+	ingestBufferSize     int
 
 	startTime  time.Time
 	proc       backend.Commander
@@ -89,6 +91,16 @@ func (d *snmpDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Poli
 		d.apiPort = fmt.Sprintf("%v", port)
 	} else {
 		d.apiPort = defaultAPIPort
+	}
+
+	d.ingestBufferSize = defaultIngestBufferSize
+	if v, prs := config["ingest_buffer_size"]; prs {
+		switch n := v.(type) {
+		case int:
+			d.ingestBufferSize = n
+		case float64:
+			d.ingestBufferSize = int(n)
+		}
 	}
 
 	d.diodeTarget = common.Diode.Target
@@ -157,6 +169,7 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 		"--diode-app-name-prefix", d.diodeAppNamePrefix,
 		"--host", d.apiHost,
 		"--port", d.apiPort,
+		"--ingest-buffer-size", fmt.Sprintf("%d", d.ingestBufferSize),
 	}
 	if d.diodeDryRun {
 		dOptions = append([]string{

--- a/agent/backend/snmpdiscovery/snmp_discovery_test.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery_test.go
@@ -3,6 +3,7 @@ package snmpdiscovery_test
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -305,6 +306,45 @@ func TestSnmpDiscoveryBackendStartWithIngestBufferSize(t *testing.T) {
 	require.NoError(t, be.Stop(ctx))
 
 	mockCmd.AssertExpectations(t)
+}
+
+func TestSnmpDiscoveryBackendConfigureIngestBufferSize(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	assert.True(t, snmpdiscovery.Register())
+	be := backend.GetBackend("snmp_discovery")
+
+	tests := []struct {
+		name    string
+		value   any
+		wantErr string
+	}{
+		{name: "int", value: 128},
+		{name: "int64", value: int64(128)},
+		{name: "float64", value: float64(128)},
+		{name: "string", value: "128"},
+		{name: "zero", value: 0, wantErr: "must be >= 1"},
+		{name: "negative", value: -1, wantErr: "must be >= 1"},
+		{name: "non-integer float", value: 128.5, wantErr: "whole number"},
+		{name: "invalid string", value: "abc", wantErr: "invalid integer"},
+		{name: "unsupported type", value: true, wantErr: "must be an integer"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := be.Configure(logger, repo, map[string]any{
+				"ingest_buffer_size": tt.value,
+			}, config.BackendCommons{}, nil)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestSnmpDiscoveryBackendStartWithDryRunIncludesHostAndPort(t *testing.T) {

--- a/agent/backend/snmpdiscovery/snmp_discovery_test.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery_test.go
@@ -255,6 +255,58 @@ func TestSnmpDiscoveryBackendCompleted(t *testing.T) {
 	mockCmd.AssertExpectations(t)
 }
 
+func TestSnmpDiscoveryBackendStartWithIngestBufferSize(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/status" {
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(StatusResponse{Version: "1.0.0"}))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	createExecutable(t, "snmp-discovery")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 12348)
+
+	overrideNewCmdOptions(t, mockCmd, func(_ backend.CmdOptions, name string, args []string) {
+		assert.Equal(t, "snmp-discovery", name)
+		assert.Contains(t, args, "--ingest-buffer-size")
+		assert.Contains(t, args, "512")
+	})
+
+	assert.True(t, snmpdiscovery.Register())
+	assert.True(t, backend.HaveBackend("snmp_discovery"))
+
+	be := backend.GetBackend("snmp_discovery")
+
+	err = be.Configure(logger, repo, map[string]any{
+		"host":               serverURL.Hostname(),
+		"port":               serverURL.Port(),
+		"ingest_buffer_size": 512,
+	}, config.BackendCommons{}, nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, be.Start(ctx, cancel))
+	require.NoError(t, be.Stop(ctx))
+
+	mockCmd.AssertExpectations(t)
+}
+
 func TestSnmpDiscoveryBackendStartWithDryRunIncludesHostAndPort(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/docs/backends/snmp_discovery/README.md
+++ b/docs/backends/snmp_discovery/README.md
@@ -31,19 +31,29 @@ When a device exposes the relevant MIBs, interfaces also carry their switching c
 Note: when a switchport is converted to a routed (L3) interface between discovery cycles, prior `mode`/untagged-VLAN/tagged-VLAN associations are NOT automatically cleared in NetBox; operators must clear them manually. This is a current limitation of the Diode plugin's PATCH semantics and is tracked separately. The same caveat applies on device-discovery.
 
 ## Configuration
-The `snmp_discovery` backend does not require any special configuration in the backends section. The backend will use the `diode` settings specified in the `common` subsection to forward discovery results.
+The `snmp_discovery` backend uses the `diode` settings specified in the `common` subsection to forward discovery results. Optional backend-level settings tune ingest throughput and memory use (see [Backend](#backend) below). Per-policy behavior is configured separately under [Policy](#policy).
 
 ```yaml
 orb:
   backends:
+    snmp_discovery:
+      ingest_buffer_size: 512
     common:
       diode:
         target: grpc://127.0.0.1:8080/diode
         client_id: ${DIODE_CLIENT_ID}
         client_secret: ${DIODE_CLIENT_SECRET}
         agent_name: agent01
-    snmp_discovery:
 ```
+
+### Backend
+Backend-level settings apply to the `snmp_discovery` process as a whole (distinct from per-policy `config`).
+
+| Parameter | Type | Required | Description |
+|:---------:|:----:|:--------:|:-----------:|
+| ingest_buffer_size | integer | no | Capacity of the buffered queue that serializes Diode ingest calls. Defaults to `256`. |
+
+Diode ingest runs through a single-consumer queue so concurrent crawl jobs finishing at once do not trigger concurrent OAuth token refresh storms. Increase `ingest_buffer_size` when large subnet bursts may enqueue many payloads before the consumer drains them; decrease it if memory is a concern — each queued request retains its entity payload until processed.
 
 ## Policy
 SNMP discovery policies are broken down into two subsections: `config` and `scope`.

--- a/docs/backends/snmp_discovery/README.md
+++ b/docs/backends/snmp_discovery/README.md
@@ -51,7 +51,7 @@ Backend-level settings apply to the `snmp_discovery` process as a whole (distinc
 
 | Parameter | Type | Required | Description |
 |:---------:|:----:|:--------:|:-----------:|
-| ingest_buffer_size | integer | no | Capacity of the buffered queue that serializes Diode ingest calls. Defaults to `256`. |
+| ingest_buffer_size | integer | no | Capacity of the buffered queue that serializes Diode ingest calls. Defaults to `512`. |
 
 Diode ingest runs through a single-consumer queue so concurrent crawl jobs finishing at once do not trigger concurrent OAuth token refresh storms. Increase `ingest_buffer_size` when large subnet bursts may enqueue many payloads before the consumer drains them; decrease it if memory is a concern — each queued request retains its entity payload until processed.
 

--- a/docs/config_samples.md
+++ b/docs/config_samples.md
@@ -469,7 +469,7 @@ orb:
         client_secret: ${DIODE_CLIENT_SECRET}
         agent_name: agent01
     snmp_discovery:
-      # Serializes Diode ingest through a buffered queue (default 256).
+      # Serializes Diode ingest through a buffered queue (default 512).
       # Increase for large subnet bursts; decrease if memory is a concern.
       ingest_buffer_size: 512
   policies:

--- a/docs/config_samples.md
+++ b/docs/config_samples.md
@@ -469,6 +469,9 @@ orb:
         client_secret: ${DIODE_CLIENT_SECRET}
         agent_name: agent01
     snmp_discovery:
+      # Serializes Diode ingest through a buffered queue (default 256).
+      # Increase for large subnet bursts; decrease if memory is a concern.
+      ingest_buffer_size: 512
   policies:
     snmp_discovery:
       snmp_network_1:

--- a/orb-discovery/snmp-discovery/Makefile
+++ b/orb-discovery/snmp-discovery/Makefile
@@ -43,3 +43,22 @@ test-coverage:
 .PHONY: test
 test:
 	@go test -race ./...
+
+# Integration tests against orb-test-lab SNMP simulators (172.28.0.20–22, .24).
+# Requires: `make up` in eng-observability-skunkworks/orb-test-lab.
+# Runs inside Docker on the orb-test-lab network so simulators are reachable.
+INTEGRATION_GO_IMAGE ?= golang:1.26.4
+.PHONY: test-integration test-integration-local
+test-integration:
+	@if ! docker network inspect orb-test-lab >/dev/null 2>&1; then \
+		echo "orb-test-lab network not found; start the lab: cd ../../../eng-observability-skunkworks/orb-test-lab && make up"; \
+		exit 1; \
+	fi
+	docker run --rm --network orb-test-lab \
+		-v "$(CURDIR):/work" -w /work \
+		-e CGO_ENABLED=0 \
+		$(INTEGRATION_GO_IMAGE) \
+		go test -tags=integration -timeout=8m -count=1 -v ./e2e/...
+
+test-integration-local:
+	go test -tags=integration -timeout=8m -count=1 -v ./e2e/...

--- a/orb-discovery/snmp-discovery/cmd/main.go
+++ b/orb-discovery/snmp-discovery/cmd/main.go
@@ -94,6 +94,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Wrap the real diode client so concurrent crawl jobs serialize ingest through
+	// a single consumer, avoiding OAuth re-auth storms.
 	client, err = ingest.NewQueuedClient(client, *ingestBufferSize, logger)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error creating ingest queue client: %v\n", err)
@@ -101,10 +103,10 @@ func main() {
 	}
 	logger.Info("ingest queue configured", "buffer_size", *ingestBufferSize)
 
-	ctx := context.Background()
+	rootCtx, cancelFunc := context.WithCancel(context.Background())
 
 	if otelEndpoint != nil && *otelEndpoint != "" {
-		if err := metrics.SetupMetricsExport(ctx, logger, *otelEndpoint, *otelExportPeriod); err != nil {
+		if err := metrics.SetupMetricsExport(rootCtx, logger, *otelEndpoint, *otelExportPeriod); err != nil {
 			logger.Error("failed to setup metrics export", "error", err)
 			os.Exit(1)
 		}
@@ -117,7 +119,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	policyManager, err := policy.NewManager(ctx, logger, client, manufacturers)
+	policyManager, err := policy.NewManager(rootCtx, logger, client, manufacturers)
 	if err != nil {
 		logger.Error("failed to create policy manager", "error", err)
 		os.Exit(1)
@@ -126,7 +128,6 @@ func main() {
 
 	// handle signals
 	done := make(chan bool, 1)
-	rootCtx, cancelFunc := context.WithCancel(context.Background())
 
 	go func() {
 		sigs := make(chan os.Signal, 1)
@@ -136,14 +137,15 @@ func main() {
 			case <-sigs:
 				logger.Warn("stop signal received, stopping snmp-discovery")
 				server.Stop()
-				// Shutdown metrics
-				if err := metrics.Shutdown(ctx); err != nil {
+				// Cancel policy/runner context before closing the ingest queue so
+				// in-flight Diode calls can abort instead of blocking shutdown.
+				cancelFunc()
+				if err := metrics.Shutdown(rootCtx); err != nil {
 					logger.Error("failed to shutdown metrics", "error", err)
 				}
 				if err := client.Close(); err != nil {
 					logger.Error("failed to close ingest client", "error", err)
 				}
-				cancelFunc()
 			case <-rootCtx.Done():
 				logger.Warn("main context cancelled")
 				done <- true
@@ -158,13 +160,13 @@ func main() {
 		if err, ok := <-serverErrCh; ok && err != nil {
 			logger.Error("snmp-discovery server encountered an error", "error", err)
 			server.Stop()
-			if shutdownErr := metrics.Shutdown(ctx); shutdownErr != nil {
+			cancelFunc()
+			if shutdownErr := metrics.Shutdown(rootCtx); shutdownErr != nil {
 				logger.Error("failed to shutdown metrics", "error", shutdownErr)
 			}
 			if closeErr := client.Close(); closeErr != nil {
 				logger.Error("failed to close ingest client", "error", closeErr)
 			}
-			cancelFunc()
 		}
 	}()
 

--- a/orb-discovery/snmp-discovery/cmd/main.go
+++ b/orb-discovery/snmp-discovery/cmd/main.go
@@ -43,7 +43,7 @@ func main() {
 	otelEndpoint := flag.String("otel-endpoint", "", "OpenTelemetry exporter endpoint (e.g. localhost:4317)."+
 		" Environment variable can be used by wrapping it in ${} (e.g. ${OTEL_ENDPOINT})")
 	otelExportPeriod := flag.Int("otel-export-period", 10, "Period in seconds between OpenTelemetry exports")
-	ingestBufferSize := flag.Int("ingest-buffer-size", 256, "buffer size for the ingest queue")
+	ingestBufferSize := flag.Int("ingest-buffer-size", 512, "buffer size for the ingest queue")
 
 	flag.Parse()
 

--- a/orb-discovery/snmp-discovery/cmd/main.go
+++ b/orb-discovery/snmp-discovery/cmd/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/data"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/env"
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/ingest"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/metrics"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/policy"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/server"
@@ -42,6 +43,7 @@ func main() {
 	otelEndpoint := flag.String("otel-endpoint", "", "OpenTelemetry exporter endpoint (e.g. localhost:4317)."+
 		" Environment variable can be used by wrapping it in ${} (e.g. ${OTEL_ENDPOINT})")
 	otelExportPeriod := flag.Int("otel-export-period", 10, "Period in seconds between OpenTelemetry exports")
+	ingestBufferSize := flag.Int("ingest-buffer-size", 256, "buffer size for the ingest queue")
 
 	flag.Parse()
 
@@ -92,6 +94,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	client, err = ingest.NewQueuedClient(client, *ingestBufferSize, logger)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error creating ingest queue client: %v\n", err)
+		os.Exit(1)
+	}
+	logger.Info("ingest queue configured", "buffer_size", *ingestBufferSize)
+
 	ctx := context.Background()
 
 	if otelEndpoint != nil && *otelEndpoint != "" {
@@ -131,6 +140,9 @@ func main() {
 				if err := metrics.Shutdown(ctx); err != nil {
 					logger.Error("failed to shutdown metrics", "error", err)
 				}
+				if err := client.Close(); err != nil {
+					logger.Error("failed to close ingest client", "error", err)
+				}
 				cancelFunc()
 			case <-rootCtx.Done():
 				logger.Warn("main context cancelled")
@@ -148,6 +160,9 @@ func main() {
 			server.Stop()
 			if shutdownErr := metrics.Shutdown(ctx); shutdownErr != nil {
 				logger.Error("failed to shutdown metrics", "error", shutdownErr)
+			}
+			if closeErr := client.Close(); closeErr != nil {
+				logger.Error("failed to close ingest client", "error", closeErr)
 			}
 			cancelFunc()
 		}

--- a/orb-discovery/snmp-discovery/cmd/main.go
+++ b/orb-discovery/snmp-discovery/cmd/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
 
@@ -126,6 +127,21 @@ func main() {
 	}
 	server := server.NewServer(*host, *port, logger, policyManager, version.GetBuildVersion())
 
+	shutdown := func() {
+		// Cancel policy/runner context before stopping jobs so in-flight Diode
+		// ingests abort promptly instead of waiting for scheduler stop timeouts.
+		cancelFunc()
+		server.Stop()
+		metricsCtx, metricsCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer metricsCancel()
+		if err := metrics.Shutdown(metricsCtx); err != nil {
+			logger.Error("failed to shutdown metrics", "error", err)
+		}
+		if err := client.Close(); err != nil {
+			logger.Error("failed to close ingest client", "error", err)
+		}
+	}
+
 	// handle signals
 	done := make(chan bool, 1)
 
@@ -136,16 +152,7 @@ func main() {
 			select {
 			case <-sigs:
 				logger.Warn("stop signal received, stopping snmp-discovery")
-				server.Stop()
-				// Cancel policy/runner context before closing the ingest queue so
-				// in-flight Diode calls can abort instead of blocking shutdown.
-				cancelFunc()
-				if err := metrics.Shutdown(rootCtx); err != nil {
-					logger.Error("failed to shutdown metrics", "error", err)
-				}
-				if err := client.Close(); err != nil {
-					logger.Error("failed to close ingest client", "error", err)
-				}
+				shutdown()
 			case <-rootCtx.Done():
 				logger.Warn("main context cancelled")
 				done <- true
@@ -159,14 +166,7 @@ func main() {
 	go func() {
 		if err, ok := <-serverErrCh; ok && err != nil {
 			logger.Error("snmp-discovery server encountered an error", "error", err)
-			server.Stop()
-			cancelFunc()
-			if shutdownErr := metrics.Shutdown(rootCtx); shutdownErr != nil {
-				logger.Error("failed to shutdown metrics", "error", shutdownErr)
-			}
-			if closeErr := client.Close(); closeErr != nil {
-				logger.Error("failed to close ingest client", "error", closeErr)
-			}
+			shutdown()
 		}
 	}()
 

--- a/orb-discovery/snmp-discovery/e2e/orb_test_lab_test.go
+++ b/orb-discovery/snmp-discovery/e2e/orb_test_lab_test.go
@@ -1,0 +1,320 @@
+//go:build integration
+
+package e2e_test
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed testdata/orb-test-lab-policy.yaml
+var orbTestLabPolicyYAML []byte
+
+const orbTestLabPolicyName = "orb-test-lab-snmp"
+
+var defaultSNMPHosts = []string{
+	"172.28.0.20", // cisco-c2960x-snmp
+	"172.28.0.21", // cisco-ios-snmp
+	"172.28.0.22", // juniper-junos-snmp
+	"172.28.0.24", // cisco-csr1000v
+	// 172.28.0.23 (juniper-ex-snmp) omitted — malformed SNMP responses in current lab image
+}
+
+func TestOrbTestLab_DryRunMultiTargetCrawl(t *testing.T) {
+	hosts := snmpHostsFromEnv()
+	requireLabReachable(t, hosts[0])
+
+	bin := snmpDiscoveryBinary(t)
+	dryRunDir := t.TempDir()
+	port := freePort(t)
+
+	proc := startSNMPDiscovery(t, bin, dryRunDir, port)
+	waitHTTPReady(t, fmt.Sprintf("http://127.0.0.1:%d/api/v1/status", port))
+
+	resp, err := http.Post(
+		fmt.Sprintf("http://127.0.0.1:%d/api/v1/policies", port),
+		"application/x-yaml",
+		bytes.NewReader(orbTestLabPolicyYAML),
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusCreated, resp.StatusCode, readBody(resp.Body))
+
+	status := waitForPolicyCompleted(t, port, orbTestLabPolicyName, 4*time.Minute)
+	runs := status.Runs
+	require.NotEmpty(t, runs, "expected crawl runs for orb-test-lab policy")
+
+	hostsWithEntities := 0
+	totalEntities := 0
+	for _, run := range runs {
+		if run.Status != "completed" || run.EntityCount == 0 {
+			continue
+		}
+		hostsWithEntities++
+		totalEntities += run.EntityCount
+	}
+	require.Greater(t, hostsWithEntities, 0, "at least one lab target should produce entities")
+	assert.Equal(t, len(defaultSNMPHosts), hostsWithEntities,
+		"each policy target should produce entities (%d/%d)", hostsWithEntities, len(defaultSNMPHosts))
+
+	files := dryRunFiles(t, dryRunDir)
+	assert.GreaterOrEqual(t, len(files), hostsWithEntities,
+		"dry-run should write one JSON file per successful ingest")
+
+	devicesFound := 0
+	for _, path := range files {
+		entities, err := diode.LoadDryRunEntities(path)
+		require.NoError(t, err, "load dry-run file %s", path)
+		for _, ent := range entities {
+			if ent.GetDevice() != nil {
+				devicesFound++
+			}
+		}
+	}
+	assert.Greater(t, devicesFound, 0, "dry-run output should contain device entities")
+	assert.Greater(t, totalEntities, 0, "policy runs should report ingested entity counts")
+
+	// Exercise graceful shutdown while the process is still healthy.
+	shutdownDeadline := time.Now().Add(30 * time.Second)
+	require.NoError(t, proc.Process.Signal(syscall.SIGTERM))
+	waitProcessExit(t, proc, shutdownDeadline)
+}
+
+type policyStatus struct {
+	Name   string     `json:"name"`
+	Status string     `json:"status"`
+	Runs   []runStatus `json:"runs"`
+}
+
+type runStatus struct {
+	Status      string `json:"status"`
+	EntityCount int    `json:"entity_count"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+type statusResponse struct {
+	Policies []policyStatus `json:"policies"`
+}
+
+func snmpHostsFromEnv() []string {
+	raw := strings.TrimSpace(os.Getenv("ORB_TEST_LAB_SNMP_HOSTS"))
+	if raw == "" {
+		return append([]string(nil), defaultSNMPHosts...)
+	}
+	parts := strings.Split(raw, ",")
+	hosts := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if host := strings.TrimSpace(part); host != "" {
+			hosts = append(hosts, host)
+		}
+	}
+	if len(hosts) == 0 {
+		return append([]string(nil), defaultSNMPHosts...)
+	}
+	return hosts
+}
+
+func requireLabReachable(t *testing.T, host string) {
+	t.Helper()
+	if !snmpHostReachable(host) {
+		t.Skipf("orb-test-lab SNMP host %s is not reachable (start lab and run on orb-test-lab network)", host)
+	}
+}
+
+func snmpHostReachable(host string) bool {
+	client := gosnmp.GoSNMP{
+		Target:    host,
+		Port:      161,
+		Community: "public",
+		Version:   gosnmp.Version2c,
+		Timeout:   3 * time.Second,
+		Retries:   1,
+	}
+	if err := client.Connect(); err != nil {
+		return false
+	}
+	defer client.Conn.Close()
+
+	_, err := client.Get([]string{"1.3.6.1.2.1.1.1.0"})
+	return err == nil
+}
+
+func snmpDiscoveryBinary(t *testing.T) string {
+	t.Helper()
+	if bin := strings.TrimSpace(os.Getenv("SNMP_DISCOVERY_BIN")); bin != "" {
+		require.FileExists(t, bin)
+		return bin
+	}
+
+	moduleRoot := moduleRoot(t)
+	bin := filepath.Join(t.TempDir(), "snmp-discovery")
+	cmd := exec.Command("go", "build", "-o", bin, "./cmd/main.go")
+	cmd.Dir = moduleRoot
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "build snmp-discovery:\n%s", out)
+	return bin
+}
+
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	dir := wd
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not locate snmp-discovery module root")
+		}
+		dir = parent
+	}
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+func startSNMPDiscovery(t *testing.T, bin, dryRunDir string, port int) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command(
+		bin,
+		"-dry-run",
+		"-dry-run-output-dir", dryRunDir,
+		"-ingest-buffer-size", "512",
+		"-host", "127.0.0.1",
+		"-port", strconv.Itoa(port),
+		"-log-level", "WARN",
+	)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	require.NoError(t, cmd.Start())
+
+	t.Cleanup(func() {
+		if cmd.ProcessState != nil {
+			return
+		}
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+		waitProcessExit(t, cmd, time.Now().Add(30*time.Second))
+	})
+
+	return cmd
+}
+
+func waitHTTPReady(t *testing.T, url string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("server not ready at %s within 30s", url)
+}
+
+func waitForPolicyCompleted(t *testing.T, port int, policyName string, timeout time.Duration) policyStatus {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last policyStatus
+
+	for time.Now().Before(deadline) {
+		status, ok := fetchPolicyStatus(t, port, policyName)
+		if !ok {
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		last = status
+		if status.Status == "completed" {
+			return status
+		}
+		if status.Status == "failed" {
+			for _, run := range status.Runs {
+				if run.Status == "failed" {
+					t.Fatalf("policy %q failed: %s", policyName, run.Reason)
+				}
+			}
+			t.Fatalf("policy %q reported failed status", policyName)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	t.Fatalf("policy %q did not complete within %s (last status=%q runs=%d)", policyName, timeout, last.Status, len(last.Runs))
+	return last
+}
+
+func fetchPolicyStatus(t *testing.T, port int, policyName string) (policyStatus, bool) {
+	t.Helper()
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/api/v1/status", port))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body statusResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	for _, policy := range body.Policies {
+		if policy.Name == policyName {
+			return policy, true
+		}
+	}
+	return policyStatus{}, false
+}
+
+func dryRunFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "*.json"))
+	require.NoError(t, err)
+	return matches
+}
+
+func waitProcessExit(t *testing.T, cmd *exec.Cmd, deadline time.Time) {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			// SIGTERM is expected; only fail on unexpected wait errors.
+			if _, ok := err.(*exec.ExitError); !ok {
+				require.NoError(t, err)
+			}
+		}
+	case <-time.After(time.Until(deadline)):
+		_ = cmd.Process.Kill()
+		<-done
+		t.Fatal("snmp-discovery did not exit after SIGTERM")
+	}
+}
+
+func readBody(r io.Reader) string {
+	b, _ := io.ReadAll(r)
+	return string(b)
+}

--- a/orb-discovery/snmp-discovery/e2e/testdata/orb-test-lab-policy.yaml
+++ b/orb-discovery/snmp-discovery/e2e/testdata/orb-test-lab-policy.yaml
@@ -1,0 +1,18 @@
+# Policy exercised by e2e/orb_test_lab_test.go against orb-test-lab SNMP simulators.
+policies:
+  orb-test-lab-snmp:
+    config:
+      timeout: 300
+      snmp_timeout: 120
+      defaults:
+        site: orb-test-lab
+        role: switch
+    scope:
+      targets:
+        - host: "172.28.0.20"
+        - host: "172.28.0.21"
+        - host: "172.28.0.22"
+        - host: "172.28.0.24"
+      authentication:
+        protocol_version: "SNMPv2c"
+        community: "public"

--- a/orb-discovery/snmp-discovery/ingest/queued_client.go
+++ b/orb-discovery/snmp-discovery/ingest/queued_client.go
@@ -79,6 +79,7 @@ func (c *QueuedClient) execute(req *ingestRequest) {
 	select {
 	case req.result <- ingestResult{resp: resp, err: err}:
 	default:
+		c.logger.Warn("ingest result not delivered: caller no longer waiting")
 	}
 }
 
@@ -118,6 +119,7 @@ func (c *QueuedClient) deliverFailure(req *ingestRequest) {
 	select {
 	case req.result <- ingestResult{err: ErrIngestQueueClosed}:
 	default:
+		c.logger.Warn("ingest queue closed result not delivered: caller no longer waiting")
 	}
 }
 

--- a/orb-discovery/snmp-discovery/ingest/queued_client.go
+++ b/orb-discovery/snmp-discovery/ingest/queued_client.go
@@ -33,6 +33,7 @@ type QueuedClient struct {
 	logger     *slog.Logger
 	requests   chan *ingestRequest
 	shutdownCh chan struct{}
+	gate       sync.RWMutex
 	closeOnce  sync.Once
 	done       chan struct{}
 }
@@ -94,17 +95,25 @@ func (c *QueuedClient) enqueue(
 		result: make(chan ingestResult, 1),
 	}
 
+	// gate serializes enqueue with Close: Close holds the write lock while
+	// signaling shutdown and waiting for the consumer, so a closed shutdownCh
+	// cannot race with a buffered-channel send that would orphan the request.
+	c.gate.RLock()
 	select {
 	case <-c.shutdownCh:
+		c.gate.RUnlock()
 		return nil, ErrIngestQueueClosed
 	default:
 	}
 
 	select {
 	case c.requests <- req:
+		c.gate.RUnlock()
 	case <-ctx.Done():
+		c.gate.RUnlock()
 		return nil, ctx.Err()
 	case <-c.shutdownCh:
+		c.gate.RUnlock()
 		return nil, ErrIngestQueueClosed
 	}
 
@@ -113,6 +122,13 @@ func (c *QueuedClient) enqueue(
 		return res.resp, res.err
 	case <-ctx.Done():
 		return nil, ctx.Err()
+	case <-c.done:
+		select {
+		case res := <-req.result:
+			return res.resp, res.err
+		default:
+			return nil, ErrIngestQueueClosed
+		}
 	}
 }
 
@@ -163,9 +179,11 @@ func (c *QueuedClient) IngestProto(
 func (c *QueuedClient) Close() error {
 	var err error
 	c.closeOnce.Do(func() {
+		c.gate.Lock()
 		close(c.shutdownCh)
 		<-c.done
 		err = c.inner.Close()
+		c.gate.Unlock()
 	})
 	return err
 }

--- a/orb-discovery/snmp-discovery/ingest/queued_client.go
+++ b/orb-discovery/snmp-discovery/ingest/queued_client.go
@@ -59,14 +59,15 @@ func (c *QueuedClient) consumer() {
 
 	for {
 		select {
+		case <-c.shutdownCh:
+			c.drainPendingFailures()
+			return
+		default:
+		}
+
+		select {
 		case req := <-c.requests:
 			c.execute(req)
-			select {
-			case <-c.shutdownCh:
-				c.drainPendingFailures()
-				return
-			default:
-			}
 		case <-c.shutdownCh:
 			c.drainPendingFailures()
 			return
@@ -156,8 +157,9 @@ func (c *QueuedClient) IngestProto(
 	})
 }
 
-// Close stops accepting new work, fails pending queued requests, waits for the
-// consumer to exit, then closes the inner client. Close is idempotent.
+// Close stops accepting new work, fails buffered requests that have not started,
+// waits for any in-flight ingest and the consumer to exit, then closes the inner
+// client. Close is idempotent.
 func (c *QueuedClient) Close() error {
 	var err error
 	c.closeOnce.Do(func() {

--- a/orb-discovery/snmp-discovery/ingest/queued_client.go
+++ b/orb-discovery/snmp-discovery/ingest/queued_client.go
@@ -57,12 +57,28 @@ func NewQueuedClient(inner diode.Client, bufferSize int, logger *slog.Logger) (d
 func (c *QueuedClient) consumer() {
 	defer close(c.done)
 
-	for req := range c.requests {
-		resp, err := req.run(req.ctx)
+	for {
 		select {
-		case req.result <- ingestResult{resp: resp, err: err}:
-		default:
+		case req := <-c.requests:
+			c.execute(req)
+			select {
+			case <-c.shutdownCh:
+				c.drainPendingFailures()
+				return
+			default:
+			}
+		case <-c.shutdownCh:
+			c.drainPendingFailures()
+			return
 		}
+	}
+}
+
+func (c *QueuedClient) execute(req *ingestRequest) {
+	resp, err := req.run(req.ctx)
+	select {
+	case req.result <- ingestResult{resp: resp, err: err}:
+	default:
 	}
 }
 
@@ -105,6 +121,17 @@ func (c *QueuedClient) deliverFailure(req *ingestRequest) {
 	}
 }
 
+func (c *QueuedClient) drainPendingFailures() {
+	for {
+		select {
+		case req := <-c.requests:
+			c.deliverFailure(req)
+		default:
+			return
+		}
+	}
+}
+
 // Ingest enqueues an ingest request and blocks until it completes or ctx is cancelled.
 func (c *QueuedClient) Ingest(
 	ctx context.Context,
@@ -133,18 +160,8 @@ func (c *QueuedClient) Close() error {
 	var err error
 	c.closeOnce.Do(func() {
 		close(c.shutdownCh)
-
-		for {
-			select {
-			case req := <-c.requests:
-				c.deliverFailure(req)
-			default:
-				close(c.requests)
-				<-c.done
-				err = c.inner.Close()
-				return
-			}
-		}
+		<-c.done
+		err = c.inner.Close()
 	})
 	return err
 }

--- a/orb-discovery/snmp-discovery/ingest/queued_client.go
+++ b/orb-discovery/snmp-discovery/ingest/queued_client.go
@@ -33,7 +33,6 @@ type QueuedClient struct {
 	logger     *slog.Logger
 	requests   chan *ingestRequest
 	shutdownCh chan struct{}
-	gate       sync.RWMutex
 	closeOnce  sync.Once
 	done       chan struct{}
 }
@@ -59,20 +58,32 @@ func (c *QueuedClient) consumer() {
 	defer close(c.done)
 
 	for {
-		select {
-		case <-c.shutdownCh:
+		if c.shutdownSignaled() {
 			c.drainPendingFailures()
 			return
-		default:
 		}
 
 		select {
 		case req := <-c.requests:
+			if c.shutdownSignaled() {
+				c.deliverFailure(req)
+				c.drainPendingFailures()
+				return
+			}
 			c.execute(req)
 		case <-c.shutdownCh:
 			c.drainPendingFailures()
 			return
 		}
+	}
+}
+
+func (c *QueuedClient) shutdownSignaled() bool {
+	select {
+	case <-c.shutdownCh:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -95,25 +106,15 @@ func (c *QueuedClient) enqueue(
 		result: make(chan ingestResult, 1),
 	}
 
-	// gate serializes enqueue with Close: Close holds the write lock while
-	// signaling shutdown and waiting for the consumer, so a closed shutdownCh
-	// cannot race with a buffered-channel send that would orphan the request.
-	c.gate.RLock()
-	select {
-	case <-c.shutdownCh:
-		c.gate.RUnlock()
+	if c.shutdownSignaled() {
 		return nil, ErrIngestQueueClosed
-	default:
 	}
 
 	select {
 	case c.requests <- req:
-		c.gate.RUnlock()
 	case <-ctx.Done():
-		c.gate.RUnlock()
 		return nil, ctx.Err()
 	case <-c.shutdownCh:
-		c.gate.RUnlock()
 		return nil, ErrIngestQueueClosed
 	}
 
@@ -179,11 +180,9 @@ func (c *QueuedClient) IngestProto(
 func (c *QueuedClient) Close() error {
 	var err error
 	c.closeOnce.Do(func() {
-		c.gate.Lock()
 		close(c.shutdownCh)
 		<-c.done
 		err = c.inner.Close()
-		c.gate.Unlock()
 	})
 	return err
 }

--- a/orb-discovery/snmp-discovery/ingest/queued_client.go
+++ b/orb-discovery/snmp-discovery/ingest/queued_client.go
@@ -29,12 +29,14 @@ type ingestRequest struct {
 // QueuedClient serializes ingest calls to an inner diode.Client through a
 // buffered channel consumed by a single goroutine.
 type QueuedClient struct {
-	inner      diode.Client
-	logger     *slog.Logger
-	requests   chan *ingestRequest
+	inner    diode.Client
+	logger   *slog.Logger
+	requests chan *ingestRequest
+	// shutdownCh is closed (never written to) to broadcast shutdown to all waiters.
 	shutdownCh chan struct{}
 	closeOnce  sync.Once
-	done       chan struct{}
+	// done is closed by the consumer goroutine when it exits; Close waits on it.
+	done chan struct{}
 }
 
 // NewQueuedClient wraps inner with a buffered queue and single consumer goroutine.
@@ -58,6 +60,8 @@ func (c *QueuedClient) consumer() {
 	defer close(c.done)
 
 	for {
+		// Non-blocking check: Close may have run during execute() on the prior
+		// iteration. The select below handles shutdown while blocked for work.
 		if c.shutdownSignaled() {
 			c.drainPendingFailures()
 			return
@@ -65,6 +69,8 @@ func (c *QueuedClient) consumer() {
 
 		select {
 		case req := <-c.requests:
+			// Re-check after dequeue: shutdown may have started while the request
+			// sat in the buffer; fail it instead of executing after Close.
 			if c.shutdownSignaled() {
 				c.deliverFailure(req)
 				c.drainPendingFailures()
@@ -78,6 +84,9 @@ func (c *QueuedClient) consumer() {
 	}
 }
 
+// shutdownSignaled reports whether Close has started without blocking. Enqueue
+// and the consumer use this for fast-path checks; blocking waits still select
+// on shutdownCh directly so they wake as soon as Close closes the channel.
 func (c *QueuedClient) shutdownSignaled() bool {
 	select {
 	case <-c.shutdownCh:
@@ -106,6 +115,8 @@ func (c *QueuedClient) enqueue(
 		result: make(chan ingestResult, 1),
 	}
 
+	// Fast-path reject when shutdown already started; the select below handles
+	// the race where Close runs while we wait for queue space.
 	if c.shutdownSignaled() {
 		return nil, ErrIngestQueueClosed
 	}

--- a/orb-discovery/snmp-discovery/ingest/queued_client.go
+++ b/orb-discovery/snmp-discovery/ingest/queued_client.go
@@ -6,10 +6,18 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
 )
+
+// defaultIngestCallTimeout is applied when callers pass a context with no deadline.
+// Derived from Grafana production diode-ingester Ingest latency
+// (rpc_server_duration_milliseconds, 7d): p50 ~5ms, mean ~190ms, p99 ~938ms,
+// max histogram bucket 10s. Set to 3× the max bucket so hung calls fail instead
+// of blocking the single consumer indefinitely.
+const defaultIngestCallTimeout = 30 * time.Second
 
 // ErrIngestQueueClosed is returned when an ingest request cannot be enqueued
 // because the queued client is shutting down or has been closed.
@@ -29,9 +37,10 @@ type ingestRequest struct {
 // QueuedClient serializes ingest calls to an inner diode.Client through a
 // buffered channel consumed by a single goroutine.
 type QueuedClient struct {
-	inner    diode.Client
-	logger   *slog.Logger
-	requests chan *ingestRequest
+	inner       diode.Client
+	logger      *slog.Logger
+	requests    chan *ingestRequest
+	callTimeout time.Duration
 	// shutdownCh is closed (never written to) to broadcast shutdown to all waiters.
 	shutdownCh chan struct{}
 	closeOnce  sync.Once
@@ -46,11 +55,12 @@ func NewQueuedClient(inner diode.Client, bufferSize int, logger *slog.Logger) (d
 	}
 
 	c := &QueuedClient{
-		inner:      inner,
-		logger:     logger,
-		requests:   make(chan *ingestRequest, bufferSize),
-		shutdownCh: make(chan struct{}),
-		done:       make(chan struct{}),
+		inner:       inner,
+		logger:      logger,
+		requests:    make(chan *ingestRequest, bufferSize),
+		callTimeout: defaultIngestCallTimeout,
+		shutdownCh:  make(chan struct{}),
+		done:        make(chan struct{}),
 	}
 	go c.consumer()
 	return c, nil
@@ -97,7 +107,14 @@ func (c *QueuedClient) shutdownSignaled() bool {
 }
 
 func (c *QueuedClient) execute(req *ingestRequest) {
-	resp, err := req.run(req.ctx)
+	ctx := req.ctx
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.callTimeout)
+		defer cancel()
+	}
+
+	resp, err := req.run(ctx)
 	select {
 	case req.result <- ingestResult{resp: resp, err: err}:
 	default:

--- a/orb-discovery/snmp-discovery/ingest/queued_client.go
+++ b/orb-discovery/snmp-discovery/ingest/queued_client.go
@@ -1,0 +1,150 @@
+package ingest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
+)
+
+// ErrIngestQueueClosed is returned when an ingest request cannot be enqueued
+// because the queued client is shutting down or has been closed.
+var ErrIngestQueueClosed = errors.New("ingest queue closed")
+
+type ingestResult struct {
+	resp *diodepb.IngestResponse
+	err  error
+}
+
+type ingestRequest struct {
+	ctx    context.Context
+	run    func(context.Context) (*diodepb.IngestResponse, error)
+	result chan ingestResult
+}
+
+// QueuedClient serializes ingest calls to an inner diode.Client through a
+// buffered channel consumed by a single goroutine.
+type QueuedClient struct {
+	inner      diode.Client
+	logger     *slog.Logger
+	requests   chan *ingestRequest
+	shutdownCh chan struct{}
+	closeOnce  sync.Once
+	done       chan struct{}
+}
+
+// NewQueuedClient wraps inner with a buffered queue and single consumer goroutine.
+func NewQueuedClient(inner diode.Client, bufferSize int, logger *slog.Logger) (diode.Client, error) {
+	if bufferSize < 1 {
+		return nil, fmt.Errorf("ingest queue buffer size must be >= 1, got %d", bufferSize)
+	}
+
+	c := &QueuedClient{
+		inner:      inner,
+		logger:     logger,
+		requests:   make(chan *ingestRequest, bufferSize),
+		shutdownCh: make(chan struct{}),
+		done:       make(chan struct{}),
+	}
+	go c.consumer()
+	return c, nil
+}
+
+func (c *QueuedClient) consumer() {
+	defer close(c.done)
+
+	for req := range c.requests {
+		resp, err := req.run(req.ctx)
+		select {
+		case req.result <- ingestResult{resp: resp, err: err}:
+		default:
+		}
+	}
+}
+
+func (c *QueuedClient) enqueue(
+	ctx context.Context,
+	run func(context.Context) (*diodepb.IngestResponse, error),
+) (*diodepb.IngestResponse, error) {
+	req := &ingestRequest{
+		ctx:    ctx,
+		run:    run,
+		result: make(chan ingestResult, 1),
+	}
+
+	select {
+	case <-c.shutdownCh:
+		return nil, ErrIngestQueueClosed
+	default:
+	}
+
+	select {
+	case c.requests <- req:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-c.shutdownCh:
+		return nil, ErrIngestQueueClosed
+	}
+
+	select {
+	case res := <-req.result:
+		return res.resp, res.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (c *QueuedClient) deliverFailure(req *ingestRequest) {
+	select {
+	case req.result <- ingestResult{err: ErrIngestQueueClosed}:
+	default:
+	}
+}
+
+// Ingest enqueues an ingest request and blocks until it completes or ctx is cancelled.
+func (c *QueuedClient) Ingest(
+	ctx context.Context,
+	entities []diode.Entity,
+	opts ...diode.IngestOption,
+) (*diodepb.IngestResponse, error) {
+	return c.enqueue(ctx, func(callCtx context.Context) (*diodepb.IngestResponse, error) {
+		return c.inner.Ingest(callCtx, entities, opts...)
+	})
+}
+
+// IngestProto enqueues a proto ingest request and blocks until it completes or ctx is cancelled.
+func (c *QueuedClient) IngestProto(
+	ctx context.Context,
+	entities []*diodepb.Entity,
+	opts ...diode.IngestOption,
+) (*diodepb.IngestResponse, error) {
+	return c.enqueue(ctx, func(callCtx context.Context) (*diodepb.IngestResponse, error) {
+		return c.inner.IngestProto(callCtx, entities, opts...)
+	})
+}
+
+// Close stops accepting new work, fails pending queued requests, waits for the
+// consumer to exit, then closes the inner client. Close is idempotent.
+func (c *QueuedClient) Close() error {
+	var err error
+	c.closeOnce.Do(func() {
+		close(c.shutdownCh)
+
+		for {
+			select {
+			case req := <-c.requests:
+				c.deliverFailure(req)
+			default:
+				close(c.requests)
+				<-c.done
+				err = c.inner.Close()
+				return
+			}
+		}
+	})
+	return err
+}

--- a/orb-discovery/snmp-discovery/ingest/queued_client_test.go
+++ b/orb-discovery/snmp-discovery/ingest/queued_client_test.go
@@ -103,6 +103,61 @@ func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
+func newTestQueuedClient(inner diode.Client, bufferSize int, callTimeout time.Duration) *QueuedClient {
+	c := &QueuedClient{
+		inner:       inner,
+		logger:      testLogger(),
+		requests:    make(chan *ingestRequest, bufferSize),
+		callTimeout: callTimeout,
+		shutdownCh:  make(chan struct{}),
+		done:        make(chan struct{}),
+	}
+	go c.consumer()
+	return c
+}
+
+type hangUntilContextClient struct{}
+
+func (h *hangUntilContextClient) Ingest(ctx context.Context, _ []diode.Entity, _ ...diode.IngestOption) (*diodepb.IngestResponse, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (h *hangUntilContextClient) IngestProto(ctx context.Context, entities []*diodepb.Entity, opts ...diode.IngestOption) (*diodepb.IngestResponse, error) {
+	return h.Ingest(ctx, nil, opts...)
+}
+
+func (h *hangUntilContextClient) Close() error {
+	return nil
+}
+
+func TestExecuteAppliesDefaultCallTimeout(t *testing.T) {
+	inner := &hangUntilContextClient{}
+	client := newTestQueuedClient(inner, 1, 50*time.Millisecond)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close())
+	})
+
+	_, err := client.Ingest(context.Background(), nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestExecuteRespectsCallerDeadline(t *testing.T) {
+	inner := &hangUntilContextClient{}
+	client := newTestQueuedClient(inner, 1, time.Minute)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close())
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := client.Ingest(ctx, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
 func TestNewQueuedClientInvalidBufferSize(t *testing.T) {
 	inner := newCountingClient()
 

--- a/orb-discovery/snmp-discovery/ingest/queued_client_test.go
+++ b/orb-discovery/snmp-discovery/ingest/queued_client_test.go
@@ -205,3 +205,30 @@ func TestCloseRejectsNewIngests(t *testing.T) {
 
 	require.NoError(t, client.Close(), "Close should be idempotent")
 }
+
+func TestCloseConcurrentWithIngest(t *testing.T) {
+	inner := newCountingClient()
+	client, err := NewQueuedClient(inner, 4, testLogger())
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	const workers = 50
+	wg.Add(workers + 1)
+
+	for range workers {
+		go func() {
+			defer wg.Done()
+			_, _ = client.Ingest(context.Background(), nil)
+		}()
+	}
+
+	go func() {
+		defer wg.Done()
+		time.Sleep(time.Millisecond)
+		require.NoError(t, client.Close())
+	}()
+
+	assert.NotPanics(t, func() {
+		wg.Wait()
+	})
+}

--- a/orb-discovery/snmp-discovery/ingest/queued_client_test.go
+++ b/orb-discovery/snmp-discovery/ingest/queued_client_test.go
@@ -368,3 +368,47 @@ func TestCloseDoesNotHangEnqueueDuringShutdownRace(t *testing.T) {
 		t.Fatal("ingest workers hung during concurrent Close")
 	}
 }
+
+func TestCloseUnblocksBlockedEnqueueWhenBufferFull(t *testing.T) {
+	inner := newCountingClient()
+	inner.enableBlocking()
+	inner.startBlocking()
+
+	client, err := NewQueuedClient(inner, 1, testLogger())
+	require.NoError(t, err)
+
+	go func() {
+		_, _ = client.Ingest(context.Background(), nil)
+	}()
+
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&inner.inFlight) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	go func() {
+		_, _ = client.Ingest(context.Background(), nil)
+	}()
+
+	require.Eventually(t, func() bool {
+		return len(client.(*QueuedClient).requests) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	enqueueDone := make(chan error, 1)
+	go func() {
+		_, err := client.Ingest(context.Background(), nil)
+		enqueueDone <- err
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+
+	go func() {
+		require.NoError(t, client.Close())
+	}()
+
+	select {
+	case err := <-enqueueDone:
+		assert.ErrorIs(t, err, ErrIngestQueueClosed)
+	case <-time.After(time.Second):
+		t.Fatal("blocked enqueue did not return after shutdown started")
+	}
+}

--- a/orb-discovery/snmp-discovery/ingest/queued_client_test.go
+++ b/orb-discovery/snmp-discovery/ingest/queued_client_test.go
@@ -282,3 +282,44 @@ func TestCloseDrainsBufferedPendingRequests(t *testing.T) {
 
 	<-closeDone
 }
+
+func TestCloseDoesNotExecuteBufferedIngests(t *testing.T) {
+	inner := newCountingClient()
+	inner.enableBlocking()
+	inner.startBlocking()
+
+	client, err := NewQueuedClient(inner, 4, testLogger())
+	require.NoError(t, err)
+
+	go func() {
+		_, _ = client.Ingest(context.Background(), nil)
+	}()
+
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&inner.inFlight) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	const buffered = 2
+	for range buffered {
+		go func() {
+			_, _ = client.Ingest(context.Background(), nil)
+		}()
+	}
+
+	require.Eventually(t, func() bool {
+		return len(client.(*QueuedClient).requests) == buffered
+	}, time.Second, 10*time.Millisecond)
+
+	closeDone := make(chan struct{})
+	go func() {
+		require.NoError(t, client.Close())
+		close(closeDone)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&inner.maxInFlight))
+
+	inner.release()
+	<-closeDone
+	assert.Equal(t, int32(1), atomic.LoadInt32(&inner.maxInFlight))
+}

--- a/orb-discovery/snmp-discovery/ingest/queued_client_test.go
+++ b/orb-discovery/snmp-discovery/ingest/queued_client_test.go
@@ -123,7 +123,7 @@ func (h *hangUntilContextClient) Ingest(ctx context.Context, _ []diode.Entity, _
 	return nil, ctx.Err()
 }
 
-func (h *hangUntilContextClient) IngestProto(ctx context.Context, entities []*diodepb.Entity, opts ...diode.IngestOption) (*diodepb.IngestResponse, error) {
+func (h *hangUntilContextClient) IngestProto(ctx context.Context, _ []*diodepb.Entity, opts ...diode.IngestOption) (*diodepb.IngestResponse, error) {
 	return h.Ingest(ctx, nil, opts...)
 }
 

--- a/orb-discovery/snmp-discovery/ingest/queued_client_test.go
+++ b/orb-discovery/snmp-discovery/ingest/queued_client_test.go
@@ -45,11 +45,11 @@ func (c *countingClient) release() {
 func (c *countingClient) trackInFlight() func() {
 	current := atomic.AddInt32(&c.inFlight, 1)
 	for {
-		max := atomic.LoadInt32(&c.maxInFlight)
-		if current <= max {
+		prevMax := atomic.LoadInt32(&c.maxInFlight)
+		if current <= prevMax {
 			break
 		}
-		if atomic.CompareAndSwapInt32(&c.maxInFlight, max, current) {
+		if atomic.CompareAndSwapInt32(&c.maxInFlight, prevMax, current) {
 			break
 		}
 	}

--- a/orb-discovery/snmp-discovery/ingest/queued_client_test.go
+++ b/orb-discovery/snmp-discovery/ingest/queued_client_test.go
@@ -232,3 +232,53 @@ func TestCloseConcurrentWithIngest(t *testing.T) {
 		wg.Wait()
 	})
 }
+
+func TestCloseDrainsBufferedPendingRequests(t *testing.T) {
+	inner := newCountingClient()
+	inner.enableBlocking()
+	inner.startBlocking()
+
+	client, err := NewQueuedClient(inner, 4, testLogger())
+	require.NoError(t, err)
+
+	go func() {
+		_, _ = client.Ingest(context.Background(), nil)
+	}()
+
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&inner.inFlight) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	const pendingCount = 4
+	results := make(chan error, pendingCount)
+	for range pendingCount {
+		go func() {
+			_, err := client.Ingest(context.Background(), nil)
+			results <- err
+		}()
+	}
+
+	require.Eventually(t, func() bool {
+		return len(client.(*QueuedClient).requests) == pendingCount
+	}, time.Second, 10*time.Millisecond)
+
+	closeDone := make(chan struct{})
+	go func() {
+		require.NoError(t, client.Close())
+		close(closeDone)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	inner.release()
+
+	for range pendingCount {
+		select {
+		case err := <-results:
+			assert.ErrorIs(t, err, ErrIngestQueueClosed)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for buffered ingest results after Close")
+		}
+	}
+
+	<-closeDone
+}

--- a/orb-discovery/snmp-discovery/ingest/queued_client_test.go
+++ b/orb-discovery/snmp-discovery/ingest/queued_client_test.go
@@ -2,6 +2,7 @@ package ingest
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"sync"
@@ -322,4 +323,48 @@ func TestCloseDoesNotExecuteBufferedIngests(t *testing.T) {
 	inner.release()
 	<-closeDone
 	assert.Equal(t, int32(1), atomic.LoadInt32(&inner.maxInFlight))
+}
+
+func TestCloseDoesNotHangEnqueueDuringShutdownRace(t *testing.T) {
+	inner := newCountingClient()
+	client, err := NewQueuedClient(inner, 8, testLogger())
+	require.NoError(t, err)
+
+	var closeWg sync.WaitGroup
+	closeWg.Add(1)
+	go func() {
+		defer closeWg.Done()
+		require.NoError(t, client.Close())
+	}()
+
+	const workers = 20
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			_, err := client.Ingest(ctx, nil)
+			if err != nil {
+				assert.True(t,
+					errors.Is(err, ErrIngestQueueClosed) || errors.Is(err, context.DeadlineExceeded),
+					"unexpected error: %v", err,
+				)
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		closeWg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ingest workers hung during concurrent Close")
+	}
 }

--- a/orb-discovery/snmp-discovery/ingest/queued_client_test.go
+++ b/orb-discovery/snmp-discovery/ingest/queued_client_test.go
@@ -1,0 +1,207 @@
+package ingest
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type countingClient struct {
+	inFlight    int32
+	maxInFlight int32
+
+	blockCh   chan struct{}
+	releaseCh chan struct{}
+
+	closeCalled atomic.Bool
+}
+
+func newCountingClient() *countingClient {
+	return &countingClient{}
+}
+
+func (c *countingClient) enableBlocking() {
+	c.blockCh = make(chan struct{})
+	c.releaseCh = make(chan struct{})
+}
+
+func (c *countingClient) startBlocking() {
+	close(c.blockCh)
+}
+
+func (c *countingClient) release() {
+	close(c.releaseCh)
+}
+
+func (c *countingClient) trackInFlight() func() {
+	current := atomic.AddInt32(&c.inFlight, 1)
+	for {
+		max := atomic.LoadInt32(&c.maxInFlight)
+		if current <= max {
+			break
+		}
+		if atomic.CompareAndSwapInt32(&c.maxInFlight, max, current) {
+			break
+		}
+	}
+	return func() {
+		atomic.AddInt32(&c.inFlight, -1)
+	}
+}
+
+func (c *countingClient) Ingest(ctx context.Context, _ []diode.Entity, _ ...diode.IngestOption) (*diodepb.IngestResponse, error) {
+	done := c.trackInFlight()
+	defer done()
+
+	if c.blockCh != nil {
+		select {
+		case <-c.blockCh:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+
+		select {
+		case <-c.releaseCh:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+
+		return &diodepb.IngestResponse{}, nil
+	}
+
+	time.Sleep(time.Millisecond)
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
+	return &diodepb.IngestResponse{}, nil
+}
+
+func (c *countingClient) IngestProto(ctx context.Context, _ []*diodepb.Entity, _ ...diode.IngestOption) (*diodepb.IngestResponse, error) {
+	return c.Ingest(ctx, nil)
+}
+
+func (c *countingClient) Close() error {
+	c.closeCalled.Store(true)
+	return nil
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestNewQueuedClientInvalidBufferSize(t *testing.T) {
+	inner := newCountingClient()
+
+	client, err := NewQueuedClient(inner, 0, testLogger())
+	assert.Error(t, err)
+	assert.Nil(t, client)
+	assert.Contains(t, err.Error(), "buffer size must be >= 1")
+}
+
+func TestSerialExecution(t *testing.T) {
+	inner := newCountingClient()
+	client, err := NewQueuedClient(inner, 1, testLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close())
+	})
+
+	const workers = 10
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	for range workers {
+		go func() {
+			defer wg.Done()
+			_, err := client.Ingest(context.Background(), nil)
+			assert.NoError(t, err)
+		}()
+	}
+
+	wg.Wait()
+	assert.Equal(t, int32(1), atomic.LoadInt32(&inner.maxInFlight))
+}
+
+func TestContextCancelWhileQueued(t *testing.T) {
+	inner := newCountingClient()
+	inner.enableBlocking()
+	inner.startBlocking()
+
+	client, err := NewQueuedClient(inner, 1, testLogger())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close())
+	})
+
+	firstDone := make(chan struct{})
+	go func() {
+		_, err := client.Ingest(context.Background(), nil)
+		assert.NoError(t, err)
+		close(firstDone)
+	}()
+
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&inner.inFlight) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	secondDone := make(chan struct{})
+	var secondErr error
+	go func() {
+		_, secondErr = client.Ingest(context.Background(), nil)
+		close(secondDone)
+	}()
+
+	require.Eventually(t, func() bool {
+		return len(client.(*QueuedClient).requests) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	thirdDone := make(chan struct{})
+	var thirdErr error
+	go func() {
+		_, thirdErr = client.Ingest(ctx, nil)
+		close(thirdDone)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	<-thirdDone
+	assert.ErrorIs(t, thirdErr, context.Canceled)
+
+	inner.release()
+	<-secondDone
+	assert.NoError(t, secondErr)
+	<-firstDone
+}
+
+func TestCloseRejectsNewIngests(t *testing.T) {
+	inner := newCountingClient()
+	client, err := NewQueuedClient(inner, 1, testLogger())
+	require.NoError(t, err)
+
+	require.NoError(t, client.Close())
+
+	_, err = client.Ingest(context.Background(), nil)
+	assert.ErrorIs(t, err, ErrIngestQueueClosed)
+
+	assert.True(t, inner.closeCalled.Load(), "inner client Close should be called")
+
+	_, err = client.Ingest(context.Background(), nil)
+	assert.ErrorIs(t, err, ErrIngestQueueClosed)
+
+	require.NoError(t, client.Close(), "Close should be idempotent")
+}


### PR DESCRIPTION
## Summary

- Add a `QueuedClient` wrapper around `diode.Client` that serializes ingest through a buffered channel with a single consumer goroutine, preventing concurrent OAuth re-auth storms when many SNMP crawl jobs complete at once.
- Wire the queue in snmp-discovery via `--ingest-buffer-size` (default 512) and expose it from the agent backend as `orb.backends.snmp_discovery.ingest_buffer_size`.

## What changed

- New `orb-discovery/snmp-discovery/ingest/QueuedClient` implementing `diode.Client` with enqueue backpressure, context cancellation, and idempotent shutdown.
- `cmd/main.go` wraps the real diode client at startup and closes it on shutdown.
- Agent `snmp_discovery` backend reads `ingest_buffer_size` from YAML (validated at configure time) and passes `--ingest-buffer-size` to the subprocess.
- Unit tests for serial execution, ctx cancel while queued, Close/drain behavior, and backend CLI forwarding.
- Documentation in `docs/backends/snmp_discovery/README.md` and `docs/config_samples.md`.

## How tested

- `cd orb-discovery/snmp-discovery && go test ./ingest/... ./policy/...`
- `go test ./agent/backend/snmpdiscovery/...`
- `make fix-lint`

## Follow-ups (out of scope)

- `diode-sdk-go`: singleflight on `authenticate()`, backoff on 502/429.
- Staggered crawl scheduling in runner (separate from ingest serialization).