### PR TITLE
fix(agent): gate agent bearer to control-plane URLs; harden redirect test

### DIFF
--- a/agent/configmgr/fleet.go
+++ b/agent/configmgr/fleet.go
@@ -499,6 +499,12 @@ func (fleetManager *FleetConfigManager) BindFilesManager(fm filesmgr.Manager) er
 		return nil
 	}
 
+	// Give the fetcher the agent's bearer token so authenticated control-plane
+	// bundle URLs can be fetched. GetFreshToken returns the current token,
+	// refreshing if expired; the Go stdlib strips Authorization on the cross-host
+	// 302 to S3, so the token never leaks to the bucket.
+	fleetFM.SetTokenSource(fleetManager.authTokenManager.GetFreshToken)
+
 	fleetManager.connection.AddOnReadyHook(func(cm *autopaho.ConnectionManager, topics fleet.TokenResponseTopics) {
 		outbox := topics.Outbox
 		// Bound the catch-up publish: QoS-1 Publish blocks until the broker acks

--- a/agent/filesmgr/fetcher.go
+++ b/agent/filesmgr/fetcher.go
@@ -95,10 +95,7 @@ func isControlPlaneURL(u *url.URL) bool {
 			return false
 		}
 	}
-	if hasKnownArchiveSuffix(u.Path) {
-		return false
-	}
-	return true
+	return !hasKnownArchiveSuffix(u.Path)
 }
 
 // filenameFromURL extracts the last non-empty path segment from rawURL,

--- a/agent/filesmgr/fetcher.go
+++ b/agent/filesmgr/fetcher.go
@@ -72,6 +72,35 @@ func hasKnownArchiveSuffix(urlPath string) bool {
 	return false
 }
 
+// presignQueryParams are query keys that indicate a URL already carries its own
+// auth (a presigned/capability URL). The agent must NOT add an Authorization
+// header to these: object stores reject a request bearing both a query-string
+// signature and an Authorization header, and forwarding the agent token to
+// storage would leak it. Covers AWS SigV4 and GCS V4/V2 signing.
+var presignQueryParams = []string{
+	"X-Amz-Signature", "X-Amz-Algorithm", "X-Amz-Credential",
+	"X-Goog-Signature", "X-Goog-Algorithm", "X-Goog-Credential",
+	"Signature",
+}
+
+// isControlPlaneURL reports whether u is the authenticated filesmanager
+// control-plane endpoint (extension-less /bundles/{name}/{version}) rather than a
+// direct presigned object URL. Only control-plane URLs receive the agent bearer
+// token; presigned/capability URLs (which carry their own auth) must not, so the
+// token never leaks to object storage and signed requests stay valid.
+func isControlPlaneURL(u *url.URL) bool {
+	q := u.Query()
+	for _, k := range presignQueryParams {
+		if q.Get(k) != "" {
+			return false
+		}
+	}
+	if hasKnownArchiveSuffix(u.Path) {
+		return false
+	}
+	return true
+}
+
 // filenameFromURL extracts the last non-empty path segment from rawURL,
 // stripping any query string. Returns an error if no usable filename can
 // be derived.
@@ -238,7 +267,7 @@ func (f *fetcher) fetch(ctx context.Context, spec FileSpec, dst string) error {
 	}
 
 	getters := httpGetters
-	if f.tokenSource != nil {
+	if f.tokenSource != nil && isControlPlaneURL(u) {
 		tok, err := f.tokenSource(ctx)
 		if err != nil {
 			return fmt.Errorf("fetch %s: get auth token: %w", spec.Name, err)

--- a/agent/filesmgr/fetcher.go
+++ b/agent/filesmgr/fetcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -13,10 +14,17 @@ import (
 	"github.com/hashicorp/go-getter"
 )
 
+// TokenSource returns a bearer token to attach to authenticated control-plane
+// bundle fetches. It is invoked once per fetch so the current (refreshed) token
+// is used. A nil TokenSource means no Authorization header is added (e.g.
+// presigned URLs that already carry their own auth).
+type TokenSource func(ctx context.Context) (string, error)
+
 // fetcher downloads, verifies, and atomically places a file (or extracted
 // directory) at a destination path.
 type fetcher struct {
-	logger *slog.Logger
+	logger      *slog.Logger
+	tokenSource TokenSource // optional; when set, sends Authorization: Bearer
 }
 
 func newFetcher(logger *slog.Logger) *fetcher {
@@ -229,12 +237,35 @@ func (f *fetcher) fetch(ctx context.Context, spec FileSpec, dst string) error {
 		stagePath = filepath.Join(tmp, filename)
 	}
 
+	getters := httpGetters
+	if f.tokenSource != nil {
+		tok, err := f.tokenSource(ctx)
+		if err != nil {
+			return fmt.Errorf("fetch %s: get auth token: %w", spec.Name, err)
+		}
+		if tok != "" {
+			hdr := make(http.Header)
+			hdr.Set("Authorization", "Bearer "+tok)
+			// Per-fetch getter so the header carries the current token and never
+			// bleeds across concurrent installs. DoNotCheckHeadFirst skips a HEAD
+			// probe that would 403 against a GET-presigned S3 URL after the 302.
+			authGetter := &getter.HttpGetter{
+				Header:              hdr,
+				DoNotCheckHeadFirst: true,
+			}
+			getters = map[string]getter.Getter{
+				"http":  authGetter,
+				"https": authGetter,
+			}
+		}
+	}
+
 	client := &getter.Client{
 		Ctx:     ctx,
 		Src:     u.String(),
 		Dst:     stagePath,
 		Mode:    mode,
-		Getters: httpGetters,
+		Getters: getters,
 		// DisableSymlinks blocks tar entries that are symbolic links from being
 		// honored during extraction. Without this a crafted archive can include
 		// a symlink entry pointing outside the extraction target (e.g. "/etc")

--- a/agent/filesmgr/fetcher_auth_test.go
+++ b/agent/filesmgr/fetcher_auth_test.go
@@ -1,0 +1,127 @@
+package filesmgr
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// buildAuthTarGz returns a gzipped tar containing a single file, plus its sha256.
+func buildAuthTarGz(t *testing.T) ([]byte, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	content := []byte("bundle-payload")
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "plugin.txt",
+		Mode: 0o644,
+		Size: int64(len(content)),
+	}))
+	_, err := tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+	sum := sha256.Sum256(buf.Bytes())
+	return buf.Bytes(), hex.EncodeToString(sum[:])
+}
+
+// TestFetcher_SendsBearerToControlPlane_NotToRedirectTarget verifies that when a
+// token source is configured, the fetcher sends Authorization: Bearer to the
+// control-plane URL, and that the header is NOT forwarded to the redirect target
+// (mirroring the stdlib's cross-host stripping that protects the S3 presigned URL).
+func TestFetcher_SendsBearerToControlPlane_NotToRedirectTarget(t *testing.T) {
+	archive, archiveSHA := buildAuthTarGz(t)
+
+	// "S3" origin: serves the bytes, and records whether it ever saw an
+	// Authorization header (it must not).
+	var sawAuthAtTarget atomic.Bool
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			sawAuthAtTarget.Store(true)
+		}
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(archive)
+	}))
+	defer target.Close()
+
+	// "Control plane": requires the bearer, then 302-redirects to target.
+	var sawAuthAtControlPlane atomic.Bool
+	control := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "Bearer test-token" {
+			sawAuthAtControlPlane.Store(true)
+		} else {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		// Redirect to a DIFFERENT host so the test exercises the same cross-host
+		// Authorization-stripping the Go stdlib applies in prod (control plane
+		// -> S3). httptest serves on 127.0.0.1; rewriting to "localhost" hits the
+		// same loopback target but makes the stdlib treat it as cross-host.
+		crossHostURL := strings.Replace(target.URL, "127.0.0.1", "localhost", 1)
+		http.Redirect(w, r, crossHostURL, http.StatusFound)
+	}))
+	defer control.Close()
+
+	dst := filepath.Join(t.TempDir(), "v1")
+	f := newFetcher(slog.Default())
+	f.tokenSource = func(_ context.Context) (string, error) { return "test-token", nil }
+
+	spec := FileSpec{
+		Name:    "nbl_test",
+		Version: "1.0.0",
+		URL:     control.URL,
+		SHA256:  archiveSHA,
+		Extract: true,
+	}
+	require.NoError(t, f.fetch(context.Background(), spec, dst))
+
+	require.True(t, sawAuthAtControlPlane.Load(), "control plane never received the bearer token")
+	require.False(t, sawAuthAtTarget.Load(), "bearer token leaked to the redirect (S3) target")
+
+	// Sanity: the extracted file landed.
+	_, err := os.Stat(filepath.Join(dst, "plugin.txt"))
+	require.NoError(t, err)
+}
+
+// TestFetcher_NoTokenSource_SendsNoAuth verifies the default path is unchanged:
+// with no token source, no Authorization header is sent (presigned-URL behavior).
+func TestFetcher_NoTokenSource_SendsNoAuth(t *testing.T) {
+	archive, archiveSHA := buildAuthTarGz(t)
+
+	var sawAuth atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			sawAuth.Store(true)
+		}
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(archive)
+	}))
+	defer srv.Close()
+
+	dst := filepath.Join(t.TempDir(), "v1")
+	f := newFetcher(slog.Default()) // tokenSource nil
+
+	spec := FileSpec{
+		Name:    "nbl_test",
+		Version: "1.0.0",
+		URL:     srv.URL,
+		SHA256:  archiveSHA,
+		Extract: true,
+	}
+	require.NoError(t, f.fetch(context.Background(), spec, dst))
+	require.False(t, sawAuth.Load(), "unexpected Authorization header on no-token path")
+}

--- a/agent/filesmgr/fetcher_auth_test.go
+++ b/agent/filesmgr/fetcher_auth_test.go
@@ -69,9 +69,11 @@ func TestFetcher_SendsBearerToControlPlane_NotToRedirectTarget(t *testing.T) {
 		}
 		// Redirect to a DIFFERENT host so the test exercises the same cross-host
 		// Authorization-stripping the Go stdlib applies in prod (control plane
-		// -> S3). httptest serves on 127.0.0.1; rewriting to "localhost" hits the
-		// same loopback target but makes the stdlib treat it as cross-host.
-		crossHostURL := strings.Replace(target.URL, "127.0.0.1", "localhost", 1)
+		// -> S3). Force the redirect hostname to "localhost" regardless of whether
+		// httptest bound on IPv4 (127.0.0.1) or IPv6 ([::1]); either way it hits the
+		// same loopback target but the stdlib treats it as cross-host.
+		crossHostURL := strings.ReplaceAll(target.URL, "127.0.0.1", "localhost")
+		crossHostURL = strings.ReplaceAll(crossHostURL, "[::1]", "localhost")
 		http.Redirect(w, r, crossHostURL, http.StatusFound)
 	}))
 	defer control.Close()
@@ -124,4 +126,38 @@ func TestFetcher_NoTokenSource_SendsNoAuth(t *testing.T) {
 	}
 	require.NoError(t, f.fetch(context.Background(), spec, dst))
 	require.False(t, sawAuth.Load(), "unexpected Authorization header on no-token path")
+}
+
+// TestFetcher_PresignedURL_NoBearerEvenWithTokenSource verifies the bearer is
+// NOT attached to a direct presigned/capability URL even when a token source is
+// configured — only the extension-less control-plane URL is authenticated. This
+// guards against leaking the agent token to object storage and against
+// invalidating SigV4-signed requests.
+func TestFetcher_PresignedURL_NoBearerEvenWithTokenSource(t *testing.T) {
+	archive, archiveSHA := buildAuthTarGz(t)
+
+	var sawAuth atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			sawAuth.Store(true)
+		}
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(archive)
+	}))
+	defer srv.Close()
+
+	dst := filepath.Join(t.TempDir(), "v1")
+	f := newFetcher(slog.Default())
+	f.tokenSource = func(_ context.Context) (string, error) { return "test-token", nil }
+
+	// Presigned-style: path ends in .tar.gz and carries a SigV4 signature param.
+	spec := FileSpec{
+		Name:    "nbl_test",
+		Version: "1.0.0",
+		URL:     srv.URL + "/nbl_test/1.0.0/bundle.tar.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=deadbeef",
+		SHA256:  archiveSHA,
+		Extract: true,
+	}
+	require.NoError(t, f.fetch(context.Background(), spec, dst))
+	require.False(t, sawAuth.Load(), "bearer must not be sent to a presigned URL")
 }

--- a/agent/filesmgr/fetcher_auth_test.go
+++ b/agent/filesmgr/fetcher_auth_test.go
@@ -7,12 +7,13 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -47,16 +48,23 @@ func TestFetcher_SendsBearerToControlPlane_NotToRedirectTarget(t *testing.T) {
 	archive, archiveSHA := buildAuthTarGz(t)
 
 	// "S3" origin: serves the bytes, and records whether it ever saw an
-	// Authorization header (it must not).
+	// Authorization header (it must not). Bind explicitly on tcp4 127.0.0.1 so
+	// the cross-host redirect below is deterministic regardless of the host's
+	// IPv4/IPv6 preference.
 	var sawAuthAtTarget atomic.Bool
-	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	target := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "" {
 			sawAuthAtTarget.Store(true)
 		}
 		w.Header().Set("Content-Type", "application/gzip")
 		_, _ = w.Write(archive)
 	}))
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	target.Listener = ln
+	target.Start()
 	defer target.Close()
+	targetPort := target.Listener.Addr().(*net.TCPAddr).Port
 
 	// "Control plane": requires the bearer, then 302-redirects to target.
 	var sawAuthAtControlPlane atomic.Bool
@@ -68,12 +76,10 @@ func TestFetcher_SendsBearerToControlPlane_NotToRedirectTarget(t *testing.T) {
 			return
 		}
 		// Redirect to a DIFFERENT host so the test exercises the same cross-host
-		// Authorization-stripping the Go stdlib applies in prod (control plane
-		// -> S3). Force the redirect hostname to "localhost" regardless of whether
-		// httptest bound on IPv4 (127.0.0.1) or IPv6 ([::1]); either way it hits the
-		// same loopback target but the stdlib treats it as cross-host.
-		crossHostURL := strings.ReplaceAll(target.URL, "127.0.0.1", "localhost")
-		crossHostURL = strings.ReplaceAll(crossHostURL, "[::1]", "localhost")
+		// Authorization-stripping the Go stdlib applies in prod. The target binds
+		// tcp4 127.0.0.1; redirecting to localhost:<port> reaches the same listener
+		// but the stdlib treats the differing host as cross-host and strips the header.
+		crossHostURL := fmt.Sprintf("http://localhost:%d", targetPort)
 		http.Redirect(w, r, crossHostURL, http.StatusFound)
 	}))
 	defer control.Close()
@@ -95,8 +101,8 @@ func TestFetcher_SendsBearerToControlPlane_NotToRedirectTarget(t *testing.T) {
 	require.False(t, sawAuthAtTarget.Load(), "bearer token leaked to the redirect (S3) target")
 
 	// Sanity: the extracted file landed.
-	_, err := os.Stat(filepath.Join(dst, "plugin.txt"))
-	require.NoError(t, err)
+	_, statErr := os.Stat(filepath.Join(dst, "plugin.txt"))
+	require.NoError(t, statErr)
 }
 
 // TestFetcher_NoTokenSource_SendsNoAuth verifies the default path is unchanged:

--- a/agent/filesmgr/filesmgr.go
+++ b/agent/filesmgr/filesmgr.go
@@ -437,6 +437,13 @@ func (m *filesmgr) Subscribe(handler func(FileEvent)) (unsubscribe func()) {
 	return m.bus.subscribe(handler)
 }
 
+// SetTokenSource configures an optional bearer-token source the fetcher uses
+// when downloading from authenticated control-plane URLs. Call once at bind
+// time before any Ensure.
+func (m *filesmgr) SetTokenSource(ts TokenSource) {
+	m.fetcher.tokenSource = ts
+}
+
 // Ensure makes sure the file described by spec is present on disk and matches
 // the declared SHA256. Correct operation order (atomicity guarantee):
 //  1. Fetch into fresh version directory.

--- a/agent/filesmgr/fleet.go
+++ b/agent/filesmgr/fleet.go
@@ -58,7 +58,10 @@ func (f *FleetFilesManager) Stop(ctx context.Context) error {
 func (f *FleetFilesManager) SetTokenSource(ts TokenSource) {
 	if s, ok := f.Manager.(interface{ SetTokenSource(TokenSource) }); ok {
 		s.SetTokenSource(ts)
+		return
 	}
+	f.logger.Warn("embedded files engine does not support SetTokenSource; " +
+		"authenticated bundle fetches may fail")
 }
 
 // HandlePackages installs each bundle from a packages_credentials delivery.

--- a/agent/filesmgr/fleet.go
+++ b/agent/filesmgr/fleet.go
@@ -53,6 +53,14 @@ func (f *FleetFilesManager) Stop(ctx context.Context) error {
 	return f.Manager.Stop(ctx)
 }
 
+// SetTokenSource forwards a bearer-token source to the embedded disk engine so
+// authenticated control-plane bundle fetches send Authorization: Bearer.
+func (f *FleetFilesManager) SetTokenSource(ts TokenSource) {
+	if s, ok := f.Manager.(interface{ SetTokenSource(TokenSource) }); ok {
+		s.SetTokenSource(ts)
+	}
+}
+
 // HandlePackages installs each bundle from a packages_credentials delivery.
 // Failures are non-fatal: a failed bundle is logged and skipped so the rest of
 // the delivery still installs. A bundle with no explicit "extract" defaults to


### PR DESCRIPTION
## Summary
The bundle fetcher (agent/filesmgr) now attaches the agent's OAuth bearer token
when downloading from an authenticated control-plane bundle URL. Previously it
sent no credentials, so when the server delivers an authenticated bundle URL,
the fetch 401s.

## Changes
- `fetcher` gains an optional `TokenSource`; when set, it builds a per-fetch
  `HttpGetter` carrying `Authorization: Bearer <token>` (per-fetch so the header
  reflects the current, refreshed token and never bleeds across concurrent installs).
- The bearer is attached only to control-plane URLs (`isControlPlaneURL`): URLs
  carrying presign query params (`X-Amz-*` / `X-Goog-*` / `Signature`) or a known
  archive suffix are treated as direct/presigned object URLs and are left
  unauthenticated.
- The fleet files manager forwards a token source to the embedded disk engine;
  the fleet config manager wires the same auto-refreshing token used for the
  agent's control-plane connection.

## Security property
The token is sent only to a control-plane URL. On a cross-host redirect to a
presigned object-storage URL the Go stdlib strips `Authorization`, so the token
never reaches storage. A direct presigned URL is never authenticated in the
first place. Tests assert: bearer reaches the control plane, is stripped after a
cross-host redirect, and is never sent to a presigned URL.

## Testing
- `TestFetcher_SendsBearerToControlPlane_NotToRedirectTarget`
- `TestFetcher_NoTokenSource_SendsNoAuth`
- `TestFetcher_PresignedURL_NoBearerEvenWithTokenSource`