### PR TITLE
fix(gnmi-discovery): strip primary_ip4 from nested device stubs except the cycle-closer

### DIFF
--- a/orb-discovery/gnmi-discovery/mapping/stubs.go
+++ b/orb-discovery/gnmi-discovery/mapping/stubs.go
@@ -40,18 +40,29 @@ func newMACMatchStub(mac *diode.MACAddress) *diode.MACAddress {
 // newDeviceStub returns a Device with matcher-only fields plus the
 // validation-required fields NetBox checks when CREATING a dcim.device from a
 // nested reference (DeviceType, Role) — needed for the cold-start cycle before
-// the rich top-level Device has been upserted. PrimaryIp4/6 go through
-// newIPMatchStub so AssignedObject is cleared (cycle break).
+// the rich top-level Device has been upserted.
+//
+// PrimaryIp4/6 are deliberately NOT carried (diode reconciler bug #545):
+// dcim.device.primary_ip4 is a circular reference the diode-netbox-plugin can
+// only resolve within a SINGLE change set, but each emitted entity is its own
+// change set. A matcher-only primary IP on a nested device stub makes the plugin
+// try to SET it — which fails ("IP not assigned to this device") on first ingest
+// and rolls back the interfaces/modules in that change set. The ONLY entity that
+// can validly set device.primary_ip4 in one change set is the top-level
+// ipam.ipaddress for the primary IP (it does the IP→interface assignment AND, via
+// its own nested device stub's primary_ip4, closes the cycle in the same change
+// set). That single cycle-closer stub is built by newDeviceStubWithPrimary in
+// PruneNestedRefs; every other nested device stub strips the primary IP here.
 //
 // INVARIANT: this must be a superset of every dcim.device matcher field
-// gnmi-discovery populates on the rich Device, plus NetBox's create-required
-// fields. AssetTag is carried (Diode's highest-precedence dcim.device matcher;
-// gnmi-discovery sets it from defaults.asset_tag). Config / Status / Platform /
-// Comments / Location / Tags are NOT matchers and NOT required for create, so
-// they are dropped — this is the whole point of the stub (Config is large).
-// source_match metadata (netbox_id) is the plugin's PK match path, so it must
-// not diverge between rich and stub; run_id annotation is matcher-irrelevant and
-// intentionally omitted.
+// gnmi-discovery populates on the rich Device (other than primary IPs, see
+// above), plus NetBox's create-required fields. AssetTag is carried (Diode's
+// highest-precedence dcim.device matcher; gnmi-discovery sets it from
+// defaults.asset_tag). Config / Status / Platform / Comments / Location / Tags
+// are NOT matchers and NOT required for create, so they are dropped — this is the
+// whole point of the stub (Config is large). source_match metadata (netbox_id) is
+// the plugin's PK match path, so it must not diverge between rich and stub; run_id
+// annotation is matcher-irrelevant and intentionally omitted.
 func newDeviceStub(d *diode.Device) *diode.Device {
 	if d == nil {
 		return nil
@@ -63,13 +74,38 @@ func newDeviceStub(d *diode.Device) *diode.Device {
 		DeviceType: d.DeviceType,
 		Role:       d.Role,
 		AssetTag:   d.AssetTag,
-		PrimaryIp4: newIPMatchStub(d.PrimaryIp4),
-		PrimaryIp6: newIPMatchStub(d.PrimaryIp6),
 	}
 	if sm, ok := d.Metadata["source_match"]; ok {
 		stub.Metadata = diode.Metadata{"source_match": sm}
 	}
 	return stub
+}
+
+// newDeviceStubWithPrimary returns a newDeviceStub for owner that ALSO re-attaches
+// the owner's set primary IP as a matcher-only stub — the sole exception to the
+// primary-IP stripping in newDeviceStub. It is used ONLY for the cycle-closer:
+// the nested device stub on the top-level ipam.ipaddress entity for the primary
+// IP (see PruneNestedRefs). AssignPrimaryIP sets at most one family per call, so
+// at most one of PrimaryIp4/PrimaryIp6 is re-attached.
+//
+// The re-attached primary is matcher-only (Address + Vrf, AssignedObject nil, via
+// newIPMatchStub) BY DESIGN: the cycle is EXECUTED by the top-level IPAddress
+// entity's own AssignedObject (which performs the IP→interface assignment), not by
+// this nested stub — the stub only lets the plugin set device.primary_ip4 within
+// that same change set. NEVER insert this stub into stubCache: it is intentionally
+// per-cycle-closer and must not leak onto other nested device refs.
+func newDeviceStubWithPrimary(owner *diode.Device) *diode.Device {
+	s := newDeviceStub(owner)
+	if s == nil {
+		return nil
+	}
+	if owner.PrimaryIp4 != nil {
+		s.PrimaryIp4 = newIPMatchStub(owner.PrimaryIp4)
+	}
+	if owner.PrimaryIp6 != nil {
+		s.PrimaryIp6 = newIPMatchStub(owner.PrimaryIp6)
+	}
+	return s
 }
 
 // newInterfaceStub returns an Interface with matcher fields plus the
@@ -101,12 +137,21 @@ func CurrentDeviceFrom(entities []diode.Entity) *diode.Device {
 // references with matcher-only stubs. Top-level rich entities are untouched —
 // only references TO them on other entities are rewritten.
 //
+// primaryIP is the cycle-closer: the LIVE *diode.IPAddress returned by
+// AssignPrimaryIP (the top-level ipam.ipaddress for the device's primary IP), or
+// nil when no primary was assigned. The nested device stub on THIS exact entity
+// (matched by pointer identity, never by value) is built with
+// newDeviceStubWithPrimary so it retains device.primary_ip4 — letting the plugin
+// close the primary-IP cycle within that one entity's change set (diode reconciler
+// bug #545). Every OTHER nested device stub strips the primary IP. When primaryIP
+// is nil there is no cycle-closer and all stubs are stripped.
+//
 // Call from the runner AFTER run_id / source_match annotation, BEFORE Ingest:
 // running earlier would either make the annotators traverse stubs (and skip the
 // rich Device) or bloat every stub with run_id, defeating the savings.
 //
 // No-op on empty input.
-func PruneNestedRefs(entities []diode.Entity, currentDevice *diode.Device) {
+func PruneNestedRefs(entities []diode.Entity, currentDevice *diode.Device, primaryIP *diode.IPAddress) {
 	if len(entities) == 0 {
 		return
 	}
@@ -130,8 +175,10 @@ func PruneNestedRefs(entities []diode.Entity, currentDevice *diode.Device) {
 		}
 	}
 
-	stubCache := map[*diode.Device]*diode.Device{}
-	stubFor := func(ref *diode.Device) *diode.Device {
+	// ownerFor resolves the top-level rich Device that a nested Device ref points
+	// at: by name, then by serial, then the single-Device fallback. Shared by the
+	// stripped path and the cycle-closer path so their resolution can't drift.
+	ownerFor := func(ref *diode.Device) *diode.Device {
 		if ref == nil {
 			return nil
 		}
@@ -145,6 +192,15 @@ func PruneNestedRefs(entities []diode.Entity, currentDevice *diode.Device) {
 		if owner == nil {
 			owner = currentDevice // single-Device fallback
 		}
+		return owner
+	}
+
+	stubCache := map[*diode.Device]*diode.Device{}
+	stubFor := func(ref *diode.Device) *diode.Device {
+		if ref == nil {
+			return nil
+		}
+		owner := ownerFor(ref)
 		if owner == nil {
 			return ref // no known top-level Device: leave the ref as-is
 		}
@@ -156,22 +212,49 @@ func PruneNestedRefs(entities []diode.Entity, currentDevice *diode.Device) {
 		return s
 	}
 
-	// stubForIface re-resolves a nested Interface ref by name against the
-	// top-level Interface index (when unambiguous) so the stub carries the rich
+	// resolveIface re-resolves a nested Interface ref by name against the
+	// top-level Interface index (when unambiguous) so the stub can carry the rich
 	// interface's Type/MAC/owner — important because some nested refs (e.g. an
 	// IPAddress.AssignedObject built in translateIPs) are minimal name+device
-	// shells without Type.
-	stubForIface := func(ref *diode.Interface) *diode.Interface {
-		if ref == nil {
-			return nil
-		}
+	// shells without Type. Mirrors the duplicate-name guard: an ambiguous name
+	// (>1 top-level interface) falls back to the ref as-is.
+	resolveIface := func(ref *diode.Interface) *diode.Interface {
 		src := ref
 		if ref.Name != nil {
 			if tops, ok := ifaceByName[*ref.Name]; ok && len(tops) == 1 {
 				src = tops[0]
 			}
 		}
+		return src
+	}
+
+	// stubForIface builds the matcher-only interface stub using the STRIPPED
+	// device stub (the common case). All references EXCEPT the cycle-closer use it.
+	stubForIface := func(ref *diode.Interface) *diode.Interface {
+		if ref == nil {
+			return nil
+		}
+		src := resolveIface(ref)
 		return newInterfaceStub(src, stubFor(src.Device))
+	}
+
+	// cycleCloserIface builds the matcher-only interface stub for the cycle-closer
+	// IPAddress: the interface keeps its rich Type/MAC (newInterfaceStub of the
+	// re-resolved rich interface — CRITICAL, without the rich Type the
+	// IP→interface create can fail NetBox validation), but its nested device stub
+	// is newDeviceStubWithPrimary so it carries primary_ip4 in this one change set.
+	// The device stub is intentionally NOT cached (it must not leak onto other
+	// nested refs).
+	cycleCloserIface := func(ref *diode.Interface) *diode.Interface {
+		if ref == nil {
+			return nil
+		}
+		src := resolveIface(ref)
+		owner := ownerFor(src.Device)
+		if owner == nil {
+			return stubForIface(ref) // no known top-level Device: fall back to stripped
+		}
+		return newInterfaceStub(src, newDeviceStubWithPrimary(owner))
 	}
 
 	for _, entity := range entities {
@@ -188,7 +271,11 @@ func PruneNestedRefs(entities []diode.Entity, currentDevice *diode.Device) {
 			}
 		case *diode.IPAddress:
 			if iface, ok := e.AssignedObject.(*diode.Interface); ok && iface != nil {
-				e.AssignedObject = stubForIface(iface)
+				if primaryIP != nil && e == primaryIP {
+					e.AssignedObject = cycleCloserIface(iface)
+				} else {
+					e.AssignedObject = stubForIface(iface)
+				}
 			}
 		case *diode.Module:
 			e.Device = stubFor(e.Device)

--- a/orb-discovery/gnmi-discovery/mapping/stubs_test.go
+++ b/orb-discovery/gnmi-discovery/mapping/stubs_test.go
@@ -34,16 +34,54 @@ func TestNewDeviceStub_DropsConfigKeepsMatchers(t *testing.T) {
 	assert.Nil(t, s.Config, "stub must NOT carry the captured config")
 	assert.Nil(t, s.Status)
 	assert.Nil(t, s.Comments)
-	// PrimaryIp4 reduced to a matcher (AssignedObject cleared → cycle break).
-	require.NotNil(t, s.PrimaryIp4)
-	assert.Equal(t, "10.0.0.1/32", *s.PrimaryIp4.Address)
-	assert.Nil(t, s.PrimaryIp4.AssignedObject)
+	// PrimaryIp4/6 stripped entirely (diode reconciler bug #545): a matcher-only
+	// device.primary_ip4 is a circular ref the plugin tries to SET and fails on
+	// first ingest, rolling back interfaces/modules. Only the cycle-closer
+	// IPAddress entity's nested stub may carry it (newDeviceStubWithPrimary).
+	assert.Nil(t, s.PrimaryIp4, "default stub must strip primary IPs (cycle-closer only)")
+	assert.Nil(t, s.PrimaryIp6, "default stub must strip primary IPs (cycle-closer only)")
 	// source_match kept; run_id annotation dropped.
 	require.NotNil(t, s.Metadata)
 	_, hasSM := s.Metadata["source_match"]
 	assert.True(t, hasSM)
 	_, hasRun := s.Metadata["run_id"]
 	assert.False(t, hasRun)
+}
+
+// TestNewDeviceStubWithPrimary_ReattachesMatcherOnly verifies the non-cached
+// sibling re-attaches the owner's set primary as an address-only matcher stub
+// (AssignedObject nil) — the matcher-only shape used by the cycle-closer.
+func TestNewDeviceStubWithPrimary_ReattachesMatcherOnly(t *testing.T) {
+	// v4 owner: PrimaryIp4 re-attached as a matcher, PrimaryIp6 stays nil.
+	ownerV4 := &diode.Device{
+		Name:       strptr("r1"),
+		DeviceType: &diode.DeviceType{Model: strptr("X"), Manufacturer: &diode.Manufacturer{Name: strptr("Nokia")}},
+		Role:       &diode.DeviceRole{Name: strptr("router")},
+		PrimaryIp4: &diode.IPAddress{Address: strptr("10.0.0.1/32"), Vrf: &diode.VRF{Name: strptr("blue")}, AssignedObject: &diode.Interface{Name: strptr("lo0")}},
+	}
+	s := newDeviceStubWithPrimary(ownerV4)
+	require.NotNil(t, s.PrimaryIp4)
+	assert.Equal(t, "10.0.0.1/32", *s.PrimaryIp4.Address)
+	require.NotNil(t, s.PrimaryIp4.Vrf)
+	assert.Equal(t, "blue", *s.PrimaryIp4.Vrf.Name)
+	assert.Nil(t, s.PrimaryIp4.AssignedObject, "matcher-only: AssignedObject cleared (execution comes from the top-level IPAddress)")
+	assert.Nil(t, s.PrimaryIp6)
+	// Other matcher fields still present (it builds on newDeviceStub).
+	assert.Equal(t, "r1", *s.Name)
+	assert.Nil(t, s.Config)
+
+	// v6 owner: PrimaryIp6 re-attached, PrimaryIp4 stays nil.
+	ownerV6 := &diode.Device{
+		Name:       strptr("r1"),
+		DeviceType: &diode.DeviceType{Model: strptr("X"), Manufacturer: &diode.Manufacturer{Name: strptr("Nokia")}},
+		Role:       &diode.DeviceRole{Name: strptr("router")},
+		PrimaryIp6: &diode.IPAddress{Address: strptr("2001:db8::1/64"), AssignedObject: &diode.Interface{Name: strptr("lo0")}},
+	}
+	s6 := newDeviceStubWithPrimary(ownerV6)
+	require.NotNil(t, s6.PrimaryIp6)
+	assert.Equal(t, "2001:db8::1/64", *s6.PrimaryIp6.Address)
+	assert.Nil(t, s6.PrimaryIp6.AssignedObject)
+	assert.Nil(t, s6.PrimaryIp4)
 }
 
 func TestPruneNestedRefs_DropsConfigFromNestedDeviceRefs(t *testing.T) {
@@ -59,7 +97,7 @@ func TestPruneNestedRefs_DropsConfigFromNestedDeviceRefs(t *testing.T) {
 	mod := &diode.Module{Device: dev, ModuleBay: bay}
 	entities := []diode.Entity{dev, eth, ip, bay, mod}
 
-	PruneNestedRefs(entities, dev)
+	PruneNestedRefs(entities, dev, nil)
 
 	// Top-level Device stays rich (keeps config).
 	require.NotNil(t, dev.Config)
@@ -79,6 +117,78 @@ func TestPruneNestedRefs_DropsConfigFromNestedDeviceRefs(t *testing.T) {
 
 	assert.Nil(t, bay.Device.Config, "module bay device stub must not carry config")
 	assert.Nil(t, mod.Device.Config, "module device stub must not carry config")
+}
+
+// TestPruneNestedRefs_CycleCloserKeepsPrimaryIP verifies the surgical fix for
+// diode reconciler bug #545: the ONLY nested device stub allowed to carry
+// primary_ip4/6 is the one on the exact IPAddress entity identified (by pointer
+// identity) as the cycle-closer. Every other nested device stub — on other
+// interfaces, modules, module bays, and non-primary IP entities — has its
+// primary IP stripped.
+func TestPruneNestedRefs_CycleCloserKeepsPrimaryIP(t *testing.T) {
+	dev := &diode.Device{
+		Name:       strptr("r1"),
+		DeviceType: &diode.DeviceType{Model: strptr("X"), Manufacturer: &diode.Manufacturer{Name: strptr("Nokia")}},
+		Role:       &diode.DeviceRole{Name: strptr("router")},
+		// The rich top-level Device keeps its rich primary (set by detachForPrimaryIP).
+		PrimaryIp4: &diode.IPAddress{Address: strptr("10.7.7.7/32")},
+	}
+	eth := &diode.Interface{Name: strptr("Loopback0"), Device: dev, Type: strptr("virtual")}
+	other := &diode.Interface{Name: strptr("Ethernet2"), Device: dev, Type: strptr("10gbase-x-sfpp")}
+	// primaryIP is the cycle-closer: the top-level ipam.ipaddress for the primary.
+	primaryIP := &diode.IPAddress{Address: strptr("10.7.7.7/32"), AssignedObject: &diode.Interface{Name: strptr("Loopback0"), Device: dev}}
+	nonPrimaryIP := &diode.IPAddress{Address: strptr("10.9.9.9/31"), AssignedObject: &diode.Interface{Name: strptr("Ethernet2"), Device: dev}}
+	bay := &diode.ModuleBay{Device: dev, Name: strptr("bay1")}
+	mod := &diode.Module{Device: dev, ModuleBay: bay}
+	entities := []diode.Entity{dev, eth, other, primaryIP, nonPrimaryIP, bay, mod}
+
+	PruneNestedRefs(entities, dev, primaryIP)
+
+	// Cycle-closer: its nested device stub KEEPS primary_ip4 as a matcher-only stub.
+	pIface, _ := primaryIP.AssignedObject.(*diode.Interface)
+	require.NotNil(t, pIface)
+	require.NotNil(t, pIface.Device)
+	require.NotNil(t, pIface.Device.PrimaryIp4, "cycle-closer nested device stub must keep primary_ip4")
+	assert.Equal(t, "10.7.7.7/32", *pIface.Device.PrimaryIp4.Address)
+	assert.Nil(t, pIface.Device.PrimaryIp4.AssignedObject, "matcher-only on the nested stub")
+	// The cycle-closer interface stub keeps its rich Type (re-resolved from Loopback0).
+	require.NotNil(t, pIface.Type, "cycle-closer interface stub must keep its Type for create validation")
+	assert.Equal(t, "virtual", *pIface.Type)
+
+	// Non-primary IP: nested device stub is STRIPPED.
+	npIface, _ := nonPrimaryIP.AssignedObject.(*diode.Interface)
+	require.NotNil(t, npIface)
+	require.NotNil(t, npIface.Device)
+	assert.Nil(t, npIface.Device.PrimaryIp4, "non-primary IP's nested device stub must strip primary_ip4")
+
+	// All other nested device refs stripped.
+	assert.Nil(t, eth.Device.PrimaryIp4, "interface nested device stub must strip primary_ip4")
+	assert.Nil(t, other.Device.PrimaryIp4)
+	assert.Nil(t, bay.Device.PrimaryIp4, "module bay nested device stub must strip primary_ip4")
+	assert.Nil(t, mod.Device.PrimaryIp4, "module nested device stub must strip primary_ip4")
+}
+
+// TestPruneNestedRefs_NilPrimaryStripsEverything verifies that with no
+// cycle-closer (primaryIP == nil) every nested device stub is stripped — there
+// is nothing to re-attach.
+func TestPruneNestedRefs_NilPrimaryStripsEverything(t *testing.T) {
+	dev := &diode.Device{
+		Name:       strptr("r1"),
+		DeviceType: &diode.DeviceType{Model: strptr("X"), Manufacturer: &diode.Manufacturer{Name: strptr("Nokia")}},
+		Role:       &diode.DeviceRole{Name: strptr("router")},
+		PrimaryIp4: &diode.IPAddress{Address: strptr("10.7.7.7/32")},
+	}
+	eth := &diode.Interface{Name: strptr("Loopback0"), Device: dev, Type: strptr("virtual")}
+	ip := &diode.IPAddress{Address: strptr("10.7.7.7/32"), AssignedObject: &diode.Interface{Name: strptr("Loopback0"), Device: dev}}
+	entities := []diode.Entity{dev, eth, ip}
+
+	PruneNestedRefs(entities, dev, nil)
+
+	ipIface, _ := ip.AssignedObject.(*diode.Interface)
+	require.NotNil(t, ipIface)
+	require.NotNil(t, ipIface.Device)
+	assert.Nil(t, ipIface.Device.PrimaryIp4, "no cycle-closer: every nested device stub stripped")
+	assert.Nil(t, eth.Device.PrimaryIp4)
 }
 
 func TestCurrentDeviceFrom(t *testing.T) {

--- a/orb-discovery/gnmi-discovery/mapping/translate_ip.go
+++ b/orb-discovery/gnmi-discovery/mapping/translate_ip.go
@@ -183,6 +183,13 @@ func translateIPs(profile *Profile, snap map[string]any, dev *diode.Device, defa
 // primary management IP (mirrors device-discovery). Exact match only; never
 // guesses. hostIP must already be stripped of any :port (the runner does this).
 //
+// It returns the LIVE matched *diode.IPAddress (still present in the entities
+// slice — NOT the detached snapshot attached to the Device), so the caller can
+// pass it to PruneNestedRefs as the cycle-closer identified by pointer identity:
+// that single top-level ipam.ipaddress is the only entity allowed to set
+// device.primary_ip4 on its nested device stub (diode reconciler bug #545).
+// Returns nil on the empty / no-device / no-match paths.
+//
 // The primary IP RETAINS its assigned interface (via detachForPrimaryIP) because
 // NetBox rejects a device primary IP that is not assigned to an interface on the
 // device ("The specified IP address … is not assigned to this device"). The
@@ -191,9 +198,9 @@ func translateIPs(profile *Profile, snap map[string]any, dev *diode.Device, defa
 // PrimaryIp4/6 cleared and its relationship pointers stripped — matching
 // snmp-discovery's detachForPrimaryIP. The rich IPAddress and Interface still
 // ride as top-level entities; only this embedded snapshot is pruned.
-func AssignPrimaryIP(entities []diode.Entity, hostIP string) {
+func AssignPrimaryIP(entities []diode.Entity, hostIP string) *diode.IPAddress {
 	if hostIP == "" || len(entities) == 0 {
-		return
+		return nil
 	}
 	// Canonicalize the target so differing IPv6 spellings still match (e.g. a
 	// policy host 2001:0db8::1 vs a discovered 2001:db8::1). targetIP is nil when
@@ -201,7 +208,7 @@ func AssignPrimaryIP(entities []diode.Entity, hostIP string) {
 	targetIP := net.ParseIP(hostIP)
 	dev, _ := entities[0].(*diode.Device)
 	if dev == nil {
-		return
+		return nil
 	}
 	for _, e := range entities {
 		ip, ok := e.(*diode.IPAddress)
@@ -224,8 +231,9 @@ func AssignPrimaryIP(entities []diode.Entity, hostIP string) {
 		} else {
 			dev.PrimaryIp4 = detachForPrimaryIP(ip, dev)
 		}
-		return
+		return ip // the LIVE matched IPAddress (cycle-closer for PruneNestedRefs)
 	}
+	return nil
 }
 
 // detachForPrimaryIP returns a copy of the matched IPAddress suitable to attach

--- a/orb-discovery/gnmi-discovery/mapping/translate_ip_test.go
+++ b/orb-discovery/gnmi-discovery/mapping/translate_ip_test.go
@@ -127,9 +127,12 @@ func TestAssignPrimaryIP(t *testing.T) {
 
 	// v4 match -> PrimaryIp4 retains the assigned interface (NetBox requires the
 	// IP to be assigned to the device), with the cycle broken via a device copy
-	// that has its primary IPs cleared.
+	// that has its primary IPs cleared. The return is the LIVE matched IPAddress
+	// (the cycle-closer), still present in the entities slice.
 	e := mk()
-	AssignPrimaryIP(e, "10.0.0.1")
+	got := AssignPrimaryIP(e, "10.0.0.1")
+	require.NotNil(t, got, "must return the matched live IPAddress")
+	require.Same(t, e[1], got, "must return the LIVE matched IPAddress (pointer identity), not a snapshot")
 	p4 := e[0].(*diode.Device).PrimaryIp4
 	require.NotNil(t, p4)
 	require.Equal(t, "10.0.0.1/31", *p4.Address)
@@ -143,7 +146,9 @@ func TestAssignPrimaryIP(t *testing.T) {
 
 	// v6 match -> PrimaryIp6
 	e = mk()
-	AssignPrimaryIP(e, "2001:db8::1")
+	got = AssignPrimaryIP(e, "2001:db8::1")
+	require.NotNil(t, got)
+	require.Same(t, e[2], got, "must return the LIVE matched v6 IPAddress")
 	p6 := e[0].(*diode.Device).PrimaryIp6
 	require.NotNil(t, p6)
 	p6ifc, ok := p6.AssignedObject.(*diode.Interface)
@@ -151,15 +156,15 @@ func TestAssignPrimaryIP(t *testing.T) {
 	require.Nil(t, p6ifc.Device.PrimaryIp6, "cycle break")
 	require.Nil(t, e[0].(*diode.Device).PrimaryIp4)
 
-	// no match -> unset
+	// no match -> unset, nil return
 	e = mk()
-	AssignPrimaryIP(e, "8.8.8.8")
+	require.Nil(t, AssignPrimaryIP(e, "8.8.8.8"))
 	require.Nil(t, e[0].(*diode.Device).PrimaryIp4)
 	require.Nil(t, e[0].(*diode.Device).PrimaryIp6)
 
-	// empty host -> no-op
+	// empty host -> no-op, nil return
 	e = mk()
-	AssignPrimaryIP(e, "")
+	require.Nil(t, AssignPrimaryIP(e, ""))
 	require.Nil(t, e[0].(*diode.Device).PrimaryIp4)
 }
 

--- a/orb-discovery/gnmi-discovery/policy/runner.go
+++ b/orb-discovery/gnmi-discovery/policy/runner.go
@@ -272,7 +272,7 @@ func (r *Runner) runOnce(t config.Target, model *mapping.DeviceModel, deb *Debou
 		snap := model.Snapshot()
 		resolveAssetTag(snap)
 		entities := mapping.Translate(profile, snap, defaults, discoveredVendor)
-		mapping.AssignPrimaryIP(entities, targetHostIP(t.Host))
+		primaryIP := mapping.AssignPrimaryIP(entities, targetHostIP(t.Host))
 		dev, _ := entities[0].(*diode.Device) // Translate always emits the Device first
 		// Attach the captured CONFIG datastore (already redacted) to the Device,
 		// when capture_config is on and the fetch succeeded. Same post-Translate
@@ -319,7 +319,7 @@ func (r *Runner) runOnce(t config.Target, model *mapping.DeviceModel, deb *Debou
 		// only on the single top-level Device instead of being duplicated onto
 		// every interface/IP/module reference. Mirrors snmp-discovery (#392) and
 		// device-discovery (#394).
-		mapping.PruneNestedRefs(entities, dev)
+		mapping.PruneNestedRefs(entities, dev, primaryIP)
 		resp, ierr := r.client.Ingest(r.ctx, entities, diode.WithIngestMetadata(diode.Metadata{
 			"policy_name": r.name, "run_id": run.ID, // keys match snmp/network backends
 		}))

--- a/orb-discovery/gnmi-discovery/policy/runner_test.go
+++ b/orb-discovery/gnmi-discovery/policy/runner_test.go
@@ -441,6 +441,9 @@ func TestRunnerSetsPrimaryIPFromHost(t *testing.T) {
 			{Updates: []gnmi.Update{
 				{Path: "/system/state/hostname", Value: "r1"},
 				{Path: "/interfaces/interface[name=Loopback0]/subinterfaces/subinterface[index=0]/ipv4/addresses/address[ip=10.7.7.7]/state/prefix-length", Value: 32},
+				// A second, non-primary address: its nested device stub must NOT
+				// carry primary_ip4 after the flush (cycle-closer is Loopback0 only).
+				{Path: "/interfaces/interface[name=Ethernet2]/subinterfaces/subinterface[index=0]/ipv4/addresses/address[ip=10.9.9.9]/state/prefix-length", Value: 31},
 			}},
 			{SyncDone: true},
 		},
@@ -461,8 +464,37 @@ func TestRunnerSetsPrimaryIPFromHost(t *testing.T) {
 	require.Eventually(t, func() bool { return client.count() >= 1 }, 2*time.Second, 20*time.Millisecond)
 	last := client.lastIngested()
 	dev := last[0].(*diode.Device)
+	// The top-level rich Device keeps its primary_ip4 (set by detachForPrimaryIP).
 	require.NotNil(t, dev.PrimaryIp4)
 	require.Equal(t, "10.7.7.7/32", *dev.PrimaryIp4.Address)
+
+	// Surgical fix (#545): after PruneNestedRefs, ONLY the cycle-closer
+	// ipam.ipaddress (the primary 10.7.7.7/32) carries primary_ip4 on its nested
+	// device stub; every other IP entity has it stripped.
+	var primaryHasNested, nonPrimaryHasNested bool
+	var sawNonPrimary bool
+	for _, e := range last {
+		ip, ok := e.(*diode.IPAddress)
+		if !ok || ip.Address == nil {
+			continue
+		}
+		iface, _ := ip.AssignedObject.(*diode.Interface)
+		if iface == nil || iface.Device == nil {
+			continue
+		}
+		hasPrimary := iface.Device.PrimaryIp4 != nil
+		if *ip.Address == "10.7.7.7/32" {
+			primaryHasNested = hasPrimary
+		} else {
+			sawNonPrimary = true
+			if hasPrimary {
+				nonPrimaryHasNested = true
+			}
+		}
+	}
+	require.True(t, primaryHasNested, "cycle-closer IP's nested device must carry primary_ip4 after flush")
+	require.True(t, sawNonPrimary, "test must observe a non-primary IP entity")
+	require.False(t, nonPrimaryHasNested, "non-primary IP's nested device must NOT carry primary_ip4")
 }
 
 func TestTargetHostIP(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a diode reconciler circular-`primary_ip4` reconcile failure for gnmi-discovery — the same issue addressed for device-discovery, here in the Go stub-pruning path. On a device whose management IP is on a separate interface, first-ingest interface/module change sets failed with `{"dcim.device":{"primary_ip4":["The specified IP address (…) is not assigned to this device."]}}`.

## Root cause

`dcim.device.primary_ip4` is a circular reference the diode-netbox-plugin can only resolve **within a single change set**, but the reconciler turns each emitted entity into its own change set. Every nested device match stub carried a matcher-only `PrimaryIp4`/`PrimaryIp6`, so any change set creating/updating the inline device tried to **set** `primary_ip4` before that IP was assigned to an interface of the device.

The only entity that can validly set it in one change set is the **top-level `ipam.ipaddress` for the primary IP** (the cycle-closer): it performs the IP→interface assignment *and*, via its nested device stub, sets `primary_ip4` in the same change set.

## Fix

- `newDeviceStub` no longer copies `PrimaryIp4`/`PrimaryIp6` (the cached/shared stub is stripped). New non-cached `newDeviceStubWithPrimary` re-attaches the primary as a matcher-only stub for the cycle-closer only.
- `AssignPrimaryIP` now **returns the live matched `*diode.IPAddress`** (not the detached snapshot). `PruneNestedRefs` takes that `primaryIP` and identifies the cycle-closer by **pointer identity** (`e == primaryIP`) — exact by construction, so no address/VRF/interface value-matching is needed. Its nested device stub is built with `newDeviceStubWithPrimary` while the interface keeps its rich `Type` (so the IP→interface create validates). Shared `ownerFor`/`resolveIface` helpers keep the stripped and cycle-closer paths from drifting.
- Top-level device entity unchanged. gnmi has no virtual-chassis master-ref builder, so nothing else to strip.

No duplicate devices: stub resolution falls through `primary_ip4` to `name+site+tenant` / `asset_tag`.

## Test plan

- [x] `GOWORK=off go test ./mapping/ ./policy/` green; `go build ./...` OK; `gofmt -l` empty; `go vet` clean; `golangci-lint run` 0 issues.
- [x] Unit: `newDeviceStub` strips primaries; `newDeviceStubWithPrimary` re-attaches matcher-only; `PruneNestedRefs` keeps `primary_ip4` only on the pointer-identified cycle-closer (interface/other-interface/module/module-bay/non-primary-IP all stripped) and the cycle-closer interface keeps its `Type`; nil-primary strips everything. `AssignPrimaryIP` returns the live entity (`require.Same`).
- [x] Runner full-flush test (`Translate`→`AssignPrimaryIP`→`PruneNestedRefs`→`Ingest` via recording client): top-level device keeps `primary_ip4`, cycle-closer IP's nested device carries it, a non-primary IP's does not.
- [x] **Live end-to-end** against a local diode + NetBox (+ diode-netbox-plugin), ingesting via the diode Go SDK entities produced by the real fixed `AssignPrimaryIP`/`PruneNestedRefs` (mgmt IP on a separate interface): **0 failed change sets**, `primary_ip4` set on the **first** ingest, all interfaces present, exactly one device.

Sibling of #422 (device-discovery); snmp-discovery to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
