### PR TITLE
fix(snmp-discovery): strip primary_ip4 from nested device stubs except the cycle-closer

### DIFF
--- a/orb-discovery/snmp-discovery/mapping/chassis.go
+++ b/orb-discovery/snmp-discovery/mapping/chassis.go
@@ -237,19 +237,24 @@ func ChassisInventoryFromOIDs(oids ObjectIDValueMap, logger *slog.Logger) *Chass
 // as VirtualChassis.Master on the top-level VC entity AND on each
 // non-master member Device's VirtualChassis.Master.
 //
-// MUST carry every matcher field the rich master Device carries —
-// divergence breaks the Diode plugin's matcher precedence cascade
-// (asset_tag -> primary_ip4 -> primary_ip6 -> oob_ip -> name+site+tenant
-// -> name+site -> rack+position+face -> virtual_chassis+vc_position)
-// and creates ghost VCs.
+// Carries the matcher fields the rich master Device carries below the
+// primary-IP rungs — divergence breaks the Diode plugin's matcher
+// precedence cascade (asset_tag -> primary_ip4 -> primary_ip6 -> oob_ip
+// -> name+site+tenant -> name+site -> rack+position+face ->
+// virtual_chassis+vc_position) and creates ghost VCs.
 //
 // MUST NOT carry VirtualChassis (non-recursion — dodges the plugin's
 // "Unable to resolve circular reference in entities" error) or
 // VcPosition (would only feed matcher #8 which is unreachable behind
 // the higher-precedence matchers above).
 //
-// primary_ip4/6 go through newIPMatchStub so AssignedObject is cleared,
-// breaking the IP -> Interface -> Device cycle.
+// MUST NOT carry primary_ip4/6 either. dcim.device.primary_ip is a
+// circular reference the reconciler resolves only within a SINGLE
+// change set, and the master ref is never the entity that closes that
+// cycle — only the top-level ipam.ipaddress entity for the primary IP
+// does, in its own change set. A primary IP on the master ref would
+// just make it try to SET primary_ip and fail on first ingest. So this
+// ref relies on asset_tag and name+site+tenant matchers instead.
 func buildMasterRef(master *diode.Device) *diode.Device {
 	if master == nil {
 		return nil
@@ -262,8 +267,6 @@ func buildMasterRef(master *diode.Device) *diode.Device {
 		Tenant:     master.Tenant,
 		Role:       master.Role,
 		DeviceType: master.DeviceType,
-		PrimaryIp4: newIPMatchStub(master.PrimaryIp4),
-		PrimaryIp6: newIPMatchStub(master.PrimaryIp6),
 	}
 	if sm, ok := master.Metadata["source_match"]; ok {
 		ref.Metadata = diode.Metadata{"source_match": sm}

--- a/orb-discovery/snmp-discovery/mapping/chassis_test.go
+++ b/orb-discovery/snmp-discovery/mapping/chassis_test.go
@@ -419,10 +419,14 @@ func TestBuildMasterRef_CarriesAllMatcherFields(t *testing.T) {
 	assert.Equal(t, "acme", *ref.Tenant.Name)
 	assert.Equal(t, "access", *ref.Role.Name)
 	assert.Equal(t, "WS-C3850-48P", *ref.DeviceType.Model)
-	assert.NotNil(t, ref.PrimaryIp4)
-	assert.Equal(t, "10.0.0.1/24", *ref.PrimaryIp4.Address)
-	assert.Nil(t, ref.PrimaryIp4.AssignedObject,
-		"primary_ip4.AssignedObject must be nil — breaks IP->Iface->Device cycle")
+	// The master ref carries no primary IP. The reconciler resolves the
+	// circular primary-IP reference only within a single change set, and
+	// the master ref is never the entity that closes that cycle (only the
+	// top-level cycle-closer IPAddress entity is). Carrying a matcher-only
+	// primary IP here would make the master ref try to SET
+	// device.primary_ip4 and fail on first ingest.
+	assert.Nil(t, ref.PrimaryIp4, "master ref must not carry primary_ip4 — it never closes the cycle")
+	assert.Nil(t, ref.PrimaryIp6)
 	assert.Nil(t, ref.VirtualChassis, "non-recursion")
 	assert.Nil(t, ref.VcPosition, "VcPosition would only feed unreachable matcher #8")
 	assert.Equal(t, diode.Metadata{"netbox_id": 42}, ref.Metadata["source_match"])

--- a/orb-discovery/snmp-discovery/mapping/mapping.go
+++ b/orb-discovery/snmp-discovery/mapping/mapping.go
@@ -324,6 +324,11 @@ type ObjectIDMapper struct {
 	resolver        hostResolver
 	ctx             context.Context
 	postPassMappers []postPassMapper
+	// primaryHits records the LIVE (emitted) IPAddress entities chosen
+	// as the device's primary IP. PruneNestedRefs consults this set so
+	// that only the cycle-closer IPAddress entity's nested device stub
+	// retains a primary IP; every other nested device stub is stripped.
+	primaryHits map[*diode.IPAddress]bool
 }
 
 // SetContext stores the scan's context on the mapper. If set, the primary-IP
@@ -811,6 +816,11 @@ func (m *ObjectIDMapper) assignPrimaryIP(device *diode.Device, entities map[diod
 
 	if len(v4Cands) > 0 {
 		if hit := pickPrimaryIPHit(m.logger, m.registry, m.targetHost, entities, v4Cands, false); hit != nil {
+			// Record the LIVE (emitted) IPAddress entity as the
+			// cycle-closer — NOT the detached snapshot below — so
+			// PruneNestedRefs can recognise it by pointer identity and
+			// keep a matcher-only primary on its nested device stub.
+			m.recordPrimaryHit(hit)
 			// Break the reference cycle before attaching. See
 			// detachForPrimaryIP doc.
 			device.PrimaryIp4 = detachForPrimaryIP(hit, device)
@@ -821,11 +831,32 @@ func (m *ObjectIDMapper) assignPrimaryIP(device *diode.Device, entities map[diod
 
 	if len(v6Cands) > 0 {
 		if hit := pickPrimaryIPHit(m.logger, m.registry, m.targetHost, entities, v6Cands, true); hit != nil {
+			m.recordPrimaryHit(hit)
 			device.PrimaryIp6 = detachForPrimaryIP6(hit, device)
 		}
 	} else {
 		m.logger.Debug("no IPv6 candidates for primary IP assignment", "target", m.targetHost)
 	}
+}
+
+// recordPrimaryHit lazily records a live IPAddress entity chosen as a
+// device primary IP. See ObjectIDMapper.primaryHits.
+func (m *ObjectIDMapper) recordPrimaryHit(hit *diode.IPAddress) {
+	if hit == nil {
+		return
+	}
+	if m.primaryHits == nil {
+		m.primaryHits = make(map[*diode.IPAddress]bool)
+	}
+	m.primaryHits[hit] = true
+}
+
+// PrimaryIPHits returns the set of LIVE IPAddress entities the mapper
+// chose as device primary IPs (the cycle-closers). PruneNestedRefs uses
+// it to keep a matcher-only primary IP on only those entities' nested
+// device stubs. Nil-safe: returns nil when no primary IP was assigned.
+func (m *ObjectIDMapper) PrimaryIPHits() map[*diode.IPAddress]bool {
+	return m.primaryHits
 }
 
 // pickPrimaryIPHit filters `entities` to IP addresses of the requested

--- a/orb-discovery/snmp-discovery/mapping/stubs.go
+++ b/orb-discovery/snmp-discovery/mapping/stubs.go
@@ -5,7 +5,11 @@
 // entity.
 package mapping
 
-import "github.com/netboxlabs/diode-sdk-go/diode"
+import (
+	"strings"
+
+	"github.com/netboxlabs/diode-sdk-go/diode"
+)
 
 // newIPMatchStub returns an IPAddress carrying only the matcher fields
 // (Address, Vrf). AssignedObject is intentionally nil — that is what
@@ -126,24 +130,33 @@ func newDeviceStub(d *diode.Device) *diode.Device {
 // newDeviceStubKeepingPrimary returns a non-cached device stub for the
 // cycle-closer: the top-level ipam.ipaddress entity that sets the
 // device's primary IP within its own change set. It starts from the
-// default (primary-IP-stripped) newDeviceStub and re-attaches whichever
-// primary the owner carries as a matcher-only stub (AssignedObject
-// cleared, so the re-attached IP itself carries no cycle).
+// default (primary-IP-stripped) newDeviceStub and re-attaches ONLY the
+// primary that corresponds to the IPAddress entity being pruned, as a
+// matcher-only stub (AssignedObject cleared, so the re-attached IP itself
+// carries no cycle): isV6 selects PrimaryIp6 vs PrimaryIp4 and primary is
+// the device's primary for that family (nil leaves it stripped).
+//
+// Only the matching family is carried. On a dual-stack device the IPv4
+// cycle-closer's change set assigns only the IPv4 address to the interface,
+// so attaching primary_ip6 there would try to set the IPv6 primary before
+// its address is assigned to the device — re-creating the first-ingest
+// circular-primary failure (and vice versa for the IPv6 cycle-closer).
 //
 // This stub MUST NEVER be inserted into PruneNestedRefs' stubCache: the
 // cached stub is the primary-IP-free shape shared across every other
 // nested reference, and overwriting it would leak the primary onto
 // stubs that cannot validly set it.
-func newDeviceStubKeepingPrimary(owner *diode.Device) *diode.Device {
+func newDeviceStubKeepingPrimary(owner *diode.Device, isV6 bool, primary *diode.IPAddress) *diode.Device {
 	if owner == nil {
 		return nil
 	}
 	stub := newDeviceStub(owner)
-	if owner.PrimaryIp4 != nil {
-		stub.PrimaryIp4 = newIPMatchStub(owner.PrimaryIp4)
-	}
-	if owner.PrimaryIp6 != nil {
-		stub.PrimaryIp6 = newIPMatchStub(owner.PrimaryIp6)
+	if primary != nil {
+		if isV6 {
+			stub.PrimaryIp6 = newIPMatchStub(primary)
+		} else {
+			stub.PrimaryIp4 = newIPMatchStub(primary)
+		}
 	}
 	return stub
 }
@@ -388,39 +401,35 @@ func PruneNestedRefs(entities []diode.Entity, currentDevice *diode.Device, prima
 					// shared primary-IP-free cache stays untouched. The
 					// interface keeps its rich Type/MAC via newInterfaceStub.
 					//
-					// Stack edge: the resolved owner may be a stack member
-					// whose own PrimaryIp4/6 is nil while the master /
-					// currentDevice carries it. newDeviceStubKeepingPrimary
-					// copies whatever primary the device it is built from
-					// carries, so we build the identity stub from the owner
-					// (member) but source the primary from the device that
-					// actually carries it: prefer the owner, fall back to
-					// currentDevice when the owner has none. This
-					// member-vs-master case is handled by the fallback below
-					// and should be confirmed against a real stacked-switch
-					// capture.
+					// Only this IPAddress's OWN family may be set here: its
+					// change set assigns just this address to the interface, so
+					// attaching the other family's primary (dual-stack) would
+					// try to set a primary whose address is not yet assigned.
+					isV6 := e.Address != nil && strings.Contains(*e.Address, ":")
 					owner := resolveIfaceOwner(iface)
 					if owner == nil {
 						// Mirror the stripped path's currentDevice fallback
 						// when the ref names no resolvable top-level Device.
 						owner = currentDevice
 					}
-					primarySrc := owner
-					if primarySrc == nil ||
-						(primarySrc.PrimaryIp4 == nil && primarySrc.PrimaryIp6 == nil) {
-						if currentDevice != nil &&
-							(currentDevice.PrimaryIp4 != nil || currentDevice.PrimaryIp6 != nil) {
-							primarySrc = currentDevice
-						}
+					// Stack edge: the resolved owner may be a stack member
+					// whose own primary is nil while the master / currentDevice
+					// carries it. Source this family's primary from the device
+					// that actually carries it — prefer the owner, fall back to
+					// currentDevice. This member-vs-master case should be
+					// confirmed against a real stacked-switch capture.
+					var primary *diode.IPAddress
+					switch {
+					case isV6 && owner != nil && owner.PrimaryIp6 != nil:
+						primary = owner.PrimaryIp6
+					case !isV6 && owner != nil && owner.PrimaryIp4 != nil:
+						primary = owner.PrimaryIp4
+					case isV6 && currentDevice != nil && currentDevice.PrimaryIp6 != nil:
+						primary = currentDevice.PrimaryIp6
+					case !isV6 && currentDevice != nil && currentDevice.PrimaryIp4 != nil:
+						primary = currentDevice.PrimaryIp4
 					}
-					devStub := newDeviceStubKeepingPrimary(owner)
-					// When the owner carried no primary, copy it from the
-					// fallback source (the master) onto the owner's stub.
-					if devStub != nil && primarySrc != owner && primarySrc != nil {
-						devStub.PrimaryIp4 = newIPMatchStub(primarySrc.PrimaryIp4)
-						devStub.PrimaryIp6 = newIPMatchStub(primarySrc.PrimaryIp6)
-					}
-					e.AssignedObject = newInterfaceStub(iface, devStub)
+					e.AssignedObject = newInterfaceStub(iface, newDeviceStubKeepingPrimary(owner, isV6, primary))
 				} else {
 					e.AssignedObject = stubForIface(iface)
 				}

--- a/orb-discovery/snmp-discovery/mapping/stubs.go
+++ b/orb-discovery/snmp-discovery/mapping/stubs.go
@@ -37,9 +37,22 @@ func newMACMatchStub(mac *diode.MACAddress) *diode.MACAddress {
 // plus the validation-required fields the diode-netbox-plugin checks
 // when CREATING a dcim.device row from a nested reference. Site,
 // Tenant, DeviceType, and Role are pointer-shared from the source —
-// already minimal in snmp-discovery, no transitive bloat. PrimaryIp4
-// and PrimaryIp6 go through newIPMatchStub so AssignedObject is
-// cleared, breaking any cycle into the rich top-level Device.
+// already minimal in snmp-discovery, no transitive bloat.
+//
+// PrimaryIp4/PrimaryIp6 are deliberately NOT carried here. The
+// dcim.device.primary_ip4 reference is circular (the IP points at an
+// interface that points at the device, while the device points back at
+// the IP), and the diode reconciler can only resolve that cycle within
+// a SINGLE change set. Each emitted entity becomes its own change set,
+// so a nested device stub that tries to SET primary_ip4 fails on first
+// ingest ("IP not assigned to this device") and rolls back the
+// interfaces / modules emitted alongside it. The only entity that can
+// validly close the cycle is the top-level ipam.ipaddress entity for
+// the primary IP itself, which performs the IP->interface assignment
+// and sets primary_ip4 in the same change set; PruneNestedRefs
+// re-attaches a matcher-only primary onto that one stub via
+// newDeviceStubKeepingPrimary. Every other nested device stub stays
+// primary-IP-free.
 //
 // Why DeviceType and Role: when the reconciler processes an Interface
 // (or other entity) whose nested Device reference does not yet match
@@ -62,14 +75,23 @@ func newMACMatchStub(mac *diode.MACAddress) *diode.MACAddress {
 //     MUST carry it so rich and stub resolve via the same matcher
 //     precedence path.
 //
+//   - PrimaryIp4 and PrimaryIp6 are NOT carried (see the function-doc
+//     paragraph above). Stripping them off the default stub means the
+//     stub resolves via a lower-precedence matcher than the rich
+//     Device's primary_ip* path — that is acceptable because every stub
+//     also carries asset_tag (when populated) and name+site+tenant, and
+//     because setting primary_ip4 from a nested stub fails ingest
+//     outright. Only the cycle-closer stub built by
+//     newDeviceStubKeepingPrimary re-attaches a matcher-only primary.
+//
 //   - VcPosition and VirtualChassis ARE populated on non-master
 //     member Devices when emitting a stack, but are intentionally
 //     NOT carried on stubs. Matcher #8 (virtual_chassis plus
 //     vc_position) sits behind higher-precedence matchers — asset_tag,
-//     primary_ip*, name+site+tenant, name+site, rack+position+face —
-//     that every member Device already carries via the fields above.
-//     Copying the rich VirtualChassis subtree onto every nested stub
-//     would just bloat the wire payload.
+//     name+site+tenant, name+site, rack+position+face — that every
+//     member Device already carries via the fields above. Copying the
+//     rich VirtualChassis subtree onto every nested stub would just
+//     bloat the wire payload.
 //
 //   - OobIp, Rack, Position, and Face remain not-populated.
 //
@@ -94,11 +116,34 @@ func newDeviceStub(d *diode.Device) *diode.Device {
 		DeviceType: d.DeviceType,
 		Role:       d.Role,
 		AssetTag:   d.AssetTag,
-		PrimaryIp4: newIPMatchStub(d.PrimaryIp4),
-		PrimaryIp6: newIPMatchStub(d.PrimaryIp6),
 	}
 	if sm, ok := d.Metadata["source_match"]; ok {
 		stub.Metadata = diode.Metadata{"source_match": sm}
+	}
+	return stub
+}
+
+// newDeviceStubKeepingPrimary returns a non-cached device stub for the
+// cycle-closer: the top-level ipam.ipaddress entity that sets the
+// device's primary IP within its own change set. It starts from the
+// default (primary-IP-stripped) newDeviceStub and re-attaches whichever
+// primary the owner carries as a matcher-only stub (AssignedObject
+// cleared, so the re-attached IP itself carries no cycle).
+//
+// This stub MUST NEVER be inserted into PruneNestedRefs' stubCache: the
+// cached stub is the primary-IP-free shape shared across every other
+// nested reference, and overwriting it would leak the primary onto
+// stubs that cannot validly set it.
+func newDeviceStubKeepingPrimary(owner *diode.Device) *diode.Device {
+	if owner == nil {
+		return nil
+	}
+	stub := newDeviceStub(owner)
+	if owner.PrimaryIp4 != nil {
+		stub.PrimaryIp4 = newIPMatchStub(owner.PrimaryIp4)
+	}
+	if owner.PrimaryIp6 != nil {
+		stub.PrimaryIp6 = newIPMatchStub(owner.PrimaryIp6)
 	}
 	return stub
 }
@@ -160,8 +205,18 @@ func CurrentDeviceFrom(entities []diode.Entity) *diode.Device {
 // would only see stubs, or (b) bloat every stub with run_id metadata,
 // defeating the savings.
 //
+// primaryHits identifies the cycle-closer IPAddress entities (the
+// top-level ipam.ipaddress entities that set a device's primary IP).
+// For those entities only, the rebuilt nested device stub retains a
+// matcher-only primary IP via newDeviceStubKeepingPrimary, because the
+// reconciler can resolve the circular primary-IP reference only within
+// that single change set. Every other nested device stub — on other
+// interfaces, modules, module bays, MAC addresses, and non-primary IPs
+// — is the default primary-IP-free stub. Pass nil to strip primary IPs
+// everywhere.
+//
 // No-op if entities is empty.
-func PruneNestedRefs(entities []diode.Entity, currentDevice *diode.Device) {
+func PruneNestedRefs(entities []diode.Entity, currentDevice *diode.Device, primaryHits map[*diode.IPAddress]bool) {
 	if len(entities) == 0 {
 		return
 	}
@@ -228,28 +283,34 @@ func PruneNestedRefs(entities []diode.Entity, currentDevice *diode.Device) {
 		return s
 	}
 
-	// stubForIface re-resolves a nested Interface ref by NAME against
-	// the top-level Interface index (when one exists) before stubbing,
-	// so a stale Parent.Device (set by ResolveSubinterfaceParents
-	// before TranslateAsStack) is corrected to the current owner.
-	stubForIface := func(ref *diode.Interface) *diode.Interface {
-		if ref == nil {
-			return nil
-		}
+	// resolveIfaceOwner returns the owner Device for a nested Interface
+	// ref, re-resolving by NAME against the top-level Interface index
+	// (when one exists) so a stale Parent.Device (set by
+	// ResolveSubinterfaceParents before TranslateAsStack) is corrected
+	// to the current owner. Only rewrites the owner when the top-level
+	// lookup is unambiguous: if multiple top-level interfaces share the
+	// same name (cross-member duplicates like `me0`/`mgmt0` on Junos VC
+	// / Cisco StackWise), the lookup cannot tell which member owns this
+	// particular ref — keeping ref.Device preserves whatever upstream
+	// routing produced (correct in the common case). Shared by
+	// stubForIface and the cycle-closer rebuild so the two paths cannot
+	// drift in how they resolve the owner.
+	resolveIfaceOwner := func(ref *diode.Interface) *diode.Device {
 		owner := ref.Device
-		// Only rewrite owner when the top-level lookup is unambiguous.
-		// If multiple top-level interfaces share the same name (cross-
-		// member duplicates like `me0`/`mgmt0` on Junos VC / Cisco
-		// StackWise), the lookup cannot tell which member owns this
-		// particular ref — leaving owner as-is preserves whatever
-		// upstream routing produced (which is correct in the common
-		// case where ref.Device already points at the right member).
 		if ref.Name != nil {
 			if tops, ok := ifaceByName[*ref.Name]; ok && len(tops) == 1 && tops[0].Device != nil {
 				owner = tops[0].Device
 			}
 		}
-		return newInterfaceStub(ref, stubFor(owner))
+		return owner
+	}
+
+	// stubForIface re-resolves a nested Interface ref before stubbing.
+	stubForIface := func(ref *diode.Interface) *diode.Interface {
+		if ref == nil {
+			return nil
+		}
+		return newInterfaceStub(ref, stubFor(resolveIfaceOwner(ref)))
 	}
 
 	for _, entity := range entities {
@@ -317,7 +378,52 @@ func PruneNestedRefs(entities []diode.Entity, currentDevice *diode.Device) {
 			}
 		case *diode.IPAddress:
 			if iface, ok := e.AssignedObject.(*diode.Interface); ok && iface != nil {
-				e.AssignedObject = stubForIface(iface)
+				if primaryHits != nil && primaryHits[e] {
+					// Cycle-closer: this IPAddress entity sets a device's
+					// primary IP within its own change set, so its nested
+					// device stub MUST retain a matcher-only primary IP.
+					// Resolve the owner exactly as the stripped path does
+					// (resolveIfaceOwner respects the duplicate-name guard),
+					// then build a NON-cached keeping-primary stub so the
+					// shared primary-IP-free cache stays untouched. The
+					// interface keeps its rich Type/MAC via newInterfaceStub.
+					//
+					// Stack edge: the resolved owner may be a stack member
+					// whose own PrimaryIp4/6 is nil while the master /
+					// currentDevice carries it. newDeviceStubKeepingPrimary
+					// copies whatever primary the device it is built from
+					// carries, so we build the identity stub from the owner
+					// (member) but source the primary from the device that
+					// actually carries it: prefer the owner, fall back to
+					// currentDevice when the owner has none. This
+					// member-vs-master case is handled by the fallback below
+					// and should be confirmed against a real stacked-switch
+					// capture.
+					owner := resolveIfaceOwner(iface)
+					if owner == nil {
+						// Mirror the stripped path's currentDevice fallback
+						// when the ref names no resolvable top-level Device.
+						owner = currentDevice
+					}
+					primarySrc := owner
+					if primarySrc == nil ||
+						(primarySrc.PrimaryIp4 == nil && primarySrc.PrimaryIp6 == nil) {
+						if currentDevice != nil &&
+							(currentDevice.PrimaryIp4 != nil || currentDevice.PrimaryIp6 != nil) {
+							primarySrc = currentDevice
+						}
+					}
+					devStub := newDeviceStubKeepingPrimary(owner)
+					// When the owner carried no primary, copy it from the
+					// fallback source (the master) onto the owner's stub.
+					if devStub != nil && primarySrc != owner && primarySrc != nil {
+						devStub.PrimaryIp4 = newIPMatchStub(primarySrc.PrimaryIp4)
+						devStub.PrimaryIp6 = newIPMatchStub(primarySrc.PrimaryIp6)
+					}
+					e.AssignedObject = newInterfaceStub(iface, devStub)
+				} else {
+					e.AssignedObject = stubForIface(iface)
+				}
 			}
 		case *diode.MACAddress:
 			if iface, ok := e.AssignedObject.(*diode.Interface); ok && iface != nil {

--- a/orb-discovery/snmp-discovery/mapping/stubs_multi_device_test.go
+++ b/orb-discovery/snmp-discovery/mapping/stubs_multi_device_test.go
@@ -33,7 +33,7 @@ func TestPruneNestedRefs_MultiDevice_InterfaceRoutesToOwningMember(t *testing.T)
 	}
 
 	entities := []diode.Entity{master, member, ifaceOnMaster, ifaceOnMember}
-	PruneNestedRefs(entities, master)
+	PruneNestedRefs(entities, master, nil)
 
 	// Top-level Devices stay rich — pruning must not touch their own DeviceType.
 	assert.NotNil(t, master.DeviceType, "rich master must remain rich (no top-level pruning)")
@@ -69,7 +69,7 @@ func TestPruneNestedRefs_MultiDevice_ParentBridgeLagRefsResolveToOwningMember(t 
 	}
 
 	entities := []diode.Entity{master, member, parent, sub}
-	PruneNestedRefs(entities, master)
+	PruneNestedRefs(entities, master, nil)
 
 	assert.Equal(t, "master-1-stack-2", *sub.Parent.Device.Name,
 		"subinterface's Parent.Device must resolve to the member, not stale master")
@@ -84,7 +84,7 @@ func TestPruneNestedRefs_MultiDevice_IPAddressRoutesViaInterface(t *testing.T) {
 		AssignedObject: memberIface,
 	}
 	entities := []diode.Entity{master, member, memberIface, ip}
-	PruneNestedRefs(entities, master)
+	PruneNestedRefs(entities, master, nil)
 
 	stub, ok := ip.AssignedObject.(*diode.Interface)
 	assert.True(t, ok)
@@ -96,7 +96,7 @@ func TestPruneNestedRefs_SingleDevice_BehaviorUnchanged(t *testing.T) {
 	iface := &diode.Interface{Name: strPtr("Gi0/0/0"), Device: dev}
 	ip := &diode.IPAddress{Address: strPtr("10.0.0.1/24"), AssignedObject: iface}
 	entities := []diode.Entity{dev, iface, ip}
-	PruneNestedRefs(entities, dev)
+	PruneNestedRefs(entities, dev, nil)
 
 	stub, _ := ip.AssignedObject.(*diode.Interface)
 	assert.Equal(t, "only", *stub.Device.Name)
@@ -136,7 +136,7 @@ func TestPruneNestedRefs_DuplicateIfaceNamesAcrossMembersPreserveExistingOwner(t
 	}
 
 	entities := []diode.Entity{master, member, masterMe0, memberMe0, masterMe0Sub, memberMe0Sub}
-	PruneNestedRefs(entities, master)
+	PruneNestedRefs(entities, master, nil)
 
 	// Each subinterface's Parent.Device stub must resolve to the
 	// member it was originally pointing at, not be rebound across
@@ -173,7 +173,7 @@ func TestPruneNestedRefs_UniqueIfaceNameStillCorrectsStaleParent(t *testing.T) {
 	}
 
 	entities := []diode.Entity{master, member, memberPort, sub}
-	PruneNestedRefs(entities, master)
+	PruneNestedRefs(entities, master, nil)
 
 	assert.Equal(t, "sw1-2", *sub.Parent.Device.Name,
 		"unique-name lookup must still rewrite stale Parent.Device to the correct member")

--- a/orb-discovery/snmp-discovery/mapping/stubs_test.go
+++ b/orb-discovery/snmp-discovery/mapping/stubs_test.go
@@ -141,7 +141,7 @@ func TestNewDeviceStubKeepingPrimary_ReattachesV4AsMatcherOnlyStub(t *testing.T)
 		},
 	}
 
-	stub := newDeviceStubKeepingPrimary(owner)
+	stub := newDeviceStubKeepingPrimary(owner, false, owner.PrimaryIp4)
 
 	require.NotNil(t, stub)
 	// Inherits the default stub's matcher / required fields.
@@ -164,7 +164,7 @@ func TestNewDeviceStubKeepingPrimary_ReattachesV6Only(t *testing.T) {
 		Name:       strPtr("sw1"),
 		PrimaryIp6: &diode.IPAddress{Address: &v6, AssignedObject: &diode.Interface{Name: strPtr("Vlan1")}},
 	}
-	stub := newDeviceStubKeepingPrimary(owner)
+	stub := newDeviceStubKeepingPrimary(owner, true, owner.PrimaryIp6)
 	require.NotNil(t, stub)
 	assert.Nil(t, stub.PrimaryIp4)
 	require.NotNil(t, stub.PrimaryIp6)
@@ -173,7 +173,7 @@ func TestNewDeviceStubKeepingPrimary_ReattachesV6Only(t *testing.T) {
 }
 
 func TestNewDeviceStubKeepingPrimary_NilOwnerReturnsNil(t *testing.T) {
-	assert.Nil(t, newDeviceStubKeepingPrimary(nil))
+	assert.Nil(t, newDeviceStubKeepingPrimary(nil, false, nil))
 }
 
 func TestNewDeviceStub_PreservesSourceMatchDropsRunID(t *testing.T) {
@@ -449,6 +449,43 @@ func TestPruneNestedRefs_PrimaryHitsKeepsPrimaryOnlyOnCycleCloser(t *testing.T) 
 	// Top-level rich Device stays rich (its own primary_ip4 untouched).
 	require.NotNil(t, rich.PrimaryIp4)
 	assert.Equal(t, v4, *rich.PrimaryIp4.Address)
+}
+
+// TestPruneNestedRefs_DualStackKeepsOnlyMatchingFamilyPerCycleCloser confirms
+// that on a dual-stack device each cycle-closer keeps ONLY its own family's
+// primary. The v4 IPAddress entity's change set assigns only the v4 address, so
+// its nested device stub must carry primary_ip4 but NOT primary_ip6 (and vice
+// versa) — otherwise it would try to set the other family's primary before that
+// address is assigned to the device.
+func TestPruneNestedRefs_DualStackKeepsOnlyMatchingFamilyPerCycleCloser(t *testing.T) {
+	v4 := "10.0.0.1/24"
+	v6 := "2001:db8::1/64"
+	ifType := strPtr("1000base-t")
+	rich := &diode.Device{
+		Name:       strPtr("sw1"),
+		Serial:     strPtr("FCW123"),
+		Site:       &diode.Site{Name: strPtr("dc1")},
+		DeviceType: &diode.DeviceType{Model: strPtr("C9300")},
+		Role:       &diode.DeviceRole{Name: strPtr("access")},
+		PrimaryIp4: &diode.IPAddress{Address: &v4},
+		PrimaryIp6: &diode.IPAddress{Address: &v6},
+	}
+	// v4 and v6 primaries on DIFFERENT interfaces (separate change sets).
+	v4Iface := &diode.Interface{Name: strPtr("Vlan1"), Device: rich, Type: ifType}
+	v4IP := &diode.IPAddress{Address: &v4, AssignedObject: v4Iface}
+	v6Iface := &diode.Interface{Name: strPtr("Vlan2"), Device: rich, Type: ifType}
+	v6IP := &diode.IPAddress{Address: &v6, AssignedObject: v6Iface}
+
+	entities := []diode.Entity{rich, v4Iface, v6Iface, v4IP, v6IP}
+	PruneNestedRefs(entities, rich, map[*diode.IPAddress]bool{v4IP: true, v6IP: true})
+
+	v4Stub := v4IP.AssignedObject.(*diode.Interface)
+	require.NotNil(t, v4Stub.Device.PrimaryIp4, "v4 cycle-closer keeps primary_ip4")
+	assert.Nil(t, v4Stub.Device.PrimaryIp6, "v4 cycle-closer must NOT carry primary_ip6")
+
+	v6Stub := v6IP.AssignedObject.(*diode.Interface)
+	require.NotNil(t, v6Stub.Device.PrimaryIp6, "v6 cycle-closer keeps primary_ip6")
+	assert.Nil(t, v6Stub.Device.PrimaryIp4, "v6 cycle-closer must NOT carry primary_ip4")
 }
 
 // TestPruneNestedRefs_NilPrimaryHitsStripsEverything confirms that

--- a/orb-discovery/snmp-discovery/mapping/stubs_test.go
+++ b/orb-discovery/snmp-discovery/mapping/stubs_test.go
@@ -97,14 +97,15 @@ func TestNewDeviceStub_KeepsMatcherAndRequiredFieldsDropsRest(t *testing.T) {
 	assert.Same(t, role, stub.Role)
 	assert.Same(t, deviceType, stub.DeviceType)
 
-	// PrimaryIp4 stubbed (no AssignedObject) — cycle break.
-	assert.NotNil(t, stub.PrimaryIp4)
-	assert.NotSame(t, rich.PrimaryIp4, stub.PrimaryIp4)
-	assert.Equal(t, &v4, stub.PrimaryIp4.Address)
-	assert.Nil(t, stub.PrimaryIp4.AssignedObject)
-
-	assert.NotNil(t, stub.PrimaryIp6)
-	assert.Equal(t, &v6, stub.PrimaryIp6.Address)
+	// Primary IPs are stripped from the default stub. The diode
+	// reconciler can only resolve the circular primary-IP reference
+	// within a single change set, and each emitted entity becomes its
+	// own change set; carrying a matcher-only primary IP here would
+	// make every nested device stub try to SET device.primary_ip4 and
+	// fail on first ingest. Only the cycle-closer IPAddress entity's
+	// nested device may carry it (see newDeviceStubKeepingPrimary).
+	assert.Nil(t, stub.PrimaryIp4)
+	assert.Nil(t, stub.PrimaryIp6)
 
 	// AssetTag propagates — it is populated via
 	// PolicyConfig.Defaults.AssetTag and the stub must carry it so
@@ -125,6 +126,54 @@ func TestNewDeviceStub_NilPrimaryIPs(t *testing.T) {
 	assert.NotNil(t, stub)
 	assert.Nil(t, stub.PrimaryIp4)
 	assert.Nil(t, stub.PrimaryIp6)
+}
+
+func TestNewDeviceStubKeepingPrimary_ReattachesV4AsMatcherOnlyStub(t *testing.T) {
+	v4 := "192.0.2.10/24"
+	owner := &diode.Device{
+		Name:       strPtr("sw1"),
+		Site:       &diode.Site{Name: strPtr("dc1")},
+		DeviceType: &diode.DeviceType{Model: strPtr("Catalyst 9300")},
+		Role:       &diode.DeviceRole{Name: strPtr("access")},
+		PrimaryIp4: &diode.IPAddress{
+			Address:        &v4,
+			AssignedObject: &diode.Interface{Name: strPtr("Vlan1")},
+		},
+	}
+
+	stub := newDeviceStubKeepingPrimary(owner)
+
+	require.NotNil(t, stub)
+	// Inherits the default stub's matcher / required fields.
+	assert.Equal(t, strPtr("sw1"), stub.Name)
+	assert.Same(t, owner.Site, stub.Site)
+	assert.Same(t, owner.Role, stub.Role)
+	assert.Same(t, owner.DeviceType, stub.DeviceType)
+	// Re-attaches the primary as a matcher-only stub: address kept,
+	// AssignedObject cleared so it carries no cycle.
+	require.NotNil(t, stub.PrimaryIp4)
+	assert.NotSame(t, owner.PrimaryIp4, stub.PrimaryIp4)
+	assert.Equal(t, &v4, stub.PrimaryIp4.Address)
+	assert.Nil(t, stub.PrimaryIp4.AssignedObject)
+	assert.Nil(t, stub.PrimaryIp6)
+}
+
+func TestNewDeviceStubKeepingPrimary_ReattachesV6Only(t *testing.T) {
+	v6 := "2001:db8::1/64"
+	owner := &diode.Device{
+		Name:       strPtr("sw1"),
+		PrimaryIp6: &diode.IPAddress{Address: &v6, AssignedObject: &diode.Interface{Name: strPtr("Vlan1")}},
+	}
+	stub := newDeviceStubKeepingPrimary(owner)
+	require.NotNil(t, stub)
+	assert.Nil(t, stub.PrimaryIp4)
+	require.NotNil(t, stub.PrimaryIp6)
+	assert.Equal(t, &v6, stub.PrimaryIp6.Address)
+	assert.Nil(t, stub.PrimaryIp6.AssignedObject)
+}
+
+func TestNewDeviceStubKeepingPrimary_NilOwnerReturnsNil(t *testing.T) {
+	assert.Nil(t, newDeviceStubKeepingPrimary(nil))
 }
 
 func TestNewDeviceStub_PreservesSourceMatchDropsRunID(t *testing.T) {
@@ -256,7 +305,7 @@ func TestPruneNestedRefs_RewritesAllNestedDeviceRefs(t *testing.T) {
 
 	entities := []diode.Entity{currentDevice, iface, parent, bridge, lag, ip, macEntity, module}
 
-	PruneNestedRefs(entities, currentDevice)
+	PruneNestedRefs(entities, currentDevice, nil)
 
 	// Top-level Device unchanged — still rich.
 	assert.Equal(t, strPtr("FCW123"), currentDevice.Serial)
@@ -298,14 +347,170 @@ func TestPruneNestedRefs_RewritesAllNestedDeviceRefs(t *testing.T) {
 func TestPruneNestedRefs_NilCurrentDeviceIsNoOp(t *testing.T) {
 	iface := &diode.Interface{Name: strPtr("eth0")}
 	entities := []diode.Entity{iface}
-	PruneNestedRefs(entities, nil)
+	PruneNestedRefs(entities, nil, nil)
 	assert.Nil(t, iface.Device)
 }
 
 func TestPruneNestedRefs_EmptySliceIsNoOp(t *testing.T) {
 	dev := &diode.Device{Name: strPtr("sw1")}
-	PruneNestedRefs(nil, dev)
+	PruneNestedRefs(nil, dev, nil)
 	assert.Equal(t, strPtr("sw1"), dev.Name)
+}
+
+// TestPruneNestedRefs_PrimaryHitsKeepsPrimaryOnlyOnCycleCloser verifies
+// the surgical primary-IP behavior: the diode reconciler can only
+// resolve the circular primary-IP reference within a single change set,
+// and the only entity that can validly do so is the top-level
+// ipam.ipaddress entity for the primary IP (the cycle-closer) — it
+// performs the IP->interface assignment AND sets device.primary_ip4 in
+// the same change set. So the nested device stub on that one IPAddress
+// keeps a matcher-only primary IP; every other nested device stub
+// (other interfaces, modules, module bays, MAC, non-primary IPs) is
+// stripped.
+func TestPruneNestedRefs_PrimaryHitsKeepsPrimaryOnlyOnCycleCloser(t *testing.T) {
+	v4 := "10.0.0.1/24"
+	site := &diode.Site{Name: strPtr("dc1")}
+	dtype := &diode.DeviceType{Model: strPtr("C9300")}
+	role := &diode.DeviceRole{Name: strPtr("access")}
+	rich := &diode.Device{
+		Name:       strPtr("sw1"),
+		Serial:     strPtr("FCW123"),
+		Site:       site,
+		DeviceType: dtype,
+		Role:       role,
+		PrimaryIp4: &diode.IPAddress{Address: &v4},
+	}
+
+	ifType := strPtr("1000base-t")
+	mgmtMac := "aa:bb:cc:dd:ee:00"
+	// Cycle-closer interface: the one the primary IP is assigned to.
+	closerIface := &diode.Interface{
+		Name:              strPtr("Vlan1"),
+		Device:            rich,
+		Type:              ifType,
+		PrimaryMacAddress: &diode.MACAddress{MacAddress: &mgmtMac},
+	}
+	primaryIP := &diode.IPAddress{Address: &v4, AssignedObject: closerIface}
+
+	// A non-primary IP on a different interface.
+	otherIface := &diode.Interface{Name: strPtr("Gi1/0/2"), Device: rich, Type: ifType}
+	otherAddr := "192.0.2.9/32"
+	otherIP := &diode.IPAddress{Address: &otherAddr, AssignedObject: otherIface}
+
+	// A MAC entity assigned to yet another interface.
+	macIface := &diode.Interface{Name: strPtr("Gi1/0/3"), Device: rich, Type: ifType}
+	macStr := "aa:bb:cc:dd:ee:ff"
+	macEntity := &diode.MACAddress{MacAddress: &macStr, AssignedObject: macIface}
+
+	// A module bay + interface module (chassis path).
+	bay := &diode.ModuleBay{Device: rich, Name: strPtr("Slot 1")}
+	module := &diode.Module{Device: rich}
+	modIface := &diode.Interface{Name: strPtr("Gi1/0/4"), Device: rich, Type: ifType, Module: module}
+
+	entities := []diode.Entity{rich, closerIface, otherIface, macIface, modIface, bay, module, primaryIP, otherIP, macEntity}
+
+	primaryHits := map[*diode.IPAddress]bool{primaryIP: true}
+	PruneNestedRefs(entities, rich, primaryHits)
+
+	// Cycle-closer: nested device keeps matcher-only primary_ip4 and the
+	// interface keeps its rich Type.
+	closerStub, ok := primaryIP.AssignedObject.(*diode.Interface)
+	require.True(t, ok)
+	require.NotNil(t, closerStub.Type, "cycle-closer interface keeps its Type")
+	require.NotNil(t, closerStub.Device)
+	require.NotNil(t, closerStub.Device.PrimaryIp4, "cycle-closer nested device keeps primary_ip4")
+	assert.Equal(t, v4, *closerStub.Device.PrimaryIp4.Address)
+	assert.Nil(t, closerStub.Device.PrimaryIp4.AssignedObject, "primary_ip4 is matcher-only")
+	// And the closer's nested device stub is NOT the shared cached stub.
+	assert.NotSame(t, closerStub.Device, otherIface.Device)
+
+	// Non-primary IP's nested device: stripped.
+	otherStub, ok := otherIP.AssignedObject.(*diode.Interface)
+	require.True(t, ok)
+	require.NotNil(t, otherStub.Device)
+	assert.Nil(t, otherStub.Device.PrimaryIp4, "non-primary IP nested device must be stripped")
+
+	// Top-level non-primary interface's own Device stub: stripped.
+	require.NotNil(t, otherIface.Device)
+	assert.Nil(t, otherIface.Device.PrimaryIp4, "non-primary interface device stub stripped")
+
+	// MAC's nested device: stripped.
+	macStub, ok := macEntity.AssignedObject.(*diode.Interface)
+	require.True(t, ok)
+	require.NotNil(t, macStub.Device)
+	assert.Nil(t, macStub.Device.PrimaryIp4, "MAC nested device must be stripped")
+
+	// Module + ModuleBay device stubs: stripped.
+	require.NotNil(t, bay.Device)
+	assert.Nil(t, bay.Device.PrimaryIp4, "module bay device stub stripped")
+	require.NotNil(t, module.Device)
+	assert.Nil(t, module.Device.PrimaryIp4, "module device stub stripped")
+
+	// Top-level rich Device stays rich (its own primary_ip4 untouched).
+	require.NotNil(t, rich.PrimaryIp4)
+	assert.Equal(t, v4, *rich.PrimaryIp4.Address)
+}
+
+// TestPruneNestedRefs_NilPrimaryHitsStripsEverything confirms that
+// without a primaryHits set (the common no-cycle-closer case), every
+// nested device stub has its primary IP stripped — including the IP
+// whose address happens to equal the device's primary.
+func TestPruneNestedRefs_NilPrimaryHitsStripsEverything(t *testing.T) {
+	v4 := "10.0.0.1/24"
+	rich := &diode.Device{
+		Name:       strPtr("sw1"),
+		PrimaryIp4: &diode.IPAddress{Address: &v4},
+	}
+	iface := &diode.Interface{Name: strPtr("Vlan1"), Device: rich, Type: strPtr("virtual")}
+	ip := &diode.IPAddress{Address: &v4, AssignedObject: iface}
+	entities := []diode.Entity{rich, iface, ip}
+
+	PruneNestedRefs(entities, rich, nil)
+
+	stub, ok := ip.AssignedObject.(*diode.Interface)
+	require.True(t, ok)
+	require.NotNil(t, stub.Device)
+	assert.Nil(t, stub.Device.PrimaryIp4,
+		"nil primaryHits: every nested device stub must be stripped")
+}
+
+// TestPruneNestedRefs_PrimaryHitsStackMemberFallsBackToMaster covers the
+// stack edge: the cycle-closer's owner interface may belong to a stack
+// member whose own PrimaryIp4 is nil, while the master/currentDevice
+// carries it. newDeviceStubKeepingPrimary copies the primary from the
+// device that actually carries it: it prefers the resolved owner and
+// falls back to currentDevice when the owner's primary is nil. This
+// member-vs-master case should be confirmed against a real stacked-
+// switch capture.
+func TestPruneNestedRefs_PrimaryHitsStackMemberFallsBackToMaster(t *testing.T) {
+	v4 := "10.0.0.1/24"
+	master := &diode.Device{
+		Name:       strPtr("stack"),
+		PrimaryIp4: &diode.IPAddress{Address: &v4},
+	}
+	// Member carries no primary IP of its own.
+	member := &diode.Device{Name: strPtr("stack-2")}
+
+	// The primary IP's interface is owned by the member.
+	memberIface := &diode.Interface{Name: strPtr("Gi2/0/1"), Device: member, Type: strPtr("1000base-t")}
+	primaryIP := &diode.IPAddress{Address: &v4, AssignedObject: memberIface}
+
+	entities := []diode.Entity{master, member, memberIface, primaryIP}
+	primaryHits := map[*diode.IPAddress]bool{primaryIP: true}
+
+	// currentDevice is the master (the device carrying the primary).
+	PruneNestedRefs(entities, master, primaryHits)
+
+	stub, ok := primaryIP.AssignedObject.(*diode.Interface)
+	require.True(t, ok)
+	// Owner resolves to the member by name.
+	assert.Equal(t, "stack-2", *stub.Device.Name, "owner stub must resolve to the member")
+	// But the member's own primary is nil, so the fallback copies the
+	// master/currentDevice primary onto the cycle-closer stub.
+	require.NotNil(t, stub.Device.PrimaryIp4,
+		"member-owner with nil primary must fall back to currentDevice's primary")
+	assert.Equal(t, v4, *stub.Device.PrimaryIp4.Address)
+	assert.Nil(t, stub.Device.PrimaryIp4.AssignedObject, "primary_ip4 stays matcher-only")
 }
 
 func TestPruneNestedRefs_StubsModuleBayAndInterfaceModule(t *testing.T) {
@@ -344,7 +549,7 @@ func TestPruneNestedRefs_StubsModuleBayAndInterfaceModule(t *testing.T) {
 	}
 	entities := []diode.Entity{rich, bay, transceiverBay, transceiver, iface}
 
-	PruneNestedRefs(entities, rich)
+	PruneNestedRefs(entities, rich, nil)
 
 	// ModuleBay.Device must be stubbed.
 	require.NotNil(t, bay.Device)
@@ -417,7 +622,7 @@ func TestPruneNestedRefs_InterfaceModuleSurvivesWhenSerialNilButBayPresent(t *te
 		Device: rich,
 		Module: transceiver,
 	}
-	PruneNestedRefs([]diode.Entity{rich, bay, transceiver, iface}, rich)
+	PruneNestedRefs([]diode.Entity{rich, bay, transceiver, iface}, rich, nil)
 
 	require.NotNil(t, iface.Module,
 		"Interface.Module must NOT be cleared when bay matcher is available even without serial")
@@ -459,7 +664,7 @@ func TestPruneNestedRefs_InterfaceModuleStubDegradesToSerialOnly(t *testing.T) {
 		Device: rich,
 		Module: transceiver,
 	}
-	PruneNestedRefs([]diode.Entity{rich, transceiver, iface}, rich)
+	PruneNestedRefs([]diode.Entity{rich, transceiver, iface}, rich, nil)
 
 	require.NotNil(t, iface.Module, "must not be cleared when serial is present")
 	assert.Equal(t, "FNS00000001", strDerefSafe(iface.Module.Serial))
@@ -494,7 +699,7 @@ func TestPruneNestedRefs_InterfaceModuleClearedWhenSerialAndBayBothMissing(t *te
 		Device: rich,
 		Module: transceiver,
 	}
-	PruneNestedRefs([]diode.Entity{rich, transceiver, iface}, rich)
+	PruneNestedRefs([]diode.Entity{rich, transceiver, iface}, rich, nil)
 
 	assert.Nil(t, iface.Module,
 		"must clear when neither Serial nor Bay can resolve the ref")
@@ -527,7 +732,7 @@ func TestPruneNestedRefs_InterfaceModuleSerialNilCleared(t *testing.T) {
 	}
 	entities := []diode.Entity{rich, transceiver, iface}
 
-	PruneNestedRefs(entities, rich)
+	PruneNestedRefs(entities, rich, nil)
 
 	assert.Nil(t, iface.Module,
 		"Interface.Module must be cleared when its Serial is nil — an identifier-less stub would be ambiguous")
@@ -551,7 +756,7 @@ func TestPruneNestedRefs_InterfaceModuleEmptyStringSerialCleared(t *testing.T) {
 		Device: rich,
 		Module: transceiver,
 	}
-	PruneNestedRefs([]diode.Entity{rich, transceiver, iface}, rich)
+	PruneNestedRefs([]diode.Entity{rich, transceiver, iface}, rich, nil)
 
 	assert.Nil(t, iface.Module,
 		"Interface.Module must be cleared when Serial points at the empty string")

--- a/orb-discovery/snmp-discovery/policy/runner.go
+++ b/orb-discovery/snmp-discovery/policy/runner.go
@@ -360,7 +360,7 @@ func (r *Runner) runWithMetadata(target config.Target, parentTarget string) {
 	ctx, cancel := context.WithTimeout(r.ctx, r.timeout)
 	defer cancel()
 
-	entities, err := r.queryTarget(ctx, target)
+	entities, primaryHits, err := r.queryTarget(ctx, target)
 	if err != nil {
 		r.logger.Error("error querying target", "host", target.Host, "error", err, "policy", policyName)
 		r.runStore.UpdateRun(policyName, targetHost, targetPort, run.ID, RunStatusFailed, err, 0)
@@ -385,7 +385,7 @@ func (r *Runner) runWithMetadata(target config.Target, parentTarget string) {
 	// the wire payload. Runs after annotation so the annotators can walk
 	// the rich shared graph with their unsafe.Pointer dedup intact —
 	// otherwise every stub would need its own metadata pass.
-	mapping.PruneNestedRefs(entities, mapping.CurrentDeviceFrom(entities))
+	mapping.PruneNestedRefs(entities, mapping.CurrentDeviceFrom(entities), primaryHits)
 
 	resp, err := r.client.Ingest(r.ctx, entities, diode.WithIngestMetadata(diode.Metadata{
 		"policy_name": policyName,
@@ -449,9 +449,15 @@ func (r *Runner) assetTagClaimer(targetID string) func(string) bool {
 	}
 }
 
-func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode.Entity, error) {
+// queryTarget walks the target, maps the result to entities, and returns
+// the entity slice along with the per-target set of cycle-closer primary
+// IP entities (the top-level ipam.ipaddress entities that set a device's
+// primary IP). The hits are returned by value — never stashed on the
+// shared Runner, which serves targets concurrently — so the caller can
+// thread them into PruneNestedRefs for this target only.
+func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode.Entity, map[*diode.IPAddress]bool, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	targetDefaults := r.resolveTargetDefaults(target)
@@ -459,7 +465,7 @@ func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode
 	mappingConfig, err := mapping.NewConfig(r.mappingConfig.Entries, r.logger, r.manufacturers, r.deviceLookup, targetDefaults, r.config.Options)
 	if err != nil {
 		r.logger.Error("error creating mapping config", "error", err)
-		return nil, err
+		return nil, nil, err
 	}
 	targetHost := strings.TrimSpace(target.Host)
 
@@ -509,7 +515,7 @@ func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode
 					attribute.String("error", ctx.Err().Error()),
 				))
 		}
-		return nil, ctx.Err()
+		return nil, nil, ctx.Err()
 	case res := <-resultCh:
 		if res.err != nil {
 			r.logger.Warn("error crawling host", "host", targetHost, "error", res.err)
@@ -520,7 +526,7 @@ func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode
 						attribute.String("error", res.err.Error()),
 					))
 			}
-			return nil, res.err
+			return nil, nil, res.err
 		}
 		oids = res.oids
 	}
@@ -553,7 +559,7 @@ func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode
 							attribute.String("error", ctx.Err().Error()),
 						))
 				}
-				return nil, ctx.Err()
+				return nil, nil, ctx.Err()
 			case res := <-vendorCh:
 				if res.err != nil {
 					r.logger.Warn("phase 2 walk failed; continuing with generic only",
@@ -679,7 +685,10 @@ func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode
 				attribute.String("policy", policyName)))
 	}
 
-	return entities, nil
+	// Capture the per-target cycle-closer primary IP hits and return them
+	// by value so the caller can thread them into PruneNestedRefs without
+	// any shared Runner state (concurrency-safe).
+	return entities, mapper.PrimaryIPHits(), nil
 }
 
 func (r *Runner) expandTargetRanges(configuredTargets []config.Target) []expandedTargetGroup {

--- a/orb-discovery/snmp-discovery/policy/runner_internal_test.go
+++ b/orb-discovery/snmp-discovery/policy/runner_internal_test.go
@@ -281,8 +281,9 @@ func TestQueryTargetContextAlreadyCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	entities, err := runner.queryTarget(ctx, config.Target{Host: "127.0.0.1", Port: 161})
+	entities, primaryHits, err := runner.queryTarget(ctx, config.Target{Host: "127.0.0.1", Port: 161})
 	assert.Nil(t, entities)
+	assert.Nil(t, primaryHits)
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
@@ -297,8 +298,9 @@ func TestQueryTargetContextTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	entities, err := runner.queryTarget(ctx, config.Target{Host: "127.0.0.1", Port: 161})
+	entities, primaryHits, err := runner.queryTarget(ctx, config.Target{Host: "127.0.0.1", Port: 161})
 	assert.Nil(t, entities)
+	assert.Nil(t, primaryHits)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
@@ -318,8 +320,9 @@ func TestQueryTargetWalkError(t *testing.T) {
 		return &testWalker{walkErr: walkErr}, nil
 	}, entries)
 
-	entities, err := runner.queryTarget(context.Background(), config.Target{Host: "127.0.0.1", Port: 161})
+	entities, primaryHits, err := runner.queryTarget(context.Background(), config.Target{Host: "127.0.0.1", Port: 161})
 	assert.Nil(t, entities)
+	assert.Nil(t, primaryHits)
 	assert.ErrorIs(t, err, walkErr)
 }
 
@@ -336,7 +339,7 @@ func TestQueryTargetSuccess(t *testing.T) {
 	}
 	runner := queryTargetRunner(snmp.NewFakeSNMPWalker, entries)
 
-	entities, err := runner.queryTarget(context.Background(), config.Target{Host: "127.0.0.1", Port: 161})
+	entities, _, err := runner.queryTarget(context.Background(), config.Target{Host: "127.0.0.1", Port: 161})
 	require.NoError(t, err)
 	assert.NotEmpty(t, entities)
 }
@@ -416,7 +419,7 @@ func TestQueryTargetAssignsPrimaryIPFromTarget(t *testing.T) {
 	}
 
 	runner := queryTargetRunner(factory, entries)
-	entities, err := runner.queryTarget(context.Background(), config.Target{Host: "10.0.0.1", Port: 161})
+	entities, primaryHits, err := runner.queryTarget(context.Background(), config.Target{Host: "10.0.0.1", Port: 161})
 	require.NoError(t, err)
 	require.NotEmpty(t, entities)
 
@@ -450,6 +453,29 @@ func TestQueryTargetAssignsPrimaryIPFromTarget(t *testing.T) {
 		"PrimaryIp4 snapshot's interface must carry a Device (Diode validation)")
 	assert.Nil(t, snapshotIface.Device.PrimaryIp4,
 		"nested Device must have PrimaryIp4 cleared to break the cycle")
+
+	// The cycle-closer is the IPAddress entity for the primary IP itself.
+	// queryTarget reports it via primaryHits keyed by the live entity.
+	require.NotNil(t, primaryHits, "queryTarget must report the primary-IP cycle-closer hits")
+	assert.True(t, primaryHits[primaryIP],
+		"the primary IPAddress entity must be flagged as a cycle-closer")
+
+	// Post-prune: the cycle-closer IP entity's nested device keeps a
+	// matcher-only primary_ip4 (it can validly close the circular
+	// reference within its own change set), while a non-primary nested
+	// device stub is stripped. Mirror the production sequence.
+	annotateEntitiesWithRunID(entities, "run-primary")
+	mapping.PruneNestedRefs(entities, mapping.CurrentDeviceFrom(entities), primaryHits)
+
+	closerIface, ok := primaryIP.AssignedObject.(*diode.Interface)
+	require.True(t, ok, "cycle-closer IP must still carry an interface stub after prune")
+	require.NotNil(t, closerIface.Type, "cycle-closer interface keeps its Type after prune")
+	require.NotNil(t, closerIface.Device, "cycle-closer interface keeps a device stub")
+	require.NotNil(t, closerIface.Device.PrimaryIp4,
+		"cycle-closer nested device keeps a matcher-only primary_ip4")
+	assert.Equal(t, "10.0.0.1/32", *closerIface.Device.PrimaryIp4.Address)
+	assert.Nil(t, closerIface.Device.PrimaryIp4.AssignedObject,
+		"cycle-closer's primary_ip4 is matcher-only (no AssignedObject)")
 }
 
 // TestQueryTargetAssignsPrimaryIPFromTarget_ModernIpAddressTable is the
@@ -557,7 +583,7 @@ func TestQueryTargetAssignsPrimaryIPFromTarget_ModernIpAddressTable(t *testing.T
 	// between scans.
 	t.Run("IPv4 target -> PrimaryIp4", func(t *testing.T) {
 		runner := queryTargetRunner(factory, entries)
-		entities, err := runner.queryTarget(context.Background(), config.Target{Host: "10.0.0.1", Port: 161})
+		entities, _, err := runner.queryTarget(context.Background(), config.Target{Host: "10.0.0.1", Port: 161})
 		require.NoError(t, err)
 		require.NotEmpty(t, entities)
 
@@ -578,7 +604,7 @@ func TestQueryTargetAssignsPrimaryIPFromTarget_ModernIpAddressTable(t *testing.T
 
 	t.Run("IPv6 target -> PrimaryIp6", func(t *testing.T) {
 		runner := queryTargetRunner(factory, entries)
-		entities, err := runner.queryTarget(context.Background(), config.Target{Host: "2001:db8::1", Port: 161})
+		entities, _, err := runner.queryTarget(context.Background(), config.Target{Host: "2001:db8::1", Port: 161})
 		require.NoError(t, err)
 		require.NotEmpty(t, entities)
 
@@ -765,7 +791,7 @@ func TestRunnerAnnotateThenPrune(t *testing.T) {
 	}
 
 	runner := queryTargetRunner(factory, entries)
-	entities, err := runner.queryTarget(context.Background(), config.Target{Host: "10.0.0.1", Port: 161})
+	entities, primaryHits, err := runner.queryTarget(context.Background(), config.Target{Host: "10.0.0.1", Port: 161})
 	require.NoError(t, err)
 	require.NotEmpty(t, entities)
 
@@ -773,7 +799,7 @@ func TestRunnerAnnotateThenPrune(t *testing.T) {
 	netboxID := 42
 	annotateDeviceWithSourceMatch(entities, netboxID)
 	annotateEntitiesWithRunID(entities, "run-abc")
-	mapping.PruneNestedRefs(entities, mapping.CurrentDeviceFrom(entities))
+	mapping.PruneNestedRefs(entities, mapping.CurrentDeviceFrom(entities), primaryHits)
 
 	// Find the rich top-level Device.
 	var richDevice *diode.Device
@@ -909,7 +935,7 @@ func TestRunWithMetadata_StandaloneSetsSerialFromEntityMib(t *testing.T) {
 	}
 
 	runner := queryTargetRunner(factory, chassisEntries())
-	entities, err := runner.queryTarget(context.Background(), config.Target{Host: "192.0.2.1", Port: 161})
+	entities, _, err := runner.queryTarget(context.Background(), config.Target{Host: "192.0.2.1", Port: 161})
 	require.NoError(t, err)
 	require.NotEmpty(t, entities)
 
@@ -984,7 +1010,7 @@ func TestRunWithMetadata_EmitsFullStackShape(t *testing.T) {
 	// Use NetboxID=42 on the target so we can verify source_match on master.
 	netboxID := 42
 	target := config.Target{Host: "192.0.2.1", Port: 161, NetboxID: &netboxID}
-	entities, err := runner.queryTarget(context.Background(), target)
+	entities, primaryHits, err := runner.queryTarget(context.Background(), target)
 	require.NoError(t, err)
 	require.NotEmpty(t, entities)
 
@@ -993,7 +1019,7 @@ func TestRunWithMetadata_EmitsFullStackShape(t *testing.T) {
 		annotateDeviceWithSourceMatch(entities, *target.NetboxID)
 	}
 	annotateEntitiesWithRunID(entities, "run-stack-123")
-	mapping.PruneNestedRefs(entities, mapping.CurrentDeviceFrom(entities))
+	mapping.PruneNestedRefs(entities, mapping.CurrentDeviceFrom(entities), primaryHits)
 
 	// Collect typed results.
 	var masterDev, memberDev *diode.Device


### PR DESCRIPTION
## Summary

Fixes a diode reconciler circular-`primary_ip4` reconcile failure for snmp-discovery — the same issue addressed for device-discovery (#422) and gnmi-discovery (#423), here in the Go SNMP mapping/prune path. On a device whose management IP is on a separate interface, first-ingest interface/module change sets failed with `{"dcim.device":{"primary_ip4":["The specified IP address (…) is not assigned to this device."]}}`.

## Root cause

`dcim.device.primary_ip4` is a circular reference the diode-netbox-plugin can resolve only **within a single change set**, but the reconciler turns each emitted entity into its own change set. Every nested device match stub carried a matcher-only `PrimaryIp4`/`PrimaryIp6`, so any change set creating/updating the inline device tried to **set** `primary_ip4` before that IP was assigned to an interface of the device.

The only entity that can validly set it in one change set is the **top-level `ipam.ipaddress` for the primary IP** (the cycle-closer): it performs the IP→interface assignment and, via its nested device stub, sets `primary_ip4` in the same change set.

## Fix

- `newDeviceStub` no longer carries `PrimaryIp4`/`PrimaryIp6` (the cached/shared stub is stripped). New non-cached `newDeviceStubKeepingPrimary` re-attaches a matcher-only primary for the cycle-closer only.
- `assignPrimaryIP` records the **live** chosen IPAddress pointers; `queryTarget` returns that set (3-tuple) so `PruneNestedRefs` identifies the cycle-closer(s) by **pointer identity** and rebuilds their nested device stub with the primary while keeping the rich interface `Type` (so the IP→interface create validates). A shared `resolveIfaceOwner` keeps the stripped and cycle-closer paths from drifting.
- The virtual-chassis master reference (`buildMasterRef`) no longer carries the primary IPs (it never closes the cycle). `AttachVrfs`/`syncDeviceShallow` degrades to a nil-guarded no-op.
- **Stack edge:** the cycle-closer's owner may be a stack member whose own primary is unset while the master carries it, so the primary is sourced from the device that actually carries it (owner, falling back to the current/master device).
- Top-level device entity unchanged. No duplicate devices: stubs resolve via `name+site+tenant` / `asset_tag`.

## Test plan

- [x] `GOWORK=off go test ./mapping/ ./policy/` green; `go build ./...` OK; `gofmt -l` empty; `go vet` clean; `golangci-lint run` 0 issues.
- [x] Unit: `newDeviceStub` strips primaries; `buildMasterRef` strips primaries; `newDeviceStubKeepingPrimary` re-attaches matcher-only; `PruneNestedRefs` keeps the primary only on the pointer-identified cycle-closer (other interfaces/modules/module-bays/MAC/non-primary IPs stripped); nil set strips everything; multi-device/stack fallback.
- [x] All `PruneNestedRefs`/`queryTarget` call sites updated for the new signatures; runner-internal post-prune assertion added.
- [x] **Live end-to-end** against a local diode + NetBox (+ plugin): drove a **two-member switch-stack** OID fixture through the real pipeline (`MapObjectIDsToEntity` → `TranslateAsStack` → `assignPrimaryIP` → `PruneNestedRefs`) and ingested via the diode Go SDK. Result: **0 failed change sets**; the master gets `primary_ip4` on first ingest, the member does not, both join the virtual chassis, interfaces present — confirming the cycle-closer and the stack-edge path.

Sibling of #422 (device-discovery) and #423 (gnmi-discovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
