### PR TITLE
chore(repo): root Makefile lint-all/test-all, cleanup, and develop version marker

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,10 @@ jobs:
           LATEST_RELEASE=$(git ls-remote --tags --refs origin 'refs/tags/v*' | sed 's#.*refs/tags/##' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
           # Non-release builds carry the short commit SHA so a develop/PR image
           # (e.g. 2.11.0-a1b2c3d) is distinguishable from the clean release (2.11.0).
-          echo "${LATEST_RELEASE:-develop}-${GITHUB_SHA::7}" > ./agent/version/BUILD_VERSION.txt
+          # Strip the leading v (LATEST_RELEASE is a v-prefixed tag) to match the
+          # release workflow, which stamps the unprefixed version.
+          base="${LATEST_RELEASE:-develop}"
+          echo "${base#v}-${GITHUB_SHA::7}" > ./agent/version/BUILD_VERSION.txt
           echo "BUILD_COMMIT_SHORT=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
 
       - name: Resolve backend versions

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,9 @@ jobs:
           # releases are tagged <backend>/v* and are excluded by the refs/tags/v*
           # pattern; ls-remote avoids release-API pagination and works at any clone depth.
           LATEST_RELEASE=$(git ls-remote --tags --refs origin 'refs/tags/v*' | sed 's#.*refs/tags/##' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
-          echo "${LATEST_RELEASE:-develop}" > ./agent/version/BUILD_VERSION.txt
+          # Non-release builds carry the short commit SHA so a develop/PR image
+          # (e.g. 2.11.0-a1b2c3d) is distinguishable from the clean release (2.11.0).
+          echo "${LATEST_RELEASE:-develop}-${GITHUB_SHA::7}" > ./agent/version/BUILD_VERSION.txt
           echo "BUILD_COMMIT_SHORT=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
 
       - name: Resolve backend versions

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -57,7 +57,9 @@ jobs:
           # releases are tagged <backend>/v* and are excluded by the refs/tags/v*
           # pattern; ls-remote avoids release-API pagination and works at any clone depth.
           LATEST_RELEASE=$(git ls-remote --tags --refs origin 'refs/tags/v*' | sed 's#.*refs/tags/##' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
-          echo "${LATEST_RELEASE:-develop}" > ./agent/version/BUILD_VERSION.txt
+          # Non-release builds carry the short commit SHA so a develop/PR image
+          # (e.g. 2.11.0-a1b2c3d) is distinguishable from the clean release (2.11.0).
+          echo "${LATEST_RELEASE:-develop}-${GITHUB_SHA::7}" > ./agent/version/BUILD_VERSION.txt
           echo "BUILD_COMMIT_SHORT=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
 
       - name: Resolve backend versions

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -59,7 +59,10 @@ jobs:
           LATEST_RELEASE=$(git ls-remote --tags --refs origin 'refs/tags/v*' | sed 's#.*refs/tags/##' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
           # Non-release builds carry the short commit SHA so a develop/PR image
           # (e.g. 2.11.0-a1b2c3d) is distinguishable from the clean release (2.11.0).
-          echo "${LATEST_RELEASE:-develop}-${GITHUB_SHA::7}" > ./agent/version/BUILD_VERSION.txt
+          # Strip the leading v (LATEST_RELEASE is a v-prefixed tag) to match the
+          # release workflow, which stamps the unprefixed version.
+          base="${LATEST_RELEASE:-develop}"
+          echo "${base#v}-${GITHUB_SHA::7}" > ./agent/version/BUILD_VERSION.txt
           echo "BUILD_COMMIT_SHORT=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
 
       - name: Resolve backend versions

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -78,9 +78,10 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install Ruff
-        run: pip install ruff
+        # Pinned so blocking lint is deterministic (matches the pinned go-lint).
+        run: pip install ruff==0.15.10
       - name: Lint with Ruff
         # Lint the whole backend (ruff default-excludes .venv/build/etc.) so
         # extra packages like device-discovery's custom_napalm/ are covered too.
+        # Blocking (no continue-on-error) so Python lint actually gates, like go-lint.
         run: ruff check --output-format=github .
-        continue-on-error: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -66,9 +66,7 @@ jobs:
       matrix:
         include:
           - dir: orb-discovery/device-discovery
-            module: device_discovery
           - dir: orb-discovery/worker
-            module: worker
     defaults:
       run:
         working-directory: ${{ matrix.dir }}
@@ -82,5 +80,7 @@ jobs:
       - name: Install Ruff
         run: pip install ruff
       - name: Lint with Ruff
-        run: ruff check --output-format=github ${{ matrix.module }}/ tests/
+        # Lint the whole backend (ruff default-excludes .venv/build/etc.) so
+        # extra packages like device-discovery's custom_napalm/ are covered too.
+        run: ruff check --output-format=github .
         continue-on-error: true

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,6 @@ COMMIT_BRANCH = $(shell branch=$$(git rev-parse --abbrev-ref HEAD); if [ "$$bran
 VERSION_PKG = github.com/netboxlabs/orb-agent/agent/version
 EXTRA_LDFLAGS ?=
 LDFLAGS ?= -X $(VERSION_PKG).buildVersion=$(ORB_VERSION) -X $(VERSION_PKG).buildBranch=$(COMMIT_BRANCH) $(EXTRA_LDFLAGS)
-OTEL_COLLECTOR_CONTRIB_VERSION ?= 0.91.0
-OTEL_CONTRIB_URL ?= "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$(OTEL_COLLECTOR_CONTRIB_VERSION)/otelcol-contrib_$(OTEL_COLLECTOR_CONTRIB_VERSION)_$(GOOS)_$(GOARCH).tar.gz"
 # Backend versions stamped into the from-source image (latest <backend>/v* tag);
 # without these the from-source backends report 0.0.0. List the tags rather than
 # `git describe` so the result does not depend on the tag being reachable from
@@ -45,16 +43,6 @@ export GOWORK = off
 
 clean:
 	rm -rf ${BUILD_DIR}
-
-cleandocker:
-	# Stops containers and removes containers, networks, volumes, and images created by up
-#	docker-compose -f docker/docker-compose.yml down --rmi all -v --remove-orphans
-	docker-compose -f docker/docker-compose.yml down -v --remove-orphans
-
-ifdef pv
-	# Remove unused volumes
-	docker volume ls -f name=orb -f dangling=true -q | xargs -r docker volume rm
-endif
 
 .PHONY: install-dev-tools
 install-dev-tools:
@@ -152,11 +140,3 @@ agent_debug_production:
 	  --tag=$(ORB_DOCKERHUB_REPO)/orb-agent:$(PRODUCTION_AGENT_DEBUG_REF_TAG) \
 	  $(BACKEND_VERSION_ARGS) \
 	  -f agent/docker/Dockerfile .
-
-pull-latest-otel-collector-contrib:
-	wget -O ./agent/backend/otel/otelcol_contrib.tar.gz $(OTEL_CONTRIB_URL)
-	tar -xvf ./agent/backend/otel/otelcol_contrib.tar.gz -C ./agent/backend/otel/
-	cp ./agent/backend/otel/otelcol-contrib .
-	rm ./agent/backend/otel/otelcol_contrib.tar.gz
-	rm ./agent/backend/otel/LICENSE
-	rm ./agent/backend/otel/README.md

--- a/Makefile
+++ b/Makefile
@@ -112,8 +112,7 @@ lint-all: lint
 	@for b in $(GO_BACKENDS); do $(MAKE) -C orb-discovery/$$b lint || exit 1; done
 	@for b in $(PY_BACKENDS); do \
 		test -d orb-discovery/$$b/.venv || { echo "missing orb-discovery/$$b/.venv — run 'make install-dev-tools'"; exit 1; }; \
-		m=$$(echo $$b | tr '-' '_'); \
-		( cd orb-discovery/$$b && . .venv/bin/activate && ruff check $$m/ tests/ ) || exit 1; \
+		( cd orb-discovery/$$b && . .venv/bin/activate && ruff check . ) || exit 1; \
 	done
 
 .PHONY: fix-lint-all
@@ -121,8 +120,7 @@ fix-lint-all: fix-lint
 	@for b in $(GO_BACKENDS); do $(MAKE) -C orb-discovery/$$b fix-lint || exit 1; done
 	@for b in $(PY_BACKENDS); do \
 		test -d orb-discovery/$$b/.venv || { echo "missing orb-discovery/$$b/.venv — run 'make install-dev-tools'"; exit 1; }; \
-		m=$$(echo $$b | tr '-' '_'); \
-		( cd orb-discovery/$$b && . .venv/bin/activate && ruff check --fix $$m/ tests/ ) || exit 1; \
+		( cd orb-discovery/$$b && . .venv/bin/activate && ruff check --fix . ) || exit 1; \
 	done
 
 .PHONY: test-all

--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,6 @@ BACKEND_VERSION_ARGS = --build-arg NETWORK_DISCOVERY_VERSION=$(ND_VERSION) --bui
 # `work` target below re-enables it explicitly for generating the file.
 export GOWORK = off
 
-# Make targets operate on the agent (a single module), so never use a local
-# go.work — workspace mode is incompatible with the -mod=mod build flow. The
-# `work` target below re-enables it explicitly for generating the file.
-export GOWORK = off
-
 # Discovery backends, grouped by toolchain — used by the *-all aggregate targets.
 GO_BACKENDS = network-discovery snmp-discovery gnmi-discovery
 PY_BACKENDS = device-discovery worker
@@ -57,7 +52,7 @@ install-dev-tools:
 		echo ">> orb-discovery/$$b: venv + dev/test deps"; \
 		( cd orb-discovery/$$b && \
 		  { test -d .venv || python3 -m venv .venv; } && \
-		  . .venv/bin/activate && pip install -q -e '.[dev,test]' ); \
+		  . .venv/bin/activate && pip install -q -e '.[dev,test]' ) || exit 1; \
 	done
 
 .PHONY: deps
@@ -111,28 +106,28 @@ fix-lint:
 
 .PHONY: lint-all
 lint-all: lint
-	@for b in $(GO_BACKENDS); do $(MAKE) -C orb-discovery/$$b lint; done
+	@for b in $(GO_BACKENDS); do $(MAKE) -C orb-discovery/$$b lint || exit 1; done
 	@for b in $(PY_BACKENDS); do \
 		test -d orb-discovery/$$b/.venv || { echo "missing orb-discovery/$$b/.venv — run 'make install-dev-tools'"; exit 1; }; \
 		m=$$(echo $$b | tr '-' '_'); \
-		( cd orb-discovery/$$b && . .venv/bin/activate && ruff check $$m/ tests/ ); \
+		( cd orb-discovery/$$b && . .venv/bin/activate && ruff check $$m/ tests/ ) || exit 1; \
 	done
 
 .PHONY: fix-lint-all
 fix-lint-all: fix-lint
-	@for b in $(GO_BACKENDS); do $(MAKE) -C orb-discovery/$$b fix-lint; done
+	@for b in $(GO_BACKENDS); do $(MAKE) -C orb-discovery/$$b fix-lint || exit 1; done
 	@for b in $(PY_BACKENDS); do \
 		test -d orb-discovery/$$b/.venv || { echo "missing orb-discovery/$$b/.venv — run 'make install-dev-tools'"; exit 1; }; \
 		m=$$(echo $$b | tr '-' '_'); \
-		( cd orb-discovery/$$b && . .venv/bin/activate && ruff check --fix $$m/ tests/ ); \
+		( cd orb-discovery/$$b && . .venv/bin/activate && ruff check --fix $$m/ tests/ ) || exit 1; \
 	done
 
 .PHONY: test-all
 test-all: test
-	@for b in $(GO_BACKENDS); do $(MAKE) -C orb-discovery/$$b test; done
+	@for b in $(GO_BACKENDS); do $(MAKE) -C orb-discovery/$$b test || exit 1; done
 	@for b in $(PY_BACKENDS); do \
 		test -d orb-discovery/$$b/.venv || { echo "missing orb-discovery/$$b/.venv — run 'make install-dev-tools'"; exit 1; }; \
-		( cd orb-discovery/$$b && . .venv/bin/activate && pytest ); \
+		( cd orb-discovery/$$b && . .venv/bin/activate && pytest ) || exit 1; \
 	done
 
 agent:

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ export GOWORK = off
 # `work` target below re-enables it explicitly for generating the file.
 export GOWORK = off
 
+# Discovery backends, grouped by toolchain — used by the *-all aggregate targets.
+GO_BACKENDS = network-discovery snmp-discovery gnmi-discovery
+PY_BACKENDS = device-discovery worker
+
 .PHONY: agent agent_bin
 
 clean:
@@ -47,6 +51,14 @@ clean:
 .PHONY: install-dev-tools
 install-dev-tools:
 	@go install github.com/mfridman/tparse@latest
+	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+	@go install github.com/jandelgado/gcov2lcov@latest
+	@for b in $(PY_BACKENDS); do \
+		echo ">> orb-discovery/$$b: venv + dev/test deps"; \
+		( cd orb-discovery/$$b && \
+		  { test -d .venv || python3 -m venv .venv; } && \
+		  . .venv/bin/activate && pip install -q -e '.[dev,test]' ); \
+	done
 
 .PHONY: deps
 deps:
@@ -96,6 +108,32 @@ lint:
 .PHONY: fix-lint
 fix-lint:
 	@golangci-lint run ./... --config .github/golangci.yaml --fix
+
+.PHONY: lint-all
+lint-all: lint
+	@for b in $(GO_BACKENDS); do $(MAKE) -C orb-discovery/$$b lint; done
+	@for b in $(PY_BACKENDS); do \
+		test -d orb-discovery/$$b/.venv || { echo "missing orb-discovery/$$b/.venv — run 'make install-dev-tools'"; exit 1; }; \
+		m=$$(echo $$b | tr '-' '_'); \
+		( cd orb-discovery/$$b && . .venv/bin/activate && ruff check $$m/ tests/ ); \
+	done
+
+.PHONY: fix-lint-all
+fix-lint-all: fix-lint
+	@for b in $(GO_BACKENDS); do $(MAKE) -C orb-discovery/$$b fix-lint; done
+	@for b in $(PY_BACKENDS); do \
+		test -d orb-discovery/$$b/.venv || { echo "missing orb-discovery/$$b/.venv — run 'make install-dev-tools'"; exit 1; }; \
+		m=$$(echo $$b | tr '-' '_'); \
+		( cd orb-discovery/$$b && . .venv/bin/activate && ruff check --fix $$m/ tests/ ); \
+	done
+
+.PHONY: test-all
+test-all: test
+	@for b in $(GO_BACKENDS); do $(MAKE) -C orb-discovery/$$b test; done
+	@for b in $(PY_BACKENDS); do \
+		test -d orb-discovery/$$b/.venv || { echo "missing orb-discovery/$$b/.venv — run 'make install-dev-tools'"; exit 1; }; \
+		( cd orb-discovery/$$b && . .venv/bin/activate && pytest ); \
+	done
 
 agent:
 	docker build --no-cache \

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,10 @@ BUILD_DIR ?= build
 CGO_ENABLED ?= 0
 GOARCH ?= $(shell go env GOARCH)
 GOOS ?= $(shell go env GOOS)
-ORB_VERSION ?= $(shell echo "$${BUILD_VERSION:-$$(cat agent/version/BUILD_VERSION.txt 2>/dev/null || git describe --tags --match 'v[0-9]*' --always 2>/dev/null || echo dev)}")
+# CI sets BUILD_VERSION (release) or writes agent/version/BUILD_VERSION.txt
+# (develop/PR). A bare local build has neither, so it is stamped local-<sha> to
+# make clear it was built locally — distinct from a develop or release image.
+ORB_VERSION ?= $(shell echo "$${BUILD_VERSION:-$$(cat agent/version/BUILD_VERSION.txt 2>/dev/null || echo local-$$(git rev-parse --short HEAD 2>/dev/null || echo unknown))}")
 COMMIT_HASH = $(shell git rev-parse --short HEAD)
 COMMIT_BRANCH = $(shell branch=$$(git rev-parse --abbrev-ref HEAD); if [ "$$branch" = "HEAD" ]; then branch=$${GITHUB_HEAD_REF:-$$GITHUB_REF_NAME}; fi; echo "$${branch:-unknown}")
 VERSION_PKG = github.com/netboxlabs/orb-agent/agent/version

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ work:
 	@echo "go.work created (git-ignored). Use 'GOWORK=off' for single-module commands."
 
 agent_bin:
-	echo "ORB_VERSION: $(ORB_VERSION)-$(COMMIT_HASH)"
+	echo "ORB_VERSION: $(ORB_VERSION)"
 	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) GOARM=$(GOARM) go build -mod=mod -ldflags="$(LDFLAGS)" -o ${BUILD_DIR}/orb-agent cmd/main.go
 
 .PHONY: test
@@ -137,7 +137,6 @@ agent:
 	  --build-arg PKTVISOR_TAG=$(PKTVISOR_TAG) \
 	  --tag=$(ORB_DOCKERHUB_REPO)/orb-agent:$(REF_TAG) \
 	  --tag=$(ORB_DOCKERHUB_REPO)/orb-agent:$(ORB_VERSION) \
-	  --tag=$(ORB_DOCKERHUB_REPO)/orb-agent:$(ORB_VERSION)-$(COMMIT_HASH) \
 	  $(BACKEND_VERSION_ARGS) \
 	  -f agent/docker/Dockerfile .
 
@@ -147,7 +146,6 @@ agent_fast:
 	  --build-arg PKTVISOR_TAG=$(PKTVISOR_TAG) \
 	  --tag=$(ORB_DOCKERHUB_REPO)/orb-agent:$(REF_TAG) \
 	  --tag=$(ORB_DOCKERHUB_REPO)/orb-agent:$(ORB_VERSION) \
-	  --tag=$(ORB_DOCKERHUB_REPO)/orb-agent:$(ORB_VERSION)-$(COMMIT_HASH) \
 	  $(BACKEND_VERSION_ARGS) \
 	  -f agent/docker/Dockerfile .
 
@@ -164,7 +162,6 @@ agent_production:
 	  --build-arg PKTVISOR_TAG=$(PKTVISOR_TAG) \
 	  --tag=$(ORB_DOCKERHUB_REPO)/orb-agent:$(PRODUCTION_AGENT_REF_TAG) \
 	  --tag=$(ORB_DOCKERHUB_REPO)/orb-agent:$(ORB_VERSION) \
-	  --tag=$(ORB_DOCKERHUB_REPO)/orb-agent:$(ORB_VERSION)-$(COMMIT_HASH) \
 	  $(BACKEND_VERSION_ARGS) \
 	  -f agent/docker/Dockerfile .
 

--- a/Makefile
+++ b/Makefile
@@ -47,15 +47,21 @@ clean:
 	rm -rf ${BUILD_DIR}
 
 .PHONY: install-dev-tools
+# Tool versions are pinned to match CI (.github/workflows) so local
+# lint-all/test-all reproduce the blocking CI jobs: golangci-lint v2.11.4 +
+# ruff 0.15.10 (lint.yaml), tparse v0.14.0 (tests.yaml) + gcov2lcov v1.1.1
+# (_backend-test-go.yaml). Keep these in sync when CI bumps them.
 install-dev-tools:
-	@go install github.com/mfridman/tparse@latest
-	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
-	@go install github.com/jandelgado/gcov2lcov@latest
+	@go install github.com/mfridman/tparse@v0.14.0
+	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+	@go install github.com/jandelgado/gcov2lcov@v1.1.1
 	@for b in $(PY_BACKENDS); do \
 		echo ">> orb-discovery/$$b: venv + dev/test deps"; \
 		( cd orb-discovery/$$b && \
 		  { test -d .venv || python3 -m venv .venv; } && \
-		  . .venv/bin/activate && pip install -q -e '.[dev,test]' ) || exit 1; \
+		  . .venv/bin/activate && \
+		  pip install -q -e '.[dev,test]' && \
+		  pip install -q ruff==0.15.10 ) || exit 1; \
 	done
 
 .PHONY: deps


### PR DESCRIPTION
## Summary

Three small root-Makefile/CI improvements (brainstormed → spec → plan → implemented task-by-task with per-task and adversarial review).

### 1. Whole-repo lint/test from root
- `make lint-all` / `fix-lint-all` / `test-all` fan out to the agent + all backends — Go backends via `$(MAKE) -C orb-discovery/<b> …`, Python backends (device/worker) via `ruff check .`/`pytest` in a per-backend `.venv`. Every loop aborts on first failure (`|| exit 1`) so a failing backend can't be masked.
- `make install-dev-tools` now also installs `golangci-lint` + `gcov2lcov` and sets up each Python backend's `.venv` (`pip install -e '.[dev,test]'`). The dev tools are **pinned to the same versions CI uses** — `golangci-lint v2.11.4`, `ruff 0.15.10`, `tparse v0.14.0`, `gcov2lcov v1.1.1` — so local `lint-all`/`test-all` reproduce the blocking CI jobs instead of drifting on `@latest`.
- The existing agent-only targets (`lint`/`test`/…) are unchanged.

### 2. Cleanup
- Removed dead targets/vars: `cleandocker` (no compose file exists), `pull-latest-otel-collector-contrib` + `OTEL_*` vars (targeted `agent/backend/otel/`, which no longer exists). The Dockerfile `otlpinf` stage is unrelated and untouched.
- Deduped a duplicated `export GOWORK = off` block.

### 3. Build-origin version marker
The agent version now makes the build origin obvious in the startup log, `orb-agent --version`, and the fleet report (no change to `agent/version`):

| Build | Embedded version | Example |
|---|---|---|
| **local `make`** | `local-<short-sha>` | `local-b643f1a` |
| **develop / PR CI** | `<latest-release>-<short-sha>` (v stripped, matching release) | `2.11.0-a1b2c3d` |
| **release CI** | clean SemVer (unchanged) | `2.11.0` |

`develop.yaml`/`build.yaml` stamp the suffixed version (with the leading `v` stripped so it matches `release.yaml`'s unprefixed form); `release.yaml` is untouched, so only true releases are suffix-free; and a bare local build is stamped `local-<sha>` (CI's `BUILD_VERSION`/`BUILD_VERSION.txt` always take precedence over the local fallback). Because the version string now already carries the short SHA for dev builds, the redundant `:$(ORB_VERSION)-$(COMMIT_HASH)` image tag (which produced `local-<sha>-<sha>`) was dropped from `agent`/`agent_fast`/`agent_production`, and the `agent_bin` echo was aligned to print the actually-stamped `$(ORB_VERSION)`.

### CI lint hardening (`lint.yaml`)
- The `py-lint` job now lints the backend project root (`ruff check .`) so device-discovery's `custom_napalm/` package is covered (ruff default-excludes `.venv`/`build`/etc.).
- Ruff is **blocking** (removed `continue-on-error`) and **pinned** (`ruff==0.15.10`), matching the pinned, blocking `go-lint`. Both device-discovery and worker pass at this pin.

## Review

Implemented via subagent-driven development (fresh implementer + spec/quality review per task). A Claude adversarial review (3 lenses, each finding verified) caught a real CI-correctness bug — the `*-all` fan-out loops swallowed failures in any non-last backend (a `for` loop's exit status is its last iteration) — fixed with `|| exit 1` on every loop. PR review additionally flagged, all now fixed: the `v`-prefix inconsistency in the develop/PR version base; `custom_napalm/` being skipped by the old `<module>/ tests/` lint paths; the redundant double-SHA image tag; the advisory (`continue-on-error`) Python lint, now blocking + pinned; and `install-dev-tools` installing dev tools at `@latest`/unpinned, now pinned to CI's versions (a Claude completeness sweep extended this beyond the two flagged tools to `tparse` + `gcov2lcov`). actionlint clean on the changed workflows.
