### PR TITLE
ci(repo): enforce orb-agent as the only "Latest" release

### DIFF
--- a/.github/actions/enforce-orb-agent-latest/action.yml
+++ b/.github/actions/enforce-orb-agent-latest/action.yml
@@ -49,13 +49,32 @@ runs:
         fi
         echo "Marked '$BACKEND_TAG' as not latest (make_latest=false)."
 
-        # 2) Positively re-assert the highest orb-agent vX.Y.Z release as Latest,
-        #    so the agent owns the badge regardless of version ordering. Agent
-        #    releases are tagged vX.Y.Z (no slash, no pre-release suffix).
-        agent_tag=$(gh release list --repo "$REPO" --limit 200 --json tagName --jq '.[].tagName' \
-          | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
+        # 2) Positively re-assert the highest PUBLISHED orb-agent vX.Y.Z release
+        #    as Latest, so the agent owns the badge regardless of version
+        #    ordering. Draft and pre-release agent releases are excluded (a
+        #    release-prep draft/prerelease must not win Latest, and GitHub
+        #    rejects --latest on them). The `gh release list` call is retried and
+        #    fails loudly — its failure is never swallowed into an empty result;
+        #    only a grep no-match (no agent release yet) is tolerated.
+        releases=""
+        listed=""
+        for attempt in 1 2 3 4 5; do
+          if releases=$(gh release list --repo "$REPO" --limit 1000 \
+              --json tagName,isDraft,isPrerelease \
+              --jq '.[] | select(.isDraft == false and .isPrerelease == false) | .tagName'); then
+            listed=1
+            break
+          fi
+          echo "gh release list failed (attempt $attempt/5); retrying in 3s..."
+          sleep 3
+        done
+        if [ -z "$listed" ]; then
+          echo "::error::gh release list failed after 5 attempts; cannot re-assert orb-agent as Latest."
+          exit 1
+        fi
+        agent_tag=$(printf '%s\n' "$releases" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
         if [ -z "$agent_tag" ]; then
-          echo "::warning::No orb-agent vX.Y.Z release found to mark as Latest; backend demotion still applied."
+          echo "::warning::No published orb-agent vX.Y.Z release found to mark as Latest; backend demotion still applied."
           exit 0
         fi
         if ! edit_with_retry "$agent_tag" --latest; then

--- a/.github/actions/enforce-orb-agent-latest/action.yml
+++ b/.github/actions/enforce-orb-agent-latest/action.yml
@@ -1,0 +1,65 @@
+name: Enforce orb-agent as "Latest"
+description: >-
+  Ensure only the orb-agent release holds the repository's "Latest" badge.
+  Demotes the backend release just published (make_latest=false) and positively
+  re-asserts the highest orb-agent vX.Y.Z release as Latest. GitHub otherwise
+  awards "Latest" to the highest-semver release, which a backend (tagged
+  <app>/v*) can eventually outrank or transiently steal on publish.
+
+inputs:
+  backend-tag:
+    description: 'Tag of the backend release just published, to demote (e.g. device-discovery/v1.2.3).'
+    required: true
+  token:
+    description: 'Token with contents: write on the repo (typically secrets.GITHUB_TOKEN).'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Demote backend, re-assert orb-agent as Latest
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        BACKEND_TAG: ${{ inputs.backend-tag }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+
+        # gh release edit retries: semantic-release has just created the release,
+        # which may not be editable for a moment. It resolves the slashed backend
+        # tag (e.g. device-discovery/v1.2.3) itself.
+        edit_with_retry() {
+          local tag="$1"; shift
+          local attempt
+          for attempt in 1 2 3 4 5; do
+            if gh release edit "$tag" --repo "$REPO" "$@"; then
+              return 0
+            fi
+            echo "Release '$tag' not editable yet (attempt $attempt/5); retrying in 3s..."
+            sleep 3
+          done
+          return 1
+        }
+
+        # 1) The backend release must never hold "Latest".
+        if ! edit_with_retry "$BACKEND_TAG" --latest=false; then
+          echo "::error::Failed to set make_latest=false on '$BACKEND_TAG' after 5 attempts."
+          exit 1
+        fi
+        echo "Marked '$BACKEND_TAG' as not latest (make_latest=false)."
+
+        # 2) Positively re-assert the highest orb-agent vX.Y.Z release as Latest,
+        #    so the agent owns the badge regardless of version ordering. Agent
+        #    releases are tagged vX.Y.Z (no slash, no pre-release suffix).
+        agent_tag=$(gh release list --repo "$REPO" --limit 200 --json tagName --jq '.[].tagName' \
+          | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
+        if [ -z "$agent_tag" ]; then
+          echo "::warning::No orb-agent vX.Y.Z release found to mark as Latest; backend demotion still applied."
+          exit 0
+        fi
+        if ! edit_with_retry "$agent_tag" --latest; then
+          echo "::error::Failed to mark '$agent_tag' as Latest after 5 attempts."
+          exit 1
+        fi
+        echo "Re-asserted '$agent_tag' as Latest."

--- a/.github/workflows/_backend-release-go.yaml
+++ b/.github/workflows/_backend-release-go.yaml
@@ -91,3 +91,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_OBSERVABILITY_RELEASE_WEBHOOK }}
         run: npx semantic-release --debug
+      - name: Ensure only orb-agent holds the "Latest" badge
+        uses: ./.github/actions/enforce-orb-agent-latest
+        with:
+          backend-tag: ${{ inputs.app-name }}/v${{ needs.get-next-version.outputs.new-release-version }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/device-discovery-release.yaml
+++ b/.github/workflows/device-discovery-release.yaml
@@ -122,7 +122,8 @@ jobs:
 
   semantic-release:
     name: Semantic release
-    needs: build
+    needs: [build, get-next-version]
+    if: needs.get-next-version.outputs.new-release-published == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -144,3 +145,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_OBSERVABILITY_RELEASE_WEBHOOK }}
         run: npx semantic-release --debug
+      - name: Ensure only orb-agent holds the "Latest" badge
+        uses: ./.github/actions/enforce-orb-agent-latest
+        with:
+          backend-tag: ${{ env.APP_NAME }}/v${{ needs.get-next-version.outputs.new-release-version }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/worker-release.yaml
+++ b/.github/workflows/worker-release.yaml
@@ -121,7 +121,8 @@ jobs:
 
   semantic-release:
     name: Semantic release
-    needs: build
+    needs: [build, get-next-version]
+    if: needs.get-next-version.outputs.new-release-published == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -143,3 +144,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_OBSERVABILITY_RELEASE_WEBHOOK }}
         run: npx semantic-release --debug
+      - name: Ensure only orb-agent holds the "Latest" badge
+        uses: ./.github/actions/enforce-orb-agent-latest
+        with:
+          backend-tag: ${{ env.APP_NAME }}/v${{ needs.get-next-version.outputs.new-release-version }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Guarantee that **only the orb-agent `vX.Y.Z` release ever holds GitHub's "Latest" badge** — backend releases (`<app>/v*`) must never hold it.

### Why this is needed
GitHub awards "Latest" to the **highest-semver** non-draft/non-prerelease release. The agent (`v2.x`) holding it today is luck of the numbers — a backend can **transiently steal it on publish** (every release is created with `make_latest=true`) and would **permanently** take it once its version outranks the agent's (snmp is already at `1.34`). This already happened on the last release and was fixed by hand.

Two constraints shaped the fix:
- The `@semantic-release/github` plugin has **no `make_latest` option** — so backends can't be created not-latest; they must be demoted after the fact.
- semantic-release runs with the default `GITHUB_TOKEN`, whose releases **don't trigger `release:` events** — so a separate event-driven policy workflow would never fire. The fix must run **inside each backend's release job**.

### What changed
New composite action **`.github/actions/enforce-orb-agent-latest`**, invoked right after `semantic-release` publishes a backend. It:
1. **Demotes** the just-published backend release — `gh release edit <app>/vX.Y.Z --latest=false`.
2. **Re-asserts** the highest orb-agent `vX.Y.Z` release as Latest — `gh release edit vX.Y.Z --latest`.

The re-assert (2) is the belt-and-suspenders: the agent positively owns "Latest" regardless of version ordering or a single backend slip, and it auto-neutralizes any backend that transiently grabbed it (GitHub allows only one Latest). Both steps retry 5× and fail loudly if they can't complete.

Wired into the 3 backend release paths:
- `_backend-release-go.yaml` (reusable → network / snmp / gnmi)
- `device-discovery-release.yaml`, `worker-release.yaml`

The two Python `semantic-release` jobs also gain an explicit `if: …new-release-published == 'true'` guard (parity with the Go reusable) so the step can never run with an empty version. **The agent release workflow is unchanged**, and existing backend releases are left as-is (already handled manually).

### Scope / behavior notes
- Backend-only pushes don't cut an agent release; this action keeps the agent's *current* `vX.Y.Z` as Latest. The orchestrated agent-release-after-backends flow then publishes the new agent version as Latest last of all.
- There is an inherent few-second window where a freshly published backend holds Latest before the action demotes it — unavoidable because the plugin can't create a release as not-latest; it self-corrects within the same job.

## Review
Implemented after brainstorming + design approval. Verified with `actionlint` (incl. embedded shellcheck) and a live check that the agent-tag detection resolves to `v2.11.0`. Two adversarial passes (a 3-lens workflow on the original demote-only change, then a focused review of the added re-assert logic) both returned **ship** — confirming bash correctness under `set -euo pipefail`, the anchored `^v[0-9]+\.[0-9]+\.[0-9]+$` regex (rejects slashed/prerelease/draft tags), empty-result handling, permissions, exact tag reconstruction, and the parallel-backends + waited-agent-release end state.
