### PR TITLE
feat(agent): add gnmi-discovery backend

### DIFF
--- a/.github/actions/resolve-backend-versions/action.yml
+++ b/.github/actions/resolve-backend-versions/action.yml
@@ -13,6 +13,9 @@ outputs:
   snmp:
     description: 'Latest released snmp-discovery version (X.Y.Z, or 0.0.0).'
     value: ${{ steps.resolve.outputs.snmp }}
+  gnmi:
+    description: 'Latest released gnmi-discovery version (X.Y.Z, or 0.0.0).'
+    value: ${{ steps.resolve.outputs.gnmi }}
   device:
     description: 'Latest released device-discovery version (X.Y.Z, or 0.0.0).'
     value: ${{ steps.resolve.outputs.device }}
@@ -38,11 +41,13 @@ runs:
         }
         nd=$(backend_version network-discovery)
         sd=$(backend_version snmp-discovery)
+        gd=$(backend_version gnmi-discovery)
         dd=$(backend_version device-discovery)
         wk=$(backend_version worker)
         {
           echo "network=${nd:-0.0.0}"
           echo "snmp=${sd:-0.0.0}"
+          echo "gnmi=${gd:-0.0.0}"
           echo "device=${dd:-0.0.0}"
           echo "worker=${wk:-0.0.0}"
         } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/_agent-release.yaml
+++ b/.github/workflows/_agent-release.yaml
@@ -15,6 +15,10 @@ on:
         description: 'snmp-discovery version to bundle (X.Y.Z).'
         required: true
         type: string
+      gnmi-version:
+        description: 'gnmi-discovery version to bundle (X.Y.Z).'
+        required: true
+        type: string
       device-version:
         description: 'device-discovery version to bundle (X.Y.Z).'
         required: true
@@ -129,6 +133,7 @@ jobs:
             BUILD_TRACK=release
             NETWORK_DISCOVERY_VERSION=${{ inputs.network-version }}
             SNMP_DISCOVERY_VERSION=${{ inputs.snmp-version }}
+            GNMI_DISCOVERY_VERSION=${{ inputs.gnmi-version }}
             DEVICE_DISCOVERY_VERSION=${{ inputs.device-version }}
             WORKER_VERSION=${{ inputs.worker-version }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,6 +70,7 @@ jobs:
             BUILD_TRACK=develop
             NETWORK_DISCOVERY_VERSION=${{ steps.backend-versions.outputs.network }}
             SNMP_DISCOVERY_VERSION=${{ steps.backend-versions.outputs.snmp }}
+            GNMI_DISCOVERY_VERSION=${{ steps.backend-versions.outputs.gnmi }}
             DEVICE_DISCOVERY_VERSION=${{ steps.backend-versions.outputs.device }}
             WORKER_VERSION=${{ steps.backend-versions.outputs.worker }}
           tags: orb-agent:scan

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -86,6 +86,7 @@ jobs:
             BUILD_TRACK=develop
             NETWORK_DISCOVERY_VERSION=${{ steps.backend-versions.outputs.network }}
             SNMP_DISCOVERY_VERSION=${{ steps.backend-versions.outputs.snmp }}
+            GNMI_DISCOVERY_VERSION=${{ steps.backend-versions.outputs.gnmi }}
             DEVICE_DISCOVERY_VERSION=${{ steps.backend-versions.outputs.device }}
             WORKER_VERSION=${{ steps.backend-versions.outputs.worker }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -175,6 +175,7 @@ jobs:
     outputs:
       network: ${{ steps.versions.outputs.network }}
       snmp: ${{ steps.versions.outputs.snmp }}
+      gnmi: ${{ steps.versions.outputs.gnmi }}
       device: ${{ steps.versions.outputs.device }}
       worker: ${{ steps.versions.outputs.worker }}
     steps:
@@ -192,6 +193,7 @@ jobs:
     with:
       network-version: ${{ needs.resolve-versions.outputs.network }}
       snmp-version: ${{ needs.resolve-versions.outputs.snmp }}
+      gnmi-version: ${{ needs.resolve-versions.outputs.gnmi }}
       device-version: ${{ needs.resolve-versions.outputs.device }}
       worker-version: ${{ needs.resolve-versions.outputs.worker }}
     secrets: inherit

--- a/agent/backend/gnmidiscovery/gnmi_discovery.go
+++ b/agent/backend/gnmidiscovery/gnmi_discovery.go
@@ -1,0 +1,610 @@
+package gnmidiscovery
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/config"
+	"github.com/netboxlabs/orb-agent/agent/filesmgr"
+	"github.com/netboxlabs/orb-agent/agent/policies"
+	"github.com/netboxlabs/orb-agent/agent/redact"
+)
+
+var _ backend.Backend = (*gnmiDiscoveryBackend)(nil)
+
+const (
+	versionTimeout      = 2
+	capabilitiesTimeout = 5
+	readinessBackoff    = 10
+	applyPolicyTimeout  = 10
+	removePolicyTimeout = 20
+	statusTimeout       = 5
+	defaultExec         = "gnmi-discovery"
+	defaultAPIHost      = "localhost"
+	defaultAPIPort      = "8075"
+)
+
+type gnmiDiscoveryBackend struct {
+	logger     *slog.Logger
+	policyRepo policies.PolicyRepo
+	exec       string
+
+	apiHost     string
+	apiPort     string
+	apiProtocol string
+
+	diodeTarget          string
+	diodeClientID        string
+	diodeClientSecret    string
+	diodeAppNamePrefix   string
+	diodeOtelEndpoint    string
+	diodeTargetFromOtel  bool
+	diodeDryRun          bool
+	diodeDryRunOutputDir string
+	diodeLogLevel        string
+
+	// gNMI-specific options
+	profilesDir      string
+	otelExportPeriod string
+	logFormat        string
+
+	startTime  time.Time
+	proc       backend.Commander
+	statusChan <-chan backend.CmdStatus
+	cancelFunc context.CancelFunc
+	ctx        context.Context
+}
+
+type info struct {
+	Version   string  `json:"version"`
+	UpTimeMin float64 `json:"up_time_seconds"`
+}
+
+// Register registers the gNMI discovery backend
+func Register() bool {
+	backend.Register("gnmi_discovery", &gnmiDiscoveryBackend{
+		apiProtocol: "http",
+		exec:        defaultExec,
+	})
+	return true
+}
+
+func (d *gnmiDiscoveryBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
+	config map[string]any, common config.BackendCommons, _ filesmgr.Manager,
+) error {
+	d.logger = logger.With("backend", "gnmi_discovery")
+	d.policyRepo = repo
+	d.diodeTargetFromOtel = false
+
+	var prs bool
+	if d.apiHost, prs = config["host"].(string); !prs {
+		d.apiHost = defaultAPIHost
+	}
+	if port, prs := config["port"]; prs {
+		d.apiPort = fmt.Sprintf("%v", port)
+	} else {
+		d.apiPort = defaultAPIPort
+	}
+
+	d.diodeTarget = common.Diode.Target
+	d.diodeClientID = common.Diode.ClientID
+	d.diodeClientSecret = common.Diode.ClientSecret
+	d.diodeAppNamePrefix = common.Diode.AgentName
+	d.diodeDryRun = common.Diode.DryRun
+	d.diodeDryRunOutputDir = common.Diode.DryRunOutputDir
+
+	if target, prs := config["target"].(string); prs {
+		d.diodeTarget = target
+	}
+	if clientID, prs := config["client_id"].(string); prs {
+		d.diodeClientID = clientID
+	}
+	if clientSecret, prs := config["client_secret"].(string); prs {
+		d.diodeClientSecret = clientSecret
+	}
+	if agentName, prs := config["agent_name"].(string); prs {
+		d.diodeAppNamePrefix = agentName
+	}
+	if dryRun, prs := config["dry_run"].(bool); prs {
+		d.diodeDryRun = dryRun
+	}
+	if dryRunOutputDir, prs := config["dry_run_output_dir"].(string); prs {
+		d.diodeDryRunOutputDir = dryRunOutputDir
+	}
+	if logLevel, prs := config["log_level"].(string); prs {
+		d.diodeLogLevel = logLevel
+	} else if debug, prs := config["debug"].(bool); prs && debug {
+		d.diodeLogLevel = "debug"
+	} else if logger.Enabled(context.Background(), slog.LevelDebug) {
+		d.diodeLogLevel = "debug"
+	}
+
+	// gNMI-specific options
+	if profilesDir, prs := config["profiles_dir"].(string); prs {
+		d.profilesDir = profilesDir
+	}
+	if period, prs := config["otel_export_period"]; prs {
+		d.otelExportPeriod = fmt.Sprintf("%v", period)
+	}
+	if logFormat, prs := config["log_format"].(string); prs {
+		d.logFormat = logFormat
+	}
+
+	if common.Otlp.Grpc != "" {
+		d.diodeOtelEndpoint = common.Otlp.Grpc
+		d.logger.Info("gnmi-discovery using OTLP endpoint",
+			"endpoint", d.diodeOtelEndpoint)
+	}
+	if d.diodeTarget == "" && d.diodeOtelEndpoint != "" {
+		d.diodeTarget = d.diodeOtelEndpoint
+		d.diodeTargetFromOtel = true
+	}
+
+	return nil
+}
+
+func (d *gnmiDiscoveryBackend) Version() (string, error) {
+	var info info
+	url := fmt.Sprintf("%s://%s:%s/api/v1/status", d.apiProtocol, d.apiHost, d.apiPort)
+	err := backend.CommonRequest("gnmi-discovery", d.proc, d.logger, url, &info, http.MethodGet,
+		http.NoBody, "application/json", versionTimeout, "detail")
+	if err != nil {
+		return "", err
+	}
+	return info.Version, nil
+}
+
+func (d *gnmiDiscoveryBackend) Start(ctx context.Context, cancelFunc context.CancelFunc) error {
+	d.startTime = time.Now()
+	d.cancelFunc = cancelFunc
+	d.ctx = ctx
+
+	dOptions := []string{
+		"--diode-app-name-prefix", d.diodeAppNamePrefix,
+		"--host", d.apiHost,
+		"--port", d.apiPort,
+	}
+	if d.diodeDryRun {
+		dOptions = append([]string{
+			"--dry-run",
+			"--dry-run-output-dir", d.diodeDryRunOutputDir,
+		}, dOptions...)
+	} else {
+		opts := []string{
+			"--diode-target", d.diodeTarget,
+		}
+		if !d.diodeTargetFromOtel {
+			opts = append(opts,
+				"--diode-client-id", d.diodeClientID,
+				"--diode-client-secret", d.diodeClientSecret,
+			)
+		}
+		dOptions = append(opts, dOptions...)
+	}
+
+	if d.diodeLogLevel != "" {
+		dOptions = append(dOptions, "--log-level", d.diodeLogLevel)
+		d.logger.Info("gnmi-discovery using log level",
+			"log_level", d.diodeLogLevel)
+	}
+
+	if d.diodeOtelEndpoint != "" {
+		dOptions = append(dOptions, "--otel-endpoint", d.diodeOtelEndpoint)
+		d.logger.Info("gnmi-discovery using OTLP metrics endpoint",
+			"endpoint", d.diodeOtelEndpoint)
+	}
+
+	// gNMI-specific options
+	if d.profilesDir != "" {
+		dOptions = append(dOptions, "--profiles-dir", d.profilesDir)
+		d.logger.Info("gnmi-discovery using profiles dir", "profiles_dir", d.profilesDir)
+	}
+	if d.otelExportPeriod != "" {
+		dOptions = append(dOptions, "--otel-export-period", d.otelExportPeriod)
+	}
+	if d.logFormat != "" {
+		dOptions = append(dOptions, "--log-format", d.logFormat)
+	}
+
+	d.logger.Info("gnmi-discovery startup", "arguments", redact.Args(dOptions))
+
+	d.proc = backend.NewCmdOptions(backend.CmdOptions{
+		Buffered:  false,
+		Streaming: true,
+	}, d.exec, dOptions...)
+	d.statusChan = d.proc.Start()
+
+	// log STDOUT and STDERR lines streaming from Cmd
+	doneChan := make(chan struct{})
+	go func() {
+		defer func() {
+			if doneChan != nil {
+				close(doneChan)
+			}
+		}()
+		stdout := d.proc.GetStdout()
+		stderr := d.proc.GetStderr()
+		for stdout != nil || stderr != nil {
+			select {
+			case line, open := <-stdout:
+				if !open {
+					stdout = nil
+					continue
+				}
+				d.logGnmiDiscoveryOutput(line, slog.LevelInfo)
+			case line, open := <-stderr:
+				if !open {
+					stderr = nil
+					continue
+				}
+				d.logGnmiDiscoveryOutput(line, slog.LevelError)
+			}
+		}
+	}()
+
+	// wait for simple startup errors
+	time.Sleep(time.Second)
+
+	status := d.proc.Status()
+
+	if status.Error != nil {
+		d.logger.Error("gnmi-discovery startup error", "error", status.Error)
+		return status.Error
+	}
+
+	if status.Complete {
+		err := d.proc.Stop()
+		if err != nil {
+			d.logger.Error("proc.Stop error", "error", err)
+		}
+		return errors.New("gnmi-discovery startup error, check log")
+	}
+
+	d.logger.Info("gnmi-discovery process started", "pid", status.PID)
+
+	var version string
+	var readinessErr error
+	for backoff := range readinessBackoff {
+		if status := d.proc.Status(); status.Complete {
+			err := d.proc.Stop()
+			if err != nil {
+				d.logger.Error("proc.Stop error", "error", err)
+			}
+			return errors.New("gnmi-discovery process ended unexpectedly, check log")
+		}
+		version, readinessErr = d.Version()
+		if readinessErr == nil {
+			d.logger.Info("gnmi-discovery readiness ok, got version", "version", version)
+			break
+		}
+		backoffDuration := time.Duration(backoff) * time.Second
+		d.logger.Info("gnmi-discovery is not ready, trying again with backoff",
+			"backoff backoffDuration", backoffDuration.String())
+		time.Sleep(backoffDuration)
+	}
+
+	if readinessErr != nil {
+		d.logger.Error("gnmi-discovery error on readiness", "error", readinessErr)
+		err := d.proc.Stop()
+		if err != nil {
+			d.logger.Error("proc.Stop error", "error", err)
+		}
+		return readinessErr
+	}
+
+	return nil
+}
+
+func (d *gnmiDiscoveryBackend) logGnmiDiscoveryOutput(line string, fallback slog.Level) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return
+	}
+
+	msg := trimmed
+	attrs := []slog.Attr(nil)
+	level := fallback
+
+	if parsedMsg, parsedAttrs, parsedLevel, ok := normalizeGnmiDiscoveryLine(trimmed, fallback); ok {
+		msg = parsedMsg
+		attrs = parsedAttrs
+		level = parsedLevel
+	}
+
+	ctx := d.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	d.logger.LogAttrs(ctx, level, msg, attrs...)
+}
+
+func (d *gnmiDiscoveryBackend) Stop(ctx context.Context) error {
+	d.logger.Info("routine call to stop gnmi-discovery", "routine", ctx.Value(config.ContextKey("routine")))
+	defer d.cancelFunc()
+	backend.StopProcess(d.logger, d.proc, d.statusChan, backend.DefaultStopGracePeriod, "gnmi_discovery")
+	return nil
+}
+
+func (d *gnmiDiscoveryBackend) FullReset(ctx context.Context) error {
+	// force a stop, which stops scrape as well. if proc is dead, it no ops.
+	if state, _, _ := backend.GetRunningStatus(d.proc); state == backend.Running {
+		if err := d.Stop(ctx); err != nil {
+			d.logger.Error("failed to stop backend on restart procedure", "error", err)
+			return err
+		}
+	}
+	// for each policy, restart the scraper
+	backendCtx, cancelFunc := context.WithCancel(context.WithValue(ctx, config.ContextKey("routine"), "gnmi-discovery"))
+	// start it
+	if err := d.Start(backendCtx, cancelFunc); err != nil {
+		d.logger.Error("failed to start backend on restart procedure", "error", err)
+		return err
+	}
+	return nil
+}
+
+func (d *gnmiDiscoveryBackend) GetStartTime() time.Time {
+	return d.startTime
+}
+
+func (d *gnmiDiscoveryBackend) GetCapabilities() (map[string]any, error) {
+	caps := make(map[string]any)
+	url := fmt.Sprintf("%s://%s:%s/api/v1/capabilities", d.apiProtocol, d.apiHost, d.apiPort)
+	err := backend.CommonRequest("gnmi-discovery", d.proc, d.logger, url, &caps, http.MethodGet,
+		http.NoBody, "application/json", capabilitiesTimeout, "detail")
+	if err != nil {
+		return nil, err
+	}
+	return caps, nil
+}
+
+func (d *gnmiDiscoveryBackend) GetRunningStatus() (backend.RunningStatus, string, error) {
+	// first check process status
+	runningStatus, errMsg, err := backend.GetRunningStatus(d.proc)
+	// if it's not running, we're done
+	if runningStatus != backend.Running {
+		return runningStatus, errMsg, err
+	}
+	// if it's running, check REST API availability too
+	if _, aiErr := d.Version(); aiErr != nil {
+		// process is running, but REST API is not accessible
+		return backend.BackendError, "process running, REST API unavailable", aiErr
+	}
+	return runningStatus, "", nil
+}
+
+func (d *gnmiDiscoveryBackend) GetInitialState() backend.RunningStatus {
+	return backend.Unknown
+}
+
+func (d *gnmiDiscoveryBackend) ApplyPolicy(data policies.PolicyData, updatePolicy bool) error {
+	if updatePolicy {
+		// To update a policy it's necessary first remove it and then apply a new version
+		if err := d.RemovePolicy(data); err != nil {
+			d.logger.Warn("policy failed to remove", "policy_id", data.ID,
+				"policy_name", data.Name, "error", err)
+		}
+	}
+
+	d.logger.Debug("gnmi-discovery policy apply", "policy_id", data.ID, "data", data.Data)
+
+	fullPolicy := map[string]any{
+		"policies": map[string]any{
+			data.Name: data.Data,
+		},
+	}
+
+	policyYaml, err := yaml.Marshal(fullPolicy)
+	if err != nil {
+		d.logger.Warn("policy yaml marshal failure", "policy_id", data.ID, "policy_name", data.Name)
+		return err
+	}
+
+	var resp map[string]any
+	url := fmt.Sprintf("%s://%s:%s/api/v1/%s", d.apiProtocol, d.apiHost, d.apiPort, "policies")
+	err = backend.CommonRequest("gnmi-discovery", d.proc, d.logger, url, &resp, http.MethodPost,
+		bytes.NewBuffer(policyYaml), "application/x-yaml", applyPolicyTimeout, "detail")
+	if err != nil {
+		d.logger.Warn("policy application failure", "policy_id", data.ID, "policy_name", data.Name)
+		return err
+	}
+
+	return nil
+}
+
+func (d *gnmiDiscoveryBackend) RemovePolicy(data policies.PolicyData) error {
+	d.logger.Debug("gnmi-discovery policy remove", "policy_id", data.ID)
+	var resp any
+	name := data.Name
+	// Since we use Name for removing policies not IDs, if there is a change, we need to remove the previous name of the policy
+	if data.PreviousPolicyData != nil && data.PreviousPolicyData.Name != data.Name {
+		name = data.PreviousPolicyData.Name
+	}
+	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", d.apiProtocol, d.apiHost, d.apiPort, name)
+	err := backend.CommonRequest("gnmi-discovery", d.proc, d.logger, url, &resp, http.MethodDelete,
+		http.NoBody, "application/json", removePolicyTimeout, "detail")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *gnmiDiscoveryBackend) GetPolicyStatus() ([]backend.PolicyStatus, error) {
+	var resp backend.StatusResponse
+	url := fmt.Sprintf("%s://%s:%s/api/v1/status", d.apiProtocol, d.apiHost, d.apiPort)
+	err := backend.CommonRequest("gnmi-discovery", d.proc, d.logger, url, &resp, http.MethodGet,
+		http.NoBody, "application/json", statusTimeout, "detail")
+	if err != nil {
+		return nil, err
+	}
+	return resp.Policies, nil
+}
+
+func normalizeGnmiDiscoveryLine(line string, fallback slog.Level) (string, []slog.Attr, slog.Level, bool) {
+	fields, ok := parseGnmiDiscoveryLogfmt(line)
+	if !ok {
+		return "", nil, fallback, false
+	}
+
+	msg, ok := fields["msg"]
+	if !ok || strings.TrimSpace(msg) == "" {
+		return "", nil, fallback, false
+	}
+
+	level := fallback
+	if lvlValue, exists := fields["level"]; exists {
+		if parsedLevel, levelOK := parseGnmiDiscoveryLevel(lvlValue); levelOK {
+			level = parsedLevel
+		}
+	}
+
+	delete(fields, "msg")
+	delete(fields, "level")
+	delete(fields, "time")
+
+	if len(fields) == 0 {
+		return msg, nil, level, true
+	}
+
+	keys := make([]string, 0, len(fields))
+	for key := range fields {
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+		keys = append(keys, key)
+	}
+
+	if len(keys) == 0 {
+		return msg, nil, level, true
+	}
+
+	sort.Strings(keys)
+
+	attrs := make([]slog.Attr, 0, len(keys))
+	for _, key := range keys {
+		attrs = append(attrs, slog.String(key, fields[key]))
+	}
+
+	return msg, attrs, level, true
+}
+
+func parseGnmiDiscoveryLevel(value string) (slog.Level, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "debug":
+		return slog.LevelDebug, true
+	case "info":
+		return slog.LevelInfo, true
+	case "warn", "warning":
+		return slog.LevelWarn, true
+	case "error", "err":
+		return slog.LevelError, true
+	default:
+		return 0, false
+	}
+}
+
+func parseGnmiDiscoveryLogfmt(line string) (map[string]string, bool) {
+	result := make(map[string]string)
+	runes := []rune(line)
+	length := len(runes)
+	index := 0
+
+	for index < length {
+		for index < length && runes[index] == ' ' {
+			index++
+		}
+		if index >= length {
+			break
+		}
+
+		keyStart := index
+		for index < length && runes[index] != '=' && runes[index] != ' ' {
+			index++
+		}
+		if index >= length || runes[index] != '=' {
+			return nil, false
+		}
+
+		key := strings.TrimSpace(string(runes[keyStart:index]))
+		index++ // skip '='
+
+		value, nextIndex, ok := readLogfmtValue(runes, index)
+		if !ok {
+			return nil, false
+		}
+
+		result[key] = value
+		index = nextIndex
+	}
+
+	if len(result) == 0 {
+		return nil, false
+	}
+
+	return result, true
+}
+
+func readLogfmtValue(runes []rune, start int) (string, int, bool) {
+	length := len(runes)
+	if start >= length {
+		return "", start, true
+	}
+
+	switch runes[start] {
+	case '"', '\'':
+		return readQuotedValue(runes, start)
+	default:
+		return readUnquotedValue(runes, start)
+	}
+}
+
+func readQuotedValue(runes []rune, start int) (string, int, bool) {
+	length := len(runes)
+	quote := runes[start]
+	index := start + 1
+	var builder strings.Builder
+
+	for index < length {
+		char := runes[index]
+		if char == '\\' && index+1 < length {
+			builder.WriteRune(runes[index+1])
+			index += 2
+			continue
+		}
+		if char == quote {
+			index++
+			for index < length && runes[index] == ' ' {
+				index++
+			}
+			return builder.String(), index, true
+		}
+		builder.WriteRune(char)
+		index++
+	}
+
+	return "", length, false
+}
+
+func readUnquotedValue(runes []rune, start int) (string, int, bool) {
+	length := len(runes)
+	index := start
+	for index < length && runes[index] != ' ' {
+		index++
+	}
+	value := string(runes[start:index])
+	for index < length && runes[index] == ' ' {
+		index++
+	}
+	return value, index, true
+}

--- a/agent/backend/gnmidiscovery/gnmi_discovery.go
+++ b/agent/backend/gnmidiscovery/gnmi_discovery.go
@@ -63,7 +63,6 @@ type gnmiDiscoveryBackend struct {
 	proc       backend.Commander
 	statusChan <-chan backend.CmdStatus
 	cancelFunc context.CancelFunc
-	ctx        context.Context
 }
 
 type info struct {
@@ -170,7 +169,10 @@ func (d *gnmiDiscoveryBackend) buildArgs() []string {
 	}
 
 	if d.diodeDryRun {
-		args = append(args, "--dry-run", "--dry-run-output-dir", d.diodeDryRunOutputDir)
+		args = append(args, "--dry-run")
+		if d.diodeDryRunOutputDir != "" {
+			args = append(args, "--dry-run-output-dir", d.diodeDryRunOutputDir)
+		}
 	} else {
 		args = append(args, "--diode-target", d.diodeTarget)
 		if !d.diodeTargetFromOtel {
@@ -211,7 +213,6 @@ func (d *gnmiDiscoveryBackend) buildArgs() []string {
 func (d *gnmiDiscoveryBackend) Start(ctx context.Context, cancelFunc context.CancelFunc) error {
 	d.startTime = time.Now()
 	d.cancelFunc = cancelFunc
-	d.ctx = ctx
 
 	dOptions := d.buildArgs()
 	d.logger.Info("gnmi-discovery startup", "arguments", redact.Args(dOptions))
@@ -235,13 +236,13 @@ func (d *gnmiDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 					stdout = nil
 					continue
 				}
-				d.logGnmiDiscoveryOutput(line, slog.LevelInfo)
+				d.logGnmiDiscoveryOutput(ctx, line, slog.LevelInfo)
 			case line, open := <-stderr:
 				if !open {
 					stderr = nil
 					continue
 				}
-				d.logGnmiDiscoveryOutput(line, slog.LevelError)
+				d.logGnmiDiscoveryOutput(ctx, line, slog.LevelError)
 			}
 		}
 	}()
@@ -301,7 +302,7 @@ func (d *gnmiDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 
 // logGnmiDiscoveryOutput logs one line of process output, parsing it as logfmt
 // (structured attrs + level) when possible and falling back to the raw line.
-func (d *gnmiDiscoveryBackend) logGnmiDiscoveryOutput(line string, fallback slog.Level) {
+func (d *gnmiDiscoveryBackend) logGnmiDiscoveryOutput(ctx context.Context, line string, fallback slog.Level) {
 	trimmed := strings.TrimSpace(line)
 	if trimmed == "" {
 		return
@@ -317,7 +318,6 @@ func (d *gnmiDiscoveryBackend) logGnmiDiscoveryOutput(line string, fallback slog
 		level = parsedLevel
 	}
 
-	ctx := d.ctx
 	if ctx == nil {
 		ctx = context.Background()
 	}

--- a/agent/backend/gnmidiscovery/gnmi_discovery.go
+++ b/agent/backend/gnmidiscovery/gnmi_discovery.go
@@ -71,7 +71,8 @@ type info struct {
 	UpTimeMin float64 `json:"up_time_seconds"`
 }
 
-// Register registers the gNMI discovery backend
+// Register registers the gNMI discovery backend with the agent's backend
+// registry under the name "gnmi_discovery".
 func Register() bool {
 	backend.Register("gnmi_discovery", &gnmiDiscoveryBackend{
 		apiProtocol: "http",
@@ -80,6 +81,17 @@ func Register() bool {
 	return true
 }
 
+// configStringOrDefault returns the stringified value of config[name], or
+// fallback when the key is absent.
+func configStringOrDefault(config map[string]any, name, fallback string) string {
+	if value, ok := config[name]; ok {
+		return fmt.Sprintf("%v", value)
+	}
+	return fallback
+}
+
+// Configure stores the backend configuration, merging the per-backend config
+// map with the shared Diode/OTLP commons (per-backend keys take precedence).
 func (d *gnmiDiscoveryBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	config map[string]any, common config.BackendCommons, _ filesmgr.Manager,
 ) error {
@@ -87,15 +99,8 @@ func (d *gnmiDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Poli
 	d.policyRepo = repo
 	d.diodeTargetFromOtel = false
 
-	var prs bool
-	if d.apiHost, prs = config["host"].(string); !prs {
-		d.apiHost = defaultAPIHost
-	}
-	if port, prs := config["port"]; prs {
-		d.apiPort = fmt.Sprintf("%v", port)
-	} else {
-		d.apiPort = defaultAPIPort
-	}
+	d.apiHost = configStringOrDefault(config, "host", defaultAPIHost)
+	d.apiPort = configStringOrDefault(config, "port", defaultAPIPort)
 
 	d.diodeTarget = common.Diode.Target
 	d.diodeClientID = common.Diode.ClientID
@@ -154,6 +159,7 @@ func (d *gnmiDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Poli
 	return nil
 }
 
+// Version returns the running gnmi-discovery version from its REST status endpoint.
 func (d *gnmiDiscoveryBackend) Version() (string, error) {
 	var info info
 	url := fmt.Sprintf("%s://%s:%s/api/v1/status", d.apiProtocol, d.apiHost, d.apiPort)
@@ -165,58 +171,60 @@ func (d *gnmiDiscoveryBackend) Version() (string, error) {
 	return info.Version, nil
 }
 
+// buildArgs assembles the gnmi-discovery process arguments from the configured
+// options. Flags are order-independent, so they are appended in a single pass.
+func (d *gnmiDiscoveryBackend) buildArgs() []string {
+	args := []string{
+		"--diode-app-name-prefix", d.diodeAppNamePrefix,
+		"--host", d.apiHost,
+		"--port", d.apiPort,
+	}
+
+	if d.diodeDryRun {
+		args = append(args, "--dry-run", "--dry-run-output-dir", d.diodeDryRunOutputDir)
+	} else {
+		args = append(args, "--diode-target", d.diodeTarget)
+		if !d.diodeTargetFromOtel {
+			args = append(args,
+				"--diode-client-id", d.diodeClientID,
+				"--diode-client-secret", d.diodeClientSecret,
+			)
+		}
+	}
+
+	if d.diodeLogLevel != "" {
+		args = append(args, "--log-level", d.diodeLogLevel)
+		d.logger.Info("gnmi-discovery using log level", "log_level", d.diodeLogLevel)
+	}
+	if d.diodeOtelEndpoint != "" {
+		args = append(args, "--otel-endpoint", d.diodeOtelEndpoint)
+		d.logger.Info("gnmi-discovery using OTLP metrics endpoint", "endpoint", d.diodeOtelEndpoint)
+	}
+
+	// gNMI-specific options
+	if d.profilesDir != "" {
+		args = append(args, "--profiles-dir", d.profilesDir)
+		d.logger.Info("gnmi-discovery using profiles dir", "profiles_dir", d.profilesDir)
+	}
+	if d.otelExportPeriod != "" {
+		args = append(args, "--otel-export-period", d.otelExportPeriod)
+	}
+	if d.logFormat != "" {
+		args = append(args, "--log-format", d.logFormat)
+	}
+
+	return args
+}
+
+// Start launches the gnmi-discovery process, streams its logs to the agent
+// logger, and blocks until the process's REST API is ready — returning an error
+// if it exits early or never becomes ready.
 func (d *gnmiDiscoveryBackend) Start(ctx context.Context, cancelFunc context.CancelFunc) error {
 	d.startTime = time.Now()
 	d.cancelFunc = cancelFunc
 	d.ctx = ctx
 
-	dOptions := []string{
-		"--diode-app-name-prefix", d.diodeAppNamePrefix,
-		"--host", d.apiHost,
-		"--port", d.apiPort,
-	}
-	if d.diodeDryRun {
-		dOptions = append([]string{
-			"--dry-run",
-			"--dry-run-output-dir", d.diodeDryRunOutputDir,
-		}, dOptions...)
-	} else {
-		opts := []string{
-			"--diode-target", d.diodeTarget,
-		}
-		if !d.diodeTargetFromOtel {
-			opts = append(opts,
-				"--diode-client-id", d.diodeClientID,
-				"--diode-client-secret", d.diodeClientSecret,
-			)
-		}
-		dOptions = append(opts, dOptions...)
-	}
-
-	if d.diodeLogLevel != "" {
-		dOptions = append(dOptions, "--log-level", d.diodeLogLevel)
-		d.logger.Info("gnmi-discovery using log level",
-			"log_level", d.diodeLogLevel)
-	}
-
-	if d.diodeOtelEndpoint != "" {
-		dOptions = append(dOptions, "--otel-endpoint", d.diodeOtelEndpoint)
-		d.logger.Info("gnmi-discovery using OTLP metrics endpoint",
-			"endpoint", d.diodeOtelEndpoint)
-	}
-
-	// gNMI-specific options
-	if d.profilesDir != "" {
-		dOptions = append(dOptions, "--profiles-dir", d.profilesDir)
-		d.logger.Info("gnmi-discovery using profiles dir", "profiles_dir", d.profilesDir)
-	}
-	if d.otelExportPeriod != "" {
-		dOptions = append(dOptions, "--otel-export-period", d.otelExportPeriod)
-	}
-	if d.logFormat != "" {
-		dOptions = append(dOptions, "--log-format", d.logFormat)
-	}
-
+	dOptions := d.buildArgs()
 	d.logger.Info("gnmi-discovery startup", "arguments", redact.Args(dOptions))
 
 	d.proc = backend.NewCmdOptions(backend.CmdOptions{
@@ -225,14 +233,10 @@ func (d *gnmiDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 	}, d.exec, dOptions...)
 	d.statusChan = d.proc.Start()
 
-	// log STDOUT and STDERR lines streaming from Cmd
-	doneChan := make(chan struct{})
+	// Stream the process's stdout/stderr to the agent logger. A closed stream
+	// reads as (_, false); we nil it so the select then blocks only on the
+	// still-open stream, and the loop exits once both are closed (process gone).
 	go func() {
-		defer func() {
-			if doneChan != nil {
-				close(doneChan)
-			}
-		}()
 		stdout := d.proc.GetStdout()
 		stderr := d.proc.GetStderr()
 		for stdout != nil || stderr != nil {
@@ -306,6 +310,8 @@ func (d *gnmiDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 	return nil
 }
 
+// logGnmiDiscoveryOutput logs one line of process output, parsing it as logfmt
+// (structured attrs + level) when possible and falling back to the raw line.
 func (d *gnmiDiscoveryBackend) logGnmiDiscoveryOutput(line string, fallback slog.Level) {
 	trimmed := strings.TrimSpace(line)
 	if trimmed == "" {
@@ -330,6 +336,7 @@ func (d *gnmiDiscoveryBackend) logGnmiDiscoveryOutput(line string, fallback slog
 	d.logger.LogAttrs(ctx, level, msg, attrs...)
 }
 
+// Stop gracefully stops the gnmi-discovery process and cancels the backend context.
 func (d *gnmiDiscoveryBackend) Stop(ctx context.Context) error {
 	d.logger.Info("routine call to stop gnmi-discovery", "routine", ctx.Value(config.ContextKey("routine")))
 	if d.cancelFunc != nil {
@@ -339,6 +346,7 @@ func (d *gnmiDiscoveryBackend) Stop(ctx context.Context) error {
 	return nil
 }
 
+// FullReset stops the gnmi-discovery process (if running) and starts it again.
 func (d *gnmiDiscoveryBackend) FullReset(ctx context.Context) error {
 	// force a stop, which stops scrape as well. if proc is dead, it no ops.
 	if state, _, _ := backend.GetRunningStatus(d.proc); state == backend.Running {
@@ -357,10 +365,12 @@ func (d *gnmiDiscoveryBackend) FullReset(ctx context.Context) error {
 	return nil
 }
 
+// GetStartTime returns the time the gnmi-discovery process was last started.
 func (d *gnmiDiscoveryBackend) GetStartTime() time.Time {
 	return d.startTime
 }
 
+// GetCapabilities returns the backend's capabilities from its REST endpoint.
 func (d *gnmiDiscoveryBackend) GetCapabilities() (map[string]any, error) {
 	caps := make(map[string]any)
 	url := fmt.Sprintf("%s://%s:%s/api/v1/capabilities", d.apiProtocol, d.apiHost, d.apiPort)
@@ -372,6 +382,8 @@ func (d *gnmiDiscoveryBackend) GetCapabilities() (map[string]any, error) {
 	return caps, nil
 }
 
+// GetRunningStatus reports the process state, also verifying the REST API is
+// reachable when the process is running.
 func (d *gnmiDiscoveryBackend) GetRunningStatus() (backend.RunningStatus, string, error) {
 	// first check process status
 	runningStatus, errMsg, err := backend.GetRunningStatus(d.proc)
@@ -387,10 +399,13 @@ func (d *gnmiDiscoveryBackend) GetRunningStatus() (backend.RunningStatus, string
 	return runningStatus, "", nil
 }
 
+// GetInitialState returns the backend's initial running state (Unknown).
 func (d *gnmiDiscoveryBackend) GetInitialState() backend.RunningStatus {
 	return backend.Unknown
 }
 
+// ApplyPolicy applies a policy via the REST API, removing the prior version
+// first when this is an update.
 func (d *gnmiDiscoveryBackend) ApplyPolicy(data policies.PolicyData, updatePolicy bool) error {
 	if updatePolicy {
 		// To update a policy it's necessary first remove it and then apply a new version
@@ -426,6 +441,8 @@ func (d *gnmiDiscoveryBackend) ApplyPolicy(data policies.PolicyData, updatePolic
 	return nil
 }
 
+// RemovePolicy deletes a policy by name via the REST API (using the previous
+// name when a policy was renamed).
 func (d *gnmiDiscoveryBackend) RemovePolicy(data policies.PolicyData) error {
 	d.logger.Debug("gnmi-discovery policy remove", "policy_id", data.ID)
 	var resp any
@@ -464,6 +481,8 @@ type gnmiStatusResponse struct {
 	} `json:"policies"`
 }
 
+// GetPolicyStatus returns per-policy run status from the REST status endpoint,
+// normalizing each run's singular target into the shared Targets slice.
 func (d *gnmiDiscoveryBackend) GetPolicyStatus() ([]backend.PolicyStatus, error) {
 	var resp gnmiStatusResponse
 	url := fmt.Sprintf("%s://%s:%s/api/v1/status", d.apiProtocol, d.apiHost, d.apiPort)
@@ -500,6 +519,8 @@ func (d *gnmiDiscoveryBackend) GetPolicyStatus() ([]backend.PolicyStatus, error)
 	return policies, nil
 }
 
+// normalizeGnmiDiscoveryLine parses a logfmt line into (message, attrs, level),
+// returning ok=false when the line is not logfmt or has no message.
 func normalizeGnmiDiscoveryLine(line string, fallback slog.Level) (string, []slog.Attr, slog.Level, bool) {
 	fields, ok := parseGnmiDiscoveryLogfmt(line)
 	if !ok {
@@ -548,6 +569,8 @@ func normalizeGnmiDiscoveryLine(line string, fallback slog.Level) (string, []slo
 	return msg, attrs, level, true
 }
 
+// parseGnmiDiscoveryLevel maps a logfmt level string to an slog.Level,
+// returning ok=false for unknown levels.
 func parseGnmiDiscoveryLevel(value string) (slog.Level, bool) {
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "debug":
@@ -563,6 +586,8 @@ func parseGnmiDiscoveryLevel(value string) (slog.Level, bool) {
 	}
 }
 
+// parseGnmiDiscoveryLogfmt parses a logfmt line into a key/value map,
+// returning ok=false if the line is empty or not valid logfmt.
 func parseGnmiDiscoveryLogfmt(line string) (map[string]string, bool) {
 	result := make(map[string]string)
 	runes := []rune(line)
@@ -604,6 +629,8 @@ func parseGnmiDiscoveryLogfmt(line string) (map[string]string, bool) {
 	return result, true
 }
 
+// readLogfmtValue reads a logfmt value (quoted or bare) starting at index
+// start, returning the value, the index after it, and ok.
 func readLogfmtValue(runes []rune, start int) (string, int, bool) {
 	length := len(runes)
 	if start >= length {
@@ -618,6 +645,8 @@ func readLogfmtValue(runes []rune, start int) (string, int, bool) {
 	}
 }
 
+// readQuotedValue reads a quoted logfmt value (handling backslash escapes)
+// starting at the opening quote, returning ok=false if it is unterminated.
 func readQuotedValue(runes []rune, start int) (string, int, bool) {
 	length := len(runes)
 	quote := runes[start]
@@ -645,6 +674,8 @@ func readQuotedValue(runes []rune, start int) (string, int, bool) {
 	return "", length, false
 }
 
+// readUnquotedValue reads a bare (space-delimited) logfmt value starting at
+// index start, returning the value and the index after the trailing spaces.
 func readUnquotedValue(runes []rune, start int) (string, int, bool) {
 	length := len(runes)
 	index := start

--- a/agent/backend/gnmidiscovery/gnmi_discovery.go
+++ b/agent/backend/gnmidiscovery/gnmi_discovery.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	neturl "net/url"
 	"sort"
 	"strings"
 	"time"
@@ -289,7 +290,7 @@ func (d *gnmiDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 		}
 		backoffDuration := time.Duration(backoff) * time.Second
 		d.logger.Info("gnmi-discovery is not ready, trying again with backoff",
-			"backoff backoffDuration", backoffDuration.String())
+			"backoff_duration", backoffDuration.String())
 		time.Sleep(backoffDuration)
 	}
 
@@ -331,7 +332,9 @@ func (d *gnmiDiscoveryBackend) logGnmiDiscoveryOutput(line string, fallback slog
 
 func (d *gnmiDiscoveryBackend) Stop(ctx context.Context) error {
 	d.logger.Info("routine call to stop gnmi-discovery", "routine", ctx.Value(config.ContextKey("routine")))
-	defer d.cancelFunc()
+	if d.cancelFunc != nil {
+		defer d.cancelFunc()
+	}
 	backend.StopProcess(d.logger, d.proc, d.statusChan, backend.DefaultStopGracePeriod, "gnmi_discovery")
 	return nil
 }
@@ -431,7 +434,7 @@ func (d *gnmiDiscoveryBackend) RemovePolicy(data policies.PolicyData) error {
 	if data.PreviousPolicyData != nil && data.PreviousPolicyData.Name != data.Name {
 		name = data.PreviousPolicyData.Name
 	}
-	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", d.apiProtocol, d.apiHost, d.apiPort, name)
+	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", d.apiProtocol, d.apiHost, d.apiPort, neturl.PathEscape(name))
 	err := backend.CommonRequest("gnmi-discovery", d.proc, d.logger, url, &resp, http.MethodDelete,
 		http.NoBody, "application/json", removePolicyTimeout, "detail")
 	if err != nil {

--- a/agent/backend/gnmidiscovery/gnmi_discovery.go
+++ b/agent/backend/gnmidiscovery/gnmi_discovery.go
@@ -81,11 +81,12 @@ func Register() bool {
 	return true
 }
 
-// configStringOrDefault returns the stringified value of config[name], or
-// fallback when the key is absent.
+// configStringOrDefault returns config[name] when it is a string, otherwise
+// fallback. A missing key, a YAML null, or a non-string value (number/bool)
+// falls back rather than being coerced to a literal like "<nil>" or "true".
 func configStringOrDefault(config map[string]any, name, fallback string) string {
-	if value, ok := config[name]; ok {
-		return fmt.Sprintf("%v", value)
+	if value, ok := config[name].(string); ok {
+		return value
 	}
 	return fallback
 }
@@ -100,33 +101,25 @@ func (d *gnmiDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Poli
 	d.diodeTargetFromOtel = false
 
 	d.apiHost = configStringOrDefault(config, "host", defaultAPIHost)
-	d.apiPort = configStringOrDefault(config, "port", defaultAPIPort)
+	// port may be given as a YAML number, so stringify whatever is present.
+	if port, ok := config["port"]; ok {
+		d.apiPort = fmt.Sprintf("%v", port)
+	} else {
+		d.apiPort = defaultAPIPort
+	}
 
-	d.diodeTarget = common.Diode.Target
-	d.diodeClientID = common.Diode.ClientID
-	d.diodeClientSecret = common.Diode.ClientSecret
-	d.diodeAppNamePrefix = common.Diode.AgentName
+	// String options fall back to the shared Diode commons when unset.
+	d.diodeTarget = configStringOrDefault(config, "target", common.Diode.Target)
+	d.diodeClientID = configStringOrDefault(config, "client_id", common.Diode.ClientID)
+	d.diodeClientSecret = configStringOrDefault(config, "client_secret", common.Diode.ClientSecret)
+	d.diodeAppNamePrefix = configStringOrDefault(config, "agent_name", common.Diode.AgentName)
+	d.diodeDryRunOutputDir = configStringOrDefault(config, "dry_run_output_dir", common.Diode.DryRunOutputDir)
+
 	d.diodeDryRun = common.Diode.DryRun
-	d.diodeDryRunOutputDir = common.Diode.DryRunOutputDir
-
-	if target, prs := config["target"].(string); prs {
-		d.diodeTarget = target
-	}
-	if clientID, prs := config["client_id"].(string); prs {
-		d.diodeClientID = clientID
-	}
-	if clientSecret, prs := config["client_secret"].(string); prs {
-		d.diodeClientSecret = clientSecret
-	}
-	if agentName, prs := config["agent_name"].(string); prs {
-		d.diodeAppNamePrefix = agentName
-	}
 	if dryRun, prs := config["dry_run"].(bool); prs {
 		d.diodeDryRun = dryRun
 	}
-	if dryRunOutputDir, prs := config["dry_run_output_dir"].(string); prs {
-		d.diodeDryRunOutputDir = dryRunOutputDir
-	}
+
 	if logLevel, prs := config["log_level"].(string); prs {
 		d.diodeLogLevel = logLevel
 	} else if debug, prs := config["debug"].(bool); prs && debug {
@@ -136,14 +129,10 @@ func (d *gnmiDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Poli
 	}
 
 	// gNMI-specific options
-	if profilesDir, prs := config["profiles_dir"].(string); prs {
-		d.profilesDir = profilesDir
-	}
+	d.profilesDir = configStringOrDefault(config, "profiles_dir", "")
+	d.logFormat = configStringOrDefault(config, "log_format", "")
 	if period, prs := config["otel_export_period"]; prs {
 		d.otelExportPeriod = fmt.Sprintf("%v", period)
-	}
-	if logFormat, prs := config["log_format"].(string); prs {
-		d.logFormat = logFormat
 	}
 
 	if common.Otlp.Grpc != "" {

--- a/agent/backend/gnmidiscovery/gnmi_discovery.go
+++ b/agent/backend/gnmidiscovery/gnmi_discovery.go
@@ -258,10 +258,7 @@ func (d *gnmiDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 	}
 
 	if status.Complete {
-		err := d.proc.Stop()
-		if err != nil {
-			d.logger.Error("proc.Stop error", "error", err)
-		}
+		backend.StopProcess(d.logger, d.proc, d.statusChan, backend.DefaultStopGracePeriod, "gnmi_discovery")
 		return errors.New("gnmi-discovery startup error, check log")
 	}
 
@@ -271,10 +268,7 @@ func (d *gnmiDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 	var readinessErr error
 	for backoff := range readinessBackoff {
 		if status := d.proc.Status(); status.Complete {
-			err := d.proc.Stop()
-			if err != nil {
-				d.logger.Error("proc.Stop error", "error", err)
-			}
+			backend.StopProcess(d.logger, d.proc, d.statusChan, backend.DefaultStopGracePeriod, "gnmi_discovery")
 			return errors.New("gnmi-discovery process ended unexpectedly, check log")
 		}
 		version, readinessErr = d.Version()
@@ -290,10 +284,7 @@ func (d *gnmiDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 
 	if readinessErr != nil {
 		d.logger.Error("gnmi-discovery error on readiness", "error", readinessErr)
-		err := d.proc.Stop()
-		if err != nil {
-			d.logger.Error("proc.Stop error", "error", err)
-		}
+		backend.StopProcess(d.logger, d.proc, d.statusChan, backend.DefaultStopGracePeriod, "gnmi_discovery")
 		return readinessErr
 	}
 

--- a/agent/backend/gnmidiscovery/gnmi_discovery.go
+++ b/agent/backend/gnmidiscovery/gnmi_discovery.go
@@ -443,15 +443,61 @@ func (d *gnmiDiscoveryBackend) RemovePolicy(data policies.PolicyData) error {
 	return nil
 }
 
+// gnmiStatusResponse mirrors gnmi-discovery's /api/v1/status. Each run carries a
+// single `target` (string), unlike the shared backend.PolicyStatusRun which
+// expects a `targets` array — so decoding straight into backend.StatusResponse
+// would drop the per-run target. We decode into this shape and normalize
+// `target` into Targets below.
+type gnmiStatusResponse struct {
+	Policies []struct {
+		Name   string `json:"name"`
+		Status string `json:"status"`
+		Runs   []struct {
+			ID          string `json:"id"`
+			Target      string `json:"target"`
+			Status      string `json:"status"`
+			Reason      string `json:"reason"`
+			EntityCount int64  `json:"entity_count"`
+			CreatedAt   int64  `json:"created_at"`
+			UpdatedAt   int64  `json:"updated_at"`
+		} `json:"runs"`
+	} `json:"policies"`
+}
+
 func (d *gnmiDiscoveryBackend) GetPolicyStatus() ([]backend.PolicyStatus, error) {
-	var resp backend.StatusResponse
+	var resp gnmiStatusResponse
 	url := fmt.Sprintf("%s://%s:%s/api/v1/status", d.apiProtocol, d.apiHost, d.apiPort)
 	err := backend.CommonRequest("gnmi-discovery", d.proc, d.logger, url, &resp, http.MethodGet,
 		http.NoBody, "application/json", statusTimeout, "detail")
 	if err != nil {
 		return nil, err
 	}
-	return resp.Policies, nil
+
+	policies := make([]backend.PolicyStatus, 0, len(resp.Policies))
+	for _, p := range resp.Policies {
+		runs := make([]backend.PolicyStatusRun, 0, len(p.Runs))
+		for _, r := range p.Runs {
+			var targets []string
+			if r.Target != "" {
+				targets = []string{r.Target}
+			}
+			runs = append(runs, backend.PolicyStatusRun{
+				ID:          r.ID,
+				Status:      r.Status,
+				Reason:      r.Reason,
+				EntityCount: r.EntityCount,
+				CreatedAt:   r.CreatedAt,
+				UpdatedAt:   r.UpdatedAt,
+				Targets:     targets,
+			})
+		}
+		policies = append(policies, backend.PolicyStatus{
+			Name:   p.Name,
+			Status: p.Status,
+			Runs:   runs,
+		})
+	}
+	return policies, nil
 }
 
 func normalizeGnmiDiscoveryLine(line string, fallback slog.Level) (string, []slog.Attr, slog.Level, bool) {

--- a/agent/backend/gnmidiscovery/gnmi_discovery_test.go
+++ b/agent/backend/gnmidiscovery/gnmi_discovery_test.go
@@ -1,0 +1,392 @@
+package gnmidiscovery_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/backend/gnmidiscovery"
+	"github.com/netboxlabs/orb-agent/agent/backend/mocks"
+	"github.com/netboxlabs/orb-agent/agent/config"
+	"github.com/netboxlabs/orb-agent/agent/policies"
+)
+
+type StatusResponse struct {
+	Version   string  `json:"version"`
+	StartTime string  `json:"start_time"`
+	UpTime    float64 `json:"up_time"`
+}
+
+func TestGnmiDiscoveryBackendStart(t *testing.T) {
+	var mu sync.Mutex
+	var deletedPaths []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.URL.Path == "/api/v1/status":
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"version": "1.3.4",
+				"policies": []map[string]any{
+					{"name": "gnmi-policy-1", "status": "running"},
+				},
+			}))
+		case r.URL.Path == "/api/v1/capabilities":
+			capabilities := map[string]any{
+				"capability": true,
+			}
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(capabilities))
+		case strings.Contains(r.URL.Path, "/api/v1/policies"):
+			if r.Method == http.MethodDelete {
+				mu.Lock()
+				deletedPaths = append(deletedPaths, r.URL.Path)
+				mu.Unlock()
+			}
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+				"status":  "success",
+				"message": "Policy operation successful",
+			}))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	createExecutable(t, "gnmi-discovery")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 12345)
+
+	overrideNewCmdOptions(t, mockCmd, func(options backend.CmdOptions, name string, args []string) {
+		assert.Equal(t, "gnmi-discovery", name, "Expected command name to be gnmi-discovery")
+		assert.False(t, options.Buffered, "Expected buffered to be false")
+		assert.True(t, options.Streaming, "Expected streaming to be true")
+		assert.Contains(t, args, "--host", "Expected args to contain host flag")
+		assert.Contains(t, args, serverURL.Hostname(), "Expected args to contain host value")
+		assert.Contains(t, args, "--port", "Expected args to contain port flag")
+		assert.Contains(t, args, serverURL.Port(), "Expected args to contain port value")
+		assert.Contains(t, args, "--diode-target", "Expected args to contain diode target flag")
+		assert.Contains(t, args, "gnmi-target", "Expected args to contain diode target")
+		assert.Contains(t, args, "--diode-client-id", "Expected args to contain diode client id flag")
+		assert.Contains(t, args, "gnmi-client", "Expected args to contain diode client id")
+		assert.Contains(t, args, "--diode-client-secret", "Expected args to contain diode client secret flag")
+		assert.Contains(t, args, "gnmi-secret", "Expected args to contain diode client secret")
+		assert.Contains(t, args, "--diode-app-name-prefix", "Expected args to contain diode app name prefix flag")
+		assert.Contains(t, args, "gnmi-agent", "Expected args to contain diode app name prefix")
+		assert.Contains(t, args, "--log-level", "Expected args to contain log level flag")
+		assert.Contains(t, args, "debug", "Expected args to contain log level value")
+		assert.Contains(t, args, "--otel-endpoint", "Expected args to contain otel endpoint flag")
+		assert.Contains(t, args, "collector:4317", "Expected args to contain otel endpoint value")
+		// gNMI-specific flags
+		assert.Contains(t, args, "--profiles-dir", "Expected args to contain profiles-dir flag")
+		assert.Contains(t, args, "/etc/gnmi/profiles", "Expected args to contain profiles-dir value")
+		assert.Contains(t, args, "--otel-export-period", "Expected args to contain otel-export-period flag")
+		assert.Contains(t, args, "30", "Expected args to contain otel-export-period value")
+		assert.Contains(t, args, "--log-format", "Expected args to contain log-format flag")
+		assert.Contains(t, args, "json", "Expected args to contain log-format value")
+	})
+
+	assert.True(t, gnmidiscovery.Register(), "Failed to register GnmiDiscovery backend")
+	assert.True(t, backend.HaveBackend("gnmi_discovery"), "Failed to get GnmiDiscovery backend")
+
+	be := backend.GetBackend("gnmi_discovery")
+
+	assert.Equal(t, backend.Unknown, be.GetInitialState())
+
+	commons := config.BackendCommons{}
+	commons.Otlp.Grpc = "collector:4317"
+	commons.Diode.Target = "default-target"
+	commons.Diode.ClientID = "default-client"
+	commons.Diode.ClientSecret = "default-secret"
+	commons.Diode.AgentName = "default-agent"
+	commons.Diode.DryRunOutputDir = "/tmp/default"
+
+	err = be.Configure(logger, repo, map[string]any{
+		"host":               serverURL.Hostname(),
+		"port":               serverURL.Port(),
+		"target":             "gnmi-target",
+		"client_id":          "gnmi-client",
+		"client_secret":      "gnmi-secret",
+		"agent_name":         "gnmi-agent",
+		"log_level":          "debug",
+		"dry_run":            false,
+		"dry_run_output_dir": "/tmp/gnmi",
+		"profiles_dir":       "/etc/gnmi/profiles",
+		"otel_export_period": 30,
+		"log_format":         "json",
+	}, commons, nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, be.Start(ctx, cancel))
+
+	startTime := be.GetStartTime()
+	assert.False(t, startTime.IsZero(), "Expected start time to be set")
+
+	status, _, err := be.GetRunningStatus()
+	require.NoError(t, err)
+	assert.Equal(t, backend.Running, status, "Expected backend to be running")
+
+	capabilities, err := be.GetCapabilities()
+	require.NoError(t, err)
+	assert.Equal(t, true, capabilities["capability"], "Expected capability to be true")
+
+	version, err := be.Version()
+	require.NoError(t, err)
+	assert.Equal(t, "1.3.4", version, "Expected version to match response")
+
+	statusProvider, ok := be.(backend.PolicyStatusProvider)
+	require.True(t, ok, "gnmi backend should implement PolicyStatusProvider")
+	policyStatus, err := statusProvider.GetPolicyStatus()
+	require.NoError(t, err)
+	require.Len(t, policyStatus, 1, "Expected one policy status from /api/v1/status")
+	assert.Equal(t, "gnmi-policy-1", policyStatus[0].Name, "Expected policy status name to match response")
+
+	data := policies.PolicyData{
+		ID:   "dummy-policy-id",
+		Name: "dummy-policy-name",
+		Data: map[string]any{"key": "value"},
+	}
+	require.NoError(t, be.ApplyPolicy(data, false))
+
+	updatedData := policies.PolicyData{
+		ID:   data.ID,
+		Name: "dummy-policy-updated",
+		Data: map[string]any{"key": "value"},
+		PreviousPolicyData: &policies.PolicyData{
+			Name: data.Name,
+		},
+	}
+	require.NoError(t, be.ApplyPolicy(updatedData, true))
+
+	// Updating a policy must remove the PREVIOUS name first, not the new one.
+	mu.Lock()
+	gotDeletes := append([]string(nil), deletedPaths...)
+	mu.Unlock()
+	require.NotEmpty(t, gotDeletes, "Expected a DELETE for the previous policy name on update")
+	lastDelete := gotDeletes[len(gotDeletes)-1]
+	assert.Contains(t, lastDelete, "/api/v1/policies/dummy-policy-name",
+		"update must DELETE the previous policy name")
+	assert.NotContains(t, lastDelete, "dummy-policy-updated",
+		"update must not DELETE the new policy name")
+
+	require.NoError(t, be.FullReset(ctx))
+
+	mockCmd.AssertExpectations(t)
+}
+
+func TestGnmiDiscoveryUsesOtelTargetWithoutCredentials(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path == "/api/v1/status" {
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(StatusResponse{Version: "1.0.0"}))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	createExecutable(t, "gnmi-discovery")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 4244)
+
+	otelEndpoint := "collector:4317"
+	overrideNewCmdOptions(t, mockCmd, func(_ backend.CmdOptions, name string, args []string) {
+		assert.Equal(t, "gnmi-discovery", name)
+		assert.Contains(t, args, "--diode-target")
+		assert.Contains(t, args, otelEndpoint)
+		assert.NotContains(t, args, "--diode-client-id")
+		assert.NotContains(t, args, "--diode-client-secret")
+		assert.NotContains(t, args, "gnmi-client")
+		assert.NotContains(t, args, "gnmi-secret")
+		assert.NotContains(t, args, "********")
+	})
+
+	assert.True(t, gnmidiscovery.Register())
+	assert.True(t, backend.HaveBackend("gnmi_discovery"))
+
+	be := backend.GetBackend("gnmi_discovery")
+
+	commons := config.BackendCommons{}
+	commons.Otlp.Grpc = otelEndpoint
+	commons.Diode.ClientID = "default-client"
+	commons.Diode.ClientSecret = "default-secret"
+	commons.Diode.AgentName = "gnmi-agent"
+
+	err = be.Configure(logger, repo, map[string]any{
+		"host":          serverURL.Hostname(),
+		"port":          serverURL.Port(),
+		"client_id":     "gnmi-client",
+		"client_secret": "gnmi-secret",
+		"agent_name":    "gnmi-agent",
+	}, commons, nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, be.Start(ctx, cancel))
+	require.NoError(t, be.Stop(ctx))
+
+	mockCmd.AssertExpectations(t)
+}
+
+func TestGnmiDiscoveryBackendCompleted(t *testing.T) {
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupCompletedProcess(mockCmd, 0, nil)
+
+	overrideNewCmdOptions(t, mockCmd, nil)
+
+	assert.True(t, gnmidiscovery.Register(), "Failed to register GnmiDiscovery backend")
+	assert.True(t, backend.HaveBackend("gnmi_discovery"), "Failed to get GnmiDiscovery backend")
+
+	be := backend.GetBackend("gnmi_discovery")
+
+	require.NoError(t, be.Configure(slog.Default(), nil, map[string]any{
+		"host": "invalid-host",
+	}, config.BackendCommons{}, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := be.Start(ctx, cancel)
+	assert.Error(t, err)
+
+	mockCmd.AssertExpectations(t)
+}
+
+func TestGnmiDiscoveryBackendStartWithDryRunIncludesHostAndPort(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/status" {
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(StatusResponse{Version: "1.0.0"}))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	createExecutable(t, "gnmi-discovery")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 12349)
+
+	overrideNewCmdOptions(t, mockCmd, func(_ backend.CmdOptions, name string, args []string) {
+		assert.Equal(t, "gnmi-discovery", name, "Expected command name to be gnmi-discovery")
+		assert.Contains(t, args, "--dry-run", "Expected args to contain dry-run flag")
+		assert.Contains(t, args, "--dry-run-output-dir", "Expected args to contain dry-run-output-dir flag")
+		assert.Contains(t, args, "/tmp/gnmi-dry-run", "Expected args to contain dry-run-output-dir value")
+		assert.Contains(t, args, "--host", "Expected args to contain host flag even in dry-run mode")
+		assert.Contains(t, args, serverURL.Hostname(), "Expected args to contain host value even in dry-run mode")
+		assert.Contains(t, args, "--port", "Expected args to contain port flag even in dry-run mode")
+		assert.Contains(t, args, serverURL.Port(), "Expected args to contain port value even in dry-run mode")
+		assert.Contains(t, args, "--diode-app-name-prefix", "Expected args to contain diode app name prefix flag")
+		assert.Contains(t, args, "gnmi-agent", "Expected args to contain diode app name prefix value")
+		assert.NotContains(t, args, "--diode-target", "Expected args to NOT contain diode target flag in dry-run mode")
+		assert.NotContains(t, args, "--diode-client-id", "Expected args to NOT contain diode client id flag in dry-run mode")
+		assert.NotContains(t, args, "--diode-client-secret", "Expected args to NOT contain diode client secret flag in dry-run mode")
+	})
+
+	assert.True(t, gnmidiscovery.Register(), "Failed to register GnmiDiscovery backend")
+	assert.True(t, backend.HaveBackend("gnmi_discovery"), "Failed to get GnmiDiscovery backend")
+
+	be := backend.GetBackend("gnmi_discovery")
+
+	commons := config.BackendCommons{}
+	commons.Diode.AgentName = "gnmi-agent"
+	commons.Diode.DryRunOutputDir = "/tmp/gnmi-dry-run"
+
+	err = be.Configure(logger, repo, map[string]any{
+		"host":               serverURL.Hostname(),
+		"port":               serverURL.Port(),
+		"agent_name":         "gnmi-agent",
+		"dry_run":            true,
+		"dry_run_output_dir": "/tmp/gnmi-dry-run",
+	}, commons, nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, be.Start(ctx, cancel))
+	require.NoError(t, be.Stop(ctx))
+
+	mockCmd.AssertExpectations(t)
+}
+
+func createExecutable(t *testing.T, name string) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	binaryPath := path.Join(tempDir, name)
+
+	file, err := os.Create(binaryPath)
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+	require.NoError(t, os.Chmod(binaryPath, 0o755))
+
+	originalPath := os.Getenv("PATH")
+	t.Setenv("PATH", tempDir+string(os.PathListSeparator)+originalPath)
+}
+
+func overrideNewCmdOptions(t *testing.T, cmd backend.Commander, assertFn func(options backend.CmdOptions, name string, args []string)) {
+	t.Helper()
+
+	original := backend.NewCmdOptions
+	backend.NewCmdOptions = func(options backend.CmdOptions, name string, args ...string) backend.Commander {
+		if assertFn != nil {
+			assertFn(options, name, args)
+		}
+		return cmd
+	}
+
+	t.Cleanup(func() {
+		backend.NewCmdOptions = original
+	})
+}

--- a/agent/backend/gnmidiscovery/gnmi_discovery_test.go
+++ b/agent/backend/gnmidiscovery/gnmi_discovery_test.go
@@ -42,7 +42,14 @@ func TestGnmiDiscoveryBackendStart(t *testing.T) {
 			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
 				"version": "1.3.4",
 				"policies": []map[string]any{
-					{"name": "gnmi-policy-1", "status": "running"},
+					{
+						"name":   "gnmi-policy-1",
+						"status": "running",
+						"runs": []map[string]any{
+							// gnmi emits a singular `target` per run, not a `targets` array.
+							{"id": "run-1", "target": "10.0.0.11:6030", "status": "completed"},
+						},
+					},
 				},
 			}))
 		case r.URL.Path == "/api/v1/capabilities":
@@ -167,6 +174,9 @@ func TestGnmiDiscoveryBackendStart(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, policyStatus, 1, "Expected one policy status from /api/v1/status")
 	assert.Equal(t, "gnmi-policy-1", policyStatus[0].Name, "Expected policy status name to match response")
+	require.Len(t, policyStatus[0].Runs, 1, "Expected one run in the policy status")
+	assert.Equal(t, []string{"10.0.0.11:6030"}, policyStatus[0].Runs[0].Targets,
+		"gnmi's singular run target must be normalized into Targets")
 
 	data := policies.PolicyData{
 		ID:   "dummy-policy-id",

--- a/agent/backend/gnmidiscovery/normalize_test.go
+++ b/agent/backend/gnmidiscovery/normalize_test.go
@@ -1,0 +1,145 @@
+package gnmidiscovery
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseGnmiDiscoveryLevel(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected slog.Level
+		ok       bool
+	}{
+		{"debug", slog.LevelDebug, true},
+		{"DEBUG", slog.LevelDebug, true},
+		{"info", slog.LevelInfo, true},
+		{"INFO", slog.LevelInfo, true},
+		{"warn", slog.LevelWarn, true},
+		{"warning", slog.LevelWarn, true},
+		{"WARNING", slog.LevelWarn, true},
+		{"error", slog.LevelError, true},
+		{"err", slog.LevelError, true},
+		{"ERROR", slog.LevelError, true},
+		{"unknown", 0, false},
+		{"", 0, false},
+		{"  info  ", slog.LevelInfo, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			level, ok := parseGnmiDiscoveryLevel(tt.input)
+			assert.Equal(t, tt.ok, ok)
+			if tt.ok {
+				assert.Equal(t, tt.expected, level)
+			}
+		})
+	}
+}
+
+func TestReadUnquotedValue(t *testing.T) {
+	runes := []rune("hello world")
+	val, idx, ok := readUnquotedValue(runes, 0)
+	assert.True(t, ok)
+	assert.Equal(t, "hello", val)
+	assert.Equal(t, 6, idx)
+}
+
+func TestReadQuotedValue_DoubleQuote(t *testing.T) {
+	runes := []rune(`"hello world" rest`)
+	val, idx, ok := readQuotedValue(runes, 0)
+	assert.True(t, ok)
+	assert.Equal(t, "hello world", val)
+	assert.Equal(t, 14, idx)
+}
+
+func TestReadQuotedValue_WithEscape(t *testing.T) {
+	runes := []rune(`"hello \"world\""`)
+	val, _, ok := readQuotedValue(runes, 0)
+	assert.True(t, ok)
+	assert.Equal(t, `hello "world"`, val)
+}
+
+func TestReadQuotedValue_Unterminated(t *testing.T) {
+	runes := []rune(`"hello`)
+	_, _, ok := readQuotedValue(runes, 0)
+	assert.False(t, ok)
+}
+
+func TestReadLogfmtValue_Quoted(t *testing.T) {
+	runes := []rune(`"hello world"`)
+	val, _, ok := readLogfmtValue(runes, 0)
+	assert.True(t, ok)
+	assert.Equal(t, "hello world", val)
+}
+
+func TestReadLogfmtValue_Unquoted(t *testing.T) {
+	runes := []rune("hello")
+	val, _, ok := readLogfmtValue(runes, 0)
+	assert.True(t, ok)
+	assert.Equal(t, "hello", val)
+}
+
+func TestReadLogfmtValue_Empty(t *testing.T) {
+	val, idx, ok := readLogfmtValue([]rune{}, 0)
+	assert.True(t, ok)
+	assert.Equal(t, "", val)
+	assert.Equal(t, 0, idx)
+}
+
+func TestParseGnmiDiscoveryLogfmt(t *testing.T) {
+	line := `level=info msg="hello world" key=value`
+	fields, ok := parseGnmiDiscoveryLogfmt(line)
+	assert.True(t, ok)
+	assert.Equal(t, "info", fields["level"])
+	assert.Equal(t, "hello world", fields["msg"])
+	assert.Equal(t, "value", fields["key"])
+}
+
+func TestParseGnmiDiscoveryLogfmt_Empty(t *testing.T) {
+	_, ok := parseGnmiDiscoveryLogfmt("")
+	assert.False(t, ok)
+}
+
+func TestParseGnmiDiscoveryLogfmt_InvalidFormat(t *testing.T) {
+	_, ok := parseGnmiDiscoveryLogfmt("not logfmt at all")
+	assert.False(t, ok)
+}
+
+func TestNormalizeGnmiDiscoveryLine_Valid(t *testing.T) {
+	line := `level=info msg="starting up" component=main`
+	msg, attrs, level, ok := normalizeGnmiDiscoveryLine(line, slog.LevelDebug)
+	assert.True(t, ok)
+	assert.Equal(t, "starting up", msg)
+	assert.Equal(t, slog.LevelInfo, level)
+	assert.Len(t, attrs, 1)
+	assert.Equal(t, "component", attrs[0].Key)
+}
+
+func TestNormalizeGnmiDiscoveryLine_NoMsg(t *testing.T) {
+	line := `level=info key=value`
+	_, _, _, ok := normalizeGnmiDiscoveryLine(line, slog.LevelDebug)
+	assert.False(t, ok)
+}
+
+func TestNormalizeGnmiDiscoveryLine_NotLogfmt(t *testing.T) {
+	_, _, _, ok := normalizeGnmiDiscoveryLine("plain text line", slog.LevelDebug)
+	assert.False(t, ok)
+}
+
+func TestNormalizeGnmiDiscoveryLine_NoAttrs(t *testing.T) {
+	line := `level=info msg="hello"`
+	msg, attrs, level, ok := normalizeGnmiDiscoveryLine(line, slog.LevelDebug)
+	assert.True(t, ok)
+	assert.Equal(t, "hello", msg)
+	assert.Equal(t, slog.LevelInfo, level)
+	assert.Nil(t, attrs)
+}
+
+func TestNormalizeGnmiDiscoveryLine_UnknownLevel_UsesFallback(t *testing.T) {
+	line := `level=verbose msg="hello"`
+	_, _, level, ok := normalizeGnmiDiscoveryLine(line, slog.LevelWarn)
+	assert.True(t, ok)
+	assert.Equal(t, slog.LevelWarn, level)
+}

--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -64,6 +64,25 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     go build -ldflags="-s -w" -trimpath -o /usr/local/bin/snmp-discovery ./cmd/main.go
 
 ########################################################################
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-trixie AS gnmi-discovery
+
+WORKDIR /src/gnmi-discovery
+
+COPY orb-discovery/gnmi-discovery/ .
+
+ARG TARGETOS TARGETARCH
+# Stamp the backend version: its version package go:embeds version/BUILD_*.txt.
+ARG GNMI_DISCOVERY_VERSION=0.0.0
+ARG BUILD_COMMIT=unknown
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    echo "${GNMI_DISCOVERY_VERSION}" > version/BUILD_VERSION.txt && \
+    echo "${BUILD_COMMIT}" > version/BUILD_COMMIT.txt && \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -ldflags="-s -w" -trimpath -o /usr/local/bin/gnmi-discovery ./cmd/main.go
+
+########################################################################
 FROM netboxlabs/pktvisor:${PKTVISOR_TAG} AS pktvisor
 
 ########################################################################
@@ -136,6 +155,8 @@ COPY --from=otlpinf /exe /usr/local/bin/otlpinf
 COPY --from=network-discovery /usr/local/bin/network-discovery /usr/local/bin/network-discovery
 
 COPY --from=snmp-discovery /usr/local/bin/snmp-discovery /usr/local/bin/snmp-discovery
+
+COPY --from=gnmi-discovery /usr/local/bin/gnmi-discovery /usr/local/bin/gnmi-discovery
 
 COPY --from=builder /build/orb-agent /usr/local/bin/orb-agent
 COPY --from=builder /src/orb-agent/agent/docker/orb-agent-entry.sh /usr/local/bin/orb-agent-entry.sh

--- a/agent/docker/default_config.yaml
+++ b/agent/docker/default_config.yaml
@@ -20,4 +20,5 @@ orb:
     network_discovery:
     device_discovery:
     snmp_discovery:
+    gnmi_discovery:
     worker:

--- a/agent/docker/default_config.yaml
+++ b/agent/docker/default_config.yaml
@@ -20,5 +20,4 @@ orb:
     network_discovery:
     device_discovery:
     snmp_discovery:
-    gnmi_discovery:
     worker:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/netboxlabs/orb-agent/agent"
 	"github.com/netboxlabs/orb-agent/agent/backend/devicediscovery"
+	"github.com/netboxlabs/orb-agent/agent/backend/gnmidiscovery"
 	"github.com/netboxlabs/orb-agent/agent/backend/networkdiscovery"
 	"github.com/netboxlabs/orb-agent/agent/backend/opentelemetryinfinity"
 	"github.com/netboxlabs/orb-agent/agent/backend/pktvisor"
@@ -34,6 +35,7 @@ var (
 
 func init() {
 	devicediscovery.Register()
+	gnmidiscovery.Register()
 	networkdiscovery.Register()
 	opentelemetryinfinity.Register()
 	snmpdiscovery.Register()

--- a/docs/backends/gnmi_discovery.md
+++ b/docs/backends/gnmi_discovery.md
@@ -1,0 +1,131 @@
+# gNMI Discovery
+The gNMI discovery backend is an event-driven network discovery service that maintains long-lived [gNMI](https://github.com/openconfig/gnmi) subscriptions and ingests device, interface, and hardware-inventory changes into NetBox via Diode within seconds of them occurring.
+
+Unlike SNMP/NAPALM-based polling, `gnmi_discovery` reacts to `ON_CHANGE` notifications from the device itself (with `SAMPLE` and `GET` fallback for devices that don't support streaming), so NetBox stays up to date continuously rather than on a polling interval.
+
+## Diode Entities
+The gNMI discovery backend uses the [Diode Go SDK](https://github.com/netboxlabs/diode-sdk-go) to ingest the following entities:
+
+* Device (with `DeviceType`, `Platform`, and serial/manufacturer enrichment)
+* Interface
+* Module / ModuleBay (hardware inventory)
+* IP Address
+* VRF
+
+## Configuration
+The `gnmi_discovery` backend requires no special configuration; `host` and `port` may be overridden. It uses the `diode` settings from the `common` subsection to forward discovery results.
+
+```yaml
+orb:
+  backends:
+    common:
+      diode:
+        target: grpc://192.168.0.100:8080/diode
+        client_id: ${DIODE_CLIENT_ID}
+        client_secret: ${DIODE_CLIENT_SECRET}
+        agent_name: agent01
+    gnmi_discovery:
+      host: 192.168.5.11 # default 0.0.0.0
+      port: 8076 # default 8075
+      log_level: ERROR # default INFO
+      log_format: JSON # default TEXT
+      profiles_dir: /opt/orb/gnmi-profiles # optional: directory of gNMI profile overrides
+      otel_export_period: 30 # optional: seconds between OpenTelemetry metric exports (default 10)
+```
+
+| Parameter | Type | Required | Description |
+|:---------:|:----:|:--------:|:-----------:|
+| host | str | no | REST API host (default `0.0.0.0`) |
+| port | int | no | REST API port (default `8075`) |
+| log_level | str | no | Log level: `DEBUG`/`INFO`/`WARN`/`ERROR` (default `INFO`) |
+| log_format | str | no | Log format: `TEXT` or `JSON` (default `TEXT`) |
+| profiles_dir | str | no | Directory of gNMI profile overrides (empty = embedded profiles only) |
+| otel_export_period | int | no | Seconds between OpenTelemetry metric exports (default `10`) |
+
+## Policy
+gNMI discovery policies are broken into two subsections: `config` and `scope`.
+
+### Config
+`config` defines behavior for the whole policy and is optional overall.
+
+| Parameter | Type | Required | Description |
+|:---------:|:----:|:--------:|:-----------:|
+| mode | str | no | Delivery mode: `auto` (default), `on_change`, `sample`, or `get`. `auto` negotiates the best mode per target (`ON_CHANGE → SAMPLE → GET`). |
+| debounce_ms | int | no | Flush delay in ms after the last notification before a snapshot is ingested (default `2000`). |
+| sample_interval_ms | int | no | `SAMPLE` subscription interval in ms (default `300000` = 5m). |
+| get_interval_ms | int | no | `GET` poll interval in ms (default `900000` = 15m). |
+| options | map | no | Per-policy toggles. `capture_config` (bool) captures the CONFIG datastore into `Device.config.running` (default off). |
+| defaults | map | no | NetBox defaults applied to discovered entities (see below). |
+
+#### Defaults
+| Key | Type | Description |
+|:---:|:----:|:-----------:|
+| site | str | NetBox site (default `undefined`) |
+| role | str | NetBox device role (default `undefined`) |
+| location | str | NetBox location (optional) |
+| tags | list | NetBox tags applied to all entities |
+| device | map | Device overrides: `manufacturer`, `model`, `platform`, `comments`, `tags` |
+| interface | map | Interface defaults: `if_type` (fallback type, default `other`), `description`, `tags` |
+| ip_address | map | IP address defaults: `role`, `tenant`, `description`, `comments`, `tags` |
+| vrf | map | VRF defaults: `tenant`, `description`, `comments`, `tags` (name/RD come from discovery) |
+| interface_patterns | list | Name-regex → NetBox type, highest precedence (first match wins). |
+| interface_exclude_patterns | list | Name-regex; matching interfaces are skipped entirely. |
+
+### Scope
+`scope` defines the list of gNMI targets to discover.
+
+| Parameter | Type | Required | Description |
+|:---------:|:----:|:--------:|:-----------:|
+| targets | list | yes | The gNMI endpoints to subscribe to (see target fields below). |
+
+#### Target
+| Key | Type | Required | Description |
+|:---:|:----:|:--------:|:-----------:|
+| host | str | yes | `host:port` of the gNMI endpoint (e.g. `10.0.0.11:6030`). When the port is omitted, the IANA gNMI port `9339` is used. |
+| username | str | no | gNMI username. `${ENV_VAR}` syntax is supported. |
+| password | str | no | gNMI password. `${ENV_VAR}` syntax is supported. |
+| tls | map | no | TLS settings: `skip_verify` (keep TLS, don't verify the cert), `insecure` (opt-in PLAINTEXT, off by default), `ca`/`cert`/`key` (optional mTLS). TLS with system root CAs is the default. |
+| mode | str | no | Per-target delivery mode override (`auto`/`on_change`/`sample`/`get`). |
+| profile | str | no | Pin a gNMI profile (auto-detected when omitted). |
+| origin | str | no | gNMI path origin (default `openconfig`); set `""` for origin-less paths. |
+| netbox_id | int | no | Pin discovery to an existing NetBox device ID. |
+| override_defaults | map | no | Per-target overrides of the policy `defaults`. |
+
+#### Interface type discovery
+Each interface's NetBox type is resolved per interface, in precedence order:
+1. `interface_exclude_patterns` — a name matching any regex is skipped (no interface emitted).
+2. `interface_patterns` — the first matching regex assigns its `type` (wins over the rest).
+3. OpenConfig `state/type` — the discovered identityref maps to a NetBox type for structural families (LAG → `lag`; loopback/VLAN/tunnel/prop-virtual → `virtual`).
+
+### Sample
+A sample policy exercising the common gNMI discovery parameters.
+```yaml
+orb:
+  ...
+  policies:
+    gnmi_discovery:
+      gnmi_fabric:
+        config:
+          mode: auto
+          debounce_ms: 2000
+          defaults:
+            site: New York NY
+            role: Router
+            tags: [gnmi-discovery, orb-agent]
+            interface_patterns:
+              - match: "^Ethernet"
+                type: 10gbase-x-sfpp
+            interface_exclude_patterns:
+              - "^Management"
+        scope:
+          targets:
+            - host: 10.0.0.11:6030       # Arista EOS default gNMI port
+              username: ${GNMI_USER}
+              password: ${GNMI_PASS}
+              tls:
+                skip_verify: true
+              profile: arista_eos
+            - host: 10.0.0.21:57400      # Nokia SR-OS default gNMI port
+              username: admin
+              password: ${GNMI_PASS}
+```

--- a/docs/backends/gnmi_discovery.md
+++ b/docs/backends/gnmi_discovery.md
@@ -25,7 +25,7 @@ orb:
         client_secret: ${DIODE_CLIENT_SECRET}
         agent_name: agent01
     gnmi_discovery:
-      host: 192.168.5.11 # default 0.0.0.0
+      host: 192.168.5.11 # default localhost
       port: 8076 # default 8075
       log_level: ERROR # default INFO
       log_format: JSON # default TEXT
@@ -35,7 +35,7 @@ orb:
 
 | Parameter | Type | Required | Description |
 |:---------:|:----:|:--------:|:-----------:|
-| host | str | no | REST API host (default `0.0.0.0`) |
+| host | str | no | REST API host (default `localhost`) |
 | port | int | no | REST API port (default `8075`) |
 | log_level | str | no | Log level: `DEBUG`/`INFO`/`WARN`/`ERROR` (default `INFO`) |
 | log_format | str | no | Log format: `TEXT` or `JSON` (default `TEXT`) |


### PR DESCRIPTION
## Summary

Adds the missing agent-side **`gnmi_discovery`** backend — the sibling to network/snmp/device discovery — so the agent can launch and manage the in-image `gnmi-discovery` binary, drive its policies, and report its status/version.

The `gnmi-discovery` binary shares network-discovery's exact `/api/v1/{status,capabilities,policies}` REST API and diode flag set, so the new backend mirrors `agent/backend/networkdiscovery` and adds the gNMI-specific surface on top.

## What's included

- **`agent/backend/gnmidiscovery/gnmi_discovery.go`** — implements `backend.Backend` (Configure/Start/Stop/FullReset/Version/GetCapabilities/GetRunningStatus/GetInitialState/ApplyPolicy/RemovePolicy/GetStartTime) + the optional `GetPolicyStatus`. Registers as `gnmi_discovery`, execs `gnmi-discovery`, REST default port **8075** (conflict-free vs 8070/8071/8072/8073/10222/10853).
- **Full gNMI config surface** on top of the network-shared flags (host/port + diode target/client-id/secret/app-name-prefix + dry-run + log-level + otel-endpoint): `profiles_dir` → `--profiles-dir`, `otel_export_period` → `--otel-export-period`, `log_format` → `--log-format`.
- Its own logfmt log normalizer (the established per-backend pattern).
- **`cmd/main.go`** — `gnmidiscovery.Register()` wired in (alphabetical).
- **`docs/backends/gnmi_discovery.md`** — backend + policy documentation.
- Tests: `gnmi_discovery_test.go` (Start asserts every flag *and value* incl. the gNMI extras; otel-target-without-creds; dry-run omits creds but keeps host/port; completed-process error path; the update path DELETEs the **previous** policy name; `GetPolicyStatus`) and `normalize_test.go`.

**Enablement is opt-in** — add `gnmi_discovery:` under `orb.backends:`. `default_config.yaml` is unchanged.

## Verification

- `go build ./...`, `go vet`, `go test -race ./agent/backend/gnmidiscovery/...` all pass; **golangci-lint: 0 issues**.
- A 3-lens adversarial review (Go correctness/concurrency, binary-contract match, test quality) returned **ship**: flag spellings + REST paths + port verified exact against the `gnmi-discovery` binary; interface complete; `fmt.Sprintf("%v")` safe for the int `otel_export_period`; dry-run/OTLP credential handling matches the binary. The two non-blocking findings (update-path DELETE assertion, `GetPolicyStatus` coverage) were addressed by strengthening the tests.

_Note:_ an unsynchronized read/write on the backend's `proc`/`ctx` fields between the monitor goroutine and `Start`/`FullReset` exists, but it is inherited verbatim from the other discovery backends (a shared-pattern issue, not introduced here) — tracked separately to preserve parity.
