### PR TITLE
fix(device-discovery): attach the location default to discovered racks

### DIFF
--- a/orb-discovery/device-discovery/device_discovery/translate.py
+++ b/orb-discovery/device-discovery/device_discovery/translate.py
@@ -158,7 +158,13 @@ def translate_device(
         "site": defaults.site,
         "tags": tags,
         "location": location,
-        "rack": Rack(name=defaults.rack, site=defaults.site) if defaults.rack else None,
+        # Attach the location to the rack too: without it NetBox has no
+        # site+location+name key to match on and duplicates the rack.
+        # `location` is None when no location default is set, leaving the rack's
+        # location unset (site+name only) as before.
+        "rack": Rack(name=defaults.rack, site=defaults.site, location=location)
+        if defaults.rack
+        else None,
         "tenant": translate_tenant(defaults.tenant),
         "description": description,
         "comments": comments,

--- a/orb-discovery/device-discovery/tests/test_translate.py
+++ b/orb-discovery/device-discovery/tests/test_translate.py
@@ -179,11 +179,25 @@ def test_translate_device_asset_tag_none_by_default(sample_device_info, sample_d
 
 
 def test_translate_device_with_rack(sample_device_info, sample_defaults):
-    """Ensure device is associated with rack, reusing defaults.site."""
+    """Ensure device is associated with rack, reusing defaults.site and location."""
     sample_defaults.rack = "Rack-01"
     device = translate_device(sample_device_info, sample_defaults)
     assert device.rack.name == "Rack-01"
     assert device.rack.site.name == "New York"
+    # The location default must be attached to the rack too, with its site
+    # embedded so NetBox can match on site+location+name.
+    assert device.rack.location.name == "local"
+    assert device.rack.location.site.name == "New York"
+
+
+def test_translate_device_rack_without_location(sample_device_info, sample_defaults):
+    """Rack carries no location when no location default is set (site+name only)."""
+    sample_defaults.rack = "Rack-01"
+    sample_defaults.location = None
+    device = translate_device(sample_device_info, sample_defaults)
+    assert device.rack.name == "Rack-01"
+    assert device.rack.site.name == "New York"
+    assert not device.rack.HasField("location")
 
 
 def test_translate_device_rack_none_by_default(sample_device_info, sample_defaults):


### PR DESCRIPTION
## Summary

Fixes [ENGHLP-1417](https://linear.app/netboxlabs/issue/ENGHLP-1417/device-discovery-omits-location-set-in-defaults) — device-discovery dropped the `location` default from discovered racks.

When a scope set both `location` and `rack` in `defaults`, the agent emitted a rack with only `site` + `name`:

```json
"rack": { "name": "06", "site": { "name": "Ohio Data Center" } }
```

The location was attached to the device but never to the rack, so NetBox had no `site+location+name` key to match on — the deviation failed, and the site-only workaround created a duplicate rack per device.

## Fix

`translate_device` already builds a `Location` from `defaults.location`; it's now also passed to the `Rack`:

```python
"rack": Rack(name=defaults.rack, site=defaults.site, location=location) if defaults.rack else None,
```

- The diode SDK `Rack` / `pb.Rack` support a `location` field.
- `location` is `None` when no location default is set, so `Rack(..., location=None)` leaves the rack's location unset (`HasField("location") == False`) — **site+name-only behavior is unchanged** when no location is configured.
- The location embeds its site (`Location(name=…, site=defaults.site)`), matching the codebase's existing "embed the site in the location for NetBox uniqueness" pattern (device `location`, prefix `scope_location`). NetBox now has the full natural key and matches/updates the existing rack instead of duplicating it.

## Tests

- `test_translate_device_with_rack` — extended to assert the emitted rack carries `location.name` **and** `location.site.name` (the regression guard; reverting the fix makes it fail).
- `test_translate_device_rack_without_location` — new: with no location default, the rack has `site`+`name` and **no** location field.

Full device-discovery suite: 1798 passed; `ruff check .` clean. Adversarial review: ship (no defects; semantics verified against the existing Location pattern).
