### PR TITLE
chore(snmp-discovery): bump diode-sdk-go to v1.10.0 in snmp-discovery

### DIFF
--- a/orb-discovery/snmp-discovery/go.mod
+++ b/orb-discovery/snmp-discovery/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-co-op/gocron/v2 v2.21.2
 	github.com/google/uuid v1.6.0
 	github.com/gosnmp/gosnmp v1.43.2
-	github.com/netboxlabs/diode-sdk-go v1.9.0
+	github.com/netboxlabs/diode-sdk-go v1.10.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0

--- a/orb-discovery/snmp-discovery/go.sum
+++ b/orb-discovery/snmp-discovery/go.sum
@@ -72,8 +72,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/netboxlabs/diode-sdk-go v1.9.0 h1:ShjFFb+Ipd/VuykwILmBf0JyoKkmjjTQARLY2/Lu6gk=
-github.com/netboxlabs/diode-sdk-go v1.9.0/go.mod h1:R30qRpuIf455IxNlC1sna8gGq7DG8tVdX6eDz+nxURw=
+github.com/netboxlabs/diode-sdk-go v1.10.0 h1:FPYVLvoGyL57A7mWMXiM1soEiXoRbRPyi5Xk/JUzglQ=
+github.com/netboxlabs/diode-sdk-go v1.10.0/go.mod h1:R30qRpuIf455IxNlC1sna8gGq7DG8tVdX6eDz+nxURw=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
 github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
## Summary

Bump `snmp-discovery` to `diode-sdk-go` v1.10.0 so the released backend picks up auth backoff on 429/5xx (OBS-3341) and aligned User-Agent headers (OBS-3342), complementing the ingest queue work in #419.

## What changed

- `orb-discovery/snmp-discovery/go.mod` / `go.sum`: `diode-sdk-go` v1.9.0 → v1.10.0

## How tested

- `cd orb-discovery/snmp-discovery && go test ./...`
- `make fix-lint`
- `make agent_fast` (local `netboxlabs/orb-agent:develop` image)
- orb-test-lab containerlab integration:
  - `make clab-test` — 5/5 protocol smoke checks passed
  - `ORB_AGENT_IMAGE=netboxlabs/orb-agent:develop make clab-discover` — snmp_discovery, device_discovery, and network_discovery dry-run JSON written to `clab/out/`

## Linear

OBS-3341 — https://linear.app/netboxlabs/issue/OBS-3341/diode-sdk-go-add-backoff-on-auth-for-4295xx-responses

OBS-3342 — https://linear.app/netboxlabs/issue/OBS-3342/diode-sdk-go-align-user-agent-with-python-sdk

Made with [Cursor](https://cursor.com)