### PR TITLE
refactor(agent): collapse diode discovery backends onto a shared base

### DIFF
--- a/agent/backend/devicediscovery/device_discovery.go
+++ b/agent/backend/devicediscovery/device_discovery.go
@@ -1,266 +1,91 @@
 package devicediscovery
 
 import (
-	"bytes"
 	"context"
-	"errors"
-	"fmt"
 	"log/slog"
-	"net/http"
 	"strings"
-	"time"
-
-	"gopkg.in/yaml.v3"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/backend/discovery"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/filesmgr"
 	"github.com/netboxlabs/orb-agent/agent/policies"
-	"github.com/netboxlabs/orb-agent/agent/redact"
 )
 
 var _ backend.Backend = (*deviceDiscoveryBackend)(nil)
 
 const (
-	versionTimeout      = 2
-	capabilitiesTimeout = 5
-	readinessBackoff    = 10
-	applyPolicyTimeout  = 10
-	removePolicyTimeout = 20
-	statusTimeout       = 5
-	defaultExec         = "device-discovery"
-	defaultAPIHost      = "localhost"
-	defaultAPIPort      = "8072"
+	defaultExec    = "device-discovery"
+	defaultAPIPort = "8072"
 )
 
 type deviceDiscoveryBackend struct {
-	logger     *slog.Logger
-	policyRepo policies.PolicyRepo
-	exec       string
-
-	apiHost     string
-	apiPort     string
-	apiProtocol string
-
-	diodeTarget          string
-	diodeClientID        string
-	diodeClientSecret    string
-	diodeAppNamePrefix   string
-	diodeOtelEndpoint    string
-	diodeTargetFromOtel  bool
-	diodeDryRun          bool
-	diodeDryRunOutputDir string
-
-	startTime  time.Time
-	proc       backend.Commander
-	statusChan <-chan backend.CmdStatus
-	cancelFunc context.CancelFunc
-	ctx        context.Context
+	discovery.Base
 }
 
-type info struct {
-	Version   string  `json:"version"`
-	UpTimeMin float64 `json:"up_time_min"`
-}
-
-// Register registers the backend
+// Register registers the device discovery backend.
 func Register() bool {
-	backend.Register("device_discovery", &deviceDiscoveryBackend{
-		apiProtocol: "http",
-		exec:        defaultExec,
-	})
+	b := &deviceDiscoveryBackend{
+		Base: discovery.Base{
+			Exec:           defaultExec,
+			APIProtocol:    "http",
+			APIPort:        defaultAPIPort,
+			NameHyphen:     "device-discovery",
+			NameUnderscore: "device_discovery",
+		},
+	}
+	b.BuildArgs = b.buildArgs
+	b.LogLine = b.logLineAdapter
+	// device has no extra config keys; ConfigureExtra intentionally left nil.
+	backend.Register("device_discovery", b)
 	return true
 }
 
 func (d *deviceDiscoveryBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	config map[string]any, common config.BackendCommons, _ filesmgr.Manager,
 ) error {
-	d.logger = logger.With("backend", "device_discovery")
-	d.policyRepo = repo
-	d.diodeTargetFromOtel = false
-
-	var prs bool
-	if d.apiHost, prs = config["host"].(string); !prs {
-		d.apiHost = defaultAPIHost
-	}
-	if port, prs := config["port"]; prs {
-		d.apiPort = fmt.Sprintf("%v", port)
-	} else {
-		d.apiPort = defaultAPIPort
-	}
-
-	d.diodeTarget = common.Diode.Target
-	d.diodeClientID = common.Diode.ClientID
-	d.diodeClientSecret = common.Diode.ClientSecret
-	d.diodeAppNamePrefix = common.Diode.AgentName
-	d.diodeDryRun = common.Diode.DryRun
-	d.diodeDryRunOutputDir = common.Diode.DryRunOutputDir
-
-	if target, prs := config["target"].(string); prs {
-		d.diodeTarget = target
-	}
-	if clientID, prs := config["client_id"].(string); prs {
-		d.diodeClientID = clientID
-	}
-	if clientSecret, prs := config["client_secret"].(string); prs {
-		d.diodeClientSecret = clientSecret
-	}
-	if agentName, prs := config["agent_name"].(string); prs {
-		d.diodeAppNamePrefix = agentName
-	}
-	if dryRun, prs := config["dry_run"].(bool); prs {
-		d.diodeDryRun = dryRun
-	}
-	if dryRunOutputDir, prs := config["dry_run_output_dir"].(string); prs {
-		d.diodeDryRunOutputDir = dryRunOutputDir
-	}
-
-	if common.Otlp.Grpc != "" {
-		d.diodeOtelEndpoint = common.Otlp.Grpc
-		d.logger.Info("device-discovery using OTLP endpoint",
-			"endpoint", d.diodeOtelEndpoint)
-	}
-	if d.diodeTarget == "" && d.diodeOtelEndpoint != "" {
-		d.diodeTarget = d.diodeOtelEndpoint
-		d.diodeTargetFromOtel = true
-	}
-
-	return nil
+	d.Logger = logger.With("backend", "device_discovery")
+	d.PolicyRepo = repo
+	return d.Base.Configure(config, common)
 }
 
-func (d *deviceDiscoveryBackend) Version() (string, error) {
-	var info info
-	url := fmt.Sprintf("%s://%s:%s/api/v1/status", d.apiProtocol, d.apiHost, d.apiPort)
-	err := backend.CommonRequest("device-discovery", d.proc, d.logger, url, &info, http.MethodGet,
-		http.NoBody, "application/json", versionTimeout, "detail")
-	if err != nil {
-		return "", err
-	}
-	return info.Version, nil
-}
-
-func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.CancelFunc) error {
-	d.startTime = time.Now()
-	d.cancelFunc = cancelFunc
-	d.ctx = ctx
-
+func (d *deviceDiscoveryBackend) buildArgs() []string {
 	dOptions := []string{
-		"--diode-app-name-prefix", d.diodeAppNamePrefix,
-		"--host", d.apiHost,
-		"--port", d.apiPort,
+		"--diode-app-name-prefix", d.DiodeAppNamePrefix,
+		"--host", d.APIHost,
+		"--port", d.APIPort,
 	}
-	if d.diodeDryRun {
+	if d.DiodeDryRun {
 		dOptions = append([]string{
 			"--dry-run",
-			"--dry-run-output-dir", d.diodeDryRunOutputDir,
+			"--dry-run-output-dir", d.DiodeDryRunOutputDir,
 		}, dOptions...)
 	} else {
 		opts := []string{
-			"--diode-target", d.diodeTarget,
+			"--diode-target", d.DiodeTarget,
 		}
-		if !d.diodeTargetFromOtel {
+		if !d.DiodeTargetFromOtel {
 			opts = append(opts,
-				"--diode-client-id", d.diodeClientID,
-				"--diode-client-secret", d.diodeClientSecret,
+				"--diode-client-id", d.DiodeClientID,
+				"--diode-client-secret", d.DiodeClientSecret,
 			)
 		}
 		dOptions = append(opts, dOptions...)
 	}
 
-	if d.diodeOtelEndpoint != "" {
-		dOptions = append(dOptions, "--otel-endpoint", d.diodeOtelEndpoint)
+	if d.DiodeOtelEndpoint != "" {
+		dOptions = append(dOptions, "--otel-endpoint", d.DiodeOtelEndpoint)
 	}
 
-	d.logger.Info("device-discovery startup", "arguments", redact.Args(dOptions))
-
-	d.proc = backend.NewCmdOptions(backend.CmdOptions{
-		Buffered:  false,
-		Streaming: true,
-	}, d.exec, dOptions...)
-	d.statusChan = d.proc.Start()
-
-	// log STDOUT and STDERR lines streaming from Cmd
-	doneChan := make(chan struct{})
-	go func() {
-		defer func() {
-			if doneChan != nil {
-				close(doneChan)
-			}
-		}()
-		stdout := d.proc.GetStdout()
-		stderr := d.proc.GetStderr()
-		for stdout != nil || stderr != nil {
-			select {
-			case line, open := <-stdout:
-				if !open {
-					stdout = nil
-					continue
-				}
-				d.logDeviceDiscoveryOutput(line, slog.LevelInfo)
-			case line, open := <-stderr:
-				if !open {
-					stderr = nil
-					continue
-				}
-				d.logDeviceDiscoveryOutput(line, slog.LevelError)
-			}
-		}
-	}()
-
-	// wait for simple startup errors
-	time.Sleep(time.Second)
-
-	status := d.proc.Status()
-
-	if status.Error != nil {
-		d.logger.Error("device-discovery startup error", "error", status.Error)
-		return status.Error
-	}
-
-	if status.Complete {
-		err := d.proc.Stop()
-		if err != nil {
-			d.logger.Error("proc.Stop error", "error", err)
-		}
-		return errors.New("device-discovery startup error, check log")
-	}
-
-	d.logger.Info("device-discovery process started", "pid", status.PID)
-
-	var version string
-	var readinessErr error
-	for backoff := range readinessBackoff {
-		if status := d.proc.Status(); status.Complete {
-			err := d.proc.Stop()
-			if err != nil {
-				d.logger.Error("proc.Stop error", "error", err)
-			}
-			return errors.New("device-discovery process ended unexpectedly, check log")
-		}
-		version, readinessErr = d.Version()
-		if readinessErr == nil {
-			d.logger.Info("device-discovery readiness ok, got version", "version", version)
-			break
-		}
-		backoffDuration := time.Duration(backoff) * time.Second
-		d.logger.Info("device-discovery is not ready, trying again with backoff",
-			"backoff backoffDuration", backoffDuration.String())
-		time.Sleep(backoffDuration)
-	}
-
-	if readinessErr != nil {
-		d.logger.Error("device-discovery error on readiness", "error", readinessErr)
-		err := d.proc.Stop()
-		if err != nil {
-			d.logger.Error("proc.Stop error", "error", err)
-		}
-		return readinessErr
-	}
-
-	return nil
+	return dOptions
 }
 
-func (d *deviceDiscoveryBackend) logDeviceDiscoveryOutput(line string, fallback slog.Level) {
+func (d *deviceDiscoveryBackend) logLineAdapter(line string, isStderr bool) {
+	fallback := slog.LevelInfo
+	if isStderr {
+		fallback = slog.LevelError
+	}
+
 	trimmed := strings.TrimSpace(line)
 	if trimmed == "" {
 		return
@@ -276,136 +101,12 @@ func (d *deviceDiscoveryBackend) logDeviceDiscoveryOutput(line string, fallback 
 		level = parsedLevel
 	}
 
-	ctx := d.ctx
+	ctx := d.Ctx
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
-	d.logger.LogAttrs(ctx, level, msg, attrs...)
-}
-
-func (d *deviceDiscoveryBackend) Stop(ctx context.Context) error {
-	d.logger.Info("routine call to stop device-discovery", "routine", ctx.Value(config.ContextKey("routine")))
-	defer d.cancelFunc()
-	backend.StopProcess(d.logger, d.proc, d.statusChan, backend.DefaultStopGracePeriod, "device_discovery")
-	return nil
-}
-
-func (d *deviceDiscoveryBackend) FullReset(ctx context.Context) error {
-	// force a stop, which stops scrape as well. if proc is dead, it no ops.
-	if state, _, _ := backend.GetRunningStatus(d.proc); state == backend.Running {
-		if err := d.Stop(ctx); err != nil {
-			d.logger.Error("failed to stop backend on restart procedure", "error", err)
-			return err
-		}
-	}
-	// for each policy, restart the scraper
-	backendCtx, cancelFunc := context.WithCancel(context.WithValue(ctx, config.ContextKey("routine"), "device-discovery"))
-	// start it
-	if err := d.Start(backendCtx, cancelFunc); err != nil {
-		d.logger.Error("failed to start backend on restart procedure", "error", err)
-		return err
-	}
-	return nil
-}
-
-func (d *deviceDiscoveryBackend) GetStartTime() time.Time {
-	return d.startTime
-}
-
-func (d *deviceDiscoveryBackend) GetCapabilities() (map[string]any, error) {
-	caps := make(map[string]any)
-	url := fmt.Sprintf("%s://%s:%s/api/v1/capabilities", d.apiProtocol, d.apiHost, d.apiPort)
-	err := backend.CommonRequest("device-discovery", d.proc, d.logger, url, &caps, http.MethodGet,
-		http.NoBody, "application/json", capabilitiesTimeout, "detail")
-	if err != nil {
-		return nil, err
-	}
-	return caps, nil
-}
-
-func (d *deviceDiscoveryBackend) GetRunningStatus() (backend.RunningStatus, string, error) {
-	// first check process status
-	runningStatus, errMsg, err := backend.GetRunningStatus(d.proc)
-	// if it's not running, we're done
-	if runningStatus != backend.Running {
-		return runningStatus, errMsg, err
-	}
-	// if it's running, check REST API availability too
-	if _, aiErr := d.Version(); aiErr != nil {
-		// process is running, but REST API is not accessible
-		return backend.BackendError, "process running, REST API unavailable", aiErr
-	}
-	return runningStatus, "", nil
-}
-
-func (d *deviceDiscoveryBackend) GetInitialState() backend.RunningStatus {
-	return backend.Unknown
-}
-
-func (d *deviceDiscoveryBackend) ApplyPolicy(data policies.PolicyData, updatePolicy bool) error {
-	if updatePolicy {
-		// To update a policy it's necessary first remove it and then apply a new version
-		if err := d.RemovePolicy(data); err != nil {
-			d.logger.Warn("policy failed to remove", "policy_id", data.ID,
-				"policy_name", data.Name, "error", err)
-		}
-	}
-
-	d.logger.Debug("device-discovery policy apply", "policy_id", data.ID, "data", data.Data)
-
-	fullPolicy := map[string]any{
-		"policies": map[string]any{
-			data.Name: data.Data,
-		},
-	}
-
-	policyYaml, err := yaml.Marshal(fullPolicy)
-	if err != nil {
-		d.logger.Warn("policy yaml marshal failure", "policy_id", data.ID, "policy_name", data.Name)
-		return err
-	}
-
-	var resp map[string]any
-	url := fmt.Sprintf("%s://%s:%s/api/v1/policies", d.apiProtocol, d.apiHost, d.apiPort)
-	err = backend.CommonRequest("device-discovery", d.proc, d.logger, url, &resp, http.MethodPost,
-		bytes.NewBuffer(policyYaml), "application/x-yaml", applyPolicyTimeout, "detail")
-	if err != nil {
-		d.logger.Warn("policy application failure", "policy_id", data.ID, "policy_name", data.Name)
-		return err
-	}
-
-	return nil
-}
-
-func (d *deviceDiscoveryBackend) RemovePolicy(data policies.PolicyData) error {
-	d.logger.Debug("device-discovery policy remove", "policy_id", data.ID)
-	var resp any
-	var name string
-	// Since we use Name for removing policies not IDs, if there is a change, we need to remove the previous name of the policy
-	if data.PreviousPolicyData != nil && data.PreviousPolicyData.Name != data.Name {
-		name = data.PreviousPolicyData.Name
-	} else {
-		name = data.Name
-	}
-	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", d.apiProtocol, d.apiHost, d.apiPort, name)
-	err := backend.CommonRequest("device-discovery", d.proc, d.logger, url, &resp, http.MethodDelete,
-		http.NoBody, "application/json", removePolicyTimeout, "detail")
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (d *deviceDiscoveryBackend) GetPolicyStatus() ([]backend.PolicyStatus, error) {
-	var resp backend.StatusResponse
-	url := fmt.Sprintf("%s://%s:%s/api/v1/status", d.apiProtocol, d.apiHost, d.apiPort)
-	err := backend.CommonRequest("device-discovery", d.proc, d.logger, url, &resp, http.MethodGet,
-		http.NoBody, "application/json", statusTimeout, "detail")
-	if err != nil {
-		return nil, err
-	}
-	return resp.Policies, nil
+	d.Logger.LogAttrs(ctx, level, msg, attrs...)
 }
 
 func normalizeDeviceDiscoveryLine(line string, fallback slog.Level) (string, []slog.Attr, slog.Level, bool) {

--- a/agent/backend/discovery/discovery.go
+++ b/agent/backend/discovery/discovery.go
@@ -1,0 +1,319 @@
+// Package discovery provides Base, the shared state and lifecycle/REST
+// machinery embedded by the diode discovery backends (network/snmp/device/gnmi).
+//
+// Base owns the behavior that is identical across those backends —
+// Configure, Start, Stop, FullReset, the REST helpers (Version, GetCapabilities,
+// GetRunningStatus, ApplyPolicy, RemovePolicy, GetPolicyStatus) and lifecycle
+// bookkeeping — while three exported func-field hooks (BuildArgs, LogLine,
+// ConfigureExtra) absorb the per-backend divergences. Because Base lives
+// in its own package and the hook bodies stay in the embedder packages, every
+// field or hook those packages read or write is exported (Go does not promote
+// unexported fields across packages).
+package discovery
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	neturl "net/url"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/config"
+	"github.com/netboxlabs/orb-agent/agent/policies"
+	"github.com/netboxlabs/orb-agent/agent/redact"
+)
+
+const (
+	versionTimeout      = 2
+	capabilitiesTimeout = 5
+	// StatusTimeout is exported because gnmi's retained GetPolicyStatus override
+	// (in its own package) passes it to backend.CommonRequest.
+	StatusTimeout       = 5
+	applyPolicyTimeout  = 10
+	removePolicyTimeout = 20
+
+	defaultAPIHost = "localhost"
+)
+
+// Base holds the shared state and lifecycle/REST methods embedded by the
+// diode discovery backends. Fields and hooks the embedder packages touch are
+// exported; statusChan/cancelFunc/startTime stay unexported (only base methods
+// use them).
+type Base struct {
+	Logger *slog.Logger
+	// PolicyRepo is set by each embedder's Configure (mirroring the canonical
+	// backends). It is exported so the embedder packages can write it; no base
+	// method reads it today.
+	PolicyRepo policies.PolicyRepo
+	Exec       string
+
+	APIHost     string
+	APIPort     string
+	APIProtocol string
+
+	DiodeTarget          string
+	DiodeClientID        string
+	DiodeClientSecret    string
+	DiodeAppNamePrefix   string
+	DiodeOtelEndpoint    string
+	DiodeTargetFromOtel  bool
+	DiodeDryRun          bool
+	DiodeDryRunOutputDir string
+	DiodeLogLevel        string
+
+	// NameHyphen is the hyphen form (e.g. "network-discovery"): the CommonRequest
+	// client id, every lifecycle log, and every error string. NameUnderscore is
+	// the underscore form (e.g. "network_discovery") passed only to StopProcess.
+	NameHyphen     string
+	NameUnderscore string
+
+	startTime  time.Time
+	Proc       backend.Commander
+	statusChan <-chan backend.CmdStatus
+	cancelFunc context.CancelFunc
+	Ctx        context.Context
+
+	// BuildArgs assembles the process arguments. The base never builds the flag
+	// list itself; each backend wires its own buildArgs (core flags diverge:
+	// device omits --log-level, gnmi appends gNMI extras, etc.).
+	BuildArgs func() []string
+	// LogLine streams one line of process output to the agent logger; each
+	// backend wraps its own normalizer + Logger.LogAttrs, reading d.Ctx.
+	LogLine func(line string, isStderr bool)
+	// ConfigureExtra runs early in Configure (after host/port, before the diode
+	// reads) so per-backend validation aborts before the OTLP log. May be nil.
+	ConfigureExtra func(config map[string]any) error
+}
+
+// Configure stores the backend configuration, merging the per-backend config map
+// with the shared Diode/OTLP commons (per-backend keys take precedence). The
+// ConfigureExtra hook runs early so per-backend validation aborts before the OTLP
+// log; the OTLP-endpoint/target-from-otel block is shared base logic.
+func (d *Base) Configure(config map[string]any, common config.BackendCommons) error {
+	d.DiodeTargetFromOtel = false
+
+	d.APIHost = backend.ConfigStringOrDefault(config, "host", defaultAPIHost)
+	// The default port differs per backend (network 8073 / snmp 8070 / device
+	// 8072 / gnmi 8075), so the embedder pre-seeds APIPort with its default in
+	// Register(); passing that seeded value as the fallback keeps it when no port
+	// is configured, and stringifies whatever (number or string) is configured.
+	d.APIPort = backend.ConfigValueOrDefault(config, "port", d.APIPort)
+
+	if d.ConfigureExtra != nil {
+		if err := d.ConfigureExtra(config); err != nil {
+			return err
+		}
+	}
+
+	d.DiodeTarget = backend.ConfigStringOrDefault(config, "target", common.Diode.Target)
+	d.DiodeClientID = backend.ConfigStringOrDefault(config, "client_id", common.Diode.ClientID)
+	d.DiodeClientSecret = backend.ConfigStringOrDefault(config, "client_secret", common.Diode.ClientSecret)
+	d.DiodeAppNamePrefix = backend.ConfigStringOrDefault(config, "agent_name", common.Diode.AgentName)
+	d.DiodeDryRun = backend.ConfigBoolOrDefault(config, "dry_run", common.Diode.DryRun)
+	d.DiodeDryRunOutputDir = backend.ConfigStringOrDefault(config, "dry_run_output_dir", common.Diode.DryRunOutputDir)
+
+	if logLevel, prs := config["log_level"].(string); prs {
+		d.DiodeLogLevel = logLevel
+	} else if debug, prs := config["debug"].(bool); prs && debug {
+		d.DiodeLogLevel = "debug"
+	} else if d.Logger.Enabled(context.Background(), slog.LevelDebug) {
+		d.DiodeLogLevel = "debug"
+	}
+
+	if common.Otlp.Grpc != "" {
+		d.DiodeOtelEndpoint = common.Otlp.Grpc
+		d.Logger.Info(d.NameHyphen+" using OTLP endpoint",
+			"endpoint", d.DiodeOtelEndpoint)
+	}
+	if d.DiodeTarget == "" && d.DiodeOtelEndpoint != "" {
+		d.DiodeTarget = d.DiodeOtelEndpoint
+		d.DiodeTargetFromOtel = true
+	}
+
+	return nil
+}
+
+// Version returns the running backend version from its REST status endpoint.
+func (d *Base) Version() (string, error) {
+	var info info
+	url := fmt.Sprintf("%s://%s:%s/api/v1/status", d.APIProtocol, d.APIHost, d.APIPort)
+	err := backend.CommonRequest(d.NameHyphen, d.Proc, d.Logger, url, &info, http.MethodGet,
+		http.NoBody, "application/json", versionTimeout, "detail")
+	if err != nil {
+		return "", err
+	}
+	return info.Version, nil
+}
+
+// Start launches the backend process via backend.StartProcess, streaming its logs
+// through the LogLine hook and blocking until its REST API is ready.
+func (d *Base) Start(ctx context.Context, cancelFunc context.CancelFunc) error {
+	d.startTime = time.Now()
+	d.cancelFunc = cancelFunc
+	d.Ctx = ctx
+
+	args := d.BuildArgs()
+	d.Logger.Info(d.NameHyphen+" startup", "arguments", redact.Args(args))
+
+	return backend.StartProcess(backend.StartSpec{
+		Logger:         d.Logger,
+		NameDisplay:    d.NameHyphen,
+		NameUnderscore: d.NameUnderscore,
+		Exec:           d.Exec,
+		Args:           args,
+		LogLine:        d.LogLine,
+		SetProc: func(p backend.Commander, ch <-chan backend.CmdStatus) {
+			d.Proc = p
+			d.statusChan = ch
+		},
+		ReadinessCheck: d.Version,
+	})
+}
+
+// Stop gracefully stops the backend process and cancels the backend context.
+func (d *Base) Stop(ctx context.Context) error {
+	d.Logger.Info("routine call to stop "+d.NameHyphen, "routine", ctx.Value(config.ContextKey("routine")))
+	if d.cancelFunc != nil {
+		defer d.cancelFunc()
+	}
+	backend.StopProcess(d.Logger, d.Proc, d.statusChan, backend.DefaultStopGracePeriod, d.NameUnderscore)
+	return nil
+}
+
+// FullReset stops the backend process (if running) and starts it again.
+func (d *Base) FullReset(ctx context.Context) error {
+	// force a stop, which stops scrape as well. if proc is dead, it no ops.
+	if state, _, _ := backend.GetRunningStatus(d.Proc); state == backend.Running {
+		if err := d.Stop(ctx); err != nil {
+			d.Logger.Error("failed to stop backend on restart procedure", "error", err)
+			return err
+		}
+	}
+	// for each policy, restart the scraper
+	backendCtx, cancelFunc := context.WithCancel(context.WithValue(ctx, config.ContextKey("routine"), d.NameHyphen))
+	// start it
+	if err := d.Start(backendCtx, cancelFunc); err != nil {
+		d.Logger.Error("failed to start backend on restart procedure", "error", err)
+		return err
+	}
+	return nil
+}
+
+// GetStartTime returns the time the backend process was last started.
+func (d *Base) GetStartTime() time.Time {
+	return d.startTime
+}
+
+// GetCapabilities returns the backend's capabilities from its REST endpoint.
+func (d *Base) GetCapabilities() (map[string]any, error) {
+	caps := make(map[string]any)
+	url := fmt.Sprintf("%s://%s:%s/api/v1/capabilities", d.APIProtocol, d.APIHost, d.APIPort)
+	err := backend.CommonRequest(d.NameHyphen, d.Proc, d.Logger, url, &caps, http.MethodGet,
+		http.NoBody, "application/json", capabilitiesTimeout, "detail")
+	if err != nil {
+		return nil, err
+	}
+	return caps, nil
+}
+
+// GetRunningStatus reports the process state, also verifying the REST API is
+// reachable when the process is running.
+func (d *Base) GetRunningStatus() (backend.RunningStatus, string, error) {
+	// first check process status
+	runningStatus, errMsg, err := backend.GetRunningStatus(d.Proc)
+	// if it's not running, we're done
+	if runningStatus != backend.Running {
+		return runningStatus, errMsg, err
+	}
+	// if it's running, check REST API availability too
+	if _, aiErr := d.Version(); aiErr != nil {
+		// process is running, but REST API is not accessible
+		return backend.BackendError, "process running, REST API unavailable", aiErr
+	}
+	return runningStatus, "", nil
+}
+
+// GetInitialState returns the backend's initial running state (Unknown).
+func (d *Base) GetInitialState() backend.RunningStatus {
+	return backend.Unknown
+}
+
+// ApplyPolicy applies a policy via the REST API, removing the prior version first
+// when this is an update.
+func (d *Base) ApplyPolicy(data policies.PolicyData, updatePolicy bool) error {
+	if updatePolicy {
+		// To update a policy it's necessary first remove it and then apply a new version
+		if err := d.RemovePolicy(data); err != nil {
+			d.Logger.Warn("policy failed to remove", "policy_id", data.ID,
+				"policy_name", data.Name, "error", err)
+		}
+	}
+
+	d.Logger.Debug(d.NameHyphen+" policy apply", "policy_id", data.ID, "data", data.Data)
+
+	fullPolicy := map[string]any{
+		"policies": map[string]any{
+			data.Name: data.Data,
+		},
+	}
+
+	policyYaml, err := yaml.Marshal(fullPolicy)
+	if err != nil {
+		d.Logger.Warn("policy yaml marshal failure", "policy_id", data.ID, "policy_name", data.Name)
+		return err
+	}
+
+	var resp map[string]any
+	url := fmt.Sprintf("%s://%s:%s/api/v1/%s", d.APIProtocol, d.APIHost, d.APIPort, "policies")
+	err = backend.CommonRequest(d.NameHyphen, d.Proc, d.Logger, url, &resp, http.MethodPost,
+		bytes.NewBuffer(policyYaml), "application/x-yaml", applyPolicyTimeout, "detail")
+	if err != nil {
+		d.Logger.Warn("policy application failure", "policy_id", data.ID, "policy_name", data.Name)
+		return err
+	}
+
+	return nil
+}
+
+// RemovePolicy deletes a policy by name via the REST API (using the previous name
+// when a policy was renamed). The name is path-escaped before being placed in the
+// request URL.
+func (d *Base) RemovePolicy(data policies.PolicyData) error {
+	d.Logger.Debug(d.NameHyphen+" policy remove", "policy_id", data.ID)
+	var resp any
+	name := data.Name
+	// Since we use Name for removing policies not IDs, if there is a change, we need to remove the previous name of the policy
+	if data.PreviousPolicyData != nil && data.PreviousPolicyData.Name != data.Name {
+		name = data.PreviousPolicyData.Name
+	}
+	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", d.APIProtocol, d.APIHost, d.APIPort, neturl.PathEscape(name))
+	err := backend.CommonRequest(d.NameHyphen, d.Proc, d.Logger, url, &resp, http.MethodDelete,
+		http.NoBody, "application/json", removePolicyTimeout, "detail")
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetPolicyStatus returns per-policy run status from the REST status endpoint.
+func (d *Base) GetPolicyStatus() ([]backend.PolicyStatus, error) {
+	var resp backend.StatusResponse
+	url := fmt.Sprintf("%s://%s:%s/api/v1/status", d.APIProtocol, d.APIHost, d.APIPort)
+	err := backend.CommonRequest(d.NameHyphen, d.Proc, d.Logger, url, &resp, http.MethodGet,
+		http.NoBody, "application/json", StatusTimeout, "detail")
+	if err != nil {
+		return nil, err
+	}
+	return resp.Policies, nil
+}
+
+// info mirrors the version payload of each backend's /api/v1/status endpoint.
+type info struct {
+	Version   string  `json:"version"`
+	UpTimeMin float64 `json:"up_time_seconds"`
+}

--- a/agent/backend/discovery/discovery_test.go
+++ b/agent/backend/discovery/discovery_test.go
@@ -1,0 +1,431 @@
+package discovery_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/backend/discovery"
+	"github.com/netboxlabs/orb-agent/agent/backend/mocks"
+	"github.com/netboxlabs/orb-agent/agent/config"
+	"github.com/netboxlabs/orb-agent/agent/policies"
+)
+
+// errConfigureExtra is a sentinel returned by the ConfigureExtra hook in tests.
+var errConfigureExtra = errors.New("configure-extra boom")
+
+// testBackend is a synthetic embedder mirroring how the real diode backends will
+// embed DiscoveryBase: it wires the three func-field hooks to its own methods.
+type testBackend struct {
+	discovery.Base
+	configureExtraErr   error
+	configureExtraCalls int
+	logLines            []string
+}
+
+func newTestBackend(logger *slog.Logger) *testBackend {
+	b := &testBackend{}
+	b.Logger = logger
+	b.APIProtocol = "http"
+	b.Exec = "discovery-test-exec"
+	b.NameHyphen = "discovery-test"
+	b.NameUnderscore = "discovery_test"
+	b.APIPort = "9999" // embedder default, overridden only when config["port"] is present
+
+	b.BuildArgs = b.buildArgs
+	b.LogLine = b.logLineAdapter
+	b.ConfigureExtra = b.configureExtra
+	return b
+}
+
+func (b *testBackend) buildArgs() []string {
+	args := []string{
+		"--diode-app-name-prefix", b.DiodeAppNamePrefix,
+		"--host", b.APIHost,
+		"--port", b.APIPort,
+	}
+	if b.DiodeDryRun {
+		args = append([]string{"--dry-run", "--dry-run-output-dir", b.DiodeDryRunOutputDir}, args...)
+	} else {
+		opts := []string{"--diode-target", b.DiodeTarget}
+		if !b.DiodeTargetFromOtel {
+			opts = append(opts, "--diode-client-id", b.DiodeClientID, "--diode-client-secret", b.DiodeClientSecret)
+		}
+		args = append(opts, args...)
+	}
+	if b.DiodeLogLevel != "" {
+		args = append(args, "--log-level", b.DiodeLogLevel)
+	}
+	if b.DiodeOtelEndpoint != "" {
+		args = append(args, "--otel-endpoint", b.DiodeOtelEndpoint)
+	}
+	return args
+}
+
+func (b *testBackend) logLineAdapter(line string, _ bool) {
+	b.logLines = append(b.logLines, line)
+}
+
+func (b *testBackend) configureExtra(_ map[string]any) error {
+	b.configureExtraCalls++
+	return b.configureExtraErr
+}
+
+// captureHandler is a slog.Handler that records every record's message and attrs.
+type captureHandler struct {
+	mu      sync.Mutex
+	records []capturedRecord
+}
+
+type capturedRecord struct {
+	msg   string
+	attrs map[string]string
+}
+
+func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	rec := capturedRecord{msg: r.Message, attrs: map[string]string{}}
+	r.Attrs(func(a slog.Attr) bool {
+		rec.attrs[a.Key] = a.Value.String()
+		return true
+	})
+	h.mu.Lock()
+	h.records = append(h.records, rec)
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *captureHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(_ string) slog.Handler      { return h }
+
+func (h *captureHandler) hasAttr(key, value string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, r := range h.records {
+		if v, ok := r.attrs[key]; ok && v == value {
+			return true
+		}
+	}
+	return false
+}
+
+// recordingServer returns an httptest server that records every request path and
+// answers the discovery REST endpoints.
+func recordingServer(t *testing.T) (*httptest.Server, *[]string) {
+	t.Helper()
+	var (
+		mu    sync.Mutex
+		paths []string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.EscapedPath())
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/status":
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(backend.StatusResponse{
+				Version: "9.8.7",
+				Policies: []backend.PolicyStatus{
+					{Name: "p1", Status: "running"},
+				},
+			}))
+		case r.URL.Path == "/api/v1/capabilities":
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"capability": true}))
+		case strings.HasPrefix(r.URL.Path, "/api/v1/policies"):
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"status": "success"}))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, &paths
+}
+
+func runningBackend(t *testing.T, logger *slog.Logger, server *httptest.Server) *testBackend {
+	t.Helper()
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	b := newTestBackend(logger)
+	b.APIHost = serverURL.Hostname()
+	b.APIPort = serverURL.Port()
+
+	// A running mock so CommonRequest's GetRunningStatus reports Running.
+	mockCmd := &mocks.MockCmd{}
+	mockCmd.On("Status").Return(backend.CmdStatus{PID: 4321, Complete: false, Exit: -1})
+	b.Proc = mockCmd
+	return b
+}
+
+func TestDiscoveryBaseConfigure(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	b := newTestBackend(logger)
+
+	commons := config.BackendCommons{}
+	commons.Otlp.Grpc = "collector:4317"
+	commons.Diode.Target = "default-target"
+	commons.Diode.ClientID = "default-client"
+	commons.Diode.ClientSecret = "default-secret"
+	commons.Diode.AgentName = "default-agent"
+	commons.Diode.DryRunOutputDir = "/tmp/default"
+
+	require.NoError(t, b.Configure(map[string]any{
+		"host":          "example.com",
+		"port":          8080,
+		"target":        "cfg-target",
+		"client_id":     "cfg-client",
+		"client_secret": "cfg-secret",
+		"agent_name":    "cfg-agent",
+		"log_level":     "debug",
+	}, commons))
+
+	assert.Equal(t, "example.com", b.APIHost)
+	assert.Equal(t, "8080", b.APIPort, "numeric port must be stringified")
+	assert.Equal(t, "cfg-target", b.DiodeTarget)
+	assert.Equal(t, "cfg-client", b.DiodeClientID)
+	assert.Equal(t, "cfg-secret", b.DiodeClientSecret)
+	assert.Equal(t, "cfg-agent", b.DiodeAppNamePrefix)
+	assert.Equal(t, "debug", b.DiodeLogLevel)
+	assert.Equal(t, "collector:4317", b.DiodeOtelEndpoint)
+	assert.False(t, b.DiodeTargetFromOtel, "explicit target must not be flagged as from-otel")
+	assert.Equal(t, 1, b.configureExtraCalls, "ConfigureExtra must run during Configure")
+
+	// PolicyRepo is exported so each embedder's Configure can store the repo.
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	b.PolicyRepo = repo
+	assert.NotNil(t, b.PolicyRepo)
+}
+
+func TestDiscoveryBaseConfigureFallsBackToCommons(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	b := newTestBackend(logger)
+
+	commons := config.BackendCommons{}
+	commons.Diode.Target = "commons-target"
+	commons.Diode.ClientID = "commons-client"
+	commons.Diode.DryRun = true
+	commons.Diode.DryRunOutputDir = "/tmp/commons"
+
+	require.NoError(t, b.Configure(map[string]any{}, commons))
+
+	assert.Equal(t, "localhost", b.APIHost, "missing host falls back to default")
+	assert.Equal(t, "9999", b.APIPort, "missing port keeps the embedder default")
+	assert.Equal(t, "commons-target", b.DiodeTarget)
+	assert.Equal(t, "commons-client", b.DiodeClientID)
+	assert.True(t, b.DiodeDryRun)
+	assert.Equal(t, "/tmp/commons", b.DiodeDryRunOutputDir)
+}
+
+func TestDiscoveryBaseConfigureOtelTargetFromOtel(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	b := newTestBackend(logger)
+
+	commons := config.BackendCommons{}
+	commons.Otlp.Grpc = "otel:4317"
+
+	require.NoError(t, b.Configure(map[string]any{}, commons))
+
+	assert.Equal(t, "otel:4317", b.DiodeOtelEndpoint)
+	assert.Equal(t, "otel:4317", b.DiodeTarget, "empty target adopts the OTLP endpoint")
+	assert.True(t, b.DiodeTargetFromOtel, "target adopted from OTLP must be flagged")
+}
+
+func TestDiscoveryBaseConfigureExtraErrorAbortsBeforeOtelLog(t *testing.T) {
+	capture := &captureHandler{}
+	logger := slog.New(capture)
+	b := newTestBackend(logger)
+	b.configureExtraErr = errConfigureExtra
+
+	commons := config.BackendCommons{}
+	commons.Otlp.Grpc = "otel:4317"
+
+	err := b.Configure(map[string]any{}, commons)
+	require.ErrorIs(t, err, errConfigureExtra)
+	assert.Equal(t, 1, b.configureExtraCalls)
+	assert.False(t, capture.hasAttr("endpoint", "otel:4317"),
+		"ConfigureExtra error must abort before the OTLP-endpoint log")
+}
+
+func TestDiscoveryBaseRESTMethods(t *testing.T) {
+	server, paths := recordingServer(t)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	b := runningBackend(t, logger, server)
+
+	version, err := b.Version()
+	require.NoError(t, err)
+	assert.Equal(t, "9.8.7", version)
+
+	caps, err := b.GetCapabilities()
+	require.NoError(t, err)
+	assert.Equal(t, true, caps["capability"])
+
+	status, err := b.GetPolicyStatus()
+	require.NoError(t, err)
+	require.Len(t, status, 1)
+	assert.Equal(t, "p1", status[0].Name)
+
+	require.NoError(t, b.ApplyPolicy(policies.PolicyData{
+		ID: "id1", Name: "policy-one", Data: map[string]any{"k": "v"},
+	}, false))
+
+	assert.Contains(t, *paths, "/api/v1/status")
+	assert.Contains(t, *paths, "/api/v1/capabilities")
+	assert.Contains(t, *paths, "/api/v1/policies")
+}
+
+func TestDiscoveryBaseRemovePolicyPathEscapes(t *testing.T) {
+	server, paths := recordingServer(t)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	b := runningBackend(t, logger, server)
+
+	require.NoError(t, b.RemovePolicy(policies.PolicyData{ID: "id1", Name: "a/b"}))
+
+	assert.Contains(t, *paths, "/api/v1/policies/a%2Fb",
+		"a slash in the policy name must be path-escaped in the request URL")
+	assert.NotContains(t, *paths, "/api/v1/policies/a/b",
+		"the raw, unescaped name must not reach the server as a path")
+}
+
+func TestDiscoveryBaseRemovePolicyUsesPreviousName(t *testing.T) {
+	server, paths := recordingServer(t)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	b := runningBackend(t, logger, server)
+
+	require.NoError(t, b.RemovePolicy(policies.PolicyData{
+		ID:                 "id1",
+		Name:               "new name",
+		PreviousPolicyData: &policies.PolicyData{Name: "old/name"},
+	}))
+
+	assert.Contains(t, *paths, "/api/v1/policies/old%2Fname",
+		"a renamed policy must be removed under its previous (escaped) name")
+}
+
+// TestDiscoveryBaseNameFormHyphen asserts the hyphen form is the CommonRequest
+// backend id: with no running process, CommonRequest emits its skip-warn carrying
+// the hyphen name as the "backend" attr.
+func TestDiscoveryBaseNameFormHyphen(t *testing.T) {
+	capture := &captureHandler{}
+	logger := slog.New(capture)
+	b := newTestBackend(logger)
+	b.Proc = nil // not running => CommonRequest logs the skip-warn
+
+	_, _ = b.Version()
+	assert.True(t, capture.hasAttr("backend", "discovery-test"),
+		"CommonRequest must receive the hyphen name form as its backend id")
+}
+
+// TestDiscoveryBaseNameFormUnderscore asserts the underscore form is the
+// StopProcess backend tag. Start (via backend.StartProcess) publishes proc +
+// statusChan to the base, so Stop's StopProcess call drains the mock's status
+// channel and logs with the underscore name.
+func TestDiscoveryBaseNameFormUnderscore(t *testing.T) {
+	server, _ := recordingServer(t)
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	createExecutable(t, "discovery-test-exec")
+
+	capture := &captureHandler{}
+	logger := slog.New(capture)
+	b := newTestBackend(logger)
+	b.APIHost = serverURL.Hostname()
+	b.APIPort = serverURL.Port()
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 12345)
+	overrideNewCmdOptions(t, mockCmd, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, b.Start(ctx, cancel))
+	require.NoError(t, b.Stop(ctx))
+	assert.True(t, capture.hasAttr("backend", "discovery_test"),
+		"StopProcess must receive the underscore name form as its backend tag")
+}
+
+func TestDiscoveryBaseStart(t *testing.T) {
+	server, _ := recordingServer(t)
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	createExecutable(t, "discovery-test-exec")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	b := newTestBackend(logger)
+	b.APIHost = serverURL.Hostname()
+	b.APIPort = serverURL.Port()
+	b.DiodeTarget = "t"
+	b.DiodeClientID = "c"
+	b.DiodeClientSecret = "s"
+	b.DiodeAppNamePrefix = "a"
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 12345)
+	overrideNewCmdOptions(t, mockCmd, func(_ backend.CmdOptions, name string, args []string) {
+		assert.Equal(t, "discovery-test-exec", name)
+		assert.Contains(t, args, "--host")
+		assert.Contains(t, args, serverURL.Hostname())
+		assert.Contains(t, args, "--diode-target")
+		assert.Contains(t, args, "t")
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, b.Start(ctx, cancel))
+	assert.False(t, b.GetStartTime().IsZero(), "Start must set the start time")
+	assert.Same(t, ctx, b.Ctx, "Start must publish the context to DiscoveryBase.Ctx")
+
+	status, _, err := b.GetRunningStatus()
+	require.NoError(t, err)
+	assert.Equal(t, backend.Running, status)
+
+	require.NoError(t, b.Stop(ctx))
+
+	mockCmd.AssertExpectations(t)
+}
+
+func createExecutable(t *testing.T, name string) {
+	t.Helper()
+	tempDir := t.TempDir()
+	binaryPath := path.Join(tempDir, name)
+	file, err := os.Create(binaryPath)
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+	require.NoError(t, os.Chmod(binaryPath, 0o755))
+	t.Setenv("PATH", tempDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func overrideNewCmdOptions(t *testing.T, cmd backend.Commander, assertFn func(options backend.CmdOptions, name string, args []string)) {
+	t.Helper()
+	original := backend.NewCmdOptions
+	backend.NewCmdOptions = func(options backend.CmdOptions, name string, args ...string) backend.Commander {
+		if assertFn != nil {
+			assertFn(options, name, args)
+		}
+		return cmd
+	}
+	t.Cleanup(func() { backend.NewCmdOptions = original })
+}

--- a/agent/backend/gnmidiscovery/gnmi_discovery.go
+++ b/agent/backend/gnmidiscovery/gnmi_discovery.go
@@ -1,200 +1,109 @@
 package gnmidiscovery
 
 import (
-	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
-	neturl "net/url"
 	"strings"
-	"time"
-
-	"gopkg.in/yaml.v3"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/backend/discovery"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/filesmgr"
 	"github.com/netboxlabs/orb-agent/agent/policies"
-	"github.com/netboxlabs/orb-agent/agent/redact"
 )
 
 var _ backend.Backend = (*gnmiDiscoveryBackend)(nil)
 
 const (
-	versionTimeout      = 2
-	capabilitiesTimeout = 5
-	readinessBackoff    = 10
-	applyPolicyTimeout  = 10
-	removePolicyTimeout = 20
-	statusTimeout       = 5
-	defaultExec         = "gnmi-discovery"
-	defaultAPIHost      = "localhost"
-	defaultAPIPort      = "8075"
+	defaultExec    = "gnmi-discovery"
+	defaultAPIPort = "8075"
 )
 
 type gnmiDiscoveryBackend struct {
-	logger     *slog.Logger
-	policyRepo policies.PolicyRepo
-	exec       string
-
-	apiHost     string
-	apiPort     string
-	apiProtocol string
-
-	diodeTarget          string
-	diodeClientID        string
-	diodeClientSecret    string
-	diodeAppNamePrefix   string
-	diodeOtelEndpoint    string
-	diodeTargetFromOtel  bool
-	diodeDryRun          bool
-	diodeDryRunOutputDir string
-	diodeLogLevel        string
+	discovery.Base
 
 	// gNMI-specific options
 	profilesDir      string
 	otelExportPeriod string
 	logFormat        string
-
-	startTime  time.Time
-	proc       backend.Commander
-	statusChan <-chan backend.CmdStatus
-	cancelFunc context.CancelFunc
-}
-
-type info struct {
-	Version   string  `json:"version"`
-	UpTimeMin float64 `json:"up_time_seconds"`
 }
 
 // Register registers the gNMI discovery backend with the agent's backend
 // registry under the name "gnmi_discovery".
 func Register() bool {
-	backend.Register("gnmi_discovery", &gnmiDiscoveryBackend{
-		apiProtocol: "http",
-		exec:        defaultExec,
-	})
+	b := &gnmiDiscoveryBackend{
+		Base: discovery.Base{
+			Exec:           defaultExec,
+			APIProtocol:    "http",
+			APIPort:        defaultAPIPort,
+			NameHyphen:     "gnmi-discovery",
+			NameUnderscore: "gnmi_discovery",
+		},
+	}
+	b.BuildArgs = b.buildArgs
+	b.LogLine = b.logLineAdapter
+	b.ConfigureExtra = b.configureExtra
+	backend.Register("gnmi_discovery", b)
 	return true
 }
 
-// configStringOrDefault returns config[name] when it is a string, otherwise
-// fallback. A missing key, a YAML null, or a non-string value (number/bool)
-// falls back rather than being coerced to a literal like "<nil>" or "true".
-func configStringOrDefault(config map[string]any, name, fallback string) string {
-	if value, ok := config[name].(string); ok {
-		return value
-	}
-	return fallback
-}
-
-// Configure stores the backend configuration, merging the per-backend config
-// map with the shared Diode/OTLP commons (per-backend keys take precedence).
 func (d *gnmiDiscoveryBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	config map[string]any, common config.BackendCommons, _ filesmgr.Manager,
 ) error {
-	d.logger = logger.With("backend", "gnmi_discovery")
-	d.policyRepo = repo
-	d.diodeTargetFromOtel = false
-
-	d.apiHost = configStringOrDefault(config, "host", defaultAPIHost)
-	// port may be given as a YAML number, so stringify whatever is present.
-	if port, ok := config["port"]; ok {
-		d.apiPort = fmt.Sprintf("%v", port)
-	} else {
-		d.apiPort = defaultAPIPort
-	}
-
-	// String options fall back to the shared Diode commons when unset.
-	d.diodeTarget = configStringOrDefault(config, "target", common.Diode.Target)
-	d.diodeClientID = configStringOrDefault(config, "client_id", common.Diode.ClientID)
-	d.diodeClientSecret = configStringOrDefault(config, "client_secret", common.Diode.ClientSecret)
-	d.diodeAppNamePrefix = configStringOrDefault(config, "agent_name", common.Diode.AgentName)
-	d.diodeDryRunOutputDir = configStringOrDefault(config, "dry_run_output_dir", common.Diode.DryRunOutputDir)
-
-	d.diodeDryRun = common.Diode.DryRun
-	if dryRun, prs := config["dry_run"].(bool); prs {
-		d.diodeDryRun = dryRun
-	}
-
-	if logLevel, prs := config["log_level"].(string); prs {
-		d.diodeLogLevel = logLevel
-	} else if debug, prs := config["debug"].(bool); prs && debug {
-		d.diodeLogLevel = "debug"
-	} else if logger.Enabled(context.Background(), slog.LevelDebug) {
-		d.diodeLogLevel = "debug"
-	}
-
-	// gNMI-specific options
-	d.profilesDir = configStringOrDefault(config, "profiles_dir", "")
-	d.logFormat = configStringOrDefault(config, "log_format", "")
-	if period, prs := config["otel_export_period"]; prs {
-		d.otelExportPeriod = fmt.Sprintf("%v", period)
-	}
-
-	if common.Otlp.Grpc != "" {
-		d.diodeOtelEndpoint = common.Otlp.Grpc
-		d.logger.Info("gnmi-discovery using OTLP endpoint",
-			"endpoint", d.diodeOtelEndpoint)
-	}
-	if d.diodeTarget == "" && d.diodeOtelEndpoint != "" {
-		d.diodeTarget = d.diodeOtelEndpoint
-		d.diodeTargetFromOtel = true
-	}
-
-	return nil
+	d.Logger = logger.With("backend", "gnmi_discovery")
+	d.PolicyRepo = repo
+	return d.Base.Configure(config, common)
 }
 
-// Version returns the running gnmi-discovery version from its REST status endpoint.
-func (d *gnmiDiscoveryBackend) Version() (string, error) {
-	var info info
-	url := fmt.Sprintf("%s://%s:%s/api/v1/status", d.apiProtocol, d.apiHost, d.apiPort)
-	err := backend.CommonRequest("gnmi-discovery", d.proc, d.logger, url, &info, http.MethodGet,
-		http.NoBody, "application/json", versionTimeout, "detail")
-	if err != nil {
-		return "", err
-	}
-	return info.Version, nil
+// configureExtra parses the gnmi-specific profiles_dir, log_format, and
+// otel_export_period keys. It runs early in Configure (after host/port, before
+// diode/OTLP reads) so the keys are populated before buildArgs consumes them.
+func (d *gnmiDiscoveryBackend) configureExtra(config map[string]any) error {
+	d.profilesDir = backend.ConfigStringOrDefault(config, "profiles_dir", "")
+	d.logFormat = backend.ConfigStringOrDefault(config, "log_format", "")
+	d.otelExportPeriod = backend.ConfigValueOrDefault(config, "otel_export_period", "")
+	return nil
 }
 
 // buildArgs assembles the gnmi-discovery process arguments from the configured
 // options. Flags are order-independent, so they are appended in a single pass.
 func (d *gnmiDiscoveryBackend) buildArgs() []string {
 	args := []string{
-		"--diode-app-name-prefix", d.diodeAppNamePrefix,
-		"--host", d.apiHost,
-		"--port", d.apiPort,
+		"--diode-app-name-prefix", d.DiodeAppNamePrefix,
+		"--host", d.APIHost,
+		"--port", d.APIPort,
 	}
 
-	if d.diodeDryRun {
+	if d.DiodeDryRun {
 		args = append(args, "--dry-run")
-		if d.diodeDryRunOutputDir != "" {
-			args = append(args, "--dry-run-output-dir", d.diodeDryRunOutputDir)
+		if d.DiodeDryRunOutputDir != "" {
+			args = append(args, "--dry-run-output-dir", d.DiodeDryRunOutputDir)
 		}
 	} else {
-		args = append(args, "--diode-target", d.diodeTarget)
-		if !d.diodeTargetFromOtel {
+		args = append(args, "--diode-target", d.DiodeTarget)
+		if !d.DiodeTargetFromOtel {
 			args = append(args,
-				"--diode-client-id", d.diodeClientID,
-				"--diode-client-secret", d.diodeClientSecret,
+				"--diode-client-id", d.DiodeClientID,
+				"--diode-client-secret", d.DiodeClientSecret,
 			)
 		}
 	}
 
-	if d.diodeLogLevel != "" {
-		args = append(args, "--log-level", d.diodeLogLevel)
-		d.logger.Info("gnmi-discovery using log level", "log_level", d.diodeLogLevel)
+	if d.DiodeLogLevel != "" {
+		args = append(args, "--log-level", d.DiodeLogLevel)
+		d.Logger.Info("gnmi-discovery using log level", "log_level", d.DiodeLogLevel)
 	}
-	if d.diodeOtelEndpoint != "" {
-		args = append(args, "--otel-endpoint", d.diodeOtelEndpoint)
-		d.logger.Info("gnmi-discovery using OTLP metrics endpoint", "endpoint", d.diodeOtelEndpoint)
+	if d.DiodeOtelEndpoint != "" {
+		args = append(args, "--otel-endpoint", d.DiodeOtelEndpoint)
+		d.Logger.Info("gnmi-discovery using OTLP metrics endpoint", "endpoint", d.DiodeOtelEndpoint)
 	}
 
 	// gNMI-specific options
 	if d.profilesDir != "" {
 		args = append(args, "--profiles-dir", d.profilesDir)
-		d.logger.Info("gnmi-discovery using profiles dir", "profiles_dir", d.profilesDir)
+		d.Logger.Info("gnmi-discovery using profiles dir", "profiles_dir", d.profilesDir)
 	}
 	if d.otelExportPeriod != "" {
 		args = append(args, "--otel-export-period", d.otelExportPeriod)
@@ -206,93 +115,14 @@ func (d *gnmiDiscoveryBackend) buildArgs() []string {
 	return args
 }
 
-// Start launches the gnmi-discovery process, streams its logs to the agent
-// logger, and blocks until the process's REST API is ready — returning an error
-// if it exits early or never becomes ready.
-func (d *gnmiDiscoveryBackend) Start(ctx context.Context, cancelFunc context.CancelFunc) error {
-	d.startTime = time.Now()
-	d.cancelFunc = cancelFunc
-
-	dOptions := d.buildArgs()
-	d.logger.Info("gnmi-discovery startup", "arguments", redact.Args(dOptions))
-
-	d.proc = backend.NewCmdOptions(backend.CmdOptions{
-		Buffered:  false,
-		Streaming: true,
-	}, d.exec, dOptions...)
-	d.statusChan = d.proc.Start()
-
-	// Stream the process's stdout/stderr to the agent logger. A closed stream
-	// reads as (_, false); we nil it so the select then blocks only on the
-	// still-open stream, and the loop exits once both are closed (process gone).
-	go func() {
-		stdout := d.proc.GetStdout()
-		stderr := d.proc.GetStderr()
-		for stdout != nil || stderr != nil {
-			select {
-			case line, open := <-stdout:
-				if !open {
-					stdout = nil
-					continue
-				}
-				d.logGnmiDiscoveryOutput(ctx, line, slog.LevelInfo)
-			case line, open := <-stderr:
-				if !open {
-					stderr = nil
-					continue
-				}
-				d.logGnmiDiscoveryOutput(ctx, line, slog.LevelError)
-			}
-		}
-	}()
-
-	// wait for simple startup errors
-	time.Sleep(time.Second)
-
-	status := d.proc.Status()
-
-	if status.Error != nil {
-		d.logger.Error("gnmi-discovery startup error", "error", status.Error)
-		return status.Error
-	}
-
-	if status.Complete {
-		backend.StopProcess(d.logger, d.proc, d.statusChan, backend.DefaultStopGracePeriod, "gnmi_discovery")
-		return errors.New("gnmi-discovery startup error, check log")
-	}
-
-	d.logger.Info("gnmi-discovery process started", "pid", status.PID)
-
-	var version string
-	var readinessErr error
-	for backoff := range readinessBackoff {
-		if status := d.proc.Status(); status.Complete {
-			backend.StopProcess(d.logger, d.proc, d.statusChan, backend.DefaultStopGracePeriod, "gnmi_discovery")
-			return errors.New("gnmi-discovery process ended unexpectedly, check log")
-		}
-		version, readinessErr = d.Version()
-		if readinessErr == nil {
-			d.logger.Info("gnmi-discovery readiness ok, got version", "version", version)
-			break
-		}
-		backoffDuration := time.Duration(backoff) * time.Second
-		d.logger.Info("gnmi-discovery is not ready, trying again with backoff",
-			"backoff_duration", backoffDuration.String())
-		time.Sleep(backoffDuration)
-	}
-
-	if readinessErr != nil {
-		d.logger.Error("gnmi-discovery error on readiness", "error", readinessErr)
-		backend.StopProcess(d.logger, d.proc, d.statusChan, backend.DefaultStopGracePeriod, "gnmi_discovery")
-		return readinessErr
-	}
-
-	return nil
-}
-
-// logGnmiDiscoveryOutput logs one line of process output, parsing it as logfmt
+// logLineAdapter logs one line of process output, parsing it as logfmt
 // (structured attrs + level) when possible and falling back to the raw line.
-func (d *gnmiDiscoveryBackend) logGnmiDiscoveryOutput(ctx context.Context, line string, fallback slog.Level) {
+func (d *gnmiDiscoveryBackend) logLineAdapter(line string, isStderr bool) {
+	fallback := slog.LevelInfo
+	if isStderr {
+		fallback = slog.LevelError
+	}
+
 	trimmed := strings.TrimSpace(line)
 	if trimmed == "" {
 		return
@@ -308,135 +138,12 @@ func (d *gnmiDiscoveryBackend) logGnmiDiscoveryOutput(ctx context.Context, line 
 		level = parsedLevel
 	}
 
+	ctx := d.Ctx
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
-	d.logger.LogAttrs(ctx, level, msg, attrs...)
-}
-
-// Stop gracefully stops the gnmi-discovery process and cancels the backend context.
-func (d *gnmiDiscoveryBackend) Stop(ctx context.Context) error {
-	d.logger.Info("routine call to stop gnmi-discovery", "routine", ctx.Value(config.ContextKey("routine")))
-	if d.cancelFunc != nil {
-		defer d.cancelFunc()
-	}
-	backend.StopProcess(d.logger, d.proc, d.statusChan, backend.DefaultStopGracePeriod, "gnmi_discovery")
-	return nil
-}
-
-// FullReset stops the gnmi-discovery process (if running) and starts it again.
-func (d *gnmiDiscoveryBackend) FullReset(ctx context.Context) error {
-	// force a stop, which stops scrape as well. if proc is dead, it no ops.
-	if state, _, _ := backend.GetRunningStatus(d.proc); state == backend.Running {
-		if err := d.Stop(ctx); err != nil {
-			d.logger.Error("failed to stop backend on restart procedure", "error", err)
-			return err
-		}
-	}
-	// for each policy, restart the scraper
-	backendCtx, cancelFunc := context.WithCancel(context.WithValue(ctx, config.ContextKey("routine"), "gnmi-discovery"))
-	// start it
-	if err := d.Start(backendCtx, cancelFunc); err != nil {
-		d.logger.Error("failed to start backend on restart procedure", "error", err)
-		return err
-	}
-	return nil
-}
-
-// GetStartTime returns the time the gnmi-discovery process was last started.
-func (d *gnmiDiscoveryBackend) GetStartTime() time.Time {
-	return d.startTime
-}
-
-// GetCapabilities returns the backend's capabilities from its REST endpoint.
-func (d *gnmiDiscoveryBackend) GetCapabilities() (map[string]any, error) {
-	caps := make(map[string]any)
-	url := fmt.Sprintf("%s://%s:%s/api/v1/capabilities", d.apiProtocol, d.apiHost, d.apiPort)
-	err := backend.CommonRequest("gnmi-discovery", d.proc, d.logger, url, &caps, http.MethodGet,
-		http.NoBody, "application/json", capabilitiesTimeout, "detail")
-	if err != nil {
-		return nil, err
-	}
-	return caps, nil
-}
-
-// GetRunningStatus reports the process state, also verifying the REST API is
-// reachable when the process is running.
-func (d *gnmiDiscoveryBackend) GetRunningStatus() (backend.RunningStatus, string, error) {
-	// first check process status
-	runningStatus, errMsg, err := backend.GetRunningStatus(d.proc)
-	// if it's not running, we're done
-	if runningStatus != backend.Running {
-		return runningStatus, errMsg, err
-	}
-	// if it's running, check REST API availability too
-	if _, aiErr := d.Version(); aiErr != nil {
-		// process is running, but REST API is not accessible
-		return backend.BackendError, "process running, REST API unavailable", aiErr
-	}
-	return runningStatus, "", nil
-}
-
-// GetInitialState returns the backend's initial running state (Unknown).
-func (d *gnmiDiscoveryBackend) GetInitialState() backend.RunningStatus {
-	return backend.Unknown
-}
-
-// ApplyPolicy applies a policy via the REST API, removing the prior version
-// first when this is an update.
-func (d *gnmiDiscoveryBackend) ApplyPolicy(data policies.PolicyData, updatePolicy bool) error {
-	if updatePolicy {
-		// To update a policy it's necessary first remove it and then apply a new version
-		if err := d.RemovePolicy(data); err != nil {
-			d.logger.Warn("policy failed to remove", "policy_id", data.ID,
-				"policy_name", data.Name, "error", err)
-		}
-	}
-
-	d.logger.Debug("gnmi-discovery policy apply", "policy_id", data.ID, "data", data.Data)
-
-	fullPolicy := map[string]any{
-		"policies": map[string]any{
-			data.Name: data.Data,
-		},
-	}
-
-	policyYaml, err := yaml.Marshal(fullPolicy)
-	if err != nil {
-		d.logger.Warn("policy yaml marshal failure", "policy_id", data.ID, "policy_name", data.Name)
-		return err
-	}
-
-	var resp map[string]any
-	url := fmt.Sprintf("%s://%s:%s/api/v1/%s", d.apiProtocol, d.apiHost, d.apiPort, "policies")
-	err = backend.CommonRequest("gnmi-discovery", d.proc, d.logger, url, &resp, http.MethodPost,
-		bytes.NewBuffer(policyYaml), "application/x-yaml", applyPolicyTimeout, "detail")
-	if err != nil {
-		d.logger.Warn("policy application failure", "policy_id", data.ID, "policy_name", data.Name)
-		return err
-	}
-
-	return nil
-}
-
-// RemovePolicy deletes a policy by name via the REST API (using the previous
-// name when a policy was renamed).
-func (d *gnmiDiscoveryBackend) RemovePolicy(data policies.PolicyData) error {
-	d.logger.Debug("gnmi-discovery policy remove", "policy_id", data.ID)
-	var resp any
-	name := data.Name
-	// Since we use Name for removing policies not IDs, if there is a change, we need to remove the previous name of the policy
-	if data.PreviousPolicyData != nil && data.PreviousPolicyData.Name != data.Name {
-		name = data.PreviousPolicyData.Name
-	}
-	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", d.apiProtocol, d.apiHost, d.apiPort, neturl.PathEscape(name))
-	err := backend.CommonRequest("gnmi-discovery", d.proc, d.logger, url, &resp, http.MethodDelete,
-		http.NoBody, "application/json", removePolicyTimeout, "detail")
-	if err != nil {
-		return err
-	}
-	return nil
+	d.Logger.LogAttrs(ctx, level, msg, attrs...)
 }
 
 // gnmiStatusResponse mirrors gnmi-discovery's /api/v1/status. Each run carries a
@@ -464,9 +171,9 @@ type gnmiStatusResponse struct {
 // normalizing each run's singular target into the shared Targets slice.
 func (d *gnmiDiscoveryBackend) GetPolicyStatus() ([]backend.PolicyStatus, error) {
 	var resp gnmiStatusResponse
-	url := fmt.Sprintf("%s://%s:%s/api/v1/status", d.apiProtocol, d.apiHost, d.apiPort)
-	err := backend.CommonRequest("gnmi-discovery", d.proc, d.logger, url, &resp, http.MethodGet,
-		http.NoBody, "application/json", statusTimeout, "detail")
+	url := fmt.Sprintf("%s://%s:%s/api/v1/status", d.APIProtocol, d.APIHost, d.APIPort)
+	err := backend.CommonRequest("gnmi-discovery", d.Proc, d.Logger, url, &resp, http.MethodGet,
+		http.NoBody, "application/json", discovery.StatusTimeout, "detail")
 	if err != nil {
 		return nil, err
 	}

--- a/agent/backend/networkdiscovery/network_discovery.go
+++ b/agent/backend/networkdiscovery/network_discovery.go
@@ -1,282 +1,98 @@
 package networkdiscovery
 
 import (
-	"bytes"
 	"context"
-	"errors"
-	"fmt"
 	"log/slog"
-	"net/http"
 	"strings"
-	"time"
-
-	"gopkg.in/yaml.v3"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/backend/discovery"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/filesmgr"
 	"github.com/netboxlabs/orb-agent/agent/policies"
-	"github.com/netboxlabs/orb-agent/agent/redact"
 )
 
 var _ backend.Backend = (*networkDiscoveryBackend)(nil)
 
 const (
-	versionTimeout      = 2
-	capabilitiesTimeout = 5
-	readinessBackoff    = 10
-	applyPolicyTimeout  = 10
-	removePolicyTimeout = 20
-	statusTimeout       = 5
-	defaultExec         = "network-discovery"
-	defaultAPIHost      = "localhost"
-	defaultAPIPort      = "8073"
+	defaultExec    = "network-discovery"
+	defaultAPIPort = "8073"
 )
 
 type networkDiscoveryBackend struct {
-	logger     *slog.Logger
-	policyRepo policies.PolicyRepo
-	exec       string
-
-	apiHost     string
-	apiPort     string
-	apiProtocol string
-
-	diodeTarget          string
-	diodeClientID        string
-	diodeClientSecret    string
-	diodeAppNamePrefix   string
-	diodeOtelEndpoint    string
-	diodeTargetFromOtel  bool
-	diodeDryRun          bool
-	diodeDryRunOutputDir string
-	diodeLogLevel        string
-
-	startTime  time.Time
-	proc       backend.Commander
-	statusChan <-chan backend.CmdStatus
-	cancelFunc context.CancelFunc
-	ctx        context.Context
-}
-
-type info struct {
-	Version   string  `json:"version"`
-	UpTimeMin float64 `json:"up_time_seconds"`
+	discovery.Base
 }
 
 // Register registers the network discovery backend
 func Register() bool {
-	backend.Register("network_discovery", &networkDiscoveryBackend{
-		apiProtocol: "http",
-		exec:        defaultExec,
-	})
+	b := &networkDiscoveryBackend{
+		Base: discovery.Base{
+			Exec:           defaultExec,
+			APIProtocol:    "http",
+			APIPort:        defaultAPIPort,
+			NameHyphen:     "network-discovery",
+			NameUnderscore: "network_discovery",
+		},
+	}
+	b.BuildArgs = b.buildArgs
+	b.LogLine = b.logLineAdapter
+	backend.Register("network_discovery", b)
 	return true
 }
 
 func (d *networkDiscoveryBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	config map[string]any, common config.BackendCommons, _ filesmgr.Manager,
 ) error {
-	d.logger = logger.With("backend", "network_discovery")
-	d.policyRepo = repo
-	d.diodeTargetFromOtel = false
-
-	var prs bool
-	if d.apiHost, prs = config["host"].(string); !prs {
-		d.apiHost = defaultAPIHost
-	}
-	if port, prs := config["port"]; prs {
-		d.apiPort = fmt.Sprintf("%v", port)
-	} else {
-		d.apiPort = defaultAPIPort
-	}
-
-	d.diodeTarget = common.Diode.Target
-	d.diodeClientID = common.Diode.ClientID
-	d.diodeClientSecret = common.Diode.ClientSecret
-	d.diodeAppNamePrefix = common.Diode.AgentName
-	d.diodeDryRun = common.Diode.DryRun
-	d.diodeDryRunOutputDir = common.Diode.DryRunOutputDir
-
-	if target, prs := config["target"].(string); prs {
-		d.diodeTarget = target
-	}
-	if clientID, prs := config["client_id"].(string); prs {
-		d.diodeClientID = clientID
-	}
-	if clientSecret, prs := config["client_secret"].(string); prs {
-		d.diodeClientSecret = clientSecret
-	}
-	if agentName, prs := config["agent_name"].(string); prs {
-		d.diodeAppNamePrefix = agentName
-	}
-	if dryRun, prs := config["dry_run"].(bool); prs {
-		d.diodeDryRun = dryRun
-	}
-	if dryRunOutputDir, prs := config["dry_run_output_dir"].(string); prs {
-		d.diodeDryRunOutputDir = dryRunOutputDir
-	}
-	if logLevel, prs := config["log_level"].(string); prs {
-		d.diodeLogLevel = logLevel
-	} else if debug, prs := config["debug"].(bool); prs && debug {
-		d.diodeLogLevel = "debug"
-	} else if logger.Enabled(context.Background(), slog.LevelDebug) {
-		d.diodeLogLevel = "debug"
-	}
-
-	if common.Otlp.Grpc != "" {
-		d.diodeOtelEndpoint = common.Otlp.Grpc
-		d.logger.Info("network-discovery using OTLP endpoint",
-			"endpoint", d.diodeOtelEndpoint)
-	}
-	if d.diodeTarget == "" && d.diodeOtelEndpoint != "" {
-		d.diodeTarget = d.diodeOtelEndpoint
-		d.diodeTargetFromOtel = true
-	}
-
-	return nil
+	d.Logger = logger.With("backend", "network_discovery")
+	d.PolicyRepo = repo
+	return d.Base.Configure(config, common)
 }
 
-func (d *networkDiscoveryBackend) Version() (string, error) {
-	var info info
-	url := fmt.Sprintf("%s://%s:%s/api/v1/status", d.apiProtocol, d.apiHost, d.apiPort)
-	err := backend.CommonRequest("network-discovery", d.proc, d.logger, url, &info, http.MethodGet,
-		http.NoBody, "application/json", versionTimeout, "detail")
-	if err != nil {
-		return "", err
-	}
-	return info.Version, nil
-}
-
-func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.CancelFunc) error {
-	d.startTime = time.Now()
-	d.cancelFunc = cancelFunc
-	d.ctx = ctx
-
+func (d *networkDiscoveryBackend) buildArgs() []string {
 	dOptions := []string{
-		"--diode-app-name-prefix", d.diodeAppNamePrefix,
-		"--host", d.apiHost,
-		"--port", d.apiPort,
+		"--diode-app-name-prefix", d.DiodeAppNamePrefix,
+		"--host", d.APIHost,
+		"--port", d.APIPort,
 	}
-	if d.diodeDryRun {
+	if d.DiodeDryRun {
 		dOptions = append([]string{
 			"--dry-run",
-			"--dry-run-output-dir", d.diodeDryRunOutputDir,
+			"--dry-run-output-dir", d.DiodeDryRunOutputDir,
 		}, dOptions...)
 	} else {
 		opts := []string{
-			"--diode-target", d.diodeTarget,
+			"--diode-target", d.DiodeTarget,
 		}
-		if !d.diodeTargetFromOtel {
+		if !d.DiodeTargetFromOtel {
 			opts = append(opts,
-				"--diode-client-id", d.diodeClientID,
-				"--diode-client-secret", d.diodeClientSecret,
+				"--diode-client-id", d.DiodeClientID,
+				"--diode-client-secret", d.DiodeClientSecret,
 			)
 		}
 		dOptions = append(opts, dOptions...)
 	}
 
-	if d.diodeLogLevel != "" {
-		dOptions = append(dOptions, "--log-level", d.diodeLogLevel)
-		d.logger.Info("network-discovery using log level",
-			"log_level", d.diodeLogLevel)
+	if d.DiodeLogLevel != "" {
+		dOptions = append(dOptions, "--log-level", d.DiodeLogLevel)
+		d.Logger.Info("network-discovery using log level",
+			"log_level", d.DiodeLogLevel)
 	}
 
-	if d.diodeOtelEndpoint != "" {
-		dOptions = append(dOptions, "--otel-endpoint", d.diodeOtelEndpoint)
-		d.logger.Info("network-discovery using OTLP metrics endpoint",
-			"endpoint", d.diodeOtelEndpoint)
+	if d.DiodeOtelEndpoint != "" {
+		dOptions = append(dOptions, "--otel-endpoint", d.DiodeOtelEndpoint)
+		d.Logger.Info("network-discovery using OTLP metrics endpoint",
+			"endpoint", d.DiodeOtelEndpoint)
 	}
 
-	d.logger.Info("network-discovery startup", "arguments", redact.Args(dOptions))
-
-	d.proc = backend.NewCmdOptions(backend.CmdOptions{
-		Buffered:  false,
-		Streaming: true,
-	}, d.exec, dOptions...)
-	d.statusChan = d.proc.Start()
-
-	// log STDOUT and STDERR lines streaming from Cmd
-	doneChan := make(chan struct{})
-	go func() {
-		defer func() {
-			if doneChan != nil {
-				close(doneChan)
-			}
-		}()
-		stdout := d.proc.GetStdout()
-		stderr := d.proc.GetStderr()
-		for stdout != nil || stderr != nil {
-			select {
-			case line, open := <-stdout:
-				if !open {
-					stdout = nil
-					continue
-				}
-				d.logNetworkDiscoveryOutput(line, slog.LevelInfo)
-			case line, open := <-stderr:
-				if !open {
-					stderr = nil
-					continue
-				}
-				d.logNetworkDiscoveryOutput(line, slog.LevelError)
-			}
-		}
-	}()
-
-	// wait for simple startup errors
-	time.Sleep(time.Second)
-
-	status := d.proc.Status()
-
-	if status.Error != nil {
-		d.logger.Error("network-discovery startup error", "error", status.Error)
-		return status.Error
-	}
-
-	if status.Complete {
-		err := d.proc.Stop()
-		if err != nil {
-			d.logger.Error("proc.Stop error", "error", err)
-		}
-		return errors.New("network-discovery startup error, check log")
-	}
-
-	d.logger.Info("network-discovery process started", "pid", status.PID)
-
-	var version string
-	var readinessErr error
-	for backoff := range readinessBackoff {
-		if status := d.proc.Status(); status.Complete {
-			err := d.proc.Stop()
-			if err != nil {
-				d.logger.Error("proc.Stop error", "error", err)
-			}
-			return errors.New("network-discovery process ended unexpectedly, check log")
-		}
-		version, readinessErr = d.Version()
-		if readinessErr == nil {
-			d.logger.Info("network-discovery readiness ok, got version", "version", version)
-			break
-		}
-		backoffDuration := time.Duration(backoff) * time.Second
-		d.logger.Info("network-discovery is not ready, trying again with backoff",
-			"backoff backoffDuration", backoffDuration.String())
-		time.Sleep(backoffDuration)
-	}
-
-	if readinessErr != nil {
-		d.logger.Error("network-discovery error on readiness", "error", readinessErr)
-		err := d.proc.Stop()
-		if err != nil {
-			d.logger.Error("proc.Stop error", "error", err)
-		}
-		return readinessErr
-	}
-
-	return nil
+	return dOptions
 }
 
-func (d *networkDiscoveryBackend) logNetworkDiscoveryOutput(line string, fallback slog.Level) {
+func (d *networkDiscoveryBackend) logLineAdapter(line string, isStderr bool) {
+	fallback := slog.LevelInfo
+	if isStderr {
+		fallback = slog.LevelError
+	}
+
 	trimmed := strings.TrimSpace(line)
 	if trimmed == "" {
 		return
@@ -292,132 +108,10 @@ func (d *networkDiscoveryBackend) logNetworkDiscoveryOutput(line string, fallbac
 		level = parsedLevel
 	}
 
-	ctx := d.ctx
+	ctx := d.Ctx
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
-	d.logger.LogAttrs(ctx, level, msg, attrs...)
-}
-
-func (d *networkDiscoveryBackend) Stop(ctx context.Context) error {
-	d.logger.Info("routine call to stop network-discovery", "routine", ctx.Value(config.ContextKey("routine")))
-	defer d.cancelFunc()
-	backend.StopProcess(d.logger, d.proc, d.statusChan, backend.DefaultStopGracePeriod, "network_discovery")
-	return nil
-}
-
-func (d *networkDiscoveryBackend) FullReset(ctx context.Context) error {
-	// force a stop, which stops scrape as well. if proc is dead, it no ops.
-	if state, _, _ := backend.GetRunningStatus(d.proc); state == backend.Running {
-		if err := d.Stop(ctx); err != nil {
-			d.logger.Error("failed to stop backend on restart procedure", "error", err)
-			return err
-		}
-	}
-	// for each policy, restart the scraper
-	backendCtx, cancelFunc := context.WithCancel(context.WithValue(ctx, config.ContextKey("routine"), "network-discovery"))
-	// start it
-	if err := d.Start(backendCtx, cancelFunc); err != nil {
-		d.logger.Error("failed to start backend on restart procedure", "error", err)
-		return err
-	}
-	return nil
-}
-
-func (d *networkDiscoveryBackend) GetStartTime() time.Time {
-	return d.startTime
-}
-
-func (d *networkDiscoveryBackend) GetCapabilities() (map[string]any, error) {
-	caps := make(map[string]any)
-	url := fmt.Sprintf("%s://%s:%s/api/v1/capabilities", d.apiProtocol, d.apiHost, d.apiPort)
-	err := backend.CommonRequest("network-discovery", d.proc, d.logger, url, &caps, http.MethodGet,
-		http.NoBody, "application/json", capabilitiesTimeout, "detail")
-	if err != nil {
-		return nil, err
-	}
-	return caps, nil
-}
-
-func (d *networkDiscoveryBackend) GetRunningStatus() (backend.RunningStatus, string, error) {
-	// first check process status
-	runningStatus, errMsg, err := backend.GetRunningStatus(d.proc)
-	// if it's not running, we're done
-	if runningStatus != backend.Running {
-		return runningStatus, errMsg, err
-	}
-	// if it's running, check REST API availability too
-	if _, aiErr := d.Version(); aiErr != nil {
-		// process is running, but REST API is not accessible
-		return backend.BackendError, "process running, REST API unavailable", aiErr
-	}
-	return runningStatus, "", nil
-}
-
-func (d *networkDiscoveryBackend) GetInitialState() backend.RunningStatus {
-	return backend.Unknown
-}
-
-func (d *networkDiscoveryBackend) ApplyPolicy(data policies.PolicyData, updatePolicy bool) error {
-	if updatePolicy {
-		// To update a policy it's necessary first remove it and then apply a new version
-		if err := d.RemovePolicy(data); err != nil {
-			d.logger.Warn("policy failed to remove", "policy_id", data.ID,
-				"policy_name", data.Name, "error", err)
-		}
-	}
-
-	d.logger.Debug("network-discovery policy apply", "policy_id", data.ID, "data", data.Data)
-
-	fullPolicy := map[string]any{
-		"policies": map[string]any{
-			data.Name: data.Data,
-		},
-	}
-
-	policyYaml, err := yaml.Marshal(fullPolicy)
-	if err != nil {
-		d.logger.Warn("policy yaml marshal failure", "policy_id", data.ID, "policy_name", data.Name)
-		return err
-	}
-
-	var resp map[string]any
-	url := fmt.Sprintf("%s://%s:%s/api/v1/%s", d.apiProtocol, d.apiHost, d.apiPort, "policies")
-	err = backend.CommonRequest("network-discovery", d.proc, d.logger, url, &resp, http.MethodPost,
-		bytes.NewBuffer(policyYaml), "application/x-yaml", applyPolicyTimeout, "detail")
-	if err != nil {
-		d.logger.Warn("policy application failure", "policy_id", data.ID, "policy_name", data.Name)
-		return err
-	}
-
-	return nil
-}
-
-func (d *networkDiscoveryBackend) RemovePolicy(data policies.PolicyData) error {
-	d.logger.Debug("network-discovery policy remove", "policy_id", data.ID)
-	var resp any
-	name := data.Name
-	// Since we use Name for removing policies not IDs, if there is a change, we need to remove the previous name of the policy
-	if data.PreviousPolicyData != nil && data.PreviousPolicyData.Name != data.Name {
-		name = data.PreviousPolicyData.Name
-	}
-	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", d.apiProtocol, d.apiHost, d.apiPort, name)
-	err := backend.CommonRequest("network-discovery", d.proc, d.logger, url, &resp, http.MethodDelete,
-		http.NoBody, "application/json", removePolicyTimeout, "detail")
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (d *networkDiscoveryBackend) GetPolicyStatus() ([]backend.PolicyStatus, error) {
-	var resp backend.StatusResponse
-	url := fmt.Sprintf("%s://%s:%s/api/v1/status", d.apiProtocol, d.apiHost, d.apiPort)
-	err := backend.CommonRequest("network-discovery", d.proc, d.logger, url, &resp, http.MethodGet,
-		http.NoBody, "application/json", statusTimeout, "detail")
-	if err != nil {
-		return nil, err
-	}
-	return resp.Policies, nil
+	d.Logger.LogAttrs(ctx, level, msg, attrs...)
 }

--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -1,79 +1,72 @@
 package snmpdiscovery
 
 import (
-	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"strconv"
 	"strings"
-	"time"
-
-	"gopkg.in/yaml.v3"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/backend/discovery"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/filesmgr"
 	"github.com/netboxlabs/orb-agent/agent/policies"
-	"github.com/netboxlabs/orb-agent/agent/redact"
 )
 
 var _ backend.Backend = (*snmpDiscoveryBackend)(nil)
 
 const (
-	versionTimeout          = 2
-	capabilitiesTimeout     = 5
-	readinessBackoff        = 10
-	applyPolicyTimeout      = 10
-	removePolicyTimeout     = 20
-	statusTimeout           = 5
 	defaultExec             = "snmp-discovery"
-	defaultAPIHost          = "localhost"
 	defaultAPIPort          = "8070"
 	defaultIngestBufferSize = 512
 )
 
 type snmpDiscoveryBackend struct {
-	logger     *slog.Logger
-	policyRepo policies.PolicyRepo
-	exec       string
-
-	apiHost     string
-	apiPort     string
-	apiProtocol string
-
-	diodeTarget          string
-	diodeClientID        string
-	diodeClientSecret    string
-	diodeAppNamePrefix   string
-	diodeOtelEndpoint    string
-	diodeTargetFromOtel  bool
-	diodeDryRun          bool
-	diodeDryRunOutputDir string
-	diodeLogLevel        string
-	ingestBufferSize     int
-
-	startTime  time.Time
-	proc       backend.Commander
-	statusChan <-chan backend.CmdStatus
-	cancelFunc context.CancelFunc
-	ctx        context.Context
-}
-
-type info struct {
-	Version   string  `json:"version"`
-	UpTimeMin float64 `json:"up_time_seconds"`
+	discovery.Base
+	ingestBufferSize int
 }
 
 // Register registers the snmp discovery backend
 func Register() bool {
-	backend.Register("snmp_discovery", &snmpDiscoveryBackend{
-		apiProtocol: "http",
-		exec:        defaultExec,
-	})
+	b := &snmpDiscoveryBackend{
+		Base: discovery.Base{
+			Exec:           defaultExec,
+			APIProtocol:    "http",
+			APIPort:        defaultAPIPort,
+			NameHyphen:     "snmp-discovery",
+			NameUnderscore: "snmp_discovery",
+		},
+	}
+	b.BuildArgs = b.buildArgs
+	b.LogLine = b.logLineAdapter
+	b.ConfigureExtra = b.configureExtra
+	backend.Register("snmp_discovery", b)
 	return true
+}
+
+func (d *snmpDiscoveryBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
+	config map[string]any, common config.BackendCommons, _ filesmgr.Manager,
+) error {
+	d.Logger = logger.With("backend", "snmp_discovery")
+	d.PolicyRepo = repo
+	return d.Base.Configure(config, common)
+}
+
+// configureExtra parses and validates the snmp-specific ingest_buffer_size key.
+// It runs early in Configure (after host/port, before diode/OTLP reads) so a
+// validation error aborts before the OTLP log — ordering preserved from the
+// original inline implementation.
+func (d *snmpDiscoveryBackend) configureExtra(config map[string]any) error {
+	d.ingestBufferSize = defaultIngestBufferSize
+	if v, prs := config["ingest_buffer_size"]; prs {
+		size, err := parseIngestBufferSize(v)
+		if err != nil {
+			return fmt.Errorf("snmp_discovery: %w", err)
+		}
+		d.ingestBufferSize = size
+	}
+	return nil
 }
 
 func parseIngestBufferSize(v any) (int, error) {
@@ -106,314 +99,52 @@ func parseIngestBufferSize(v any) (int, error) {
 	return n, nil
 }
 
-func (d *snmpDiscoveryBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
-	config map[string]any, common config.BackendCommons, _ filesmgr.Manager,
-) error {
-	d.logger = logger.With("backend", "snmp_discovery")
-	d.policyRepo = repo
-	d.diodeTargetFromOtel = false
-
-	var prs bool
-	if d.apiHost, prs = config["host"].(string); !prs {
-		d.apiHost = defaultAPIHost
-	}
-	if port, prs := config["port"]; prs {
-		d.apiPort = fmt.Sprintf("%v", port)
-	} else {
-		d.apiPort = defaultAPIPort
-	}
-
-	d.ingestBufferSize = defaultIngestBufferSize
-	if v, prs := config["ingest_buffer_size"]; prs {
-		size, err := parseIngestBufferSize(v)
-		if err != nil {
-			return fmt.Errorf("snmp_discovery: %w", err)
-		}
-		d.ingestBufferSize = size
-	}
-
-	d.diodeTarget = common.Diode.Target
-	d.diodeClientID = common.Diode.ClientID
-	d.diodeClientSecret = common.Diode.ClientSecret
-	d.diodeAppNamePrefix = common.Diode.AgentName
-	d.diodeDryRun = common.Diode.DryRun
-	d.diodeDryRunOutputDir = common.Diode.DryRunOutputDir
-
-	if target, prs := config["target"].(string); prs {
-		d.diodeTarget = target
-	}
-	if clientID, prs := config["client_id"].(string); prs {
-		d.diodeClientID = clientID
-	}
-	if clientSecret, prs := config["client_secret"].(string); prs {
-		d.diodeClientSecret = clientSecret
-	}
-	if agentName, prs := config["agent_name"].(string); prs {
-		d.diodeAppNamePrefix = agentName
-	}
-	if dryRun, prs := config["dry_run"].(bool); prs {
-		d.diodeDryRun = dryRun
-	}
-	if dryRunOutputDir, prs := config["dry_run_output_dir"].(string); prs {
-		d.diodeDryRunOutputDir = dryRunOutputDir
-	}
-	if logLevel, prs := config["log_level"].(string); prs {
-		d.diodeLogLevel = logLevel
-	} else if debug, prs := config["debug"].(bool); prs && debug {
-		d.diodeLogLevel = "debug"
-	} else if logger.Enabled(context.Background(), slog.LevelDebug) {
-		d.diodeLogLevel = "debug"
-	}
-
-	if common.Otlp.Grpc != "" {
-		d.diodeOtelEndpoint = common.Otlp.Grpc
-		d.logger.Info("snmp-discovery using OTLP metrics endpoint",
-			"endpoint", d.diodeOtelEndpoint)
-	}
-	if d.diodeTarget == "" && d.diodeOtelEndpoint != "" {
-		d.diodeTarget = d.diodeOtelEndpoint
-		d.diodeTargetFromOtel = true
-	}
-
-	return nil
-}
-
-func (d *snmpDiscoveryBackend) Version() (string, error) {
-	var info info
-	url := fmt.Sprintf("%s://%s:%s/api/v1/status", d.apiProtocol, d.apiHost, d.apiPort)
-	err := backend.CommonRequest("snmp-discovery", d.proc, d.logger, url, &info, http.MethodGet,
-		http.NoBody, "application/json", versionTimeout, "detail")
-	if err != nil {
-		return "", err
-	}
-	return info.Version, nil
-}
-
-func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.CancelFunc) error {
-	d.startTime = time.Now()
-	d.cancelFunc = cancelFunc
-	d.ctx = ctx
-
+func (d *snmpDiscoveryBackend) buildArgs() []string {
 	dOptions := []string{
-		"--diode-app-name-prefix", d.diodeAppNamePrefix,
-		"--host", d.apiHost,
-		"--port", d.apiPort,
+		"--diode-app-name-prefix", d.DiodeAppNamePrefix,
+		"--host", d.APIHost,
+		"--port", d.APIPort,
 		"--ingest-buffer-size", fmt.Sprintf("%d", d.ingestBufferSize),
 	}
-	if d.diodeDryRun {
+	if d.DiodeDryRun {
 		dOptions = append([]string{
 			"--dry-run",
-			"--dry-run-output-dir", d.diodeDryRunOutputDir,
+			"--dry-run-output-dir", d.DiodeDryRunOutputDir,
 		}, dOptions...)
 	} else {
 		opts := []string{
-			"--diode-target", d.diodeTarget,
+			"--diode-target", d.DiodeTarget,
 		}
-		if !d.diodeTargetFromOtel {
+		if !d.DiodeTargetFromOtel {
 			opts = append(opts,
-				"--diode-client-id", d.diodeClientID,
-				"--diode-client-secret", d.diodeClientSecret,
+				"--diode-client-id", d.DiodeClientID,
+				"--diode-client-secret", d.DiodeClientSecret,
 			)
 		}
 		dOptions = append(opts, dOptions...)
 	}
 
-	if d.diodeLogLevel != "" {
-		dOptions = append(dOptions, "--log-level", d.diodeLogLevel)
-		d.logger.Info("snmp-discovery using log level",
-			"log_level", d.diodeLogLevel)
+	if d.DiodeLogLevel != "" {
+		dOptions = append(dOptions, "--log-level", d.DiodeLogLevel)
+		d.Logger.Info("snmp-discovery using log level",
+			"log_level", d.DiodeLogLevel)
 	}
 
-	if d.diodeOtelEndpoint != "" {
-		dOptions = append(dOptions, "--otel-endpoint", d.diodeOtelEndpoint)
-		d.logger.Info("snmp-discovery using OTLP endpoint",
-			"endpoint", d.diodeOtelEndpoint)
+	if d.DiodeOtelEndpoint != "" {
+		dOptions = append(dOptions, "--otel-endpoint", d.DiodeOtelEndpoint)
+		d.Logger.Info("snmp-discovery using OTLP endpoint",
+			"endpoint", d.DiodeOtelEndpoint)
 	}
 
-	d.logger.Info("snmp-discovery startup", "arguments", redact.Args(dOptions))
-
-	d.proc = backend.NewCmdOptions(backend.CmdOptions{
-		Buffered:  false,
-		Streaming: true,
-	}, d.exec, dOptions...)
-	d.statusChan = d.proc.Start()
-
-	// log STDOUT and STDERR lines streaming from Cmd
-	doneChan := make(chan struct{})
-	go func() {
-		defer func() {
-			if doneChan != nil {
-				close(doneChan)
-			}
-		}()
-		stdout := d.proc.GetStdout()
-		stderr := d.proc.GetStderr()
-		for stdout != nil || stderr != nil {
-			select {
-			case line, open := <-stdout:
-				if !open {
-					stdout = nil
-					continue
-				}
-				d.logSnmpDiscoveryOutput(line, slog.LevelInfo)
-			case line, open := <-stderr:
-				if !open {
-					stderr = nil
-					continue
-				}
-				d.logSnmpDiscoveryOutput(line, slog.LevelError)
-			}
-		}
-	}()
-
-	// wait for simple startup errors
-	time.Sleep(time.Second)
-
-	status := d.proc.Status()
-
-	if status.Error != nil {
-		d.logger.Error("snmp-discovery startup error", "error", status.Error)
-		return status.Error
-	}
-
-	if status.Complete {
-		err := d.proc.Stop()
-		if err != nil {
-			d.logger.Error("proc.Stop error", "error", err)
-		}
-		return errors.New("snmp-discovery startup error, check log")
-	}
-
-	d.logger.Info("snmp-discovery process started", "pid", status.PID)
-
-	var version string
-	var readinessErr error
-	for backoff := 1; backoff <= readinessBackoff; backoff++ {
-		if status := d.proc.Status(); status.Complete {
-			err := d.proc.Stop()
-			if err != nil {
-				d.logger.Error("proc.Stop error", "error", err)
-			}
-			return errors.New("snmp-discovery process ended unexpectedly, check log")
-		}
-		version, readinessErr = d.Version()
-		if readinessErr == nil {
-			d.logger.Info("snmp-discovery readiness ok, got version", "version", version)
-			break
-		}
-		backoffDuration := time.Duration(backoff) * time.Second
-		d.logger.Info("snmp-discovery is not ready, trying again with backoff",
-			"backoff backoffDuration", backoffDuration.String())
-		time.Sleep(backoffDuration)
-	}
-
-	if readinessErr != nil {
-		d.logger.Error("snmp-discovery error on readiness", "error", readinessErr)
-		err := d.proc.Stop()
-		if err != nil {
-			d.logger.Error("proc.Stop error", "error", err)
-		}
-		return readinessErr
-	}
-
-	return nil
+	return dOptions
 }
 
-func (d *snmpDiscoveryBackend) Stop(ctx context.Context) error {
-	d.logger.Info("routine call to stop snmp-discovery", "routine", ctx.Value(config.ContextKey("routine")))
-	defer d.cancelFunc()
-	backend.StopProcess(d.logger, d.proc, d.statusChan, backend.DefaultStopGracePeriod, "snmp_discovery")
-	return nil
-}
-
-func (d *snmpDiscoveryBackend) FullReset(ctx context.Context) error {
-	// force a stop, which stops scrape as well. if proc is dead, it no ops.
-	if state, _, _ := backend.GetRunningStatus(d.proc); state == backend.Running {
-		if err := d.Stop(ctx); err != nil {
-			d.logger.Error("failed to stop backend on restart procedure", "error", err)
-			return err
-		}
-	}
-	// for each policy, restart the scraper
-	backendCtx, cancelFunc := context.WithCancel(context.WithValue(ctx, config.ContextKey("routine"), "snmp-discovery"))
-	// start it
-	if err := d.Start(backendCtx, cancelFunc); err != nil {
-		d.logger.Error("failed to start backend on restart procedure", "error", err)
-		return err
-	}
-	return nil
-}
-
-func (d *snmpDiscoveryBackend) GetStartTime() time.Time {
-	return d.startTime
-}
-
-func (d *snmpDiscoveryBackend) GetCapabilities() (map[string]any, error) {
-	caps := make(map[string]any)
-	url := fmt.Sprintf("%s://%s:%s/api/v1/capabilities", d.apiProtocol, d.apiHost, d.apiPort)
-	err := backend.CommonRequest("snmp-discovery", d.proc, d.logger, url, &caps, http.MethodGet,
-		http.NoBody, "application/json", capabilitiesTimeout, "detail")
-	if err != nil {
-		return nil, err
-	}
-	return caps, nil
-}
-
-func (d *snmpDiscoveryBackend) GetRunningStatus() (backend.RunningStatus, string, error) {
-	// first check process status
-	runningStatus, errMsg, err := backend.GetRunningStatus(d.proc)
-	// if it's not running, we're done
-	if runningStatus != backend.Running {
-		return runningStatus, errMsg, err
-	}
-	// if it's running, check REST API availability too
-	if _, aiErr := d.Version(); aiErr != nil {
-		// process is running, but REST API is not accessible
-		return backend.BackendError, "process running, REST API unavailable", aiErr
-	}
-	return runningStatus, "", nil
-}
-
-func (d *snmpDiscoveryBackend) GetInitialState() backend.RunningStatus {
-	return backend.Unknown
-}
-
-func (d *snmpDiscoveryBackend) ApplyPolicy(data policies.PolicyData, updatePolicy bool) error {
-	if updatePolicy {
-		// To update a policy it's necessary first remove it and then apply a new version
-		if err := d.RemovePolicy(data); err != nil {
-			d.logger.Warn("policy failed to remove", "policy_id", data.ID,
-				"policy_name", data.Name, "error", err)
-		}
+func (d *snmpDiscoveryBackend) logLineAdapter(line string, isStderr bool) {
+	fallback := slog.LevelInfo
+	if isStderr {
+		fallback = slog.LevelError
 	}
 
-	d.logger.Debug("snmp-discovery policy apply", "policy_id", data.ID, "data", data.Data)
-
-	fullPolicy := map[string]any{
-		"policies": map[string]any{
-			data.Name: data.Data,
-		},
-	}
-
-	policyYaml, err := yaml.Marshal(fullPolicy)
-	if err != nil {
-		d.logger.Warn("policy yaml marshal failure", "policy_id", data.ID, "policy_name", data.Name)
-		return err
-	}
-
-	var resp map[string]any
-	url := fmt.Sprintf("%s://%s:%s/api/v1/%s", d.apiProtocol, d.apiHost, d.apiPort, "policies")
-	err = backend.CommonRequest("snmp-discovery", d.proc, d.logger, url, &resp, http.MethodPost,
-		bytes.NewBuffer(policyYaml), "application/x-yaml", applyPolicyTimeout, "detail")
-	if err != nil {
-		d.logger.Warn("policy application failure", "policy_id", data.ID, "policy_name", data.Name)
-		return err
-	}
-
-	return nil
-}
-
-func (d *snmpDiscoveryBackend) logSnmpDiscoveryOutput(line string, fallback slog.Level) {
 	trimmed := strings.TrimSpace(line)
 	if trimmed == "" {
 		return
@@ -429,38 +160,10 @@ func (d *snmpDiscoveryBackend) logSnmpDiscoveryOutput(line string, fallback slog
 		level = parsedLevel
 	}
 
-	ctx := d.ctx
+	ctx := d.Ctx
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
-	d.logger.LogAttrs(ctx, level, msg, attrs...)
-}
-
-func (d *snmpDiscoveryBackend) RemovePolicy(data policies.PolicyData) error {
-	d.logger.Debug("snmp-discovery policy remove", "policy_id", data.ID)
-	var resp any
-	name := data.Name
-	// Since we use Name for removing policies not IDs, if there is a change, we need to remove the previous name of the policy
-	if data.PreviousPolicyData != nil && data.PreviousPolicyData.Name != data.Name {
-		name = data.PreviousPolicyData.Name
-	}
-	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", d.apiProtocol, d.apiHost, d.apiPort, name)
-	err := backend.CommonRequest("snmp-discovery", d.proc, d.logger, url, &resp, http.MethodDelete,
-		http.NoBody, "application/json", removePolicyTimeout, "detail")
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (d *snmpDiscoveryBackend) GetPolicyStatus() ([]backend.PolicyStatus, error) {
-	var resp backend.StatusResponse
-	url := fmt.Sprintf("%s://%s:%s/api/v1/status", d.apiProtocol, d.apiHost, d.apiPort)
-	err := backend.CommonRequest("snmp-discovery", d.proc, d.logger, url, &resp, http.MethodGet,
-		http.NoBody, "application/json", statusTimeout, "detail")
-	if err != nil {
-		return nil, err
-	}
-	return resp.Policies, nil
+	d.Logger.LogAttrs(ctx, level, msg, attrs...)
 }


### PR DESCRIPTION
## Stage 3 of 3 — discovery base for the four diode backends

Final stacked PR. **Base: the Stage 2 branch (`refactor/be-dedup-2-process-helpers`)** — review/merge Stages 1 and 2 first; this diff shows only Stage 3.

Introduces `agent/backend/discovery.Base` (exported, embeddable) and migrates the four diode backends (network / snmp / device / gnmi) onto it, replacing each one's duplicated `Configure` / `Start` / `Stop` / `FullReset` / REST methods with the shared base. Per-backend deltas are wired via three exported func-field hooks (`BuildArgs` / `LogLine` / `ConfigureExtra`); gnmi keeps its `GetPolicyStatus` override (target→targets remap). Net for this stage: roughly −450 LOC.

Notes for reviewers:
- `Base` and its hook/field set are **exported** because the four embedders live in separate packages and Go does not promote unexported fields across packages.
- Each backend's default port is seeded in `Register()` (network 8073 / snmp 8070 / device 8072 / gnmi 8075); the base reads `port` from config only when present.
- `buildArgs` is copied verbatim per backend (flags + conditionals unchanged); device's colon normalizer and snmp's `ingest_buffer_size` validation are preserved via the hooks.

### Sanctioned behavior changes (intentional)
- `RemovePolicy` now path-escapes the policy name for network/snmp/device (gnmi already did).
- snmp readiness backoff normalized `1..10` → `0..9` (~55s → ~45s).
- snmp's Configure OTLP-endpoint log `"using OTLP metrics endpoint"` → `"using OTLP endpoint"` (majority form).
- Start-failure teardown via `StopProcess` for the four (gnmi already did).

Everything else — emitted flags, REST contracts, per-backend log output, error strings — is unchanged, guarded by each backend's existing tests.

## Verification
- `go build ./...`, `go test -race ./agent/backend/...` green (incl. a synthetic-embedder suite for the base: RemovePolicy path-escape, both name-form assertions, Configure ordering).
- `golangci-lint run ./agent/... --config .github/golangci.yaml` — 0 issues; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
