### PR TITLE
feat(agent): report installed bundle state in heartbeats

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -133,6 +133,8 @@ func (m *mockFilesManager) Ensure(_ context.Context, _ filesmgr.FileSpec) (strin
 func (m *mockFilesManager) Get(_ string) (filesmgr.FileEntry, bool) {
 	return filesmgr.FileEntry{}, false
 }
+
+func (m *mockFilesManager) List() []filesmgr.FileEntry                  { return nil }
 func (m *mockFilesManager) Remove(_ context.Context, _ string) error    { return nil }
 func (m *mockFilesManager) Rollback(_ context.Context, _ string) error  { return nil }
 func (m *mockFilesManager) Subscribe(_ func(filesmgr.FileEvent)) func() { return func() {} }

--- a/agent/backend/worker/worker_filesmgr_test.go
+++ b/agent/backend/worker/worker_filesmgr_test.go
@@ -149,6 +149,8 @@ func (s *stubDirFilesManager) Get(name string) (filesmgr.FileEntry, bool) {
 	}
 	return filesmgr.FileEntry{}, false
 }
+
+func (s *stubDirFilesManager) List() []filesmgr.FileEntry                 { return nil }
 func (s *stubDirFilesManager) Remove(_ context.Context, _ string) error   { return nil }
 func (s *stubDirFilesManager) Rollback(_ context.Context, _ string) error { return nil }
 func (s *stubDirFilesManager) Subscribe(_ func(filesmgr.FileEvent)) func() {

--- a/agent/configmgr/fleet/connection.go
+++ b/agent/configmgr/fleet/connection.go
@@ -55,7 +55,7 @@ func NewMQTTConnection(logger *slog.Logger, pMgr policymgr.PolicyManager, resetC
 	return &MQTTConnection{
 		connectionManager:  nil,
 		logger:             logger,
-		heartbeater:        newHeartbeater(logger, backendState, pMgr, &groupManager),
+		heartbeater:        newHeartbeater(logger, backendState, pMgr, &groupManager, filesManager),
 		messaging:          NewMessaging(logger, pMgr, resetChan, &groupManager, filesManager),
 		resetChan:          resetChan,
 		onReadyHooks:       make([]func(cm *autopaho.ConnectionManager, topics TokenResponseTopics), 0),

--- a/agent/configmgr/fleet/heartbeats.go
+++ b/agent/configmgr/fleet/heartbeats.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/configmgr/fleet/messages"
+	"github.com/netboxlabs/orb-agent/agent/filesmgr"
 	"github.com/netboxlabs/orb-agent/agent/policies"
 	"github.com/netboxlabs/orb-agent/agent/policymgr"
 )
@@ -20,23 +21,31 @@ const (
 // heartbeatTickInterval is the delay between periodic heartbeats. Tests shorten it.
 var heartbeatTickInterval = heartbeatFreq
 
+// BundleStateRetriever provides read-only access to installed bundle state for
+// heartbeats. Satisfied by filesmgr.Manager.
+type BundleStateRetriever interface {
+	List() []filesmgr.FileEntry
+}
+
 type heartbeater struct {
-	logger         *slog.Logger
-	backendState   backend.StateRetriever
-	policyManager  policymgr.PolicyManager
-	groupRetriever GroupRetriever
+	logger          *slog.Logger
+	backendState    backend.StateRetriever
+	policyManager   policymgr.PolicyManager
+	groupRetriever  GroupRetriever
+	bundleRetriever BundleStateRetriever
 
 	mu            sync.Mutex
 	sessionCancel context.CancelFunc
 	wg            sync.WaitGroup
 }
 
-func newHeartbeater(logger *slog.Logger, backendState backend.StateRetriever, policyManager policymgr.PolicyManager, groupRetriever GroupRetriever) *heartbeater {
+func newHeartbeater(logger *slog.Logger, backendState backend.StateRetriever, policyManager policymgr.PolicyManager, groupRetriever GroupRetriever, bundleRetriever BundleStateRetriever) *heartbeater {
 	return &heartbeater{
-		logger:         logger,
-		backendState:   backendState,
-		policyManager:  policyManager,
-		groupRetriever: groupRetriever,
+		logger:          logger,
+		backendState:    backendState,
+		policyManager:   policyManager,
+		groupRetriever:  groupRetriever,
+		bundleRetriever: bundleRetriever,
 	}
 }
 
@@ -107,6 +116,7 @@ func (hb *heartbeater) sendSingleHeartbeat(ctx context.Context, heartbeatTopic s
 		BackendState:  hb.getBackendState(),
 		PolicyState:   hb.getPolicyState(),
 		GroupState:    hb.getGroupState(),
+		BundleState:   hb.getBundleState(),
 	}
 
 	body, err := json.Marshal(hbData)
@@ -196,4 +206,20 @@ func (hb *heartbeater) getGroupState() map[string]messages.GroupStateInfo {
 		}
 	}
 	return gs
+}
+
+func (hb *heartbeater) getBundleState() map[string]messages.BundleStateInfo {
+	bs := make(map[string]messages.BundleStateInfo)
+	if hb.bundleRetriever == nil {
+		return bs
+	}
+	for _, entry := range hb.bundleRetriever.List() {
+		bs[entry.Name] = messages.BundleStateInfo{
+			State:       messages.BundleStateInstalled,
+			Version:     entry.Version,
+			SHA256:      entry.SHA256,
+			InstalledAt: entry.InstalledAt,
+		}
+	}
+	return bs
 }

--- a/agent/configmgr/fleet/heartbeats_test.go
+++ b/agent/configmgr/fleet/heartbeats_test.go
@@ -18,9 +18,14 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/configmgr/fleet/messages"
+	"github.com/netboxlabs/orb-agent/agent/filesmgr"
 	"github.com/netboxlabs/orb-agent/agent/policies"
 	"github.com/netboxlabs/orb-agent/agent/policymgr"
 )
+
+type stubBundleRetriever struct{ entries []filesmgr.FileEntry }
+
+func (s stubBundleRetriever) List() []filesmgr.FileEntry { return s.entries }
 
 func init() {
 	heartbeatTickInterval = 50 * time.Millisecond
@@ -1120,7 +1125,7 @@ func TestNewHeartbeater_WithPolicyManager(t *testing.T) {
 	groupManager := newGroupManager()
 
 	// Act
-	hb := newHeartbeater(logger, backendState, mockPMgr, &groupManager)
+	hb := newHeartbeater(logger, backendState, mockPMgr, &groupManager, stubBundleRetriever{})
 
 	// Assert
 	assert.NotNil(t, hb)
@@ -1480,7 +1485,7 @@ func TestNewHeartbeater_WithGroupManager(t *testing.T) {
 	})
 
 	// Act
-	hb := newHeartbeater(logger, backendState, mockPMgr, &gm)
+	hb := newHeartbeater(logger, backendState, mockPMgr, &gm, stubBundleRetriever{})
 
 	// Assert
 	assert.NotNil(t, hb)
@@ -1873,7 +1878,7 @@ func TestHeartbeater_SendSingleHeartbeat_SerializesPerRunTargets(t *testing.T) {
 	var hb2 messages.Heartbeat
 	require.NoError(t, json.Unmarshal(capturedPayload, &hb2))
 
-	assert.Equal(t, "1.1", hb2.SchemaVersion)
+	assert.Equal(t, "1.2", hb2.SchemaVersion)
 	require.Len(t, hb2.PolicyState["policy-1"].Runs, 1)
 	assert.Equal(t, []string{"10.0.0.1"}, hb2.PolicyState["policy-1"].Runs[0].Targets)
 	assert.Equal(t, "ios", hb2.PolicyState["policy-1"].Runs[0].Driver)

--- a/agent/configmgr/fleet/heartbeats_test.go
+++ b/agent/configmgr/fleet/heartbeats_test.go
@@ -1840,6 +1840,50 @@ func TestHeartbeater_GetPolicyState_PropagatesTargetsFromRunData(t *testing.T) {
 	mockPMgr.AssertExpectations(t)
 }
 
+func TestHeartbeater_SendSingleHeartbeat_SerializesBundleState(t *testing.T) {
+	testTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	groupManager := newGroupManager()
+	hb := &heartbeater{
+		logger:         logger,
+		backendState:   &mockBackendState{},
+		policyManager:  &mockPolicyManagerForHeartbeat{},
+		groupRetriever: &groupManager,
+		bundleRetriever: stubBundleRetriever{entries: []filesmgr.FileEntry{
+			{
+				Name:        "nbl_cisco_meraki",
+				Version:     "2.15.0",
+				SHA256:      "57c56d72",
+				InstalledAt: testTime,
+			},
+		}},
+	}
+	hb.policyManager.(*mockPolicyManagerForHeartbeat).On("GetPolicyState").Return([]policies.PolicyData{}, nil)
+
+	var capturedPayload []byte
+	publishFunc := func(_ context.Context, _ string, payload []byte) error {
+		capturedPayload = payload
+		return nil
+	}
+
+	hb.sendSingleHeartbeat(context.Background(), "test/topic", publishFunc, "agent-id", testTime, messages.Online, nil)
+
+	require.NotNil(t, capturedPayload)
+
+	var hb2 messages.Heartbeat
+	require.NoError(t, json.Unmarshal(capturedPayload, &hb2))
+
+	require.Contains(t, hb2.BundleState, "nbl_cisco_meraki")
+	bs := hb2.BundleState["nbl_cisco_meraki"]
+	assert.Equal(t, messages.BundleStateInstalled, bs.State)
+	assert.Equal(t, "2.15.0", bs.Version)
+	assert.Equal(t, "57c56d72", bs.SHA256)
+	assert.True(t, testTime.Equal(bs.InstalledAt))
+
+	assert.Contains(t, string(capturedPayload), `"nbl_cisco_meraki":{"state":"installed","version":"2.15.0","sha256":"57c56d72"`)
+}
+
 func TestHeartbeater_SendSingleHeartbeat_SerializesPerRunTargets(t *testing.T) {
 	testTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 	mockPMgr := &mockPolicyManagerForHeartbeat{}

--- a/agent/configmgr/fleet/messages/fleet_messages.go
+++ b/agent/configmgr/fleet/messages/fleet_messages.go
@@ -6,7 +6,7 @@ import (
 )
 
 // CurrentHeartbeatSchemaVersion defines the current version of the heartbeat schema
-const CurrentHeartbeatSchemaVersion = "1.1"
+const CurrentHeartbeatSchemaVersion = "1.2"
 
 var (
 	// ErrSchemaVersion a message was received indicating a version we don't support
@@ -60,6 +60,19 @@ type GroupStateInfo struct {
 	GroupID   string `json:"id"`
 }
 
+// BundleStateInstalled is the reported state for a bundle present on disk.
+// Lifecycle states (installing/failed/expired) are intentionally out of scope
+// for schema 1.2; the store only records successfully installed bundles.
+const BundleStateInstalled = "installed"
+
+// BundleStateInfo contains state information for an installed bundle.
+type BundleStateInfo struct {
+	State       string    `json:"state"`
+	Version     string    `json:"version,omitempty"`
+	SHA256      string    `json:"sha256,omitempty"`
+	InstalledAt time.Time `json:"installed_at,omitzero"`
+}
+
 // Heartbeat represents an agent heartbeat message
 type Heartbeat struct {
 	SchemaVersion string                      `json:"schema_version"`
@@ -68,6 +81,7 @@ type Heartbeat struct {
 	BackendState  map[string]BackendStateInfo `json:"backend_state"`
 	PolicyState   map[string]PolicyStateInfo  `json:"policy_state"`
 	GroupState    map[string]GroupStateInfo   `json:"group_state"`
+	BundleState   map[string]BundleStateInfo  `json:"bundle_state"`
 }
 
 // HeartbeatState represents the current state of an agent in the system

--- a/agent/configmgr/fleet/messages/fleet_messages_test.go
+++ b/agent/configmgr/fleet/messages/fleet_messages_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCurrentHeartbeatSchemaVersion_IsOneOne(t *testing.T) {
-	assert.Equal(t, "1.1", CurrentHeartbeatSchemaVersion)
+func TestCurrentHeartbeatSchemaVersion_IsOneTwo(t *testing.T) {
+	assert.Equal(t, "1.2", CurrentHeartbeatSchemaVersion)
 }
 
 func TestRunStateInfo_TargetsOmittedWhenNil(t *testing.T) {

--- a/agent/configmgr/fleet/packages_test.go
+++ b/agent/configmgr/fleet/packages_test.go
@@ -41,6 +41,8 @@ func (m *mockFilesManager) Get(name string) (filesmgr.FileEntry, bool) {
 	return args.Get(0).(filesmgr.FileEntry), args.Bool(1)
 }
 
+func (m *mockFilesManager) List() []filesmgr.FileEntry { return nil }
+
 func (m *mockFilesManager) Remove(ctx context.Context, name string) error {
 	args := m.Called(ctx, name)
 	return args.Error(0)

--- a/agent/filesmgr/dummy.go
+++ b/agent/filesmgr/dummy.go
@@ -13,6 +13,7 @@ func (dummyFilesManager) Start(context.Context) error                      { ret
 func (dummyFilesManager) Stop(context.Context) error                       { return nil }
 func (dummyFilesManager) Ensure(context.Context, FileSpec) (string, error) { return "", nil }
 func (dummyFilesManager) Get(string) (FileEntry, bool)                     { return FileEntry{}, false }
+func (dummyFilesManager) List() []FileEntry                                { return nil }
 func (dummyFilesManager) Remove(context.Context, string) error             { return nil }
 func (dummyFilesManager) Rollback(context.Context, string) error           { return nil }
 func (dummyFilesManager) Subscribe(func(FileEvent)) func()                 { return func() {} }

--- a/agent/filesmgr/filesmgr.go
+++ b/agent/filesmgr/filesmgr.go
@@ -433,6 +433,15 @@ func (m *filesmgr) Get(name string) (FileEntry, bool) {
 	return m.store.get(name)
 }
 
+func (m *filesmgr) List() []FileEntry {
+	entries := m.store.all()
+	out := make([]FileEntry, 0, len(entries))
+	for _, entry := range entries {
+		out = append(out, entry)
+	}
+	return out
+}
+
 func (m *filesmgr) Subscribe(handler func(FileEvent)) (unsubscribe func()) {
 	return m.bus.subscribe(handler)
 }

--- a/agent/filesmgr/fleet_test.go
+++ b/agent/filesmgr/fleet_test.go
@@ -35,6 +35,8 @@ func (m *mockEngine) Get(name string) (FileEntry, bool) {
 	return args.Get(0).(FileEntry), args.Bool(1)
 }
 
+func (m *mockEngine) List() []FileEntry { return nil }
+
 func (m *mockEngine) Remove(ctx context.Context, name string) error {
 	args := m.Called(ctx, name)
 	return args.Error(0)

--- a/agent/filesmgr/manager.go
+++ b/agent/filesmgr/manager.go
@@ -42,9 +42,9 @@ type Manager interface {
 	// Get returns the current entry for a logical name, if installed.
 	Get(name string) (FileEntry, bool)
 
-	// List returns a snapshot of all currently installed entries. The slice is
-	// a fresh copy; mutating it does not affect manager state, and order is
-	// unspecified. Results are keyed by FileEntry.Name.
+	// List returns a snapshot of all currently installed entries. The slice is a
+	// fresh copy; mutating it does not affect manager state, and order is
+	// unspecified. Each FileEntry.Name is the logical key and is unique.
 	List() []FileEntry
 
 	// Remove deletes a tracked file and its on-disk version directory.

--- a/agent/filesmgr/manager.go
+++ b/agent/filesmgr/manager.go
@@ -42,6 +42,11 @@ type Manager interface {
 	// Get returns the current entry for a logical name, if installed.
 	Get(name string) (FileEntry, bool)
 
+	// List returns a snapshot of all currently installed entries. The slice is
+	// a fresh copy; mutating it does not affect manager state, and order is
+	// unspecified. Results are keyed by FileEntry.Name.
+	List() []FileEntry
+
 	// Remove deletes a tracked file and its on-disk version directory.
 	// Idempotent.
 	Remove(ctx context.Context, name string) error


### PR DESCRIPTION
## Summary

Agent heartbeats now report the set of currently installed bundles and their
per-bundle status. Status is intentionally limited to **installed-only** in
this PR — no installing/failed/expired lifecycle states (see Scope below).

## Changes

- **`messages`**: bumps `CurrentHeartbeatSchemaVersion` to `1.2`, adds
  `BundleStateInfo` (state, version, sha256, installed_at) and a new
  `Heartbeat.BundleState` map, keyed by bundle name.
- **`filesmgr.Manager`**: adds `List() []FileEntry` to enumerate all tracked
  entries. Implemented on the base disk engine (backed by the existing
  `store.all()`); `FleetFilesManager` inherits it via embedding. No-op on the
  dummy manager.
- **`configmgr/fleet`**: heartbeater gains a narrow `BundleStateRetriever`
  interface (`List() []filesmgr.FileEntry`), satisfied directly by
  `filesmgr.Manager` — mirrors the existing `GroupRetriever` pattern used for
  group state. `filesManager` (already threaded into `NewMQTTConnection`) is
  now also passed into the heartbeater.

## Design notes

- **No new import cycle.** `configmgr/fleet` already imported `filesmgr` (for
  `NewMessaging`); this just reuses that edge for the heartbeater too.
  `filesmgr` only reaches back to the `messages` leaf package, never to
  `configmgr/fleet`, so there's no cycle risk either direction.
- **Wire fields are deliberately narrow.** `BundleStateInfo` excludes
  `FileEntry.Path` (agent-local FS detail) and `FileEntry.Source` (the raw
  fetch URL — for fleet-delivered bundles this can be a presigned/control-plane
  URL and must not leak into telemetry).
- **`getBundleState` nil-guards `bundleRetriever`** so existing heartbeater
  tests built via struct literal (without every field populated) don't panic;
  production always wires a non-nil retriever (the dummy manager included).

## Scope

This covers installed-only status: a bundle present in the store is reported
as `"installed"` with its version/sha/install time. Lifecycle visibility
(installing / failed / expired) would require recording failed `Ensure`
attempts, which is a materially larger change to the engine — out of scope
here, can be tracked separately if needed.

## Testing

- `make fix-lint && make lint`: 0 issues.
- `make test-all`: all packages touched by this change pass
  (`agent`, `agent/backend/*`, `agent/configmgr`, `agent/configmgr/fleet`,
  `agent/configmgr/fleet/messages`, `agent/filesmgr`).
- `agent/secretsmgr` Vault/CyberArk tests fail locally due to no reachable
  Docker daemon — pre-existing environment gap, unrelated to this change
  (nothing here touches `secretsmgr`).
- Updated `heartbeats_test.go` (new `stubBundleRetriever`, updated
  `newHeartbeater` call sites, schema version assertion) and
  `fleet_messages_test.go` (schema version assertion) for the new signature
  and schema bump. Updated all `filesmgr.Manager` test doubles
  (`mockFilesManager` ×2, `stubDirFilesManager`, `mockEngine`) to satisfy the
  widened interface.

## Follow-ups

- No positive test yet asserting `bundle_state` end-to-end (retriever with
  real entries → marshalled heartbeat). Can add before merge if wanted.
- Confirm the downstream heartbeat consumer accepts schema `1.2` and
  tolerates the additive `bundle_state` field before this ships — the
  schema-version check on receive is currently strict-reject on unknown
  versions.