### PR TITLE
feat(agent): add provider-agnostic secret reference scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Supported secrets managers:
 - [Delinea Secret Server](./docs/secretsmgr/delinea.md)
 - [Delinea DevOps Secrets Vault (DSV)](./docs/secretsmgr/dsv.md)
 
+Regardless of which provider is active, policies can also reference secrets via the
+provider-agnostic [`${secret://…}` scheme](./docs/secretsmgr/secret_references.md).
+
 The secrets manager to use, and its connection settings, can also be selected and configured entirely via environment variables — independently of the config manager and without editing the YAML file. See [Environment-Driven Configuration](./docs/advanced_config/env_config.md).
 
 ### Environment variable configuration

--- a/agent/secretsmgr/fleet.go
+++ b/agent/secretsmgr/fleet.go
@@ -21,7 +21,11 @@ import (
 var _ Manager = (*FleetSecretsManager)(nil)
 
 // fleetRefRegex matches fleet secret references in the format ${fleet://path}
-var fleetRefRegex = regexp.MustCompile(`\${fleet://([^}]+)}`)
+// or the provider-agnostic ${secret://path} form. The body uses * (zero or
+// more) so an empty body like "${secret://}" still matches and is rejected
+// with a clear error instead of leaking the literal placeholder to the
+// backend — mirroring the shared resolver.
+var fleetRefRegex = regexp.MustCompile(`\${(?:fleet|` + genericScheme + `)://([^}]*)}`)
 
 const defaultSecretRequestTimeout = 30 * time.Second
 
@@ -345,7 +349,9 @@ func collectFleetPaths(v any, set map[string]struct{}) {
 		// Align with processString: only the first ${fleet://...} is resolved; the rest
 		// of the string is discarded when substituting (legacy single-token behavior).
 		idx := fleetRefRegex.FindStringSubmatchIndex(val)
-		if len(idx) >= 4 {
+		if len(idx) >= 4 && idx[2] != idx[3] {
+			// empty bodies are skipped here; processString rejects them with
+			// a clear error rather than requesting an empty path
 			set[val[idx[2]:idx[3]]] = struct{}{}
 		}
 	case map[string]any:
@@ -447,6 +453,9 @@ func (f *FleetSecretsManager) processString(s string, id string) (string, error)
 	}
 
 	fleetPath := s[match[2]:match[3]]
+	if fleetPath == "" {
+		return "", fmt.Errorf("invalid fleet secret reference: empty body in %s", s)
+	}
 
 	// Check if secret exists in cache and update policy tracking
 	f.mu.Lock()
@@ -527,7 +536,7 @@ func (f *FleetSecretsManager) requestSecrets(ctx context.Context, paths []string
 
 	f.logger.Info("requesting secrets", "paths", paths, "policy_ids", policyIDs)
 	if f.publisher == nil {
-		return nil, fmt.Errorf("MQTT publisher not bound")
+		return nil, fmt.Errorf("MQTT publisher not bound: the fleet secrets manager has no active MQTT session; note that secret references inside the agent configuration are resolved at startup, before the session is established, and always fail here — use them in policies instead")
 	}
 
 	requestID := uuid.New().String()

--- a/agent/secretsmgr/fleet_test.go
+++ b/agent/secretsmgr/fleet_test.go
@@ -48,6 +48,35 @@ func TestFleetSecretsManager_processString(t *testing.T) {
 		assert.Equal(t, "secretvalue", result)
 	})
 
+	t.Run("valid generic secret reference", func(t *testing.T) {
+		fm := NewFleetSecretsManager(logger, config.FleetSecretsManager{Timeout: intPtr(5)})
+		fm.ctx = ctx
+		fm.requestTopic = "test/request"
+		fm.responseTopic = "test/response"
+		fm.updatedTopic = "test/updated"
+
+		mockPub := &asyncMockPublisher{fm: fm}
+		fm.publisher = mockPub
+		fm.subscriber = &mockSubscriber{}
+
+		result, err := fm.processString("${secret://orb/agents/database/password}", "policy1")
+		assert.NoError(t, err)
+		assert.Equal(t, "secretvalue", result)
+	})
+
+	t.Run("empty body rejected", func(t *testing.T) {
+		// An empty body must produce a clear error rather than leaking the
+		// literal placeholder to the backend, for both reference forms.
+		fm := NewFleetSecretsManager(logger, config.FleetSecretsManager{Timeout: intPtr(1)})
+		fm.ctx = ctx
+
+		_, err := fm.processString("${fleet://}", "policy1")
+		assert.ErrorContains(t, err, "empty body")
+
+		_, err = fm.processString("${secret://}", "policy1")
+		assert.ErrorContains(t, err, "empty body")
+	})
+
 	t.Run("cached secret", func(t *testing.T) {
 		fm := NewFleetSecretsManager(logger, config.FleetSecretsManager{Timeout: intPtr(1)})
 		fm.ctx = ctx

--- a/agent/secretsmgr/manager.go
+++ b/agent/secretsmgr/manager.go
@@ -51,10 +51,35 @@ func (v *dummyManager) Start(_ context.Context) error {
 func (v *dummyManager) RegisterUpdatePoliciesCallback(_ func(map[string]bool)) {
 }
 
+// SolvePolicySecrets passes provider-specific placeholders through untouched
+// (pre-existing behavior), but fails fast on a generic ${secret://…} reference:
+// it explicitly asks for the active secrets manager, and there is none — better
+// a clear error than the literal placeholder reaching the backend.
 func (v *dummyManager) SolvePolicySecrets(payload config.PolicyPayload) (config.PolicyPayload, error) {
+	if _, err := processValue(payload.Data, genericScheme, payload.ID, rejectGenericRef); err != nil {
+		return payload, err
+	}
 	return payload, nil
 }
 
+// SolveConfigSecrets applies the same fail-fast rule to config-level values.
 func (v *dummyManager) SolveConfigSecrets(backends map[string]any, configManager config.ManagerConfig) (map[string]any, config.ManagerConfig, error) {
+	if _, err := processValue(backends, genericScheme, "_backends", rejectGenericRef); err != nil {
+		return backends, configManager, err
+	}
+	cmMap, err := structToMap(configManager)
+	if err != nil {
+		return backends, configManager, err
+	}
+	if _, err := processValue(cmMap, genericScheme, "_config_manager", rejectGenericRef); err != nil {
+		return backends, configManager, err
+	}
 	return backends, configManager, nil
+}
+
+// rejectGenericRef is the dummy manager's resolver: any ${secret://…} reference
+// is an error because no secrets manager is configured to resolve it. The
+// message is neutral because the reference may sit in a policy or in config.
+func rejectGenericRef(body, _ string) (string, error) {
+	return "", fmt.Errorf("a managed secret reference (${secret://%s}) was found but no secrets manager is configured", body)
 }

--- a/agent/secretsmgr/manager_test.go
+++ b/agent/secretsmgr/manager_test.go
@@ -1,0 +1,99 @@
+package secretsmgr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/config"
+)
+
+// TestDummyManager_SolvePolicySecrets_GenericSchemeErrors verifies that the
+// dummy manager (active when no secrets manager is configured) fails fast on a
+// ${secret://…} reference instead of passing it through as a literal.
+func TestDummyManager_SolvePolicySecrets_GenericSchemeErrors(t *testing.T) {
+	dm := &dummyManager{}
+
+	payload := config.PolicyPayload{
+		ID: "policy1",
+		Data: map[string]any{
+			"key": "${secret://x}",
+		},
+	}
+
+	_, err := dm.SolvePolicySecrets(payload)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no secrets manager is configured")
+}
+
+// TestDummyManager_SolvePolicySecrets_ProviderSchemePassesThrough verifies
+// pre-existing behavior is unchanged: provider-specific placeholders and plain
+// values pass through untouched when no secrets manager is configured.
+func TestDummyManager_SolvePolicySecrets_ProviderSchemePassesThrough(t *testing.T) {
+	dm := &dummyManager{}
+
+	payload := config.PolicyPayload{
+		ID: "policy1",
+		Data: map[string]any{
+			"provider": "${vault://x}",
+			"plain":    "plain value",
+		},
+	}
+
+	out, err := dm.SolvePolicySecrets(payload)
+	require.NoError(t, err)
+	data := out.Data.(map[string]any)
+	assert.Equal(t, "${vault://x}", data["provider"])
+	assert.Equal(t, "plain value", data["plain"])
+}
+
+// TestDummyManager_SolveConfigSecrets_GenericSchemeErrors verifies the
+// config-secrets path also rejects a ${secret://…} reference found in the
+// backends map.
+func TestDummyManager_SolveConfigSecrets_GenericSchemeErrors(t *testing.T) {
+	dm := &dummyManager{}
+
+	backends := map[string]any{
+		"otel": map[string]any{"token": "${secret://y}"},
+	}
+
+	_, _, err := dm.SolveConfigSecrets(backends, config.ManagerConfig{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no secrets manager is configured")
+}
+
+// TestDummyManager_SolveConfigSecrets_ConfigManagerGenericSchemeErrors verifies
+// the ManagerConfig branch (structToMap round-trip) also rejects a ${secret://…}
+// reference — it is a distinct code path from the backends walk.
+func TestDummyManager_SolveConfigSecrets_ConfigManagerGenericSchemeErrors(t *testing.T) {
+	dm := &dummyManager{}
+
+	cm := config.ManagerConfig{}
+	cm.Sources.Fleet.ClientSecret = "${secret://x}"
+
+	_, _, err := dm.SolveConfigSecrets(map[string]any{}, cm)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no secrets manager is configured")
+}
+
+// TestDummyManager_SolveConfigSecrets_Passthrough verifies provider-specific
+// schemes, ${VAR} placeholders, and plain values pass through the config path
+// untouched with no error.
+func TestDummyManager_SolveConfigSecrets_Passthrough(t *testing.T) {
+	dm := &dummyManager{}
+
+	backends := map[string]any{
+		"otel": map[string]any{
+			"token": "${vault://kv/app/token}",
+			"plain": "just a value",
+		},
+	}
+	cm := config.ManagerConfig{}
+	cm.Sources.Fleet.ClientSecret = "${FLEET_CLIENT_SECRET}"
+
+	gotBackends, gotCM, err := dm.SolveConfigSecrets(backends, cm)
+	require.NoError(t, err)
+	assert.Equal(t, backends, gotBackends)
+	assert.Equal(t, cm, gotCM)
+}

--- a/agent/secretsmgr/polling_test.go
+++ b/agent/secretsmgr/polling_test.go
@@ -149,6 +149,52 @@ func TestPollingBase_SolvePolicySecrets(t *testing.T) {
 	require.Equal(t, "s3cret", auth["token"])
 }
 
+// TestPollingBase_SolvePolicySecrets_GenericScheme verifies that the
+// provider-agnostic ${secret://…} scheme resolves identically to the
+// provider's native scheme, and that a payload mixing both forms across two
+// separate string leaves resolves both.
+func TestPollingBase_SolvePolicySecrets_GenericScheme(t *testing.T) {
+	s := newStubFetcher()
+	s.setValue("TOKEN", "s3cret")
+	s.setValue("OTHER", "0th3r")
+	b := newBaseForTest(t, "scheme", s.fn)
+
+	payload := config.PolicyPayload{
+		ID: "p1",
+		Data: map[string]any{
+			"auth": map[string]any{
+				"native":  "${scheme://TOKEN}",
+				"generic": "${secret://OTHER}",
+			},
+		},
+	}
+	out, err := b.SolvePolicySecrets(payload)
+	require.NoError(t, err)
+	auth := out.Data.(map[string]any)["auth"].(map[string]any)
+	require.Equal(t, "s3cret", auth["native"])
+	require.Equal(t, "0th3r", auth["generic"])
+}
+
+// TestPollingBase_SolveConfigSecrets_GenericScheme verifies the config-secrets
+// path also accepts the provider-agnostic ${secret://…} scheme.
+func TestPollingBase_SolveConfigSecrets_GenericScheme(t *testing.T) {
+	s := newStubFetcher()
+	s.setValue("FS", "fs1")
+	b := newBaseForTest(t, "scheme", s.fn)
+
+	backends := map[string]any{}
+	cm := config.ManagerConfig{
+		Active: "fleet",
+		Sources: config.Sources{
+			Fleet: config.FleetManager{ClientSecret: "${secret://FS}"},
+		},
+	}
+
+	_, outCM, err := b.SolveConfigSecrets(backends, cm)
+	require.NoError(t, err)
+	require.Equal(t, "fs1", outCM.Sources.Fleet.ClientSecret)
+}
+
 func TestPollingBase_SolveConfigSecretsClearsTracking(t *testing.T) {
 	s := newStubFetcher()
 	s.setValue("BE", "be1")

--- a/agent/secretsmgr/resolver.go
+++ b/agent/secretsmgr/resolver.go
@@ -15,6 +15,10 @@ type cachedSecret struct {
 	policyIDs map[string]bool
 }
 
+// genericScheme is the provider-agnostic reference scheme: ${secret://…} is
+// resolved by whichever secrets manager is active.
+const genericScheme = "secret"
+
 // resolverFunc returns the resolved value for a single placeholder body
 // (the substring between "<scheme>://" and the closing "}"). policyID is the
 // policy that triggered the lookup; the resolver is expected to record it for
@@ -46,7 +50,7 @@ func processString(s, scheme, policyID string, resolve resolverFunc) (string, er
 	// matches and is forwarded to the resolver, which can reject it with
 	// a clear grammar error. A "+" quantifier would pass it through to the
 	// backend literally.
-	re := regexp.MustCompile(`\${` + regexp.QuoteMeta(scheme) + `://([^}]*)}`)
+	re := regexp.MustCompile(`\${(?:` + regexp.QuoteMeta(scheme) + `|` + regexp.QuoteMeta(genericScheme) + `)://([^}]*)}`)
 	if !re.MatchString(s) {
 		return s, nil
 	}

--- a/docs/secretsmgr/cyberark.md
+++ b/docs/secretsmgr/cyberark.md
@@ -60,7 +60,7 @@ The agent does not eagerly authenticate at startup — the first secret fetch is
 
 ## Usage
 
-The Orb Agent supports four reference shapes. Use whichever is most concise for your environment.
+The Orb Agent supports four reference shapes. Use whichever is most concise for your environment. In any of these forms, `${secret://…}` may be used instead of `${cyberark://…}` — see [Provider-agnostic secret references](./secret_references.md).
 
 > **Reserved characters.** The `/` character is reserved by the placeholder grammar and may not appear inside any AppID, Safe, Object, or Field name referenced from a placeholder. CyberArk itself permits a wider character set for these names; if your existing accounts use `/` in their identifiers, you must either rename them or open a follow-up issue requesting percent-escape (`%2F`) support.
 

--- a/docs/secretsmgr/delinea.md
+++ b/docs/secretsmgr/delinea.md
@@ -41,7 +41,7 @@ The Delinea SDK supports username/password authentication only. The Orb Agent us
 
 ## Usage
 
-To use a secret from Delinea in your policy configuration, use one of the two reference forms:
+To use a secret from Delinea in your policy configuration, use one of the two reference forms. In either form, `${secret://…}` may be used instead of `${delinea://…}` — see [Provider-agnostic secret references](./secret_references.md).
 
 ### By numeric secret ID
 

--- a/docs/secretsmgr/doppler.md
+++ b/docs/secretsmgr/doppler.md
@@ -43,7 +43,7 @@ The provider does not eagerly authenticate at startup — the first secret fetch
 
 ## Usage
 
-To use a secret from Doppler in your policy configuration, use one of the two reference forms:
+To use a secret from Doppler in your policy configuration, use one of the two reference forms. In either form, `${secret://…}` may be used instead of `${doppler://…}` — see [Provider-agnostic secret references](./secret_references.md).
 
 ### Short form (uses agent defaults)
 

--- a/docs/secretsmgr/secret_references.md
+++ b/docs/secretsmgr/secret_references.md
@@ -1,0 +1,67 @@
+# Provider-agnostic secret references
+
+Every secrets manager (Vault, Delinea, Doppler, CyberArk, and Fleet) accepts its own
+placeholder scheme — `${vault://…}`, `${delinea://…}`, `${doppler://…}`,
+`${cyberark://…}`, `${fleet://…}` — in policy and configuration fields. Alongside those,
+the Orb Agent also accepts a provider-agnostic scheme:
+
+```
+${secret://<body>}
+```
+
+`${secret://<body>}` is resolved by whichever secrets manager is **active** on the
+agent (the `secrets_manager.active` setting): Vault, Delinea, Doppler, CyberArk, or
+Fleet. This lets a policy or config value reference a managed secret without naming
+a specific provider, so the same placeholder can be reused across agents configured
+with different secrets managers.
+
+## Body grammar is unchanged
+
+`secret://` only replaces the provider name in the placeholder — it does not change
+how the body is interpreted. The active provider parses `<body>` exactly as it would
+the body of its own scheme. For example, if Vault is active:
+
+```
+${secret://kv//app/cred/password}
+```
+
+resolves identically to:
+
+```
+${vault://kv//app/cred/password}
+```
+
+See each provider's own documentation for its body grammar:
+
+- [HashiCorp Vault](./vault.md)
+- [Doppler](./doppler.md)
+- [CyberArk (CCP)](./cyberark.md)
+- [Delinea Secret Server](./delinea.md)
+- Fleet — path-style references (`${fleet://path}`) delivered by the fleet control plane
+
+Provider-specific schemes keep working unchanged — `${secret://…}` is purely an
+additional, optional alternative form; it does not deprecate or replace them.
+
+## No secrets manager configured
+
+If no secrets manager is active (`secrets_manager.active` is unset or invalid), a
+policy or config value that uses a `${secret://…}` reference fails fast with a
+clear error rather than being forwarded to the backend as a literal string:
+
+```
+a managed secret reference (${secret://<body>}) was found but no secrets manager is configured
+```
+
+Provider-specific schemes (`${vault://…}` etc.) keep their pre-existing behavior
+and pass through unresolved in this case.
+
+## Fleet secrets manager and config-level references
+
+With the **fleet** secrets manager active, secret references inside the agent's own
+configuration (backend settings, `config_manager` fields) cannot be resolved: config
+resolution runs at startup, before the MQTT session that fleet secret requests
+travel over is established, and the agent fails to start with a clear error. This
+is a pre-existing property of the fleet provider and applies equally to
+`${fleet://…}` and `${secret://…}` config references. References inside
+**policies** are unaffected — policies arrive after the connection is up. The
+other providers resolve config-level references at startup normally.

--- a/docs/secretsmgr/vault.md
+++ b/docs/secretsmgr/vault.md
@@ -88,7 +88,7 @@ auth_args:
 
 ## Usage
 
-The Orb Agent supports three reference grammars; pick whichever fits your Vault layout. They are checked in priority order — fully qualified, short form, then legacy.
+The Orb Agent supports three reference grammars; pick whichever fits your Vault layout. They are checked in priority order — fully qualified, short form, then legacy. In any of these forms, `${secret://…}` may be used instead of `${vault://…}` — see [Provider-agnostic secret references](./secret_references.md).
 
 ### Fully qualified (recommended for multi-segment mounts)
 


### PR DESCRIPTION
## What

Adds a provider-agnostic secret reference scheme: `${secret://<body>}` is resolved by whichever secrets manager is active on the agent (vault, delinea, doppler, cyberark, or fleet). A policy or config can now reference a managed secret without naming the provider, so the same reference works on any agent regardless of which secrets manager it is configured with, and upstream layers can submit references without knowing the agent's provider.

Fully backward compatible: the provider-specific schemes (`${vault://…}`, `${fleet://…}`, …) keep working unchanged. `secret` is a reserved scheme (no provider uses that name). The reference body stays in the active provider's own grammar — `secret://` removes the provider name from the reference, not the provider's path format.

## How

- `agent/secretsmgr/resolver.go`: the shared placeholder matcher now accepts the generic scheme as an alternative to the provider's own (`${(?:<scheme>|secret)://…}`, non-capturing so match indices are unchanged). All four polling providers pick this up with zero per-provider changes, for both policy and config resolution; first-match/whole-string semantics are untouched.
- `agent/secretsmgr/fleet.go`: same alternation in the fleet reference regex, so the generic scheme also works with the fleet secrets manager (policy references).
- Known limitation (pre-existing, now documented): with the fleet secrets manager active, secret references inside the agent's own CONFIG cannot resolve — config resolution runs at startup, before the MQTT session is established, and this has always been true for `${fleet://…}` config references. The previously cryptic `MQTT publisher not bound` error now explains this case. Policy references are unaffected.
- No secrets manager configured: a `${secret://…}` reference now fails fast with `a managed secret reference (${secret://…}) was found but no secrets manager is configured` — the generic scheme explicitly requests the active manager, so a clear error beats the literal placeholder reaching the backend. Provider-specific schemes keep their pre-existing passthrough behavior.

## Docs

New `docs/secretsmgr/secret_references.md` documenting the generic scheme, the per-provider body grammar, the no-manager fail-fast error, and the fleet config-level limitation; linked from the README and from each provider page.

## Testing

- Generic scheme resolves identically to the native scheme through the shared polling base (policy and config paths) and through the fleet manager.
- A payload mixing a native reference and a generic reference resolves both.
- Dummy manager: generic reference errors (policy path, backends map, and the ManagerConfig branch); provider-specific references and plain values pass through unchanged with no error.
- All existing tests pass unchanged. Gates: `go build ./...`, `go test -count=1 -race ./agent/secretsmgr/...` (including the Docker-backed Vault tests), `golangci-lint --config .github/golangci.yaml` = 0 issues, gofumpt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
