### PR TITLE
fix(agent): bump pip to 26.1.2 to fix CVE-2026-8643

### DIFF
--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -89,7 +89,7 @@ FROM netboxlabs/pktvisor:${PKTVISOR_TAG} AS pktvisor
 FROM python:3.14-alpine AS python-builder
 
 # Upgrade pip to latest version with fewer vulnerabilities
-RUN python -m pip install --upgrade --no-cache-dir pip==26.1 && \
+RUN python -m pip install --upgrade --no-cache-dir pip==26.1.2 && \
     rm -rf /usr/local/lib/python3.14/ensurepip/_bundled/pip-*.whl
 
 # Install the Python backends from in-repo source (was: published PyPI packages


### PR DESCRIPTION
pip 26.1 treats `console_scripts`/`gui_scripts` entry point names as paths without sanitizing the resolved absolute path against the installation directory, allowing a malicious wheel to overwrite arbitrary files during install ([CVE-2026-8643](https://avd.aquasec.com/nvd/cve-2026-8643), fixed in 26.1.2).

This is squarely in the agent's threat model: the worker backend pip-installs policy packages (`package: nbl_vmware_vcenter` etc.) at runtime, exercising pip's wheel-installation path on every deployment.

Closes code-scanning alert #235 (Trivy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)