### PR TITLE
feat(agent): log active secrets manager and startup result

### DIFF
--- a/agent/secretsmgr/cyberark.go
+++ b/agent/secretsmgr/cyberark.go
@@ -65,6 +65,8 @@ func (c *cyberarkManager) Start(ctx context.Context) error {
 		*f.ptr = resolved
 	}
 
+	c.preLogger.Info("starting secrets manager", "active", "cyberark", "url", c.config.URL)
+
 	if c.config.URL == "" {
 		return fmt.Errorf("cyberark: url is required")
 	}
@@ -149,7 +151,11 @@ func (c *cyberarkManager) Start(ctx context.Context) error {
 	}
 
 	c.init(ctx, c.preLogger, "cyberark", c.fetch)
-	return c.startScheduler(c.config.Schedule)
+	if err := c.startScheduler(c.config.Schedule); err != nil {
+		return err
+	}
+	c.preLogger.Info("secrets manager started", "active", "cyberark")
+	return nil
 }
 
 // ccpErrorEnvelope is the JSON CyberArk sends on non-2xx responses.

--- a/agent/secretsmgr/delinea.go
+++ b/agent/secretsmgr/delinea.go
@@ -43,6 +43,8 @@ func (d *delineaManager) Start(ctx context.Context) error {
 		*f.ptr = resolved
 	}
 
+	d.preLogger.Info("starting secrets manager", "active", "delinea", "server_url", d.config.ServerURL, "tenant", d.config.Tenant)
+
 	if (d.config.ServerURL == "" && d.config.Tenant == "") ||
 		(d.config.ServerURL != "" && d.config.Tenant != "") {
 		return fmt.Errorf("exactly one of server_url or tenant must be set")
@@ -70,7 +72,11 @@ func (d *delineaManager) Start(ctx context.Context) error {
 	d.client = c
 
 	d.init(ctx, d.preLogger, "delinea", d.fetch)
-	return d.startScheduler(d.config.Schedule)
+	if err := d.startScheduler(d.config.Schedule); err != nil {
+		return err
+	}
+	d.preLogger.Info("secrets manager started", "active", "delinea")
+	return nil
 }
 
 // fetch performs the actual SDK call for a parsed body.

--- a/agent/secretsmgr/doppler.go
+++ b/agent/secretsmgr/doppler.go
@@ -52,15 +52,16 @@ func (d *dopplerManager) Start(ctx context.Context) error {
 		*f.ptr = resolved
 	}
 
-	if d.config.Token == "" {
-		return fmt.Errorf("doppler: token is required")
-	}
-
 	d.apiHost = d.config.APIHost
 	if d.apiHost == "" {
 		d.apiHost = defaultDopplerAPIHost
 	}
 	d.apiHost = strings.TrimRight(d.apiHost, "/")
+	d.preLogger.Info("starting secrets manager", "active", "doppler", "api_host", d.apiHost)
+
+	if d.config.Token == "" {
+		return fmt.Errorf("doppler: token is required")
+	}
 
 	timeout := defaultDopplerTimeout
 	if d.config.Timeout != nil && *d.config.Timeout > 0 {
@@ -69,7 +70,11 @@ func (d *dopplerManager) Start(ctx context.Context) error {
 	d.httpClient = &http.Client{Timeout: timeout}
 
 	d.init(ctx, d.preLogger, "doppler", d.fetch)
-	return d.startScheduler(d.config.Schedule)
+	if err := d.startScheduler(d.config.Schedule); err != nil {
+		return err
+	}
+	d.preLogger.Info("secrets manager started", "active", "doppler")
+	return nil
 }
 
 // parseBody splits a placeholder body into (project, config, name) according

--- a/agent/secretsmgr/fleet.go
+++ b/agent/secretsmgr/fleet.go
@@ -254,8 +254,10 @@ func (f *FleetSecretsManager) handleUpdateNotification(payload []byte) error {
 
 // Start initializes the Fleet secrets manager
 func (f *FleetSecretsManager) Start(ctx context.Context) error {
+	f.logger.Info("starting secrets manager", "active", "fleet")
 	f.ctx = ctx
 	f.usedVars = make(map[string]fleetCachedSecret)
+	f.logger.Info("secrets manager started", "active", "fleet")
 	return nil
 }
 

--- a/agent/secretsmgr/start_logging_test.go
+++ b/agent/secretsmgr/start_logging_test.go
@@ -1,0 +1,135 @@
+package secretsmgr
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/config"
+)
+
+// newCapturingLogger returns a JSON slog logger writing into the returned buffer.
+func newCapturingLogger() (*slog.Logger, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	return slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo})), buf
+}
+
+func TestVaultStart_LogsStartingAndConnectionEstablished(t *testing.T) {
+	cluster, _ := createTestVault(t)
+	client := getTestVaultClient(t)
+	addr := "http://" + cluster.ClusterNodes[0].HostPort
+
+	logger, buf := newCapturingLogger()
+	vm := &vaultManager{
+		preLogger: logger,
+		config: config.VaultManager{
+			Address:  addr,
+			Auth:     "token",
+			AuthArgs: map[string]any{"token": client.Token()},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, vm.Start(ctx))
+
+	logs := buf.String()
+	assert.Contains(t, logs, "starting secrets manager")
+	assert.Contains(t, logs, `"active":"vault"`)
+	assert.Contains(t, logs, addr)
+	assert.Contains(t, logs, "secrets manager connection established")
+}
+
+func TestVaultStart_LogsStartingBeforeFailure(t *testing.T) {
+	logger, buf := newCapturingLogger()
+	vm := &vaultManager{
+		preLogger: logger,
+		config:    config.VaultManager{Address: "http://127.0.0.1:1"},
+	}
+
+	require.Error(t, vm.Start(context.Background()))
+
+	logs := buf.String()
+	assert.Contains(t, logs, "starting secrets manager")
+	assert.Contains(t, logs, `"active":"vault"`)
+	assert.NotContains(t, logs, "secrets manager connection established")
+}
+
+func TestDopplerStart_LogsStartingAndStarted(t *testing.T) {
+	logger, buf := newCapturingLogger()
+	d := &dopplerManager{preLogger: logger, config: config.DopplerManager{Token: "tok"}}
+
+	require.NoError(t, d.Start(context.Background()))
+
+	logs := buf.String()
+	assert.Contains(t, logs, "starting secrets manager")
+	assert.Contains(t, logs, `"active":"doppler"`)
+	assert.Contains(t, logs, defaultDopplerAPIHost)
+	assert.Contains(t, logs, "secrets manager started")
+	assert.NotContains(t, logs, "tok", "token must never be logged")
+}
+
+func TestDopplerStart_LogsStartingBeforeFailure(t *testing.T) {
+	logger, buf := newCapturingLogger()
+	d := &dopplerManager{preLogger: logger, config: config.DopplerManager{}}
+
+	require.Error(t, d.Start(context.Background()))
+
+	logs := buf.String()
+	assert.Contains(t, logs, "starting secrets manager")
+	assert.Contains(t, logs, `"active":"doppler"`)
+	assert.NotContains(t, logs, "secrets manager started")
+}
+
+func TestDelineaStart_LogsStartingAndStarted(t *testing.T) {
+	logger, buf := newCapturingLogger()
+	m := &delineaManager{
+		preLogger: logger,
+		config: config.DelineaManager{
+			ServerURL: "https://secrets.example.invalid",
+			Username:  "svc_orb",
+			Password:  "hunter2",
+		},
+	}
+
+	require.NoError(t, m.Start(context.Background()))
+
+	logs := buf.String()
+	assert.Contains(t, logs, "starting secrets manager")
+	assert.Contains(t, logs, `"active":"delinea"`)
+	assert.Contains(t, logs, "https://secrets.example.invalid")
+	assert.Contains(t, logs, "secrets manager started")
+	assert.NotContains(t, logs, "hunter2", "password must never be logged")
+}
+
+func TestCyberArkStart_LogsStartingAndStarted(t *testing.T) {
+	logger, buf := newCapturingLogger()
+	c := &cyberarkManager{
+		preLogger: logger,
+		config:    config.CyberArkManager{URL: "https://ccp.example.invalid", AppID: "orb"},
+	}
+
+	require.NoError(t, c.Start(context.Background()))
+
+	logs := buf.String()
+	assert.Contains(t, logs, "starting secrets manager")
+	assert.Contains(t, logs, `"active":"cyberark"`)
+	assert.Contains(t, logs, "https://ccp.example.invalid")
+	assert.Contains(t, logs, "secrets manager started")
+}
+
+func TestFleetStart_LogsStartingAndStarted(t *testing.T) {
+	logger, buf := newCapturingLogger()
+	f := NewFleetSecretsManager(logger, config.FleetSecretsManager{})
+
+	require.NoError(t, f.Start(context.Background()))
+
+	logs := buf.String()
+	assert.Contains(t, logs, "starting secrets manager")
+	assert.Contains(t, logs, `"active":"fleet"`)
+	assert.Contains(t, logs, "secrets manager started")
+}

--- a/agent/secretsmgr/vault.go
+++ b/agent/secretsmgr/vault.go
@@ -25,6 +25,8 @@ type vaultManager struct {
 }
 
 func (v *vaultManager) Start(ctx context.Context) error {
+	v.preLogger.Info("starting secrets manager", "active", "vault", "address", v.config.Address)
+
 	if v.config.Mount != "" && hasEmptySegment(v.config.Mount) {
 		return fmt.Errorf("invalid sources.vault.mount %q: contains an empty path segment", v.config.Mount)
 	}
@@ -66,7 +68,14 @@ func (v *vaultManager) Start(ctx context.Context) error {
 	if err := v.startScheduler(v.config.Schedule); err != nil {
 		return err
 	}
-	return v.addTokenLifecycleWatcher()
+	if err := v.addTokenLifecycleWatcher(); err != nil {
+		return err
+	}
+	// Authentication above round-tripped to the server, so the connection is
+	// genuinely validated at this point — unlike the other managers, which
+	// only reach their backend on first fetch.
+	v.preLogger.Info("secrets manager connection established", "active", "vault")
+	return nil
 }
 
 func (v *vaultManager) addTokenLifecycleWatcher() error {


### PR DESCRIPTION
Closes [OBS-3430](https://linear.app/netboxlabs/issue/OBS-3430/add-info-log-for-active-secrets-manager-and-connection-validation).

## Why

When a secrets manager is configured, the agent logged nothing on success and only a generic ERROR on failure, with no indication of which manager was active or where it was connecting.

## What operators see now

Each manager logs at INFO before doing any work, so a subsequent failure has context:

```
{"level":"INFO","msg":"starting secrets manager","active":"vault","address":"http://host.docker.internal:8200"}
```

and a success line when Start completes. Wording is deliberately truthful per manager:

- **vault** → `secrets manager connection established` — vault authenticates against the server during Start, so the connection is genuinely validated.
- **doppler / delinea / cyberark / fleet** → `secrets manager started` — these only reach their backend on the first secret fetch, so no connection claim is made. (Adding real connection probes was considered and left out: it would change failure semantics — the agent would refuse to start on a transient network blip — and CyberArk CCP has no ping endpoint short of fetching a real account.)

Endpoint fields logged: vault `address`, doppler `api_host` (post-default), delinea `server_url`/`tenant`, cyberark `url`. No credentials, tokens, or auth args are logged, pinned by test assertions.

## Tests

TDD: 7 new tests in `agent/secretsmgr/start_logging_test.go` (watched fail first) covering the starting line, the success line, starting-before-failure ordering, and that secrets never appear in output. `go test -race ./agent/...` passes; `make fix-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)