### PR TITLE
fix(agent): treat backend 404 on policy removal as already-removed

### DIFF
--- a/agent/backend/utils.go
+++ b/agent/backend/utils.go
@@ -34,6 +34,17 @@ func GetRunningStatus(proc Commander) (RunningStatus, string, error) {
 	return Running, "", nil
 }
 
+// HTTPError is returned by CommonRequest for non-2xx responses so callers can
+// branch on the status code (e.g. treat a 404 on DELETE as already-removed).
+// Message is the fully formatted detail; Error returns it unchanged.
+type HTTPError struct {
+	StatusCode int
+	Message    string
+}
+
+// Error returns the pre-formatted message.
+func (e *HTTPError) Error() string { return e.Message }
+
 // CommonRequest is a generic function to make HTTP requests to the backend
 func CommonRequest(backendName string, proc Commander, logger *slog.Logger, url string, payload any,
 	method string, body io.Reader, contentType string, timeout int32, errorMsg string,
@@ -70,21 +81,21 @@ func CommonRequest(backendName string, proc Commander, logger *slog.Logger, url 
 	if (res.StatusCode < 200) || (res.StatusCode > 299) {
 		body, err := io.ReadAll(res.Body)
 		if err != nil {
-			return fmt.Errorf("non 2xx HTTP error code from %s, no or invalid body: %d", backendName, res.StatusCode)
+			return &HTTPError{StatusCode: res.StatusCode, Message: fmt.Sprintf("non 2xx HTTP error code from %s, no or invalid body: %d", backendName, res.StatusCode)}
 		}
 		if len(body) == 0 {
-			return fmt.Errorf("%d empty body", res.StatusCode)
+			return &HTTPError{StatusCode: res.StatusCode, Message: fmt.Sprintf("%d empty body", res.StatusCode)}
 		} else if body[0] == '{' {
 			var jsonBody map[string]any
 			if err := json.Unmarshal(body, &jsonBody); err == nil {
 				if errMsg, ok := jsonBody[errorMsg]; ok {
-					return fmt.Errorf("%d %s", res.StatusCode, errMsg)
+					return &HTTPError{StatusCode: res.StatusCode, Message: fmt.Sprintf("%d %s", res.StatusCode, errMsg)}
 				}
 			} else {
-				return fmt.Errorf("%d %s", res.StatusCode, body)
+				return &HTTPError{StatusCode: res.StatusCode, Message: fmt.Sprintf("%d %s", res.StatusCode, body)}
 			}
 		} else {
-			return fmt.Errorf("%d %s", res.StatusCode, body)
+			return &HTTPError{StatusCode: res.StatusCode, Message: fmt.Sprintf("%d %s", res.StatusCode, body)}
 		}
 	}
 

--- a/agent/backend/utils_test.go
+++ b/agent/backend/utils_test.go
@@ -2,10 +2,15 @@ package backend_test
 
 import (
 	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
 )
@@ -66,4 +71,45 @@ func TestGetRunningStatus_Stopped(t *testing.T) {
 	assert.Equal(t, backend.Offline, status)
 	assert.Equal(t, "backend process ended", detail)
 	assert.NoError(t, err)
+}
+
+func TestCommonRequest_Non2xxReturnsHTTPError(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	proc := &mockCommander{status: backend.CmdStatus{PID: 123}}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail": "policy 'test-job' not found"}`))
+	}))
+	defer srv.Close()
+
+	var resp any
+	err := backend.CommonRequest("testbackend", proc, logger, srv.URL, &resp,
+		http.MethodDelete, http.NoBody, "application/json", 5, "detail")
+
+	require.Error(t, err)
+	var httpErr *backend.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusNotFound, httpErr.StatusCode)
+	assert.Contains(t, err.Error(), "404 policy 'test-job' not found")
+}
+
+func TestCommonRequest_Non2xxEmptyBodyReturnsHTTPError(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	proc := &mockCommander{status: backend.CmdStatus{PID: 123}}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	var resp any
+	err := backend.CommonRequest("testbackend", proc, logger, srv.URL, &resp,
+		http.MethodGet, http.NoBody, "application/json", 5, "detail")
+
+	require.Error(t, err)
+	var httpErr *backend.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusInternalServerError, httpErr.StatusCode)
 }

--- a/agent/policymgr/manager.go
+++ b/agent/policymgr/manager.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/config"
@@ -193,7 +194,18 @@ func (a *policyManager) RemovePolicy(policyID string, policyName string, beName 
 	be := backend.GetBackend(beName)
 	err := be.RemovePolicy(pd)
 	if err != nil {
-		a.logger.Error("backend remove policy failed: will still remove from PolicyManager", "policy_id", policyID, "error", err)
+		var httpErr *backend.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			// Expected for run-once policies the backend already dropped after
+			// completion: the desired state (policy absent) is reached, so this
+			// is a no-op. Kept at WARN (not DEBUG) because a 404 here can also
+			// signal a rename-bookkeeping bug leaving a stale policy running
+			// under another name on the backend.
+			a.logger.Warn("policy not present on backend at removal; treating as already removed",
+				"policy_id", policyID, "policy_name", pd.Name, "error", err)
+		} else {
+			a.logger.Error("backend remove policy failed: will still remove from PolicyManager", "policy_id", policyID, "error", err)
+		}
 	}
 	// Remove policy from orb-agent local repo
 	err = a.repo.Remove(pd.ID)

--- a/agent/policymgr/manager_test.go
+++ b/agent/policymgr/manager_test.go
@@ -1400,3 +1400,63 @@ func TestRemovePolicy_PendingRenameTargetsBackendName(t *testing.T) {
 
 	mockBe.AssertExpectations(t)
 }
+
+func removePolicySetup(t *testing.T, beName string, removeErr error) (policymgr.PolicyManager, *strings.Builder) {
+	t.Helper()
+	logs := &strings.Builder{}
+	logger := slog.New(slog.NewTextHandler(logs, nil))
+	secretsMgr := new(mockSecretsManager)
+
+	mockBe := &mockBackend{name: beName}
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	backend.Register(beName, mockBe)
+
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+
+	addPayload := config.PolicyPayload{
+		Action:    "manage",
+		ID:        "policy1",
+		Name:      "Test Policy",
+		Backend:   beName,
+		Version:   1,
+		Data:      map[string]any{},
+		DatasetID: "dataset1",
+	}
+	secretsMgr.On("SolvePolicySecrets", addPayload).Return(addPayload, nil)
+	mockBe.On("ApplyPolicy", mock.Anything, false).Return(nil)
+	mgr.ManagePolicy(addPayload)
+
+	mockBe.On("RemovePolicy", mock.Anything).Return(removeErr)
+	return mgr, logs
+}
+
+func TestRemovePolicyBackend404IsNoOpNotError(t *testing.T) {
+	notFound := &backend.HTTPError{StatusCode: 404, Message: "policy 'Test Policy' not found"}
+	mgr, logs := removePolicySetup(t, "testbackend404", notFound)
+
+	err := mgr.RemovePolicy("policy1", "Test Policy", "testbackend404")
+	require.NoError(t, err)
+
+	state, err := mgr.GetPolicyState()
+	require.NoError(t, err)
+	assert.Empty(t, state, "policy must still be removed from the local PolicyManager")
+
+	assert.NotContains(t, logs.String(), "level=ERROR", "a 404 on removal is a no-op, not an error")
+	assert.Contains(t, logs.String(), "level=WARN")
+	assert.Contains(t, logs.String(), "already removed")
+}
+
+func TestRemovePolicyBackendNon404StillLogsError(t *testing.T) {
+	serverErr := &backend.HTTPError{StatusCode: 500, Message: "boom"}
+	mgr, logs := removePolicySetup(t, "testbackend500", serverErr)
+
+	err := mgr.RemovePolicy("policy1", "Test Policy", "testbackend500")
+	require.NoError(t, err)
+
+	state, err := mgr.GetPolicyState()
+	require.NoError(t, err)
+	assert.Empty(t, state)
+
+	assert.Contains(t, logs.String(), "level=ERROR", "non-404 backend failures must stay ERROR")
+}


### PR DESCRIPTION
Closes [OBS-3575](https://linear.app/netboxlabs/issue/OBS-3575/agent-attempts-to-delete-policy-from-backend-even-when-run-is-valid).

## Why

Run-once policies are dropped by the backend after completion, so the agent's cleanup `DELETE` gets a `404 policy not found` and logged a spurious `ERROR` even though the run succeeded and the desired state (policy absent) was reached.

Fixed **agent-side deliberately**: the backend's 404 is truthful REST; it's the agent's cleanup intent ("ensure absent") for which 404 means success. One fix here covers all seven backends — including pktvisor, whose API we don't control — and every backend version already in the field.

## What

- `backend.CommonRequest` now returns a typed `*HTTPError` carrying the status code for all non-2xx responses. Error strings are byte-identical to before — only the type changed, so existing log output and error handling are unaffected.
- `policymgr.RemovePolicy` branches on it: **404 → WARN** ("policy not present on backend at removal; treating as already removed"), anything else keeps the existing ERROR.

Deliberately **WARN, not DEBUG** (ticket offered either): removal deletes by name with rename bookkeeping via `PreviousPolicyData` — a 404 can also mean that bookkeeping broke and a stale policy is still running on the backend under another name. WARN keeps that visible.

Also deliberately **no existence-check-before-delete** (ticket's alternative): TOCTOU race, doubles the API calls, no benefit over tolerating the 404.

## Tests

TDD (watched fail first): 2 tests pinning the typed `HTTPError` from `CommonRequest` via httptest (404 JSON detail + empty-body 500), and 2 policymgr tests asserting 404→WARN-no-ERROR and 500→still-ERROR, both verifying local repo removal proceeds. `go test -race ./agent/...`: 21 packages pass. `make fix-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)