### PR TITLE
fix(snmp-discovery): derive stack member ids with a single scheme per member set

### DIFF
--- a/orb-discovery/snmp-discovery/mapping/chassis.go
+++ b/orb-discovery/snmp-discovery/mapping/chassis.go
@@ -41,7 +41,7 @@ func (m *ChassisInventoryMapper) Map(
 
 // ChassisMember is one row of ENTITY-MIB entPhysicalTable identified
 // as a top-level chassis (class=3, containedIn=0). The ID is the
-// derived logical member id (see deriveMemberID); EntPhysicalIndex is
+// derived logical member id (see assignMemberIDs); EntPhysicalIndex is
 // the raw row index used for entAliasMappingTable chain walks.
 // AssetTag is the trimmed entPhysicalAssetID value ("" when unset or not walked).
 type ChassisMember struct {
@@ -108,9 +108,9 @@ func isStackContainerParent(oids ObjectIDValueMap, idx string) bool {
 //     container; used by Cisco StackWise Virtual on the 9400/9500/9600
 //     series and similar pair architectures).
 //
-// Returns members sorted ascending by ID. Member id derivation uses
-// the full 3-tier precedence in deriveMemberID (ParentRelPos > 0 →
-// trailing-int parse of EntName → ordinal fallback).
+// Returns members sorted ascending by ID. Member ids are derived
+// set-wide by assignMemberIDs (one scheme for all members:
+// parentRelPos → entPhysicalName trailing int → ordinal).
 func extractInventory(oids ObjectIDValueMap, logger *slog.Logger) ChassisInventory {
 	candidates := []string{}
 	for oid, v := range oids {
@@ -147,17 +147,16 @@ func extractInventory(oids ObjectIDValueMap, logger *slog.Logger) ChassisInvento
 		})
 	}
 
-	// Sort by entPhysicalIndex first so the ordinal fallback is
-	// deterministic when neither parentRelPos nor entPhysicalName
-	// provides an id signal.
+	// Sort by entPhysicalIndex first so assignMemberIDs' set-wide
+	// ordinal tier (used when neither the parentRelPos column nor
+	// entPhysicalName is usable for the whole set) assigns
+	// deterministic walk-order ids.
 	slices.SortFunc(members, func(a, b ChassisMember) int {
 		ai, _ := strconv.Atoi(a.EntPhysicalIndex)
 		bi, _ := strconv.Atoi(b.EntPhysicalIndex)
 		return ai - bi
 	})
-	for i := range members {
-		members[i].ID = deriveMemberID(members[i], i+1)
-	}
+	assignMemberIDs(members, logger)
 	// Dedup pass 1: drop later-occurring duplicates of the same serial,
 	// keep the lowest-id occurrence. Track dropped ids and their
 	// entPhysicalIndexes for the routing warn-and-skip rule.
@@ -353,25 +352,188 @@ func trimSNMPString(s string) string {
 
 var trailingIntRe = regexp.MustCompile(`(\d+)\s*$`)
 
-// deriveMemberID picks the logical member id with precedence:
-//  1. ParentRelPos when > 0 (ENTITY-MIB standard signal)
-//  2. Trailing integer in EntName ("Switch 1", "FPC 0", "Member 7")
-//  3. ordinalFallback (the caller-supplied 1-based position after
-//     sorting by entPhysicalIndex)
+// prelState classifies the member set's entPhysicalParentRelPos values.
+type prelState int
+
+const (
+	prelUsable    prelState = iota // all values > 0 and distinct: use as ids
+	prelAmbiguous                  // all values > 0 but duplicated: device asserts two rows at one position
+	prelAbsent                     // any value <= 0: unpopulated or zero-based numbering
+)
+
+// assignMemberIDs derives every member's logical id using ONE scheme for
+// the whole set. Per-member tier fallback (the previous deriveMemberID)
+// mixed schemes across siblings: a member with parentRelPos=0 fell to the
+// name tier while the rest used the prel tier, and on devices that number
+// entPhysicalParentRelPos zero-based the two schemes are offset by one —
+// colliding ids sent valid members into the ambiguous-id dedup (#458).
 //
-// ParentRelPos == 0 deliberately defers to (2)/(3): the column is
-// often unpopulated and 0 is the "unknown / not in a relative
-// position" sentinel per RFC 6933.
-func deriveMemberID(m ChassisMember, ordinalFallback int) int {
-	if m.ParentRelPos > 0 {
-		return m.ParentRelPos
+// Tier precedence, first usable wins for ALL members:
+//  1. parentRelPos when USABLE (every value > 0, distinct);
+//  2. entPhysicalName trailing int — usable iff every member has one and
+//     they are distinct (0 is allowed: FPC-style members are genuinely
+//     zero-numbered);
+//  3. when parentRelPos is AMBIGUOUS (duplicate positive positions) or
+//     names are AMBIGUOUS (full coverage, duplicate numbers) and the other
+//     signal could not rescue, keep the colliding values so the caller's
+//     ambiguity dedup refuses those rows — silently renumbering them
+//     would mis-attribute ifName-routed interfaces;
+//  4. ordinal 1..N in slice order (callers pass entPhysicalIndex-sorted
+//     members, so this is walk order).
+//
+// Scheme selection runs over the pre-dedup member rows: a duplicate-serial
+// junk row with an out-of-scheme prel/name can downgrade the tier for the
+// whole set. Accepted for now — no real walk exhibiting it is known, and
+// pass-1 serial dedup still bounds the damage.
+//
+// Any value <= 0 marks the WHOLE prel column untrustworthy (prelAbsent):
+// duplicates inside a zero-containing set carry no position signal and do
+// not trigger ambiguity refusal — the column is simply abandoned.
+// Observability: a wrong-but-distinct assignment is silent downstream
+// (vc_position, member device names, ifName routing all trust the ids),
+// so every lossy or low-confidence set-wide rejection of a PRESENT signal
+// is warn-logged; the high-confidence names-rescue path logs Info (only
+// when prel carried any positive signal — an all-zero column is normal).
+func assignMemberIDs(members []ChassisMember, logger *slog.Logger) {
+	if len(members) == 0 {
+		return
 	}
-	if match := trailingIntRe.FindString(m.EntName); match != "" {
-		if id, err := strconv.Atoi(strings.TrimSpace(match)); err == nil {
-			return id
+	prel, state := parentRelIDs(members)
+	if state == prelUsable {
+		applyIDs(members, prel)
+		return
+	}
+	names, nstate := nameIDs(members)
+	if nstate == nameUsable {
+		// High-confidence outcome: names carry explicit distinct numbers.
+		// Info (not Warn) when prel had signal — a zero-based prel column
+		// with numbered names is this code's normal, correct path, and a
+		// permanent Warn on every poll would be noise.
+		if hasPositivePrel(members) {
+			logger.Info("member id: entPhysicalParentRelPos unusable set-wide, using entPhysicalName-derived ids",
+				"reason", prelStateReason(state), "members", len(members))
+		}
+		applyIDs(members, names)
+		return
+	}
+	// From here every outcome is lossy or low-confidence: Warn. Colliding
+	// ids are deliberately KEPT so the caller's ambiguity dedup refuses
+	// those rows — silently renumbering them would mis-attribute
+	// ifName-routed interfaces.
+	if state == prelAmbiguous {
+		logger.Warn("member id: duplicate positive entPhysicalParentRelPos and no usable names; keeping colliding ids for ambiguity refusal",
+			"members", len(members))
+		applyIDs(members, prel)
+		return
+	}
+	if nstate == nameAmbiguous {
+		logger.Warn("member id: duplicate entPhysicalName numbers and no usable positions; keeping colliding ids for ambiguity refusal",
+			"members", len(members))
+		applyIDs(members, names)
+		return
+	}
+	if partialNames(members) {
+		logger.Warn("member id: entPhysicalName carries numbers on some members only; ignoring name signal set-wide",
+			"members", len(members))
+	}
+	if hasPositivePrel(members) {
+		logger.Warn("member id: no usable id signal; assigning ordinal member ids in walk order",
+			"members", len(members))
+	}
+	ordinal := make([]int, len(members))
+	for i := range ordinal {
+		ordinal[i] = i + 1
+	}
+	applyIDs(members, ordinal)
+}
+
+func hasPositivePrel(members []ChassisMember) bool {
+	for _, m := range members {
+		if m.ParentRelPos > 0 {
+			return true
 		}
 	}
-	return ordinalFallback
+	return false
+}
+
+func partialNames(members []ChassisMember) bool {
+	n := 0
+	for _, m := range members {
+		if trailingIntRe.FindString(m.EntName) != "" {
+			n++
+		}
+	}
+	return n > 0 && n < len(members)
+}
+
+func prelStateReason(s prelState) string {
+	if s == prelAmbiguous {
+		return "duplicate positive positions"
+	}
+	return "contains zero or negative positions"
+}
+
+func applyIDs(members []ChassisMember, ids []int) {
+	for i := range members {
+		members[i].ID = ids[i]
+	}
+}
+
+// parentRelIDs returns the members' parentRelPos values and their
+// classification. The values are only meaningful for prelUsable (distinct
+// ids) and prelAmbiguous (deliberately colliding ids for the caller's
+// ambiguity dedup); prelAbsent returns nil.
+func parentRelIDs(members []ChassisMember) ([]int, prelState) {
+	ids := make([]int, len(members))
+	seen := make(map[int]struct{}, len(members))
+	state := prelUsable
+	for i, m := range members {
+		if m.ParentRelPos <= 0 {
+			return nil, prelAbsent
+		}
+		if _, dup := seen[m.ParentRelPos]; dup {
+			state = prelAmbiguous
+		}
+		seen[m.ParentRelPos] = struct{}{}
+		ids[i] = m.ParentRelPos
+	}
+	return ids, state
+}
+
+// nameState classifies the member set's entPhysicalName trailing-int values.
+type nameState int
+
+const (
+	nameUsable    nameState = iota // every member has a trailing int, all distinct: use as ids
+	nameAmbiguous                  // every member has a trailing int, but duplicated: device asserts one number twice
+	nameAbsent                     // at least one member has no trailing int
+)
+
+// nameIDs returns trailing-integer ids parsed from entPhysicalName and
+// their classification. Zero is a valid id here (FPC-style members are
+// genuinely zero-numbered). The ids are meaningful for nameUsable
+// (distinct) and nameAmbiguous (deliberately colliding, for the caller's
+// ambiguity refusal); nameAbsent returns nil.
+func nameIDs(members []ChassisMember) ([]int, nameState) {
+	ids := make([]int, len(members))
+	seen := make(map[int]struct{}, len(members))
+	state := nameUsable
+	for i, m := range members {
+		match := trailingIntRe.FindString(m.EntName)
+		if match == "" {
+			return nil, nameAbsent
+		}
+		id, err := strconv.Atoi(strings.TrimSpace(match))
+		if err != nil {
+			return nil, nameAbsent
+		}
+		if _, dup := seen[id]; dup {
+			state = nameAmbiguous
+		}
+		seen[id] = struct{}{}
+		ids[i] = id
+	}
+	return ids, state
 }
 
 // resolveAssetTags maps member ID -> the entPhysicalAssetID value that

--- a/orb-discovery/snmp-discovery/mapping/chassis_fixtures_test.go
+++ b/orb-discovery/snmp-discovery/mapping/chassis_fixtures_test.go
@@ -122,3 +122,33 @@ func fixtureCiscoCat9400xStackWiseVirtual() ObjectIDValueMap {
 		".1.3.6.1.2.1.47.1.1.1.1.13.500": {Value: "C9407R"},
 	}
 }
+
+// fixtureZeroBasedParentRelWrappedStack returns an ObjectIDValueMap shaped
+// like a 4-member stack (issue #458): a class=11 stack container at index 1
+// that shares member 1's serial, wrapping four class=3 chassis rows whose
+// entPhysicalParentRelPos is ZERO-BASED (0,1,2,3) while entPhysicalName
+// carries the true member numbers 1, 2, 4, 5 — non-sequential, as after a
+// member replacement — so tests can distinguish name-derived ids from a
+// broken ordinal assignment that would coincide with sequential names.
+func fixtureZeroBasedParentRelWrappedStack() ObjectIDValueMap {
+	oids := ObjectIDValueMap{
+		".1.3.6.1.2.1.1.5.0": {Value: "stack.example"},
+		// Stack container (class=11) — shares member 1's serial; never a member.
+		".1.3.6.1.2.1.47.1.1.1.1.4.1":  {Value: "0"},
+		".1.3.6.1.2.1.47.1.1.1.1.5.1":  {Value: "11"},
+		".1.3.6.1.2.1.47.1.1.1.1.6.1":  {Value: "-1"},
+		".1.3.6.1.2.1.47.1.1.1.1.7.1":  {Value: "Stack"},
+		".1.3.6.1.2.1.47.1.1.1.1.11.1": {Value: "SN0000000001"},
+	}
+	serials := []string{"SN0000000001", "SN0000000013", "SN0000000023", "SN0000000027"}
+	memberNums := []int{1, 2, 4, 5}
+	for i := 0; i < 4; i++ {
+		idx := fmt.Sprintf("%d", (i+1)*1000)
+		oids[".1.3.6.1.2.1.47.1.1.1.1.4."+idx] = Value{Value: "1"}
+		oids[".1.3.6.1.2.1.47.1.1.1.1.5."+idx] = Value{Value: "3"}
+		oids[".1.3.6.1.2.1.47.1.1.1.1.6."+idx] = Value{Value: fmt.Sprintf("%d", i)} // ZERO-BASED
+		oids[".1.3.6.1.2.1.47.1.1.1.1.7."+idx] = Value{Value: fmt.Sprintf("Switch %d", memberNums[i])}
+		oids[".1.3.6.1.2.1.47.1.1.1.1.11."+idx] = Value{Value: serials[i]}
+	}
+	return oids
+}

--- a/orb-discovery/snmp-discovery/mapping/chassis_test.go
+++ b/orb-discovery/snmp-discovery/mapping/chassis_test.go
@@ -1,6 +1,7 @@
 package mapping
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"strings"
@@ -261,37 +262,6 @@ func TestTrimSNMPString(t *testing.T) {
 			assert.Equal(t, tc.want, trimSNMPString(tc.in))
 		})
 	}
-}
-
-func TestDeriveMemberID_ParentRelPosWins(t *testing.T) {
-	m := ChassisMember{ParentRelPos: 5, EntName: "Switch 9"}
-	assert.Equal(t, 5, deriveMemberID(m, 0))
-}
-
-func TestDeriveMemberID_NameTrailingIntFallback(t *testing.T) {
-	cases := []struct {
-		entName string
-		want    int
-	}{
-		{"Switch 1", 1},
-		{"Switch 2", 2},
-		{"FPC 0", 0},
-		{"Member 7", 7},
-		{"Virtual Chassis Member 3", 3},
-		{"Chassis 12", 12},
-	}
-	for _, tc := range cases {
-		t.Run(tc.entName, func(t *testing.T) {
-			m := ChassisMember{ParentRelPos: 0, EntName: tc.entName}
-			assert.Equal(t, tc.want, deriveMemberID(m, 99))
-		})
-	}
-}
-
-func TestDeriveMemberID_FinalIndexFallback(t *testing.T) {
-	// parentRelPos=0, EntName has no trailing int → use ordinal fallback.
-	m := ChassisMember{ParentRelPos: 0, EntName: "Chassis"}
-	assert.Equal(t, 4, deriveMemberID(m, 4))
 }
 
 func TestExtractInventory_JunosFPC_TrailingIntFromName(t *testing.T) {
@@ -1518,4 +1488,243 @@ func TestTranslateAsStack_DefaultsTagRegisteredWithClaimer(t *testing.T) {
 		assert.Equal(t, "OPERATOR-TAG", *master.AssetTag,
 			"operator-supplied defaults tag is never stripped; the claimer's warn covers the conflict")
 	})
+}
+
+// Regression for issue #458: zero-based entPhysicalParentRelPos must not
+// collide with name-derived ids. All four members survive with the true
+// 1-based member numbers taken from entPhysicalName.
+func TestExtractInventory_ZeroBasedParentRelStack(t *testing.T) {
+	inv := extractInventory(fixtureZeroBasedParentRelWrappedStack(), slog.Default())
+
+	require.Len(t, inv.Members, 4)
+	assert.Empty(t, inv.DroppedIDs)
+	// Non-sequential member numbers (1,2,4,5) prove the ids came from the
+	// name tier, not ordinal walk order.
+	wantIDs := []int{1, 2, 4, 5}
+	for i, m := range inv.Members {
+		assert.Equal(t, wantIDs[i], m.ID)
+		assert.Equal(t, fmt.Sprintf("Switch %d", wantIDs[i]), m.EntName)
+	}
+	assert.Equal(t, "SN0000000001", inv.Members[0].Serial)
+	assert.Equal(t, "SN0000000027", inv.Members[3].Serial)
+}
+
+// End-to-end on the same fixture: the NetBox-visible symptoms of #458 —
+// vc_position numbering and member device naming — must be correct.
+// Mirrors TestTranslateAsStack_JunosQFX_4MemberVC (4-member shape) and
+// TestTranslateAsStack_CiscoStackWiseVirtual_EmitsVCAndMember
+// (wrapped-container shape). TranslateAsStack does NOT set VcPosition on
+// the master, and a 4-member stack emits master + 3 member Devices.
+func TestTranslateAsStack_ZeroBasedParentRelStack(t *testing.T) {
+	logger := slog.Default()
+	master := &diode.Device{
+		Name: strPtr("stack.example"),
+		Site: &diode.Site{Name: strPtr("dc1")},
+		DeviceType: &diode.DeviceType{
+			Model:        strPtr("Model-48P"),
+			Manufacturer: &diode.Manufacturer{Name: strPtr("Example")},
+		},
+	}
+	entities := []diode.Entity{master}
+
+	out := TranslateAsStack(entities, fixtureZeroBasedParentRelWrappedStack(), nil, nil, logger)
+
+	var vc *diode.VirtualChassis
+	var members []*diode.Device
+	for _, e := range out {
+		switch v := e.(type) {
+		case *diode.VirtualChassis:
+			vc = v
+		case *diode.Device:
+			if v != master {
+				members = append(members, v)
+			}
+		}
+	}
+	assert.NotNil(t, vc, "4-member stack must emit a VirtualChassis")
+
+	// Master: serial from the lowest-id chassis row, no VcPosition.
+	assert.Equal(t, "SN0000000001", *master.Serial)
+	assert.Nil(t, master.VcPosition)
+
+	// Exactly 3 non-master member Devices with vc_position 2, 4, 5 and
+	// the "{vcName}-{id}" naming convention.
+	require.Len(t, members, 3, "4-member stack -> master + 3 member Devices")
+	wantPositions := []int64{2, 4, 5}
+	for i, m := range members {
+		assert.Equal(t, wantPositions[i], *m.VcPosition)
+		assert.Equal(t, fmt.Sprintf("stack.example-%d", wantPositions[i]), *m.Name)
+	}
+
+	// The class=11 container row ("Stack") must never become a Device.
+	for _, e := range out {
+		if d, ok := e.(*diode.Device); ok {
+			assert.NotEqual(t, "Stack", strDeref(d.Name))
+		}
+	}
+}
+
+func TestAssignMemberIDs_PrelTierAllPositiveDistinct(t *testing.T) {
+	members := []ChassisMember{
+		{ParentRelPos: 2, EntName: "Switch 9"},
+		{ParentRelPos: 5, EntName: "Switch 1"},
+	}
+	assignMemberIDs(members, slog.Default())
+	assert.Equal(t, 2, members[0].ID, "prel wins over conflicting names when whole set is usable")
+	assert.Equal(t, 5, members[1].ID)
+}
+
+func TestAssignMemberIDs_ZeroInPrelSetFallsToNames(t *testing.T) {
+	members := []ChassisMember{
+		{ParentRelPos: 0, EntName: "Switch 1"},
+		{ParentRelPos: 1, EntName: "Switch 2"},
+		{ParentRelPos: 2, EntName: "Switch 3"},
+	}
+	assignMemberIDs(members, slog.Default())
+	assert.Equal(t, []int{1, 2, 3}, []int{members[0].ID, members[1].ID, members[2].ID},
+		"a set containing prel=0 must use one scheme for ALL members, not mix tiers")
+}
+
+func TestAssignMemberIDs_DuplicatePrelFallsToNames(t *testing.T) {
+	members := []ChassisMember{
+		{ParentRelPos: 1, EntName: "Member 3"},
+		{ParentRelPos: 1, EntName: "Member 7"},
+	}
+	assignMemberIDs(members, slog.Default())
+	assert.Equal(t, 3, members[0].ID)
+	assert.Equal(t, 7, members[1].ID)
+}
+
+func TestAssignMemberIDs_NamesAllowZero(t *testing.T) {
+	// FPC-style members are genuinely zero-numbered; id 0 must survive.
+	members := []ChassisMember{
+		{ParentRelPos: 0, EntName: "FPC 0"},
+		{ParentRelPos: 0, EntName: "FPC 1"},
+	}
+	assignMemberIDs(members, slog.Default())
+	assert.Equal(t, 0, members[0].ID)
+	assert.Equal(t, 1, members[1].ID)
+}
+
+func TestAssignMemberIDs_AmbiguousPrelWithoutNamesKeepsCollision(t *testing.T) {
+	// Duplicate positive prel and no usable names: the device asserts two
+	// rows at one position. assignMemberIDs must KEEP the colliding ids so
+	// extractInventory's ambiguity dedup refuses the rows (it must never
+	// silently renumber them via ordinal — that would mis-attribute
+	// ifName-routed interfaces).
+	members := []ChassisMember{
+		{ParentRelPos: 1, EntName: ""},
+		{ParentRelPos: 1, EntName: ""},
+	}
+	assignMemberIDs(members, slog.Default())
+	assert.Equal(t, 1, members[0].ID)
+	assert.Equal(t, 1, members[1].ID)
+}
+
+func TestAssignMemberIDs_RejectedPrelValuesAreAbandonedNotRebased(t *testing.T) {
+	// Pins the design choice: a rejected prel tier is ABANDONED — a future
+	// "shift zero-based prel by +1" heuristic would yield {1,2} here and
+	// must fail this test. Names win with their own values.
+	members := []ChassisMember{
+		{ParentRelPos: 0, EntName: "Member 5"},
+		{ParentRelPos: 1, EntName: "Member 7"},
+	}
+	assignMemberIDs(members, slog.Default())
+	assert.Equal(t, 5, members[0].ID)
+	assert.Equal(t, 7, members[1].ID)
+}
+
+func TestAssignMemberIDs_NameFormats(t *testing.T) {
+	// Name-parse variety preserved from the deleted per-member tests.
+	members := []ChassisMember{
+		{ParentRelPos: 0, EntName: "Virtual Chassis Member 3"},
+		{ParentRelPos: 0, EntName: "Chassis 12"},
+		{ParentRelPos: 0, EntName: "Member 7"},
+	}
+	assignMemberIDs(members, slog.Default())
+	assert.Equal(t, 3, members[0].ID)
+	assert.Equal(t, 12, members[1].ID)
+	assert.Equal(t, 7, members[2].ID)
+}
+
+func TestAssignMemberIDs_SingleMember(t *testing.T) {
+	members := []ChassisMember{{ParentRelPos: 0, EntName: "Chassis"}}
+	assignMemberIDs(members, slog.Default())
+	assert.Equal(t, 1, members[0].ID)
+}
+
+func TestAssignMemberIDs_PartialNamesDiscardedWithWarn(t *testing.T) {
+	// One numbered name + one blank: per-member mixing is the #458 bug
+	// class, so the name signal is discarded set-wide (ordinal wins) — but
+	// loudly, because the surviving assignment may cross-wire ifName
+	// routing.
+	logs := &strings.Builder{}
+	logger := slog.New(slog.NewTextHandler(logs, nil))
+	members := []ChassisMember{
+		{ParentRelPos: 0, EntName: "Switch 2"},
+		{ParentRelPos: 0, EntName: ""},
+	}
+	assignMemberIDs(members, logger)
+	assert.Equal(t, 1, members[0].ID)
+	assert.Equal(t, 2, members[1].ID)
+	assert.Contains(t, logs.String(), "ignoring name signal set-wide")
+}
+
+func TestAssignMemberIDs_ZeroBasedPrelLogsInfoWhenNamesRescue(t *testing.T) {
+	// Names rescuing a zero-based prel column is the normal corrected path
+	// for issue #458 devices: logged at INFO (TextHandler default level
+	// emits Info), never WARN — this device now works correctly.
+	logs := &strings.Builder{}
+	logger := slog.New(slog.NewTextHandler(logs, nil))
+	members := []ChassisMember{
+		{ParentRelPos: 0, EntName: "Switch 1"},
+		{ParentRelPos: 1, EntName: "Switch 2"},
+	}
+	assignMemberIDs(members, logger)
+	assert.Contains(t, logs.String(), "entPhysicalParentRelPos unusable set-wide")
+	assert.NotContains(t, logs.String(), "level=WARN")
+}
+
+func TestAssignMemberIDs_ZeroWithDuplicatePositivesUsesOrdinal(t *testing.T) {
+	// Design choice pinned: ANY <=0 value marks the whole prel column
+	// untrustworthy (prelAbsent) — duplicates inside a zero-containing set
+	// carry no position signal, so with no usable names the set gets
+	// ordinal ids rather than ambiguity refusal.
+	members := []ChassisMember{
+		{ParentRelPos: 0, EntName: ""},
+		{ParentRelPos: 2, EntName: ""},
+		{ParentRelPos: 2, EntName: ""},
+	}
+	assignMemberIDs(members, slog.Default())
+	assert.Equal(t, []int{1, 2, 3}, []int{members[0].ID, members[1].ID, members[2].ID})
+}
+
+func TestAssignMemberIDs_DuplicateNamesWithoutPrelKeptForRefusal(t *testing.T) {
+	// Full-coverage but duplicated name numbers with no positional signal:
+	// the device asserts the same member number twice. Keep the colliding
+	// ids so extractInventory's ambiguity dedup refuses the rows — never
+	// silently renumber them via ordinal (that would cross-wire
+	// ifName-routed interfaces).
+	logs := &strings.Builder{}
+	logger := slog.New(slog.NewTextHandler(logs, nil))
+	members := []ChassisMember{
+		{ParentRelPos: 0, EntName: "Slot 1"},
+		{ParentRelPos: 0, EntName: "Slot 1"},
+	}
+	assignMemberIDs(members, logger)
+	assert.Equal(t, 1, members[0].ID)
+	assert.Equal(t, 1, members[1].ID)
+	assert.Contains(t, logs.String(), "duplicate entPhysicalName numbers")
+}
+
+func TestAssignMemberIDs_OrdinalFallback(t *testing.T) {
+	// No usable prel set (dup zeros), no usable names (one lacks a trailing
+	// int) -> ordinal 1..N in slice (entPhysicalIndex) order for ALL members.
+	members := []ChassisMember{
+		{ParentRelPos: 0, EntName: "Chassis"},
+		{ParentRelPos: 0, EntName: "Chassis 7"},
+	}
+	assignMemberIDs(members, slog.Default())
+	assert.Equal(t, 1, members[0].ID)
+	assert.Equal(t, 2, members[1].ID)
 }


### PR DESCRIPTION
Fixes #458.

## Root cause

Not the duplicate serial: the reporter's stack container row is class 11 and is correctly never a member candidate, so its shared serial is harmless (as are the class-1 StackPort rows sharing stack-cable serials in the full walk). Their attached `entPhysicalTable` shows the members carry **zero-based** `entPhysicalParentRelPos` (0,1,2,3) while `entPhysicalName` carries the true 1-based member numbers. `deriveMemberID` mixed tiers per member — the prel=0 member fell to the name tier (id 1) while its siblings used the prel tier (ids 1,2,3) — so two members collided on id 1 and the ambiguous-id dedup dropped both (including the master), while the survivors kept off-by-one ids that would corrupt `vc_position`.

## Fix

`assignMemberIDs` derives ids with one scheme for the whole member set:

- `parentRelPos` only when every value is positive and distinct;
- else name trailing ints when every member has one and they're distinct (0 allowed — FPC-style members are genuinely zero-numbered);
- **ambiguity is still refused, never renumbered**: duplicate positive positions (or duplicate full-coverage name numbers) with no rescuing signal keep their colliding ids so the existing pass-2 dedup drops those rows exactly as before;
- else ordinal in walk order.

Set-wide tier rejection of a present signal is logged (Info when names rescue cleanly — the corrected path for this device class — Warn for lossy outcomes), with structured fields.

Validated against the reporter's full attached walk: members now get ids 1–4 with nothing dropped. The regression fixture uses non-sequential member numbers (1,2,4,5) so a broken ordinal assignment cannot masquerade as the name tier.

Known accepted limitation (documented in the code): scheme selection runs over pre-dedup rows, so a hypothetical duplicate-serial class-3 row with out-of-scheme prel could downgrade the tier for the set — no real walk exhibiting this is known, and pass-1 serial dedup bounds the damage.

## Corpus scan (LibreNMS, 1,880 real-device recordings)

Every recording with ≥2 chassis-class rows was classified by `parentRelPos` scheme:

- **22 devices with clean 1-based sets** (Cisco SVL pairs, Cisco SB, Eltex, Huawei CE, …) — byte-identical behavior, confirming the no-change guarantee.
- **3 zero-based devices**: Catalyst **9200L** (`{0,1,2}`, "Switch 1..3" — reproduces #458 verbatim today), Catalyst **2960-X** (`{0,2,3}` — the *same box* mixes offset and non-offset prel semantics, proving per-member trust of prel is unfixable in principle), ZTE ZXA10 C320 (no names → ordinal; positions shift `{1,3}`→`{1,2}`, an accepted delta on a device that isn't a switch stack).
- **0 devices with ambiguous duplicate positives** — the preserved refusal path is a rare fail-safe, as expected.
- One accepted delta on a Rittal LCP cooling unit with garbage prel (`{-1,1,1,2,3}`): old code tier-mixed into dropping 3 of 5 rows; new code emits ordinal ids with warns. Neither treatment is meaningful for a non-stack device.

## Lab dry-run validation (orb-test-lab snmpsim, real recordings, real binary)

Ran the branch binary in `--dry-run` via the policy API against LibreNMS recordings replayed by the lab's snmpsim (c9200l serials grafted — LibreNMS anonymizes them to empty, which trips the pre-existing empty-serial drop; container shares member 1's serial exactly like the reporter's device):

| Catalyst 9200L (zero-based `{0,1,2}`) | old (develop) | this PR |
|---|---|---|
| log | `WARN chassis row dropped: ambiguous duplicate member id id=1 count=2` | `INFO member id: … using entPhysicalName-derived ids` |
| output | **1 device carrying Switch 3's serial** — master + Switch 2 dropped, no VC | VirtualChassis + master (member 1's serial) + members at vc_position 2, 3 |

The old failure is worse than the issue describes: the stack reaches NetBox impersonated by its third member. Catalyst 2960-X (unmodified recording, 152 entities) ingests cleanly as a no-regression check on a messier real walk.

## Review & tests

Plan and commit each went through multi-round adversarial review (three plan rounds, two commit rounds). TDD throughout: regression fixture reproducing the reporter's exact walk shape (watched fail: 2 survivors with wrong ids + dropped id 1), TranslateAsStack end-to-end (vc_position/naming), and 13 set-level unit tests covering every tier, both ambiguity-refusal paths, and log contracts. Sentinel tests pinning existing dedup/refusal semantics pass unmodified. Full `go test -race ./...` green; `make fix-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
