### PR TITLE
feat(snmp-discovery): support device tenant in policy defaults

### DIFF
--- a/docs/backends/snmp_discovery/README.md
+++ b/docs/backends/snmp_discovery/README.md
@@ -90,6 +90,7 @@ SNMP discovery policies are broken down into two subsections: `config` and `scop
 | location | string | no | Default location for discovered devices. Accepts a literal name or an SNMP OID reference (see [Default values from SNMP OIDs](#default-values-from-snmp-oids)) |
 | asset_tag | string | no | Default asset tag for discovered devices. Accepts a literal value or an SNMP OID reference (see [Default values from SNMP OIDs](#default-values-from-snmp-oids)). NetBox enforces a 50-character limit; resolved values longer than 50 characters are warn-logged and skipped |
 | role | string | no | Default role for discovered devices |
+| tenant | string \| map | no | Default tenant for discovered devices. Accepts a bare tenant name or a map with `name` + optional `group` / `description` / `comments` / `tags` (see the [tenant map](#tenant-map) below). Applies to Device entities only — IP address, prefix, and VLAN tenants keep their own per-entity defaults (`ip_address.tenant`, `prefix.tenant`, `vlan.tenant`). Virtual-chassis members inherit the master's tenant. In a per-target `override_defaults`, tenant merges field-wise: overriding `name` keeps an inherited `group` |
 | interface_patterns | list  | no | User-defined interface type patterns (see [Interface Type Matching](./interface.md)) |
 | interface_exclude_patterns | list | no | Regex patterns to exclude interfaces (and their IPs) from ingestion (see [Interface Exclusion](./interface.md#interface-exclusion-patterns)) |
 
@@ -135,6 +136,17 @@ SNMP discovery policies are broken down into two subsections: `config` and `scop
 | ├─ group | string | VLAN group name. When set, every emitted VLAN is attached to an `ipam.vlangroup` scoped to `defaults.site`: the group's `scope_site` is populated from `defaults.site` |
 | ├─ tenant | string | VLAN tenant |
 | ├─ status | string | VLAN status override (`active`, `reserved`, `deprecated`). When unset, status is derived from `dot1qVlanStaticRowStatus`: `active(1)` → `active`, `notInService(2)` → `reserved`. |
+
+##### Tenant Map
+The top-level `tenant` default accepts either a bare string (tenant name) or a map:
+
+| Parameter | Type | Description |
+|---------|----|-----------|
+| name | string  | Tenant name |
+| group | string  | Tenant group name |
+| description | string  | Tenant description |
+| comments | string  | Tenant comments |
+| tags | list  | Tenant tags |
 
 ### Scope Section
 | Parameter | Type | Required | Description |
@@ -213,6 +225,7 @@ config:
     location: ".1.3.6.1.2.1.1.6.0"     # Resolve from sysLocation (or use a literal like "rack-42")
     asset_tag: ".1.3.6.1.2.1.1.4.0"    # Resolve from sysContact (or use a literal)
     role: "network"
+    tenant: "network-ops"              # Bare name, or a map: { name: network-ops, group: infrastructure }
     ip_address:
       description: "SNMP discovered IP"
       role: "management"

--- a/orb-discovery/snmp-discovery/README.md
+++ b/orb-discovery/snmp-discovery/README.md
@@ -47,6 +47,7 @@ policies:
         site: "datacenter-01"
         location: "rack-42"
         role: "network"
+        tenant: "customer-a" # (Optional) Tenant applied to discovered devices. Accepts a plain string or a mapping: {name, group, description, comments, tags}
         ip_address:
           description: "SNMP discovered IP"
           role: "management"
@@ -156,7 +157,7 @@ policies:
 
 ### Per-Target Override Defaults
 
-SNMP discovery supports per-target default overrides, allowing you to customize site, role, tags, and other entity defaults for individual targets while maintaining policy-wide defaults as fallbacks.
+SNMP discovery supports per-target default overrides, allowing you to customize site, role, tenant, tags, and other entity defaults for individual targets while maintaining policy-wide defaults as fallbacks. The `tenant` default accepts either a plain string (the tenant name) or a mapping, and overrides merge field-wise — a per-target override can refine one tenant field (e.g. `name`) without restating the rest.
 
 #### Example Configuration
 
@@ -167,6 +168,9 @@ policies:
       defaults:
         site: "New York"
         role: "switch"
+        tenant:
+          name: "customer-a"
+          group: "customers"
         tags: ["snmp", "network"]
     scope:
       targets:
@@ -179,6 +183,12 @@ policies:
             site: "New York/DC-A"
             role: "router"
             tags: ["core", "production"]
+
+        # Scalar tenant override: sets the tenant name for this target
+        # while keeping the policy-level group "customers" (field-wise merge)
+        - host: "192.168.1.4"
+          override_defaults:
+            tenant: "customer-b"
 
         # Override nested defaults
         - host: "192.168.1.3"

--- a/orb-discovery/snmp-discovery/config/config.go
+++ b/orb-discovery/snmp-discovery/config/config.go
@@ -62,6 +62,67 @@ func (v *VrfParameters) UnmarshalYAML(node *yaml.Node) error {
 	}
 }
 
+// TenantParameters names the tenant applied to discovered devices. Accepts
+// either a plain string (tenant name) or a mapping, mirroring
+// device-discovery's defaults.tenant. Merged field-wise at override time
+// (see mergeTenantParameters), with the same accepted divergence as
+// VrfParameters: a scalar override sets Name only and cannot clear other
+// inherited fields, because post-unmarshal the scalar and mapping forms
+// are indistinguishable.
+type TenantParameters struct {
+	Name        string   `yaml:"name"`
+	Group       string   `yaml:"group,omitempty"`
+	Description string   `yaml:"description,omitempty"`
+	Comments    string   `yaml:"comments,omitempty"`
+	Tags        []string `yaml:"tags,omitempty"`
+}
+
+// UnmarshalYAML accepts a scalar tenant name or a mapping.
+func (t *TenantParameters) UnmarshalYAML(node *yaml.Node) error {
+	// Reset up front so a stale receiver doesn't keep fields from a
+	// previous mapping-form pass when the new YAML is scalar.
+	*t = TenantParameters{}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if node.Tag == "!!null" {
+			return nil
+		}
+		t.Name = node.Value
+		return nil
+	case yaml.MappingNode:
+		type alias TenantParameters
+		var a alias
+		if err := node.Decode(&a); err != nil {
+			return err
+		}
+		*t = TenantParameters(a)
+		return nil
+	default:
+		return fmt.Errorf("tenant: expected string or mapping, got node kind %d", node.Kind)
+	}
+}
+
+// mergeTenantParameters overlays non-zero override fields onto dst in
+// place, mirroring mergeVrfParameters so a per-target override can refine
+// a single knob without restating the rest.
+func mergeTenantParameters(dst, override *TenantParameters) {
+	if override.Name != "" {
+		dst.Name = override.Name
+	}
+	if override.Group != "" {
+		dst.Group = override.Group
+	}
+	if override.Description != "" {
+		dst.Description = override.Description
+	}
+	if override.Comments != "" {
+		dst.Comments = override.Comments
+	}
+	if len(override.Tags) > 0 {
+		dst.Tags = override.Tags
+	}
+}
+
 // Status represents the status of the snmp-discovery service
 type Status struct {
 	StartTime     time.Time `json:"start_time"`
@@ -204,6 +265,7 @@ type Defaults struct {
 	Location                 string             `yaml:"location,omitempty"`
 	Role                     string             `yaml:"role,omitempty"`
 	AssetTag                 string             `yaml:"asset_tag,omitempty"`
+	Tenant                   TenantParameters   `yaml:"tenant,omitempty"`
 	IPAddress                IPAddressDefaults  `yaml:"ip_address,omitempty"`
 	Prefix                   PrefixDefaults     `yaml:"prefix,omitempty"`
 	Interface                InterfaceDefaults  `yaml:"interface,omitempty"`
@@ -255,6 +317,7 @@ func MergeDefaults(policyDefaults, overrideDefaults *Defaults) *Defaults {
 	if overrideDefaults.AssetTag != "" {
 		merged.AssetTag = overrideDefaults.AssetTag
 	}
+	mergeTenantParameters(&merged.Tenant, &overrideDefaults.Tenant)
 	if len(overrideDefaults.Tags) > 0 {
 		merged.Tags = overrideDefaults.Tags
 	}

--- a/orb-discovery/snmp-discovery/config/config_test.go
+++ b/orb-discovery/snmp-discovery/config/config_test.go
@@ -801,3 +801,64 @@ func TestOptions_InterfaceNameSourceMode(t *testing.T) {
 	// happens at policy parse (Manager.applyDefaults), not here.
 	assert.Equal(t, "wat", (&Options{InterfaceNameSource: &bogus}).InterfaceNameSourceMode())
 }
+
+func TestTenantParameters_UnmarshalScalar(t *testing.T) {
+	var d Defaults
+	err := yaml.Unmarshal([]byte("tenant: acme\n"), &d)
+	require.NoError(t, err)
+	assert.Equal(t, "acme", d.Tenant.Name)
+	assert.Empty(t, d.Tenant.Group)
+}
+
+func TestTenantParameters_UnmarshalMapping(t *testing.T) {
+	var d Defaults
+	err := yaml.Unmarshal([]byte(
+		"tenant:\n  name: acme\n  group: customers\n  description: main tenant\n  comments: managed\n  tags: [a, b]\n"), &d)
+	require.NoError(t, err)
+	assert.Equal(t, "acme", d.Tenant.Name)
+	assert.Equal(t, "customers", d.Tenant.Group)
+	assert.Equal(t, "main tenant", d.Tenant.Description)
+	assert.Equal(t, "managed", d.Tenant.Comments)
+	assert.Equal(t, []string{"a", "b"}, d.Tenant.Tags)
+}
+
+func TestTenantParameters_UnmarshalNullAndReceiverReset(t *testing.T) {
+	// Mirrors the VrfParameters reset semantics: re-decoding into the same
+	// struct must not leak fields from a previous mapping-form pass, and a
+	// YAML null leaves the zero value.
+	var tp TenantParameters
+	require.NoError(t, yaml.Unmarshal([]byte("name: acme\ngroup: customers\n"), &tp))
+	require.NoError(t, yaml.Unmarshal([]byte("plainname"), &tp))
+	assert.Equal(t, "plainname", tp.Name)
+	assert.Empty(t, tp.Group, "scalar re-decode must reset Group")
+
+	var d Defaults
+	require.NoError(t, yaml.Unmarshal([]byte("tenant: null\n"), &d))
+	assert.Empty(t, d.Tenant.Name)
+}
+
+func TestTenantParameters_UnmarshalBadKind(t *testing.T) {
+	var d Defaults
+	err := yaml.Unmarshal([]byte("tenant:\n  - a\n  - b\n"), &d)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tenant: expected string or mapping")
+}
+
+func TestMergeDefaults_TenantFieldWise(t *testing.T) {
+	policy := &Defaults{Tenant: TenantParameters{Name: "acme", Group: "customers"}}
+
+	merged := MergeDefaults(policy, &Defaults{})
+	assert.Equal(t, "acme", merged.Tenant.Name, "empty override keeps policy tenant")
+	assert.Equal(t, "customers", merged.Tenant.Group)
+
+	// Field-wise like mergeVrfParameters: a name-only override must KEEP
+	// the policy group (device-discovery deep-merges overrides the same way).
+	merged = MergeDefaults(policy, &Defaults{Tenant: TenantParameters{Name: "other"}})
+	assert.Equal(t, "other", merged.Tenant.Name)
+	assert.Equal(t, "customers", merged.Tenant.Group)
+
+	// Group-only override refines group while keeping the policy name.
+	merged = MergeDefaults(policy, &Defaults{Tenant: TenantParameters{Group: "internal"}})
+	assert.Equal(t, "acme", merged.Tenant.Name)
+	assert.Equal(t, "internal", merged.Tenant.Group)
+}

--- a/orb-discovery/snmp-discovery/mapping/chassis_test.go
+++ b/orb-discovery/snmp-discovery/mapping/chassis_test.go
@@ -515,8 +515,9 @@ func TestTranslateAsStack_StandaloneSetsSerialAndReturnsUnchangedShape(t *testin
 func TestTranslateAsStack_TwoMemberStackEmitsVCAndMember(t *testing.T) {
 	logger := slog.Default()
 	master := &diode.Device{
-		Name: strPtr("3850-stack.example"),
-		Site: &diode.Site{Name: strPtr("dc1")},
+		Name:   strPtr("3850-stack.example"),
+		Site:   &diode.Site{Name: strPtr("dc1")},
+		Tenant: &diode.Tenant{Name: strPtr("acme")},
 		DeviceType: &diode.DeviceType{
 			Model:        strPtr("WS-C3850-48P"),
 			Manufacturer: &diode.Manufacturer{Name: strPtr("Cisco")},
@@ -548,6 +549,16 @@ func TestTranslateAsStack_TwoMemberStackEmitsVCAndMember(t *testing.T) {
 	assert.Len(t, members, 1)
 	assert.Equal(t, "FCW2147L0K4", *members[0].Serial)
 	assert.Equal(t, int64(2), *members[0].VcPosition)
+
+	// Tenant propagation: members and the VC master ref inherit the
+	// master's tenant (which defaults.tenant sets on the master device).
+	require.NotNil(t, members[0].Tenant)
+	assert.Equal(t, "acme", *members[0].Tenant.Name,
+		"member device inherits master tenant")
+	require.NotNil(t, vc.Master)
+	require.NotNil(t, vc.Master.Tenant)
+	assert.Equal(t, "acme", *vc.Master.Tenant.Name,
+		"VC master ref carries master tenant")
 
 	// Master remains plain (no VcPosition, no VirtualChassis).
 	assert.Nil(t, master.VcPosition)

--- a/orb-discovery/snmp-discovery/mapping/mappers.go
+++ b/orb-discovery/snmp-discovery/mapping/mappers.go
@@ -1108,6 +1108,23 @@ func (m *DeviceMapper) applyDefaults(entity *diode.Device, defaults *config.Defa
 		}
 	}
 
+	if entity.Tenant == nil && defaults.Tenant.Name != "" {
+		tenant := &diode.Tenant{Name: &defaults.Tenant.Name}
+		if defaults.Tenant.Group != "" {
+			tenant.Group = &diode.TenantGroup{Name: &defaults.Tenant.Group}
+		}
+		if defaults.Tenant.Description != "" {
+			tenant.Description = &defaults.Tenant.Description
+		}
+		if defaults.Tenant.Comments != "" {
+			tenant.Comments = &defaults.Tenant.Comments
+		}
+		for i := range defaults.Tenant.Tags {
+			tenant.Tags = append(tenant.Tags, &diode.Tag{Name: &defaults.Tenant.Tags[i]})
+		}
+		entity.Tenant = tenant
+	}
+
 	if defaults.Location != "" {
 		if resolved, ok := data.ResolveDefault(defaults.Location, walked); ok {
 			// Builds a fresh Location, overriding anything a future

--- a/orb-discovery/snmp-discovery/mapping/mappers_test.go
+++ b/orb-discovery/snmp-discovery/mapping/mappers_test.go
@@ -4864,3 +4864,190 @@ func TestInterfaceMapper_Map_NameSourceModes(t *testing.T) {
 		})
 	}
 }
+
+// TestDeviceMapper_Map_TenantDefaultApplied verifies that a fully
+// populated top-level defaults.tenant lands on the emitted device with
+// all fields set (Group as *diode.TenantGroup{Name}, Tags as
+// []*diode.Tag by Name). Mirrors the standalone harness of
+// TestDeviceMapper_Map_DefaultsResolveFromWalkedSnapshot.
+func TestDeviceMapper_Map_TenantDefaultApplied(t *testing.T) {
+	logger := slog.Default()
+	mapper := mapping.NewDeviceMapper(&MockManufacturerDataRetriever{}, &MockDeviceLookup{}, logger)
+
+	values := map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+		"1.3.6.1.2.1.1.5.0": {
+			OID:    "1.3.6.1.2.1.1.5.0",
+			Index:  "0",
+			Parent: "1.3.6.1.2.1.1.5",
+			Value:  "router1",
+			Type:   mapping.OctetString,
+		},
+	}
+	mappingEntry := &mapping.Entry{
+		OID:    "1.3.6.1.2.1.1",
+		Entity: "device",
+		Field:  "_id",
+		MappingEntries: []mapping.Entry{
+			{OID: "1.3.6.1.2.1.1.5", Entity: "device", Field: "name"},
+		},
+	}
+	defaults := &config.Defaults{
+		Tenant: config.TenantParameters{
+			Name:        "acme",
+			Group:       "customers",
+			Description: "d",
+			Comments:    "c",
+			Tags:        []string{"a", "b"},
+		},
+	}
+
+	registry := mapping.NewEntityRegistry(logger)
+	entity := mapper.Map(values, mappingEntry, registry, defaults)
+	require.NotNil(t, entity)
+	device, ok := entity.(*diode.Device)
+	require.True(t, ok)
+
+	require.NotNil(t, device.Tenant)
+	require.NotNil(t, device.Tenant.Name)
+	assert.Equal(t, "acme", *device.Tenant.Name)
+	require.NotNil(t, device.Tenant.Group)
+	require.NotNil(t, device.Tenant.Group.Name)
+	assert.Equal(t, "customers", *device.Tenant.Group.Name)
+	require.NotNil(t, device.Tenant.Description)
+	assert.Equal(t, "d", *device.Tenant.Description)
+	require.NotNil(t, device.Tenant.Comments)
+	assert.Equal(t, "c", *device.Tenant.Comments)
+	require.Len(t, device.Tenant.Tags, 2)
+	require.NotNil(t, device.Tenant.Tags[0].Name)
+	assert.Equal(t, "a", *device.Tenant.Tags[0].Name)
+	require.NotNil(t, device.Tenant.Tags[1].Name)
+	assert.Equal(t, "b", *device.Tenant.Tags[1].Name)
+}
+
+// TestDeviceMapper_Map_TenantDefaultNameOnly verifies the scalar form:
+// only Name is set on the emitted tenant; Group, Description, Comments
+// stay nil and Tags stays empty.
+func TestDeviceMapper_Map_TenantDefaultNameOnly(t *testing.T) {
+	logger := slog.Default()
+	mapper := mapping.NewDeviceMapper(&MockManufacturerDataRetriever{}, &MockDeviceLookup{}, logger)
+
+	values := map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+		"1.3.6.1.2.1.1.5.0": {
+			OID:    "1.3.6.1.2.1.1.5.0",
+			Index:  "0",
+			Parent: "1.3.6.1.2.1.1.5",
+			Value:  "router1",
+			Type:   mapping.OctetString,
+		},
+	}
+	mappingEntry := &mapping.Entry{
+		OID:    "1.3.6.1.2.1.1",
+		Entity: "device",
+		Field:  "_id",
+		MappingEntries: []mapping.Entry{
+			{OID: "1.3.6.1.2.1.1.5", Entity: "device", Field: "name"},
+		},
+	}
+	defaults := &config.Defaults{
+		Tenant: config.TenantParameters{Name: "acme"},
+	}
+
+	registry := mapping.NewEntityRegistry(logger)
+	entity := mapper.Map(values, mappingEntry, registry, defaults)
+	require.NotNil(t, entity)
+	device, ok := entity.(*diode.Device)
+	require.True(t, ok)
+
+	require.NotNil(t, device.Tenant)
+	require.NotNil(t, device.Tenant.Name)
+	assert.Equal(t, "acme", *device.Tenant.Name)
+	assert.Nil(t, device.Tenant.Group)
+	assert.Nil(t, device.Tenant.Description)
+	assert.Nil(t, device.Tenant.Comments)
+	assert.Empty(t, device.Tenant.Tags)
+}
+
+// TestDeviceMapper_Map_TenantDefaultUnsetLeavesNil pins the current
+// behavior: with no defaults.tenant configured, the emitted device
+// carries no tenant.
+func TestDeviceMapper_Map_TenantDefaultUnsetLeavesNil(t *testing.T) {
+	logger := slog.Default()
+	mapper := mapping.NewDeviceMapper(&MockManufacturerDataRetriever{}, &MockDeviceLookup{}, logger)
+
+	values := map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+		"1.3.6.1.2.1.1.5.0": {
+			OID:    "1.3.6.1.2.1.1.5.0",
+			Index:  "0",
+			Parent: "1.3.6.1.2.1.1.5",
+			Value:  "router1",
+			Type:   mapping.OctetString,
+		},
+	}
+	mappingEntry := &mapping.Entry{
+		OID:    "1.3.6.1.2.1.1",
+		Entity: "device",
+		Field:  "_id",
+		MappingEntries: []mapping.Entry{
+			{OID: "1.3.6.1.2.1.1.5", Entity: "device", Field: "name"},
+		},
+	}
+	defaults := &config.Defaults{Site: "dc1"}
+
+	registry := mapping.NewEntityRegistry(logger)
+	entity := mapper.Map(values, mappingEntry, registry, defaults)
+	require.NotNil(t, entity)
+	device, ok := entity.(*diode.Device)
+	require.True(t, ok)
+
+	assert.Nil(t, device.Tenant)
+}
+
+// TestIPAddressMapper_Map_DeviceTenantDoesNotCascade pins the
+// no-cascade design decision: the top-level defaults.tenant is
+// device-only (matching device-discovery semantics) and must never leak
+// onto IP addresses — only defaults.ip_address.tenant does that.
+func TestIPAddressMapper_Map_DeviceTenantDoesNotCascade(t *testing.T) {
+	logger := slog.Default()
+
+	values := map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+		"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
+			OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
+			Index:  "192.168.1.1",
+			Parent: "1.3.6.1.2.1.4.20.1.1",
+			Value:  "192.168.1.1",
+			Type:   mapping.IPAddress,
+		},
+	}
+	mappingEntry := &mapping.Entry{
+		OID:    "1.3.6.1.2.1.4.20.1.1",
+		Entity: "ipAddress",
+		Field:  "_id",
+		MappingEntries: []mapping.Entry{
+			{
+				OID:    "1.3.6.1.2.1.4.20.1.1",
+				Entity: "ipAddress",
+				Field:  "_id",
+			},
+			{
+				OID:    "1.3.6.1.2.1.4.20.1.1",
+				Entity: "ipAddress",
+				Field:  "address",
+			},
+		},
+	}
+	// Top-level device tenant set; defaults.ip_address.tenant unset.
+	defaults := &config.Defaults{
+		Tenant: config.TenantParameters{Name: "acme", Group: "customers"},
+	}
+
+	registry := mapping.NewEntityRegistry(logger)
+	mapper := mapping.NewIPAddressMapper(logger)
+	entity := mapper.Map(values, mappingEntry, registry, defaults)
+
+	require.NotNil(t, entity)
+	ipAddress, ok := entity.(*diode.IPAddress)
+	require.True(t, ok)
+	assert.Equal(t, "192.168.1.1/32", *ipAddress.Address)
+	assert.Nil(t, ipAddress.Tenant,
+		"top-level defaults.tenant must not cascade to IP addresses")
+}

--- a/orb-discovery/snmp-discovery/mapping/vlan_mapper_test.go
+++ b/orb-discovery/snmp-discovery/mapping/vlan_mapper_test.go
@@ -357,6 +357,43 @@ func TestVlanMapper_EmitVLANs_AppliesDefaults(t *testing.T) {
 	}
 }
 
+// TestVlanMapper_PostMap_DeviceTenantDoesNotCascade pins the no-cascade
+// design decision: the top-level defaults.tenant is device-only
+// (matching device-discovery semantics) and must never leak onto
+// emitted VLANs — only defaults.vlan.tenant sets a VLAN tenant.
+func TestVlanMapper_PostMap_DeviceTenantDoesNotCascade(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	registry := NewEntityRegistry(logger)
+
+	// Minimal: one VLAN with a static name row so it will always be emitted.
+	rows := ObjectIDValueMap{
+		".1.3.6.1.2.1.17.7.1.4.3.1.1.10": Value{Value: "Engineering", Type: OctetString},
+		".1.3.6.1.2.1.17.7.1.4.3.1.5.10": Value{Value: "1", Type: Integer},
+	}
+
+	// Top-level device tenant set; defaults.vlan.tenant unset.
+	defaults := &config.Defaults{
+		Tenant: config.TenantParameters{Name: "acme", Group: "customers"},
+	}
+
+	vm := NewVlanMapper(logger, config.Options{CreateUnknownVlans: ptrBool(true)})
+	emitted := vm.PostMap(rows, registry, defaults)
+
+	var got *diode.VLAN
+	for _, e := range emitted {
+		if v, ok := e.(*diode.VLAN); ok && v.Vid != nil && *v.Vid == 10 {
+			got = v
+			break
+		}
+	}
+	if got == nil {
+		t.Fatal("expected VLAN entity for VID 10, got none")
+	}
+	if got.Tenant != nil {
+		t.Errorf("Tenant: got %+v, want nil (top-level defaults.tenant must not cascade to VLANs)", got.Tenant)
+	}
+}
+
 // TestVlanMapper_EmitVLANs_StripsNullBytesFromName verifies that NUL-padded or
 // NUL-interrupted dot1qVlanStaticName values (seen on FS switches and other vendor
 // agents) are sanitized before reaching the Diode payload. NetBox/PostgreSQL rejects


### PR DESCRIPTION
Fixes [ENGHLP-1479](https://linear.app/netboxlabs/issue/ENGHLP-1479/snmp-discovery-support-device-tenant-in-policy-defaults).

## Why

snmp-discovery had no way to set a tenant on discovered devices: every scan emitted tenant-less devices, which can never match a tenant-owned NetBox device, so each scan created a duplicate with tenant `None`. (Per-entity tenants for `ip_address`/`prefix`/`vlan` already existed — devices were the only entity without the knob.)

## What

Top-level `defaults.tenant`, mirroring device-discovery's placement and semantics:

```yaml
defaults:
  tenant: customer-a            # scalar: tenant name
  # or:
  tenant:
    name: customer-a
    group: customers            # optional: group/description/comments/tags
```

- Applied to **device entities only** — deliberately no cascade to IP/prefix/VLAN tenants (matching device-discovery, where `defaults.tenant` is device-only; the per-entity knobs remain authoritative). Pinned by negative tests.
- `override_defaults.tenant` merges **field-wise** (like `vrf`): a per-target override can refine one field (e.g. `name`) without restating the rest.
- Virtual-chassis members, the master ref, and nested device stubs inherit the tenant through the existing `master.Tenant` copies — no chassis changes needed.

## Upgrade behavior (matcher implications)

- Tenant-owned NetBox devices now match via the diode plugin's `name+site+tenant` rung — the ticket's fix.
- Devices previously created tenant-less by earlier scans are matched via the higher-precedence rungs (`primary_ip4/6`, `asset_tag`, or `virtual_chassis+vc_position` for VC members) and are **updated in place** with the new tenant — no duplicates.
- Caution: a device already owned by a **different** tenant will likewise match via those higher rungs and be silently re-tenanted — operators with mixed-tenant sites should scope tenants via per-target `override_defaults`.

## Review & tests

Plan and commits went through multi-round adversarial review. TDD: config-layer tests (scalar/mapping/null/bad-kind decode, receiver reset, field-wise merge incl. group-only override), device-mapper emission tests (full fields / name-only / unset-stays-nil), no-cascade negative tests for IPAddress and VLAN mappers, and a VC propagation pin on the existing TranslateAsStack test. YAML-alias decoding and per-target `MergeDefaults` copy semantics verified empirically. Full `go test -race ./...` green; `go vet` clean; `make fix-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)