### PR TITLE
fix(agent): honor orb.debug.enable from the config file

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -48,6 +49,33 @@ func Version(_ *cobra.Command, _ []string) {
 	os.Exit(0)
 }
 
+// newRootLogger builds the agent's JSON logger on a mutable LevelVar so the
+// level can be raised after the config file is parsed. The logger must exist
+// before config.Load so the ORB_ env overlay can log through it; when debug
+// comes only from the YAML file, the overlay's debug-level skip diagnostics
+// are suppressed (the level is still Info while the file is being parsed) —
+// only the -d flag captures those.
+func newRootLogger(w io.Writer, debugFlag bool) (*slog.Logger, *slog.LevelVar) {
+	level := new(slog.LevelVar) // defaults to Info
+	if debugFlag {
+		level.Set(slog.LevelDebug)
+	}
+	h := slog.NewJSONHandler(w, &slog.HandlerOptions{Level: level, AddSource: false})
+	return slog.New(h), level
+}
+
+// applyConfigDebug raises the log level to Debug when the config file asks
+// for it (orb.debug.enable) and returns the effective debug state (flag OR
+// config) that downstream consumers (BackendCommons.Debug, backend -d
+// propagation) must see so YAML debug behaves exactly like -d.
+func applyConfigDebug(logger *slog.Logger, level *slog.LevelVar, debugFlag bool, cfg config.Config) bool {
+	if cfg.OrbAgent.Debug.Enable && !debugFlag {
+		level.Set(slog.LevelDebug)
+		logger.Debug("debug logging enabled via config file (orb.debug.enable)")
+	}
+	return debugFlag || cfg.OrbAgent.Debug.Enable
+}
+
 // Run starts the agent
 func Run(_ *cobra.Command, _ []string) {
 	if len(cfgFiles) == 0 {
@@ -55,14 +83,7 @@ func Run(_ *cobra.Command, _ []string) {
 	}
 
 	// logger (constructed before Load so unknown ORB_ overrides can be logged)
-	var l slog.Level
-	if debug {
-		l = slog.LevelDebug
-	} else {
-		l = slog.LevelInfo
-	}
-	h := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: l, AddSource: false})
-	logger := slog.New(h)
+	logger, logLevel := newRootLogger(os.Stdout, debug)
 
 	configData, err := config.Load(cfgFiles, logger)
 	if err != nil {
@@ -71,8 +92,10 @@ func Run(_ *cobra.Command, _ []string) {
 
 	logger.Info("backends loaded", "backends", redact.SensitiveData(configData.OrbAgent.Backends))
 
+	effectiveDebug := applyConfigDebug(logger, logLevel, debug, configData)
+
 	// new agent
-	a, err := agent.New(logger, configData, debug)
+	a, err := agent.New(logger, configData, effectiveDebug)
 	if err != nil {
 		logger.Error("agent start up error", "error", err)
 		os.Exit(1)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/netboxlabs/orb-agent/agent/config"
+)
+
+func configWithDebug(enable bool) config.Config {
+	var c config.Config
+	c.OrbAgent.Debug.Enable = enable
+	return c
+}
+
+func TestNewRootLogger_FlagSetsDebugImmediately(t *testing.T) {
+	var buf bytes.Buffer
+	logger, level := newRootLogger(&buf, true)
+	assert.Equal(t, slog.LevelDebug, level.Level())
+	assert.True(t, logger.Enabled(context.Background(), slog.LevelDebug))
+}
+
+func TestNewRootLogger_DefaultIsInfo(t *testing.T) {
+	var buf bytes.Buffer
+	logger, level := newRootLogger(&buf, false)
+	assert.Equal(t, slog.LevelInfo, level.Level())
+	assert.False(t, logger.Enabled(context.Background(), slog.LevelDebug))
+}
+
+func TestApplyConfigDebug_YAMLOnlyEnablesDebug(t *testing.T) {
+	var buf bytes.Buffer
+	logger, level := newRootLogger(&buf, false)
+
+	effective := applyConfigDebug(logger, level, false, configWithDebug(true))
+
+	assert.True(t, effective)
+	assert.Equal(t, slog.LevelDebug, level.Level())
+	assert.True(t, logger.Enabled(context.Background(), slog.LevelDebug))
+	// The switch itself must be visible in the (now debug-enabled) output.
+	assert.Contains(t, buf.String(), "debug logging enabled via config file")
+}
+
+func TestApplyConfigDebug_FlagOnlyStaysDebugNoDuplicateAnnounce(t *testing.T) {
+	var buf bytes.Buffer
+	logger, level := newRootLogger(&buf, true)
+
+	effective := applyConfigDebug(logger, level, true, configWithDebug(false))
+
+	assert.True(t, effective)
+	assert.Equal(t, slog.LevelDebug, level.Level())
+	assert.NotContains(t, buf.String(), "debug logging enabled via config file")
+}
+
+func TestApplyConfigDebug_BothOff(t *testing.T) {
+	var buf bytes.Buffer
+	logger, level := newRootLogger(&buf, false)
+
+	effective := applyConfigDebug(logger, level, false, configWithDebug(false))
+
+	assert.False(t, effective)
+	assert.Equal(t, slog.LevelInfo, level.Level())
+	assert.False(t, logger.Enabled(context.Background(), slog.LevelDebug))
+}
+
+func TestApplyConfigDebug_BothOnNoDuplicateAnnounce(t *testing.T) {
+	var buf bytes.Buffer
+	logger, level := newRootLogger(&buf, true)
+
+	effective := applyConfigDebug(logger, level, true, configWithDebug(true))
+
+	assert.True(t, effective)
+	assert.Equal(t, slog.LevelDebug, level.Level())
+	assert.NotContains(t, buf.String(), "debug logging enabled via config file",
+		"flag already enabled debug; config adds nothing to announce")
+}

--- a/docs/config_samples.md
+++ b/docs/config_samples.md
@@ -605,6 +605,16 @@ When running in dry run mode, the agent will:
 This allows you to inspect the data that would be collected and sent to Diode Server before configuring the actual connection.
 This feature is supported by the [Device Discovery](./backends/device_discovery/README.md), [Network Discovery](./backends/network_discovery.md), [Worker](./backends/worker.md) and [SNMP Discovery](./backends/snmp_discovery/README.md) backends.
 
+## Debug Logging
+
+Setting `orb.debug.enable: true` in the config file enables debug-level logging, equivalent to running the agent with the `-d` flag, except that debug messages emitted while the config file is still being parsed (such as the skipped `ORB_*` override diagnostics described in [Environment Variable Configuration](./env_config.md)) are only captured with `-d`.
+
+```yaml
+orb:
+  debug:
+    enable: true   # equivalent to the -d flag; backends inherit debug too
+```
+
 ## Exporting OpenTelemetry Metrics
 
 The backends support exporting metrics using OpenTelemetryover GRPC.


### PR DESCRIPTION
Fixes [OBS-3432](https://linear.app/netboxlabs/issue/OBS-3432/agent-debug-mode-configured-via-yaml-does-not-enable-debug-logs-only).

## Root cause

`orb.debug.enable` was parsed into the config struct but had **zero consumers**: the logger level was fixed from the `-d` flag before `config.Load` ran, and `agent.New` received the raw flag — so YAML-configured debug produced no debug logs and no backend debug propagation.

## Fix

The logger now sits on a `slog.LevelVar` that is raised to Debug immediately after the config file is parsed (with a debug-level announcement line), and `agent.New` receives `flag OR config` so `BackendCommons.Debug` (worker's `--debug`) and the `logger.Enabled(Debug)` inference in the gnmi/network/snmp backends behave identically to `-d`.

Two behavior notes:

- **Parse-time caveat**: debug-level diagnostics emitted while the config file is still being parsed (the ORB_ overlay's invalid-name/empty-value skip lines) are suppressed when debug comes only from YAML — the level is still Info at that point. `-d` remains the way to capture those. Documented in `docs/config_samples.md`.
- **OTLP deployments**: when the OTLP log bridge is configured, `logger.Enabled(Debug)` already returns true today via the otelslog multi-handler (pre-existing), so the `logger.Enabled` propagation leg only changes behavior in non-OTLP setups.

Side benefit: `ORB_DEBUG__ENABLE=true` (the standard env overlay) now also enables debug, consistent with every other config key.

## Verification

TDD (RED watched: undefined helpers) with 6 unit tests pinning flag-immediate, default-info, yaml-only flip + announcement, no-duplicate-announce, and both-off. **Live-verified end to end** on a built binary: `enable: true` without `-d` emits DEBUG lines (announcement + organic agent debug lines); `enable: false` without `-d` emits zero; `-d` alone is byte-identical to before including the pre-parse ORB_ overlay debug line. `go test -race ./cmd/... ./agent/...` green; `make fix-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)