### PR TITLE
fix(agent): rename internal default-config env out of the ORB_ namespace

### DIFF
--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -139,7 +139,7 @@ RUN mkdir -p /opt/orb /opt/orb/files /opt/orb/pip-cache /usr/local/share/orb-age
 
 ENV PATH=/opt/orb/files:$PATH
 ENV PIP_CACHE_DIR=/opt/orb/pip-cache
-ENV ORB_DEFAULT_CONFIG=/usr/local/share/orb-agent/default_config.yaml
+ENV DEFAULT_CONFIG_PATH=/usr/local/share/orb-agent/default_config.yaml
 
 # Copy Python site-packages and binaries from builder (includes pip and package executables)
 COPY --from=python-builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages

--- a/agent/docker/orb-agent-entry.sh
+++ b/agent/docker/orb-agent-entry.sh
@@ -32,7 +32,7 @@ if [ -f "asn.mmdb.gz" ]; then
 fi
 
 ## Agent Configuration ##
-DEFAULT_CONFIG_PATH="${ORB_DEFAULT_CONFIG:-/usr/local/share/orb-agent/default_config.yaml}"
+DEFAULT_CONFIG_PATH="${DEFAULT_CONFIG_PATH:-/usr/local/share/orb-agent/default_config.yaml}"
 agent_args=("$@")
 
 if [ -n "${FLEET_CLIENT_ID}" ] && [ -n "${FLEET_CLIENT_SECRET}" ]; then


### PR DESCRIPTION
Fixes [OBS-3429](https://linear.app/netboxlabs/issue/OBS-3429/remove-or-reword-debug-log-for-orb-default-config-and-add-info-log).

## Root cause

`ORB_DEFAULT_CONFIG` — set by the Docker image and read by the entrypoint to locate the fallback config — used the `ORB_` prefix that the env overlay reserves for config overrides. So every startup the overlay flagged it: `ignoring ORB_ environment variable that is not a valid config override` — a DEBUG line that reads like an actionable error but has nothing to act on.

## Fix

**Rename it out of the `ORB_` namespace** rather than carve out an exception. The variable becomes `DEFAULT_CONFIG_PATH` (the name the entrypoint already uses for its local), so the overlay never inspects it and the diagnostic cannot fire — no allowlist to maintain, and the `ORB_` namespace stays exclusively "config overrides."

Safe as a plain rename, not a breaking change: an org-wide code search found orb-agent's own Dockerfile and entrypoint are the **only** setter/reader — no deployment manifest, helm chart, or test sets it (the `nbl-unified-platform-tests` hits are a Python constant holding the *path string*, passed via `-c`, not the env var).

## Verification

Entrypoint rename traced through both branches (the fleet-creds default-config injection is intact); `${DEFAULT_CONFIG_PATH:-…}` is a standard env-or-default expansion; shellcheck clean (only a pre-existing unrelated SC2164). With the rename, no `ORB_`-prefixed non-override variable exists in a stock container, so the reported diagnostic is gone by construction. `go test -race ./cmd/... ./agent/...` green; `make fix-lint` clean.

## Note on scope

The ticket also mentioned adding an INFO log of the config file in use at startup. That half is intentionally left out per maintainer direction; this PR is scoped to removing the misleading diagnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)