### PR TITLE
fix(agent): fail startup on an unsupported secrets_manager type

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -98,7 +98,11 @@ var _ Agent = (*orbAgent)(nil)
 
 // New creates a new agent
 func New(logger *slog.Logger, c config.Config, debug bool) (Agent, error) {
-	sm := secretsmgr.New(logger, c.OrbAgent.SecretsManager)
+	sm, err := secretsmgr.New(logger, c.OrbAgent.SecretsManager)
+	if err != nil {
+		logger.Error("error during create secrets manager, exiting", "error", err)
+		return nil, err
+	}
 	fm := filesmgr.New(logger, c.OrbAgent.FilesManager)
 	pm, err := policymgr.New(logger, sm, c)
 	if err != nil {

--- a/agent/secretsmgr/cyberark_test.go
+++ b/agent/secretsmgr/cyberark_test.go
@@ -610,12 +610,13 @@ func TestCyberArkPollSecrets_FailureEvictsAndReportsFalse(t *testing.T) {
 
 func TestNewManager_ReturnsCyberArkManagerWhenActive(t *testing.T) {
 	logger := newTestLogger()
-	m := New(logger, config.ManagerSecrets{
+	m, err := New(logger, config.ManagerSecrets{
 		Active: "cyberark",
 		Sources: config.SecretsSources{
 			CyberArk: config.CyberArkManager{URL: "https://ccp.example.com", AppID: "orb"},
 		},
 	})
+	require.NoError(t, err)
 	_, ok := m.(*cyberarkManager)
 	require.True(t, ok, "New() with active=cyberark must return *cyberarkManager, got %T", m)
 }

--- a/agent/secretsmgr/doppler_test.go
+++ b/agent/secretsmgr/doppler_test.go
@@ -429,12 +429,13 @@ func TestDopplerPollSecrets_FailureEvictsAndReportsFalse(t *testing.T) {
 
 func TestNewManager_ReturnsDopplerManagerWhenActive(t *testing.T) {
 	logger := newTestLogger()
-	m := New(logger, config.ManagerSecrets{
+	m, err := New(logger, config.ManagerSecrets{
 		Active: "doppler",
 		Sources: config.SecretsSources{
 			Doppler: config.DopplerManager{Token: "dp.st.anything"},
 		},
 	})
+	require.NoError(t, err)
 	_, ok := m.(*dopplerManager)
 	require.True(t, ok, "New() with active=doppler must return *dopplerManager, got %T", m)
 }

--- a/agent/secretsmgr/manager.go
+++ b/agent/secretsmgr/manager.go
@@ -2,6 +2,7 @@ package secretsmgr
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/netboxlabs/orb-agent/agent/config"
@@ -15,22 +16,25 @@ type Manager interface {
 	SolveConfigSecrets(backends map[string]any, configManager config.ManagerConfig) (map[string]any, config.ManagerConfig, error)
 }
 
-// New creates a new instance of ConfigManager based on the configuration
-func New(logger *slog.Logger, c config.ManagerSecrets) Manager {
+// New creates a secrets Manager from configuration. An empty active type is a
+// no-op manager; a non-empty unrecognized type is a configuration error.
+func New(logger *slog.Logger, c config.ManagerSecrets) (Manager, error) {
 	switch c.Active {
 	case "vault":
-		return &vaultManager{preLogger: logger, config: c.Sources.Vault}
+		return &vaultManager{preLogger: logger, config: c.Sources.Vault}, nil
 	case "fleet":
-		return NewFleetSecretsManager(logger, c.Sources.Fleet)
+		return NewFleetSecretsManager(logger, c.Sources.Fleet), nil
 	case "delinea":
-		return &delineaManager{preLogger: logger, config: c.Sources.Delinea}
+		return &delineaManager{preLogger: logger, config: c.Sources.Delinea}, nil
 	case "doppler":
-		return &dopplerManager{preLogger: logger, config: c.Sources.Doppler}
+		return &dopplerManager{preLogger: logger, config: c.Sources.Doppler}, nil
 	case "cyberark":
-		return &cyberarkManager{preLogger: logger, config: c.Sources.CyberArk}
+		return &cyberarkManager{preLogger: logger, config: c.Sources.CyberArk}, nil
+	case "":
+		logger.Info("no secrets manager specified, skipping")
+		return &dummyManager{}, nil
 	default:
-		logger.Info("no secrets manager specified or invalid type, skipping")
-		return &dummyManager{}
+		return nil, fmt.Errorf("unsupported secrets manager type %q (supported: vault, fleet, delinea, doppler, cyberark)", c.Active)
 	}
 }
 

--- a/agent/secretsmgr/vault_test.go
+++ b/agent/secretsmgr/vault_test.go
@@ -861,6 +861,7 @@ func TestNew(t *testing.T) {
 		name         string
 		config       config.ManagerSecrets
 		expectedType string
+		expectErr    bool
 	}{
 		{
 			name: "vault manager",
@@ -882,11 +883,11 @@ func TestNew(t *testing.T) {
 			expectedType: "*secretsmgr.dummyManager",
 		},
 		{
-			name: "dummy manager when active is invalid",
+			name: "error when active is unsupported",
 			config: config.ManagerSecrets{
 				Active: "invalid",
 			},
-			expectedType: "*secretsmgr.dummyManager",
+			expectErr: true,
 		},
 		{
 			name: "delinea manager",
@@ -906,8 +907,13 @@ func TestNew(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			manager := New(logger, tt.config)
-
+			manager, err := New(logger, tt.config)
+			if tt.expectErr {
+				assert.Error(t, err)
+				assert.Nil(t, manager)
+				return
+			}
+			assert.NoError(t, err)
 			assert.NotNil(t, manager)
 			assert.Equal(t, tt.expectedType, fmt.Sprintf("%T", manager))
 		})

--- a/docs/advanced_config/env_config.md
+++ b/docs/advanced_config/env_config.md
@@ -30,7 +30,7 @@ ORB_SECRETS_MANAGER__ACTIVE=vault
 ORB_SECRETS_MANAGER__SOURCES__VAULT__ADDRESS=http://127.0.0.1:8200
 ```
 
-`ORB_` → root `orb`, then `SECRETS_MANAGER` → `secrets_manager` (single `_` preserved), `SOURCES` → `sources`, `VAULT` → `vault`, `ADDRESS` → `address`. `ORB_SECRETS_MANAGER__ACTIVE` accepts one of `vault`, `doppler`, `delinea`, `cyberark`, `fleet`.
+`ORB_` → root `orb`, then `SECRETS_MANAGER` → `secrets_manager` (single `_` preserved), `SOURCES` → `sources`, `VAULT` → `vault`, `ADDRESS` → `address`. `ORB_SECRETS_MANAGER__ACTIVE` accepts one of `vault`, `doppler`, `delinea`, `cyberark`, `fleet`. An empty or unset active value skips the secrets manager and the agent starts normally, but a non-empty unsupported value now fails startup with an error listing the supported types.
 
 The same scheme applies to any other `orb.*` key — for example `ORB_CONFIG_MANAGER__ACTIVE` or `ORB_BACKENDS__...` — not just the secrets manager.
 


### PR DESCRIPTION
Fixes [OBS-3431](https://linear.app/netboxlabs/issue/OBS-3431/agent-should-fail-to-start-when-an-unsupported-secrets-manager-type-is).

## Root cause

`secretsmgr.New`'s `default` switch arm returned a no-op `dummyManager` for **both** an empty (unconfigured) `secrets_manager.active` and any unrecognized value. So `ORB_SECRETS_MANAGER__ACTIVE=invalid` (or any typo) started the agent normally while silently resolving no credentials, with no signal the config was invalid — both cases logged the same `no secrets manager specified or invalid type, skipping`.

## Fix

`New` now returns `(Manager, error)` and splits the two cases:
- **empty/unset active** → no-op `dummyManager`, no error, logs `no secrets manager specified, skipping` (unchanged startup behavior);
- **non-empty unsupported value** → error listing the supported types, propagated by `agent.New` so the agent exits at startup (`cmd/main.go` already logs + `os.Exit(1)` on an `agent.New` error).

## Verification

TDD: the existing `TestNew` table's `invalid → dummyManager` case (which encoded the bug) is changed to `invalid → error`; the empty → dummyManager case stays green as the pin. **Live-verified** on a built binary against the ticket's repro: `ORB_SECRETS_MANAGER__ACTIVE=invalid` exits **non-zero** with `unsupported secrets manager type "invalid" (supported: vault, fleet, delinea, doppler, cyberark)`; no env var still logs the skip line and proceeds past secrets init; a set-but-empty value is dropped by the env overlay and also skips. `go test -race ./cmd/... ./agent/...` green (22 pkgs); `make fix-lint` clean.

One small consequence worth noting: a mis-cased or whitespaced value (`Vault`, ` vault `) that previously skipped silently now fails startup. That is desirable, and the docs have only ever specified lowercase type names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)