### PR TITLE
fix(snmp-discovery): carry description/speed/mtu/enabled on IP-assigned interface stubs

### DIFF
--- a/orb-discovery/snmp-discovery/mapping/stubs.go
+++ b/orb-discovery/snmp-discovery/mapping/stubs.go
@@ -161,21 +161,23 @@ func newDeviceStubKeepingPrimary(owner *diode.Device, isV6 bool, primary *diode.
 	return stub
 }
 
-// newInterfaceStub returns an Interface populated with matcher fields
-// plus the validation-required `Type` field. Used wherever an
-// Interface appears as a nested reference: Parent, Bridge, Lag,
-// IPAddress.AssignedObject, MACAddress.AssignedObject. PrimaryMacAddress
-// is preserved (via newMACMatchStub) so the stub keeps the
-// unique_primary_mac_address matcher precedence and resolves to the
-// same interface as the rich top-level entity.
+// newInterfaceStub returns an Interface populated with the matcher
+// fields plus the interface's plain attributes (type, description,
+// speed, mtu, enabled). Used wherever an Interface appears as a nested
+// reference: Parent, Bridge, Lag, IPAddress.AssignedObject,
+// MACAddress.AssignedObject. PrimaryMacAddress is preserved (via
+// newMACMatchStub) so the stub keeps the unique_primary_mac_address
+// matcher precedence and resolves to the same interface as the rich
+// top-level entity.
 //
-// Why Type: snmp-discovery filters interfaces that are referenced as
-// IPAddress.AssignedObject from top-level emission to avoid emitting
-// them twice (mapping.go:716-718). For those interfaces, the nested
-// stub is the *only* wire payload representing them. If first-time
-// discovery needs to create the interface row, NetBox rejects creation
-// without `type`. Pointer-sharing iface.Type costs negligible bytes
-// and prevents the lossy first-discovery path.
+// Why the plain attributes: snmp-discovery filters interfaces that are
+// referenced as IPAddress.AssignedObject from top-level emission to
+// avoid emitting them twice. For those interfaces the nested stub is
+// the *only* wire payload, so it must carry both `type` (NetBox
+// rejects first-time interface creation without it) and the plain
+// attributes the mapper computed, or they are silently lost. Pointer-
+// sharing them costs negligible bytes. Structural refs (parent/bridge/
+// lag) are intentionally dropped; they carry their own nested payloads.
 func newInterfaceStub(iface *diode.Interface, deviceStub *diode.Device) *diode.Interface {
 	if iface == nil {
 		return nil
@@ -184,6 +186,10 @@ func newInterfaceStub(iface *diode.Interface, deviceStub *diode.Device) *diode.I
 		Name:              iface.Name,
 		Device:            deviceStub,
 		Type:              iface.Type,
+		Description:       iface.Description,
+		Speed:             iface.Speed,
+		Mtu:               iface.Mtu,
+		Enabled:           iface.Enabled,
 		PrimaryMacAddress: newMACMatchStub(iface.PrimaryMacAddress),
 	}
 }

--- a/orb-discovery/snmp-discovery/mapping/stubs_test.go
+++ b/orb-discovery/snmp-discovery/mapping/stubs_test.go
@@ -214,17 +214,23 @@ func TestNewInterfaceStub_Nil(t *testing.T) {
 	assert.Nil(t, newInterfaceStub(nil, nil))
 }
 
-func TestNewInterfaceStub_KeepsNameDeviceMACTypeDropsRest(t *testing.T) {
+func TestNewInterfaceStub_KeepsAttributesDropsStructuralRefs(t *testing.T) {
 	mac := "aa:bb:cc:dd:ee:ff"
 	ifType := strPtr("1000base-t")
+	desc := strPtr("ACA-VOIP")
+	speed := int64Ptr(1000000)
+	mtu := int64Ptr(1500)
+	enabled := boolPtr(true)
 	deviceStub := &diode.Device{Name: strPtr("sw1")}
 	rich := &diode.Interface{
-		Name:              strPtr("Gi1/0/1"),
+		Name:              strPtr("Vlan101"),
 		Device:            &diode.Device{Name: strPtr("sw1"), Serial: strPtr("FCW123")},
 		PrimaryMacAddress: &diode.MACAddress{MacAddress: &mac, Description: strPtr("primary")},
 		Type:              ifType,
-		Mtu:               int64Ptr(1500),
-		Description:       strPtr("uplink"),
+		Description:       desc,
+		Speed:             speed,
+		Mtu:               mtu,
+		Enabled:           enabled,
 		Parent:            &diode.Interface{Name: strPtr("Po1")},
 		Bridge:            &diode.Interface{Name: strPtr("br0")},
 		Lag:               &diode.Interface{Name: strPtr("Po1")},
@@ -234,22 +240,24 @@ func TestNewInterfaceStub_KeepsNameDeviceMACTypeDropsRest(t *testing.T) {
 
 	assert.NotNil(t, stub)
 	assert.NotSame(t, rich, stub)
-	assert.Equal(t, strPtr("Gi1/0/1"), stub.Name)
+	assert.Equal(t, strPtr("Vlan101"), stub.Name)
 	assert.Same(t, deviceStub, stub.Device, "must use the supplied device stub, not rich.Device")
 
-	// Type pointer-shared so NetBox create-validation succeeds when the
-	// stub is the only wire representation of an interface (see
-	// newInterfaceStub doc-comment).
+	// Type + plain attributes pointer-shared so NetBox create-validation
+	// succeeds and ifAlias/speed/mtu/enabled survive when the stub is the
+	// only wire representation of the interface.
 	assert.Same(t, ifType, stub.Type)
+	assert.Same(t, desc, stub.Description)
+	assert.Same(t, speed, stub.Speed)
+	assert.Same(t, mtu, stub.Mtu)
+	assert.Same(t, enabled, stub.Enabled)
 
 	assert.NotNil(t, stub.PrimaryMacAddress)
 	assert.NotSame(t, rich.PrimaryMacAddress, stub.PrimaryMacAddress)
 	assert.Equal(t, &mac, stub.PrimaryMacAddress.MacAddress)
 	assert.Nil(t, stub.PrimaryMacAddress.Description)
 
-	// Other fields cleared.
-	assert.Nil(t, stub.Mtu)
-	assert.Nil(t, stub.Description)
+	// Structural refs stay cleared (they carry their own nested payloads).
 	assert.Nil(t, stub.Parent)
 	assert.Nil(t, stub.Bridge)
 	assert.Nil(t, stub.Lag)


### PR DESCRIPTION
Fixes netboxlabs/orb-agent#467.

## Root cause

An interface referenced as an IP address's assigned object is dropped from top-level emission (`getAssignedInterfaces` / the `!isAssigned` filter in mapping.go) and represented **only** by the nested stub from `newInterfaceStub` (mapping/stubs.go). That stub carried `name`/`device`/`type`/MAC and dropped everything else — so an L3 SVI (which carries an IP) reached NetBox with **no ifAlias description, speed, mtu, or enabled**, while an L2 interface (emitted top-level) kept them. Not an ifType/L2-vs-L3 branch — purely a consequence of the IP-assignment stub being lossy.

## Fix

`newInterfaceStub` now also pointer-carries `description`, `speed`, `mtu`, `enabled` (the plain attributes the rich `InterfaceMapper` populates). These are attributes, not matchers, so interface matching and the primary-IP cycle logic are unaffected. Structural refs (`parent`/`bridge`/`lag`) stay dropped (they carry their own nested payloads).

## Verification

* TDD: the existing stub test (which pinned `description`/`mtu` as nil) is flipped to assert all four are carried, structural refs still dropped.
* **Live before/after** via snmpsim dry-run (parent commit built in an isolated worktree for a true baseline): a crafted device with an L2 port `Gi0/1` and an L3 SVI `Vlan101` (with an assigned IP), both carrying ifAlias/speed/mtu/adminStatus. Before: the `Vlan101` assigned-object stub had only name/type/device. After: `description=ACA-VOIP, speed=1000000, mtu=9000, enabled=true`; `Gi0/1` unchanged.
* `go test -race ./...` green; `make fix-lint` clean.

## Scope notes

* **device-discovery and gnmi-discovery do not have this bug** (investigated): device-discovery always emits every interface top-level with full attributes (the IP ref is matcher-only); gnmi-discovery shares this stub architecture but never filters IP-bearing interfaces out of top-level emission (OpenConfig nests IPs under the interface), so the description rides on the top-level entity.
* Interface `tags` from policy defaults are still dropped from these stubs (a nested-ref list, same class of loss) — left as a follow-up, out of scope here.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)