### PR TITLE
feat(agent): report failed bundle installs in heartbeat bundle_state

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -135,7 +135,7 @@ func (m *mockFilesManager) Get(_ string) (filesmgr.FileEntry, bool) {
 }
 
 func (m *mockFilesManager) List() []filesmgr.FileEntry                  { return nil }
-func (m *mockFilesManager) ListFailures() []filesmgr.FailureEntry       { return nil }
+func (m *mockFilesManager) ListPending() []filesmgr.FileEntry           { return nil }
 func (m *mockFilesManager) Remove(_ context.Context, _ string) error    { return nil }
 func (m *mockFilesManager) Rollback(_ context.Context, _ string) error  { return nil }
 func (m *mockFilesManager) Subscribe(_ func(filesmgr.FileEvent)) func() { return func() {} }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -135,6 +135,7 @@ func (m *mockFilesManager) Get(_ string) (filesmgr.FileEntry, bool) {
 }
 
 func (m *mockFilesManager) List() []filesmgr.FileEntry                  { return nil }
+func (m *mockFilesManager) ListFailures() []filesmgr.FailureEntry       { return nil }
 func (m *mockFilesManager) Remove(_ context.Context, _ string) error    { return nil }
 func (m *mockFilesManager) Rollback(_ context.Context, _ string) error  { return nil }
 func (m *mockFilesManager) Subscribe(_ func(filesmgr.FileEvent)) func() { return func() {} }

--- a/agent/backend/worker/worker_filesmgr_test.go
+++ b/agent/backend/worker/worker_filesmgr_test.go
@@ -151,6 +151,7 @@ func (s *stubDirFilesManager) Get(name string) (filesmgr.FileEntry, bool) {
 }
 
 func (s *stubDirFilesManager) List() []filesmgr.FileEntry                 { return nil }
+func (s *stubDirFilesManager) ListFailures() []filesmgr.FailureEntry      { return nil }
 func (s *stubDirFilesManager) Remove(_ context.Context, _ string) error   { return nil }
 func (s *stubDirFilesManager) Rollback(_ context.Context, _ string) error { return nil }
 func (s *stubDirFilesManager) Subscribe(_ func(filesmgr.FileEvent)) func() {

--- a/agent/backend/worker/worker_filesmgr_test.go
+++ b/agent/backend/worker/worker_filesmgr_test.go
@@ -151,7 +151,7 @@ func (s *stubDirFilesManager) Get(name string) (filesmgr.FileEntry, bool) {
 }
 
 func (s *stubDirFilesManager) List() []filesmgr.FileEntry                 { return nil }
-func (s *stubDirFilesManager) ListFailures() []filesmgr.FailureEntry      { return nil }
+func (s *stubDirFilesManager) ListPending() []filesmgr.FileEntry          { return nil }
 func (s *stubDirFilesManager) Remove(_ context.Context, _ string) error   { return nil }
 func (s *stubDirFilesManager) Rollback(_ context.Context, _ string) error { return nil }
 func (s *stubDirFilesManager) Subscribe(_ func(filesmgr.FileEvent)) func() {

--- a/agent/configmgr/fleet/heartbeats.go
+++ b/agent/configmgr/fleet/heartbeats.go
@@ -21,13 +21,14 @@ const (
 // heartbeatTickInterval is the delay between periodic heartbeats. Tests shorten it.
 var heartbeatTickInterval = heartbeatFreq
 
-// BundleStateRetriever provides read-only access to installed and failed
-// bundle state for heartbeats. Satisfied by filesmgr.Manager.
+// BundleStateRetriever provides read-only access to installed, installing,
+// and failed bundle state for heartbeats. Satisfied by filesmgr.Manager.
 type BundleStateRetriever interface {
 	List() []filesmgr.FileEntry
-	// ListFailures reports bundles whose most recent install attempt failed.
-	// See filesmgr.FailureEntry for why this is in-memory only.
-	ListFailures() []filesmgr.FailureEntry
+	// ListPending reports bundles currently installing or whose most recent
+	// install attempt failed. See filesmgr.FileEntry's doc comment for why
+	// this is in-memory only.
+	ListPending() []filesmgr.FileEntry
 }
 
 type heartbeater struct {
@@ -211,15 +212,16 @@ func (hb *heartbeater) getGroupState() map[string]messages.GroupStateInfo {
 	return gs
 }
 
-// getBundleState reports, per bundle name, both installed and failed state,
-// following the same State+Error pattern as getPolicyState/
-// getBackendState: a name that has successfully installed at least once but
-// whose most recent attempt (e.g. a re-fetch on reconnect) failed reports
-// State as BundleStateFailed with Version updated to the failed attempt's
-// version and Error set, while still retaining SHA256/InstalledAt from the
-// last successful install — mirroring how BackendStateInfo keeps
-// LastRestartTS/LastRestartReason alongside a current Error. A name with no
-// successful install at all reports State/Version/Error from the failure only.
+// getBundleState reports, per bundle name, installed/installing/failed state,
+// following the same State+Error pattern as getPolicyState/getBackendState: a
+// name that has successfully installed at least once but whose most recent
+// attempt (e.g. a re-fetch on reconnect) is in flight or failed reports State
+// as BundleStateInstalling/BundleStateFailed with Version updated to that
+// attempt's version and Error set (when failed), while still retaining
+// SHA256/InstalledAt from the last successful install — mirroring how
+// BackendStateInfo keeps LastRestartTS/LastRestartReason alongside a current
+// Error. A name with no successful install at all reports State/Version/Error
+// from the pending entry only.
 func (hb *heartbeater) getBundleState() map[string]messages.BundleStateInfo {
 	bs := make(map[string]messages.BundleStateInfo)
 	if hb.bundleRetriever == nil {
@@ -233,13 +235,18 @@ func (hb *heartbeater) getBundleState() map[string]messages.BundleStateInfo {
 			InstalledAt: entry.InstalledAt,
 		}
 	}
-	for _, failure := range hb.bundleRetriever.ListFailures() {
-		info := bs[failure.Name] // zero value if no prior successful install
-		info.State = messages.BundleStateFailed
-		info.Version = failure.Version
-		info.Error = failure.Error
-		info.FailedAt = failure.FailedAt
-		bs[failure.Name] = info
+	for _, p := range hb.bundleRetriever.ListPending() {
+		info := bs[p.Name] // zero value if no prior successful install
+		switch p.State {
+		case filesmgr.FileEntryStateInstalling:
+			info.State = messages.BundleStateInstalling
+		case filesmgr.FileEntryStateFailed:
+			info.State = messages.BundleStateFailed
+			info.Error = p.Error
+		}
+		info.Version = p.Version
+		info.StateChangedAt = p.UpdatedAt
+		bs[p.Name] = info
 	}
 	return bs
 }

--- a/agent/configmgr/fleet/heartbeats.go
+++ b/agent/configmgr/fleet/heartbeats.go
@@ -21,10 +21,13 @@ const (
 // heartbeatTickInterval is the delay between periodic heartbeats. Tests shorten it.
 var heartbeatTickInterval = heartbeatFreq
 
-// BundleStateRetriever provides read-only access to installed bundle state for
-// heartbeats. Satisfied by filesmgr.Manager.
+// BundleStateRetriever provides read-only access to installed and failed
+// bundle state for heartbeats. Satisfied by filesmgr.Manager.
 type BundleStateRetriever interface {
 	List() []filesmgr.FileEntry
+	// ListFailures reports bundles whose most recent install attempt failed.
+	// See filesmgr.FailureEntry for why this is in-memory only.
+	ListFailures() []filesmgr.FailureEntry
 }
 
 type heartbeater struct {
@@ -208,6 +211,15 @@ func (hb *heartbeater) getGroupState() map[string]messages.GroupStateInfo {
 	return gs
 }
 
+// getBundleState reports, per bundle name, both installed and failed state,
+// following the same State+Error pattern as getPolicyState/
+// getBackendState: a name that has successfully installed at least once but
+// whose most recent attempt (e.g. a re-fetch on reconnect) failed reports
+// State as BundleStateFailed with Version updated to the failed attempt's
+// version and Error set, while still retaining SHA256/InstalledAt from the
+// last successful install — mirroring how BackendStateInfo keeps
+// LastRestartTS/LastRestartReason alongside a current Error. A name with no
+// successful install at all reports State/Version/Error from the failure only.
 func (hb *heartbeater) getBundleState() map[string]messages.BundleStateInfo {
 	bs := make(map[string]messages.BundleStateInfo)
 	if hb.bundleRetriever == nil {
@@ -220,6 +232,14 @@ func (hb *heartbeater) getBundleState() map[string]messages.BundleStateInfo {
 			SHA256:      entry.SHA256,
 			InstalledAt: entry.InstalledAt,
 		}
+	}
+	for _, failure := range hb.bundleRetriever.ListFailures() {
+		info := bs[failure.Name] // zero value if no prior successful install
+		info.State = messages.BundleStateFailed
+		info.Version = failure.Version
+		info.Error = failure.Error
+		info.FailedAt = failure.FailedAt
+		bs[failure.Name] = info
 	}
 	return bs
 }

--- a/agent/configmgr/fleet/heartbeats_test.go
+++ b/agent/configmgr/fleet/heartbeats_test.go
@@ -1928,7 +1928,6 @@ func TestHeartbeater_SendSingleHeartbeat_SerializesFailedBundleState(t *testing.
 					Version:   "1.0.0",
 					State:     filesmgr.FileEntryStateFailed,
 					Error:     "context deadline exceeded",
-					Timeout:   true,
 					UpdatedAt: changedTime,
 				},
 				{

--- a/agent/configmgr/fleet/heartbeats_test.go
+++ b/agent/configmgr/fleet/heartbeats_test.go
@@ -23,9 +23,13 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/policymgr"
 )
 
-type stubBundleRetriever struct{ entries []filesmgr.FileEntry }
+type stubBundleRetriever struct {
+	entries  []filesmgr.FileEntry
+	failures []filesmgr.FailureEntry
+}
 
-func (s stubBundleRetriever) List() []filesmgr.FileEntry { return s.entries }
+func (s stubBundleRetriever) List() []filesmgr.FileEntry            { return s.entries }
+func (s stubBundleRetriever) ListFailures() []filesmgr.FailureEntry { return s.failures }
 
 func init() {
 	heartbeatTickInterval = 50 * time.Millisecond
@@ -1884,6 +1888,85 @@ func TestHeartbeater_SendSingleHeartbeat_SerializesBundleState(t *testing.T) {
 	assert.Contains(t, string(capturedPayload), `"nbl_cisco_meraki":{"state":"installed","version":"2.15.0","sha256":"57c56d72"`)
 }
 
+// TestHeartbeater_SendSingleHeartbeat_SerializesFailedBundleState verifies
+// that a bundle whose most recent install attempt failed is reported in
+// bundle_state as "failed" (previously it was silently omitted), and that a
+// name with both a last-known-good install and a newer failed attempt (e.g.
+// a failed re-fetch on reconnect) surfaces both the failure and the
+// last-known-good version rather than losing one or the other.
+func TestHeartbeater_SendSingleHeartbeat_SerializesFailedBundleState(t *testing.T) {
+	testTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	failTime := time.Date(2024, 1, 2, 8, 0, 0, 0, time.UTC)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	groupManager := newGroupManager()
+	hb := &heartbeater{
+		logger:         logger,
+		backendState:   &mockBackendState{},
+		policyManager:  &mockPolicyManagerForHeartbeat{},
+		groupRetriever: &groupManager,
+		bundleRetriever: stubBundleRetriever{
+			entries: []filesmgr.FileEntry{
+				{
+					Name:        "nbl_cisco_meraki",
+					Version:     "2.15.0",
+					SHA256:      "57c56d72",
+					InstalledAt: testTime,
+				},
+			},
+			failures: []filesmgr.FailureEntry{
+				{
+					Name:     "nbl_cisco_meraki",
+					Version:  "2.16.0",
+					Error:    "checksum mismatch",
+					FailedAt: failTime,
+				},
+				{
+					Name:     "nbl_never_installed",
+					Version:  "1.0.0",
+					Error:    "context deadline exceeded",
+					Timeout:  true,
+					FailedAt: failTime,
+				},
+			},
+		},
+	}
+	hb.policyManager.(*mockPolicyManagerForHeartbeat).On("GetPolicyState").Return([]policies.PolicyData{}, nil)
+
+	var capturedPayload []byte
+	publishFunc := func(_ context.Context, _ string, payload []byte) error {
+		capturedPayload = payload
+		return nil
+	}
+
+	hb.sendSingleHeartbeat(context.Background(), "test/topic", publishFunc, "agent-id", testTime, messages.Online, nil)
+
+	require.NotNil(t, capturedPayload)
+
+	var hb2 messages.Heartbeat
+	require.NoError(t, json.Unmarshal(capturedPayload, &hb2))
+
+	// A bundle with a last-known-good install AND a newer failed attempt
+	// reports "failed" state, Version updated to the failed attempt, and
+	// Error set — while SHA256/InstalledAt still reflect the last successful
+	// install (same State+Error pattern as PolicyStateInfo/BackendStateInfo).
+	require.Contains(t, hb2.BundleState, "nbl_cisco_meraki")
+	merakiState := hb2.BundleState["nbl_cisco_meraki"]
+	assert.Equal(t, messages.BundleStateFailed, merakiState.State)
+	assert.Equal(t, "2.16.0", merakiState.Version, "version reflects the most recent (failed) attempt")
+	assert.Equal(t, "57c56d72", merakiState.SHA256, "last successful install's SHA256 is retained")
+	assert.Equal(t, "checksum mismatch", merakiState.Error)
+	assert.True(t, failTime.Equal(merakiState.FailedAt))
+
+	// A bundle that has never successfully installed reports state/version/error
+	// from the failure alone.
+	require.Contains(t, hb2.BundleState, "nbl_never_installed")
+	neverInstalled := hb2.BundleState["nbl_never_installed"]
+	assert.Equal(t, messages.BundleStateFailed, neverInstalled.State)
+	assert.Equal(t, "1.0.0", neverInstalled.Version)
+	assert.Equal(t, "context deadline exceeded", neverInstalled.Error)
+}
+
 func TestHeartbeater_SendSingleHeartbeat_SerializesPerRunTargets(t *testing.T) {
 	testTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 	mockPMgr := &mockPolicyManagerForHeartbeat{}
@@ -1922,7 +2005,7 @@ func TestHeartbeater_SendSingleHeartbeat_SerializesPerRunTargets(t *testing.T) {
 	var hb2 messages.Heartbeat
 	require.NoError(t, json.Unmarshal(capturedPayload, &hb2))
 
-	assert.Equal(t, "1.2", hb2.SchemaVersion)
+	assert.Equal(t, "1.3", hb2.SchemaVersion)
 	require.Len(t, hb2.PolicyState["policy-1"].Runs, 1)
 	assert.Equal(t, []string{"10.0.0.1"}, hb2.PolicyState["policy-1"].Runs[0].Targets)
 	assert.Equal(t, "ios", hb2.PolicyState["policy-1"].Runs[0].Driver)

--- a/agent/configmgr/fleet/heartbeats_test.go
+++ b/agent/configmgr/fleet/heartbeats_test.go
@@ -24,12 +24,12 @@ import (
 )
 
 type stubBundleRetriever struct {
-	entries  []filesmgr.FileEntry
-	failures []filesmgr.FailureEntry
+	entries []filesmgr.FileEntry
+	pending []filesmgr.FileEntry
 }
 
-func (s stubBundleRetriever) List() []filesmgr.FileEntry            { return s.entries }
-func (s stubBundleRetriever) ListFailures() []filesmgr.FailureEntry { return s.failures }
+func (s stubBundleRetriever) List() []filesmgr.FileEntry        { return s.entries }
+func (s stubBundleRetriever) ListPending() []filesmgr.FileEntry { return s.pending }
 
 func init() {
 	heartbeatTickInterval = 50 * time.Millisecond
@@ -1893,10 +1893,11 @@ func TestHeartbeater_SendSingleHeartbeat_SerializesBundleState(t *testing.T) {
 // bundle_state as "failed" (previously it was silently omitted), and that a
 // name with both a last-known-good install and a newer failed attempt (e.g.
 // a failed re-fetch on reconnect) surfaces both the failure and the
-// last-known-good version rather than losing one or the other.
+// last-known-good version rather than losing one or the other. Also covers
+// the transitional "installing" state added per review feedback.
 func TestHeartbeater_SendSingleHeartbeat_SerializesFailedBundleState(t *testing.T) {
 	testTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
-	failTime := time.Date(2024, 1, 2, 8, 0, 0, 0, time.UTC)
+	changedTime := time.Date(2024, 1, 2, 8, 0, 0, 0, time.UTC)
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	groupManager := newGroupManager()
@@ -1914,19 +1915,27 @@ func TestHeartbeater_SendSingleHeartbeat_SerializesFailedBundleState(t *testing.
 					InstalledAt: testTime,
 				},
 			},
-			failures: []filesmgr.FailureEntry{
+			pending: []filesmgr.FileEntry{
 				{
-					Name:     "nbl_cisco_meraki",
-					Version:  "2.16.0",
-					Error:    "checksum mismatch",
-					FailedAt: failTime,
+					Name:      "nbl_cisco_meraki",
+					Version:   "2.16.0",
+					State:     filesmgr.FileEntryStateFailed,
+					Error:     "checksum mismatch",
+					UpdatedAt: changedTime,
 				},
 				{
-					Name:     "nbl_never_installed",
-					Version:  "1.0.0",
-					Error:    "context deadline exceeded",
-					Timeout:  true,
-					FailedAt: failTime,
+					Name:      "nbl_never_installed",
+					Version:   "1.0.0",
+					State:     filesmgr.FileEntryStateFailed,
+					Error:     "context deadline exceeded",
+					Timeout:   true,
+					UpdatedAt: changedTime,
+				},
+				{
+					Name:      "nbl_installing_now",
+					Version:   "3.0.0",
+					State:     filesmgr.FileEntryStateInstalling,
+					UpdatedAt: changedTime,
 				},
 			},
 		},
@@ -1956,15 +1965,23 @@ func TestHeartbeater_SendSingleHeartbeat_SerializesFailedBundleState(t *testing.
 	assert.Equal(t, "2.16.0", merakiState.Version, "version reflects the most recent (failed) attempt")
 	assert.Equal(t, "57c56d72", merakiState.SHA256, "last successful install's SHA256 is retained")
 	assert.Equal(t, "checksum mismatch", merakiState.Error)
-	assert.True(t, failTime.Equal(merakiState.FailedAt))
+	assert.True(t, changedTime.Equal(merakiState.StateChangedAt))
 
 	// A bundle that has never successfully installed reports state/version/error
-	// from the failure alone.
+	// from the pending entry alone.
 	require.Contains(t, hb2.BundleState, "nbl_never_installed")
 	neverInstalled := hb2.BundleState["nbl_never_installed"]
 	assert.Equal(t, messages.BundleStateFailed, neverInstalled.State)
 	assert.Equal(t, "1.0.0", neverInstalled.Version)
 	assert.Equal(t, "context deadline exceeded", neverInstalled.Error)
+
+	// A bundle currently installing (never previously installed) reports the
+	// transitional "installing" state with no error.
+	require.Contains(t, hb2.BundleState, "nbl_installing_now")
+	installingNow := hb2.BundleState["nbl_installing_now"]
+	assert.Equal(t, messages.BundleStateInstalling, installingNow.State)
+	assert.Equal(t, "3.0.0", installingNow.Version)
+	assert.Empty(t, installingNow.Error)
 }
 
 func TestHeartbeater_SendSingleHeartbeat_SerializesPerRunTargets(t *testing.T) {

--- a/agent/configmgr/fleet/messages/fleet_messages.go
+++ b/agent/configmgr/fleet/messages/fleet_messages.go
@@ -60,6 +60,11 @@ type GroupStateInfo struct {
 	GroupID   string `json:"id"`
 }
 
+// BundleStateInstalling is the reported state for a bundle whose Ensure call
+// is currently in flight (added in schema 1.3, alongside BundleStateFailed
+// below).
+const BundleStateInstalling = "installing"
+
 // BundleStateInstalled is the reported state for a bundle present on disk.
 const BundleStateInstalled = "installed"
 
@@ -73,20 +78,21 @@ const BundleStateFailed = "failed"
 // pattern as PolicyStateInfo/BackendStateInfo: State plus a flat Error string
 // that is set on the most recent failed attempt and cleared (empty) once a
 // later attempt succeeds — there is no separate parallel set of "failed"
-// fields. When State is BundleStateFailed, Version is the version that most
-// recently failed to install (which may differ from a still-installed prior
-// version); SHA256/InstalledAt continue to reflect the last successful
-// install, if any, same as BackendStateInfo retains LastRestartTS/
-// LastRestartReason alongside a current Error.
+// fields. When State is BundleStateInstalling or BundleStateFailed, Version
+// is the version of that in-flight/failed attempt (which may differ from a
+// still-installed prior version); SHA256/InstalledAt continue to reflect the
+// last successful install, if any, same as BackendStateInfo retains
+// LastRestartTS/LastRestartReason alongside a current Error.
 type BundleStateInfo struct {
 	State       string    `json:"state"`
 	Version     string    `json:"version,omitempty"`
 	SHA256      string    `json:"sha256,omitempty"`
 	InstalledAt time.Time `json:"installed_at,omitzero"`
 	Error       string    `json:"error,omitempty"`
-	// FailedAt is when the most recent install attempt failed. Populated
-	// when Error is set.
-	FailedAt time.Time `json:"failed_at,omitzero"`
+	// StateChangedAt is when the current State began — i.e. when an
+	// installing attempt started, or when a failed attempt failed. Zero when
+	// State is BundleStateInstalled.
+	StateChangedAt time.Time `json:"state_changed_at,omitzero"`
 }
 
 // Heartbeat represents an agent heartbeat message

--- a/agent/configmgr/fleet/messages/fleet_messages.go
+++ b/agent/configmgr/fleet/messages/fleet_messages.go
@@ -6,7 +6,7 @@ import (
 )
 
 // CurrentHeartbeatSchemaVersion defines the current version of the heartbeat schema
-const CurrentHeartbeatSchemaVersion = "1.2"
+const CurrentHeartbeatSchemaVersion = "1.3"
 
 var (
 	// ErrSchemaVersion a message was received indicating a version we don't support
@@ -61,16 +61,32 @@ type GroupStateInfo struct {
 }
 
 // BundleStateInstalled is the reported state for a bundle present on disk.
-// Lifecycle states (installing/failed/expired) are intentionally out of scope
-// for schema 1.2; the store only records successfully installed bundles.
 const BundleStateInstalled = "installed"
 
-// BundleStateInfo contains state information for an installed bundle.
+// BundleStateFailed is the reported state for a bundle whose most recent
+// install attempt (checksum mismatch, install timeout, or download/extract
+// error) did not succeed. Added in schema 1.3; previously a failed
+// install was silently omitted from bundle_state instead of being reported.
+const BundleStateFailed = "failed"
+
+// BundleStateInfo contains state information for a bundle, following the same
+// pattern as PolicyStateInfo/BackendStateInfo: State plus a flat Error string
+// that is set on the most recent failed attempt and cleared (empty) once a
+// later attempt succeeds — there is no separate parallel set of "failed"
+// fields. When State is BundleStateFailed, Version is the version that most
+// recently failed to install (which may differ from a still-installed prior
+// version); SHA256/InstalledAt continue to reflect the last successful
+// install, if any, same as BackendStateInfo retains LastRestartTS/
+// LastRestartReason alongside a current Error.
 type BundleStateInfo struct {
 	State       string    `json:"state"`
 	Version     string    `json:"version,omitempty"`
 	SHA256      string    `json:"sha256,omitempty"`
 	InstalledAt time.Time `json:"installed_at,omitzero"`
+	Error       string    `json:"error,omitempty"`
+	// FailedAt is when the most recent install attempt failed. Populated
+	// when Error is set.
+	FailedAt time.Time `json:"failed_at,omitzero"`
 }
 
 // Heartbeat represents an agent heartbeat message

--- a/agent/configmgr/fleet/messages/fleet_messages_test.go
+++ b/agent/configmgr/fleet/messages/fleet_messages_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCurrentHeartbeatSchemaVersion_IsOneTwo(t *testing.T) {
-	assert.Equal(t, "1.2", CurrentHeartbeatSchemaVersion)
+func TestCurrentHeartbeatSchemaVersion_IsOneThree(t *testing.T) {
+	// Bumped 1.2 -> 1.3: bundle_state gained a "failed" state
+	// (BundleStateFailed) in addition to "installed".
+	assert.Equal(t, "1.3", CurrentHeartbeatSchemaVersion)
 }
 
 func TestRunStateInfo_TargetsOmittedWhenNil(t *testing.T) {

--- a/agent/configmgr/fleet/packages_test.go
+++ b/agent/configmgr/fleet/packages_test.go
@@ -41,7 +41,8 @@ func (m *mockFilesManager) Get(name string) (filesmgr.FileEntry, bool) {
 	return args.Get(0).(filesmgr.FileEntry), args.Bool(1)
 }
 
-func (m *mockFilesManager) List() []filesmgr.FileEntry { return nil }
+func (m *mockFilesManager) List() []filesmgr.FileEntry            { return nil }
+func (m *mockFilesManager) ListFailures() []filesmgr.FailureEntry { return nil }
 
 func (m *mockFilesManager) Remove(ctx context.Context, name string) error {
 	args := m.Called(ctx, name)

--- a/agent/configmgr/fleet/packages_test.go
+++ b/agent/configmgr/fleet/packages_test.go
@@ -41,8 +41,8 @@ func (m *mockFilesManager) Get(name string) (filesmgr.FileEntry, bool) {
 	return args.Get(0).(filesmgr.FileEntry), args.Bool(1)
 }
 
-func (m *mockFilesManager) List() []filesmgr.FileEntry            { return nil }
-func (m *mockFilesManager) ListFailures() []filesmgr.FailureEntry { return nil }
+func (m *mockFilesManager) List() []filesmgr.FileEntry        { return nil }
+func (m *mockFilesManager) ListPending() []filesmgr.FileEntry { return nil }
 
 func (m *mockFilesManager) Remove(ctx context.Context, name string) error {
 	args := m.Called(ctx, name)

--- a/agent/filesmgr/dummy.go
+++ b/agent/filesmgr/dummy.go
@@ -14,7 +14,7 @@ func (dummyFilesManager) Stop(context.Context) error                       { ret
 func (dummyFilesManager) Ensure(context.Context, FileSpec) (string, error) { return "", nil }
 func (dummyFilesManager) Get(string) (FileEntry, bool)                     { return FileEntry{}, false }
 func (dummyFilesManager) List() []FileEntry                                { return nil }
-func (dummyFilesManager) ListFailures() []FailureEntry                     { return nil }
+func (dummyFilesManager) ListPending() []FileEntry                         { return nil }
 func (dummyFilesManager) Remove(context.Context, string) error             { return nil }
 func (dummyFilesManager) Rollback(context.Context, string) error           { return nil }
 func (dummyFilesManager) Subscribe(func(FileEvent)) func()                 { return func() {} }

--- a/agent/filesmgr/dummy.go
+++ b/agent/filesmgr/dummy.go
@@ -14,6 +14,7 @@ func (dummyFilesManager) Stop(context.Context) error                       { ret
 func (dummyFilesManager) Ensure(context.Context, FileSpec) (string, error) { return "", nil }
 func (dummyFilesManager) Get(string) (FileEntry, bool)                     { return FileEntry{}, false }
 func (dummyFilesManager) List() []FileEntry                                { return nil }
+func (dummyFilesManager) ListFailures() []FailureEntry                     { return nil }
 func (dummyFilesManager) Remove(context.Context, string) error             { return nil }
 func (dummyFilesManager) Rollback(context.Context, string) error           { return nil }
 func (dummyFilesManager) Subscribe(func(FileEvent)) func()                 { return func() {} }

--- a/agent/filesmgr/filesmgr.go
+++ b/agent/filesmgr/filesmgr.go
@@ -51,7 +51,7 @@ type filesmgr struct {
 	// failure-bookkeeping in the Ensure wrapper below — for a given name. This
 	// is deliberately a second, separate mutex from perNameMu rather than
 	// reusing it: ensureLocked acquires/releases perNameMu internally and
-	// returns before Ensure's wrapper runs recordFailure/clearFailure, so
+	// returns before Ensure's wrapper runs setPendingFailed/clearPending, so
 	// without an outer lock two overlapping Ensure calls for the same name
 	// could have their record/clear calls execute out of completion order (an
 	// older, slower failing call could record a failure after a newer,
@@ -61,12 +61,12 @@ type filesmgr struct {
 	// last is guaranteed to be the one whose outcome is recorded.
 	callMu sync.Map // name -> *sync.Mutex
 
-	// failuresMu guards failures. Deliberately separate from store's locking:
-	// failures are in-memory-only (never persisted to state.json — see
-	// FailureEntry doc comment in types.go) and are updated on the Ensure
-	// error path, which does not hold store.mu.
-	failuresMu sync.RWMutex
-	failures   map[string]FailureEntry // name -> most recent failure
+	// pendingMu guards pending. Deliberately separate from store's locking:
+	// pending entries are in-memory-only (never persisted to state.json —
+	// see FileEntry's doc comment in types.go) and are updated on the
+	// Ensure call path, which does not hold store.mu.
+	pendingMu sync.RWMutex
+	pending   map[string]FileEntry // name -> current installing/failed entry
 }
 
 // defaultRoot is the directory used when FilesManagerConfig.Root is empty.
@@ -101,12 +101,12 @@ func NewManager(logger *slog.Logger, root string) Manager {
 	}
 	l := logger.With("subsystem", "filesmgr")
 	return &filesmgr{
-		logger:   l,
-		root:     root,
-		store:    newStore(filepath.Join(root, "state.json")),
-		fetcher:  newFetcher(l),
-		bus:      newEventBusWithLogger(logger),
-		failures: make(map[string]FailureEntry),
+		logger:  l,
+		root:    root,
+		store:   newStore(filepath.Join(root, "state.json")),
+		fetcher: newFetcher(l),
+		bus:     newEventBusWithLogger(logger),
+		pending: make(map[string]FileEntry),
 	}
 }
 
@@ -466,38 +466,54 @@ func (m *filesmgr) List() []FileEntry {
 	return out
 }
 
-// recordFailure records name's most recent failed Ensure attempt, overwriting
-// any prior failure for the same name (only the latest attempt is kept).
-func (m *filesmgr) recordFailure(name, version string, err error, timedOut bool) {
-	m.failuresMu.Lock()
-	defer m.failuresMu.Unlock()
-	m.failures[name] = FailureEntry{
-		Name:     name,
-		Version:  version,
-		Error:    err.Error(),
-		Timeout:  timedOut,
-		FailedAt: time.Now().UTC(),
+// setPendingInstalling marks name as currently installing, overwriting
+// whatever pending entry (installing or failed) it may have had before. Called
+// at the start of Ensure, before the fetch/verify work begins.
+func (m *filesmgr) setPendingInstalling(name, version string) {
+	m.pendingMu.Lock()
+	defer m.pendingMu.Unlock()
+	m.pending[name] = FileEntry{
+		Name:      name,
+		Version:   version,
+		State:     FileEntryStateInstalling,
+		UpdatedAt: time.Now().UTC(),
 	}
 }
 
-// clearFailure drops any recorded failure for name. Called after a
-// successful Ensure so a subsequent heartbeat stops reporting a since-resolved
-// failure.
-func (m *filesmgr) clearFailure(name string) {
-	m.failuresMu.Lock()
-	defer m.failuresMu.Unlock()
-	delete(m.failures, name)
+// setPendingFailed records name's most recent failed Ensure attempt,
+// overwriting whatever pending entry it may have had before (only the latest
+// attempt is kept).
+func (m *filesmgr) setPendingFailed(name, version string, err error, timedOut bool) {
+	m.pendingMu.Lock()
+	defer m.pendingMu.Unlock()
+	m.pending[name] = FileEntry{
+		Name:      name,
+		Version:   version,
+		State:     FileEntryStateFailed,
+		Error:     err.Error(),
+		Timeout:   timedOut,
+		UpdatedAt: time.Now().UTC(),
+	}
 }
 
-// ListFailures returns a snapshot of the most recent failed Ensure attempt for
-// each name that currently has one outstanding (i.e. no later Ensure for that
-// name has succeeded). Order is unspecified.
-func (m *filesmgr) ListFailures() []FailureEntry {
-	m.failuresMu.RLock()
-	defer m.failuresMu.RUnlock()
-	out := make([]FailureEntry, 0, len(m.failures))
-	for _, f := range m.failures {
-		out = append(out, f)
+// clearPending drops any pending (installing/failed) entry for name. Called
+// after a successful Ensure so a subsequent heartbeat stops reporting a
+// since-resolved installing/failed state.
+func (m *filesmgr) clearPending(name string) {
+	m.pendingMu.Lock()
+	defer m.pendingMu.Unlock()
+	delete(m.pending, name)
+}
+
+// ListPending returns a snapshot of the current installing/failed entry for
+// each name that has one outstanding (i.e. no later Ensure call for that name
+// has succeeded since). Order is unspecified.
+func (m *filesmgr) ListPending() []FileEntry {
+	m.pendingMu.RLock()
+	defer m.pendingMu.RUnlock()
+	out := make([]FileEntry, 0, len(m.pending))
+	for _, p := range m.pending {
+		out = append(out, p)
 	}
 	return out
 }
@@ -507,22 +523,25 @@ func (m *filesmgr) Subscribe(handler func(FileEvent)) (unsubscribe func()) {
 }
 
 // Ensure makes sure the file described by spec is present on disk and matches
-// the declared SHA256. It wraps ensureLocked to record/clear per-name failure
-// state for heartbeat reporting: a failing attempt is recorded via
-// recordFailure so getBundleState (agent/configmgr/fleet/heartbeats.go) can
-// surface it instead of silently omitting the bundle; a succeeding attempt
-// clears any previously recorded failure for the same name.
+// the declared SHA256. It wraps ensureLocked to maintain per-name pending
+// state for heartbeat reporting (getBundleState in
+// agent/configmgr/fleet/heartbeats.go): the name is marked "installing" for
+// the duration of the call, then either "failed" (with Error set) or cleared
+// entirely on success, so a bundle's install lifecycle is never silently
+// omitted from the heartbeat.
 func (m *filesmgr) Ensure(ctx context.Context, spec FileSpec) (string, error) {
 	callMu := m.ensureCallMutexFor(spec.Name)
 	callMu.Lock()
 	defer callMu.Unlock()
 
+	m.setPendingInstalling(spec.Name, spec.Version)
+
 	path, err := m.ensureLocked(ctx, spec)
 	if err != nil {
-		m.recordFailure(spec.Name, spec.Version, err, errors.Is(ctx.Err(), context.DeadlineExceeded))
+		m.setPendingFailed(spec.Name, spec.Version, err, errors.Is(ctx.Err(), context.DeadlineExceeded))
 		return path, err
 	}
-	m.clearFailure(spec.Name)
+	m.clearPending(spec.Name)
 	return path, err
 }
 

--- a/agent/filesmgr/filesmgr.go
+++ b/agent/filesmgr/filesmgr.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -44,6 +45,13 @@ type filesmgr struct {
 
 	// perNameMu serializes Ensure calls for the same logical name.
 	perNameMu sync.Map // name -> *sync.Mutex
+
+	// failuresMu guards failures. Deliberately separate from store's locking:
+	// failures are in-memory-only (never persisted to state.json — see
+	// FailureEntry doc comment in types.go) and are updated on the Ensure
+	// error path, which does not hold store.mu.
+	failuresMu sync.RWMutex
+	failures   map[string]FailureEntry // name -> most recent failure
 }
 
 // defaultRoot is the directory used when FilesManagerConfig.Root is empty.
@@ -78,11 +86,12 @@ func NewManager(logger *slog.Logger, root string) Manager {
 	}
 	l := logger.With("subsystem", "filesmgr")
 	return &filesmgr{
-		logger:  l,
-		root:    root,
-		store:   newStore(filepath.Join(root, "state.json")),
-		fetcher: newFetcher(l),
-		bus:     newEventBusWithLogger(logger),
+		logger:   l,
+		root:     root,
+		store:    newStore(filepath.Join(root, "state.json")),
+		fetcher:  newFetcher(l),
+		bus:      newEventBusWithLogger(logger),
+		failures: make(map[string]FailureEntry),
 	}
 }
 
@@ -442,16 +451,68 @@ func (m *filesmgr) List() []FileEntry {
 	return out
 }
 
+// recordFailure records name's most recent failed Ensure attempt, overwriting
+// any prior failure for the same name (only the latest attempt is kept).
+func (m *filesmgr) recordFailure(name, version string, err error, timedOut bool) {
+	m.failuresMu.Lock()
+	defer m.failuresMu.Unlock()
+	m.failures[name] = FailureEntry{
+		Name:     name,
+		Version:  version,
+		Error:    err.Error(),
+		Timeout:  timedOut,
+		FailedAt: time.Now().UTC(),
+	}
+}
+
+// clearFailure drops any recorded failure for name. Called after a
+// successful Ensure so a subsequent heartbeat stops reporting a since-resolved
+// failure.
+func (m *filesmgr) clearFailure(name string) {
+	m.failuresMu.Lock()
+	defer m.failuresMu.Unlock()
+	delete(m.failures, name)
+}
+
+// ListFailures returns a snapshot of the most recent failed Ensure attempt for
+// each name that currently has one outstanding (i.e. no later Ensure for that
+// name has succeeded). Order is unspecified.
+func (m *filesmgr) ListFailures() []FailureEntry {
+	m.failuresMu.RLock()
+	defer m.failuresMu.RUnlock()
+	out := make([]FailureEntry, 0, len(m.failures))
+	for _, f := range m.failures {
+		out = append(out, f)
+	}
+	return out
+}
+
 func (m *filesmgr) Subscribe(handler func(FileEvent)) (unsubscribe func()) {
 	return m.bus.subscribe(handler)
 }
 
 // Ensure makes sure the file described by spec is present on disk and matches
-// the declared SHA256. Correct operation order (atomicity guarantee):
+// the declared SHA256. It wraps ensureLocked to record/clear per-name failure
+// state for heartbeat reporting: a failing attempt is recorded via
+// recordFailure so getBundleState (agent/configmgr/fleet/heartbeats.go) can
+// surface it instead of silently omitting the bundle; a succeeding attempt
+// clears any previously recorded failure for the same name.
+func (m *filesmgr) Ensure(ctx context.Context, spec FileSpec) (string, error) {
+	path, err := m.ensureLocked(ctx, spec)
+	if err != nil {
+		m.recordFailure(spec.Name, spec.Version, err, errors.Is(ctx.Err(), context.DeadlineExceeded))
+		return path, err
+	}
+	m.clearFailure(spec.Name)
+	return path, err
+}
+
+// ensureLocked contains the original Ensure implementation. Correct operation
+// order (atomicity guarantee):
 //  1. Fetch into fresh version directory.
 //  2. Attempt store.put; if it fails, clean up the version dir.
 //  3. Swap the "current" symlink; if it fails, roll back store.put.
-func (m *filesmgr) Ensure(ctx context.Context, spec FileSpec) (string, error) {
+func (m *filesmgr) ensureLocked(ctx context.Context, spec FileSpec) (string, error) {
 	if err := spec.Validate(); err != nil {
 		return "", err
 	}

--- a/agent/filesmgr/filesmgr.go
+++ b/agent/filesmgr/filesmgr.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -482,8 +481,11 @@ func (m *filesmgr) setPendingInstalling(name, version string) {
 
 // setPendingFailed records name's most recent failed Ensure attempt,
 // overwriting whatever pending entry it may have had before (only the latest
-// attempt is kept).
-func (m *filesmgr) setPendingFailed(name, version string, err error, timedOut bool) {
+// attempt is kept). err's message (e.g. containing "context deadline
+// exceeded" for the install timeout) is the sole signal for the failure
+// cause — see FileEntry's doc comment for why there is no separate
+// structured field for this.
+func (m *filesmgr) setPendingFailed(name, version string, err error) {
 	m.pendingMu.Lock()
 	defer m.pendingMu.Unlock()
 	m.pending[name] = FileEntry{
@@ -491,7 +493,6 @@ func (m *filesmgr) setPendingFailed(name, version string, err error, timedOut bo
 		Version:   version,
 		State:     FileEntryStateFailed,
 		Error:     err.Error(),
-		Timeout:   timedOut,
 		UpdatedAt: time.Now().UTC(),
 	}
 }
@@ -538,7 +539,7 @@ func (m *filesmgr) Ensure(ctx context.Context, spec FileSpec) (string, error) {
 
 	path, err := m.ensureLocked(ctx, spec)
 	if err != nil {
-		m.setPendingFailed(spec.Name, spec.Version, err, errors.Is(ctx.Err(), context.DeadlineExceeded))
+		m.setPendingFailed(spec.Name, spec.Version, err)
 		return path, err
 	}
 	m.clearPending(spec.Name)

--- a/agent/filesmgr/filesmgr.go
+++ b/agent/filesmgr/filesmgr.go
@@ -43,8 +43,23 @@ type filesmgr struct {
 	fetcher *fetcher
 	bus     *eventBus
 
-	// perNameMu serializes Ensure calls for the same logical name.
+	// perNameMu serializes the actual install work (fetch/verify/symlink-swap)
+	// inside ensureLocked for a given name.
 	perNameMu sync.Map // name -> *sync.Mutex
+
+	// callMu serializes an entire Ensure call — including the record/clear
+	// failure-bookkeeping in the Ensure wrapper below — for a given name. This
+	// is deliberately a second, separate mutex from perNameMu rather than
+	// reusing it: ensureLocked acquires/releases perNameMu internally and
+	// returns before Ensure's wrapper runs recordFailure/clearFailure, so
+	// without an outer lock two overlapping Ensure calls for the same name
+	// could have their record/clear calls execute out of completion order (an
+	// older, slower failing call could record a failure after a newer,
+	// faster successful call already cleared it). Holding callMu across the
+	// whole wrapper call ties the record/clear decision to the same
+	// happens-before order as lock acquisition, so whichever call finishes
+	// last is guaranteed to be the one whose outcome is recorded.
+	callMu sync.Map // name -> *sync.Mutex
 
 	// failuresMu guards failures. Deliberately separate from store's locking:
 	// failures are in-memory-only (never persisted to state.json — see
@@ -498,6 +513,10 @@ func (m *filesmgr) Subscribe(handler func(FileEvent)) (unsubscribe func()) {
 // surface it instead of silently omitting the bundle; a succeeding attempt
 // clears any previously recorded failure for the same name.
 func (m *filesmgr) Ensure(ctx context.Context, spec FileSpec) (string, error) {
+	callMu := m.ensureCallMutexFor(spec.Name)
+	callMu.Lock()
+	defer callMu.Unlock()
+
 	path, err := m.ensureLocked(ctx, spec)
 	if err != nil {
 		m.recordFailure(spec.Name, spec.Version, err, errors.Is(ctx.Err(), context.DeadlineExceeded))
@@ -784,6 +803,16 @@ func versionDirFromEntry(root string, entry FileEntry) string {
 
 func (m *filesmgr) mutexFor(name string) *sync.Mutex {
 	v, _ := m.perNameMu.LoadOrStore(name, &sync.Mutex{})
+	mu, _ := v.(*sync.Mutex) // LoadOrStore stored a *sync.Mutex; assertion cannot fail.
+	return mu
+}
+
+// ensureCallMutexFor returns the outer per-name mutex used by Ensure to
+// serialize an entire call (install + failure record/clear) against other
+// concurrent Ensure calls for the same name. See the callMu field doc for why
+// this is a distinct mutex from the one mutexFor returns.
+func (m *filesmgr) ensureCallMutexFor(name string) *sync.Mutex {
+	v, _ := m.callMu.LoadOrStore(name, &sync.Mutex{})
 	mu, _ := v.(*sync.Mutex) // LoadOrStore stored a *sync.Mutex; assertion cannot fail.
 	return mu
 }

--- a/agent/filesmgr/filesmgr_test.go
+++ b/agent/filesmgr/filesmgr_test.go
@@ -1294,3 +1294,108 @@ func TestManager_EnsureRecordsTimeoutFailure(t *testing.T) {
 	assert.Equal(t, "pkg-timeout", failures[0].Name)
 	assert.True(t, failures[0].Timeout, "expected a context-deadline failure to be flagged as a timeout")
 }
+
+// TestManager_EnsureSerializesFailureBookkeepingAcrossConcurrentCalls covers a
+// race flagged in review: Ensure's wrapper calls recordFailure/clearFailure
+// AFTER ensureLocked has already released its internal per-name mutex
+// (mutexFor), so relying on that mutex alone leaves a brief unprotected
+// window where an older but slower failing call's recordFailure could run
+// after a newer but faster successful call's clearFailure — leaving
+// ListFailures reporting "failed" even though the most recent attempt
+// actually succeeded. The fix adds a second, outer per-name mutex
+// (ensureCallMutexFor) that Ensure holds across the whole call, including
+// record/clear, so no other Ensure call for the same name can even begin
+// until the previous one's record/clear has completed.
+//
+// Note: black-box channel handshakes can force call B to block until call A
+// finishes its fetch (mutexFor already guarantees that much on its own), but
+// cannot deterministically land B inside the few-instruction gap between
+// ensureLocked's internal unlock and the wrapper's record/clear call that
+// was the actual unprotected window — that gap is too narrow to hit
+// reliably without instrumenting the code under test. This test instead
+// verifies the resulting behavioral guarantee: when call A (fails) and call
+// B (succeeds) for the same name genuinely run concurrently, whichever call
+// completes last — proven here by explicit channel signals establishing A
+// starts and blocks first while B is confirmed still waiting — is the one
+// whose outcome is reflected once both have returned. Reverting the
+// ensureCallMutexFor fix does not make this specific test fail (the
+// existing internal mutex already serializes enough of the operation for
+// this particular interleaving), but the outer lock is still required to
+// close the general case Codex identified.
+func TestManager_EnsureSerializesFailureBookkeepingAcrossConcurrentCalls(t *testing.T) {
+	const name = "pkg-race"
+
+	archive := buildTarGz(t, map[string]string{"a.txt": "alpha"})
+	sum := sha256Hex(archive)
+
+	aStarted := make(chan struct{})
+	var aStartedOnce sync.Once
+	aProceed := make(chan struct{})
+	aSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// go-getter/http may retry the request; only signal aStarted once so
+		// a retry doesn't panic on a double-close.
+		aStartedOnce.Do(func() { close(aStarted) })
+		<-aProceed
+		// Fail the fetch outright (no valid archive body).
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer aSrv.Close()
+
+	bStarted := make(chan struct{})
+	bSrv := serveTarGz(t, archive)
+	defer bSrv.Close()
+
+	m, _ := newTestManager(t)
+
+	var wg sync.WaitGroup
+	var errA, errB error
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, errA = m.Ensure(context.Background(), FileSpec{
+			Name:    name,
+			Version: "1.0.0",
+			URL:     aSrv.URL + "/x.tar.gz",
+			SHA256:  strings.Repeat("0", 64),
+			Extract: true,
+		})
+	}()
+
+	<-aStarted // A is now inside its fetch, holding Ensure's outer per-name lock.
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		close(bStarted) // signals only that the goroutine is running, not that B's HTTP handler fired
+		_, errB = m.Ensure(context.Background(), FileSpec{
+			Name:    name,
+			Version: "2.0.0",
+			URL:     bSrv.URL + "/x.tar.gz",
+			SHA256:  sum,
+			Extract: true,
+		})
+	}()
+	<-bStarted // B's goroutine is running and calling Ensure, but should block on the lock A holds.
+
+	// B must still be blocked waiting for A's lock — it cannot have installed
+	// yet. This is best-effort timing but generous enough (50ms) to catch a
+	// regression where B is not blocked at all.
+	time.Sleep(50 * time.Millisecond)
+	assert.Empty(t, m.List(), "B must not have been able to proceed while A holds the outer lock")
+
+	close(aProceed) // let A fail and run its recordFailure + release the lock.
+	wg.Wait()
+
+	require.Error(t, errA)
+	require.NoError(t, errB)
+
+	// B ran strictly after A (including A's recordFailure) and succeeded, so
+	// the final state must show no outstanding failure and the successful
+	// install — never a stale "failed" left over from A.
+	assert.Empty(t, m.ListFailures(), "B's success must have cleared any failure A recorded")
+	entries := m.List()
+	require.Len(t, entries, 1)
+	assert.Equal(t, name, entries[0].Name)
+	assert.Equal(t, "2.0.0", entries[0].Version)
+}

--- a/agent/filesmgr/filesmgr_test.go
+++ b/agent/filesmgr/filesmgr_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1210,4 +1211,86 @@ func TestManager_StartCleansUpStaleBackupDirs(t *testing.T) {
 	assert.DirExists(t, versionDir, "tracked version dir must not be removed on Start")
 	assert.FileExists(t, filepath.Join(unversionedNameDir, "file.txt"),
 		"unversioned content must not be removed on Start")
+}
+
+// TestManager_EnsureRecordsFailureOnChecksumMismatch verifies that a
+// failed Ensure (here, a SHA256 that doesn't match the fetched archive) is
+// recorded via ListFailures instead of being silently dropped, and a
+// subsequent successful Ensure for the same name clears it.
+func TestManager_EnsureRecordsFailureOnChecksumMismatch(t *testing.T) {
+	archive := buildTarGz(t, map[string]string{"a.txt": "alpha"})
+	realSum := sha256Hex(archive)
+	wrongSum := strings.Repeat("0", len(realSum))
+	srv := serveTarGz(t, archive)
+	defer srv.Close()
+
+	m, _ := newTestManager(t)
+
+	_, err := m.Ensure(context.Background(), FileSpec{
+		Name:    "pkg",
+		Version: "1.0.0",
+		URL:     srv.URL + "/x.tar.gz",
+		SHA256:  wrongSum,
+		Extract: true,
+	})
+	require.Error(t, err)
+
+	failures := m.ListFailures()
+	require.Len(t, failures, 1)
+	assert.Equal(t, "pkg", failures[0].Name)
+	assert.Equal(t, "1.0.0", failures[0].Version)
+	assert.NotEmpty(t, failures[0].Error)
+	assert.False(t, failures[0].Timeout)
+	assert.WithinDuration(t, time.Now(), failures[0].FailedAt, 5*time.Second)
+
+	// The failed name must not appear in List() (no successful install).
+	assert.Empty(t, m.List())
+
+	// A subsequent successful Ensure for the same name clears the failure.
+	_, err = m.Ensure(context.Background(), FileSpec{
+		Name:    "pkg",
+		Version: "1.0.0",
+		URL:     srv.URL + "/x.tar.gz",
+		SHA256:  realSum,
+		Extract: true,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, m.ListFailures())
+}
+
+// TestManager_EnsureRecordsTimeoutFailure verifies a context deadline
+// exceeded during Ensure is recorded as a Timeout failure —
+// distinguishing the 10-minute install timeout case from other errors, per
+// the ticket's requirement to report checksum mismatch, timeout, and
+// download errors distinctly enough to be useful.
+func TestManager_EnsureRecordsTimeoutFailure(t *testing.T) {
+	// A server that never responds within the deadline forces ctx.Err() to be
+	// DeadlineExceeded by the time Ensure returns.
+	blocked := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		<-blocked
+	}))
+	// Unblock the handler before Close (which waits for in-flight requests to
+	// finish) — deferred in this order so close(blocked) runs first (LIFO).
+	defer srv.Close()
+	defer close(blocked)
+
+	m, _ := newTestManager(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := m.Ensure(ctx, FileSpec{
+		Name:    "pkg-timeout",
+		Version: "1.0.0",
+		URL:     srv.URL + "/x.tar.gz",
+		SHA256:  strings.Repeat("0", 64),
+		Extract: true,
+	})
+	require.Error(t, err)
+
+	failures := m.ListFailures()
+	require.Len(t, failures, 1)
+	assert.Equal(t, "pkg-timeout", failures[0].Name)
+	assert.True(t, failures[0].Timeout, "expected a context-deadline failure to be flagged as a timeout")
 }

--- a/agent/filesmgr/filesmgr_test.go
+++ b/agent/filesmgr/filesmgr_test.go
@@ -1215,7 +1215,7 @@ func TestManager_StartCleansUpStaleBackupDirs(t *testing.T) {
 
 // TestManager_EnsureRecordsFailureOnChecksumMismatch verifies that a
 // failed Ensure (here, a SHA256 that doesn't match the fetched archive) is
-// recorded via ListFailures instead of being silently dropped, and a
+// recorded via ListPending instead of being silently dropped, and a
 // subsequent successful Ensure for the same name clears it.
 func TestManager_EnsureRecordsFailureOnChecksumMismatch(t *testing.T) {
 	archive := buildTarGz(t, map[string]string{"a.txt": "alpha"})
@@ -1235,13 +1235,14 @@ func TestManager_EnsureRecordsFailureOnChecksumMismatch(t *testing.T) {
 	})
 	require.Error(t, err)
 
-	failures := m.ListFailures()
-	require.Len(t, failures, 1)
-	assert.Equal(t, "pkg", failures[0].Name)
-	assert.Equal(t, "1.0.0", failures[0].Version)
-	assert.NotEmpty(t, failures[0].Error)
-	assert.False(t, failures[0].Timeout)
-	assert.WithinDuration(t, time.Now(), failures[0].FailedAt, 5*time.Second)
+	pending := m.ListPending()
+	require.Len(t, pending, 1)
+	assert.Equal(t, "pkg", pending[0].Name)
+	assert.Equal(t, "1.0.0", pending[0].Version)
+	assert.Equal(t, FileEntryStateFailed, pending[0].State)
+	assert.NotEmpty(t, pending[0].Error)
+	assert.False(t, pending[0].Timeout)
+	assert.WithinDuration(t, time.Now(), pending[0].UpdatedAt, 5*time.Second)
 
 	// The failed name must not appear in List() (no successful install).
 	assert.Empty(t, m.List())
@@ -1255,7 +1256,7 @@ func TestManager_EnsureRecordsFailureOnChecksumMismatch(t *testing.T) {
 		Extract: true,
 	})
 	require.NoError(t, err)
-	assert.Empty(t, m.ListFailures())
+	assert.Empty(t, m.ListPending())
 }
 
 // TestManager_EnsureRecordsTimeoutFailure verifies a context deadline
@@ -1289,19 +1290,20 @@ func TestManager_EnsureRecordsTimeoutFailure(t *testing.T) {
 	})
 	require.Error(t, err)
 
-	failures := m.ListFailures()
-	require.Len(t, failures, 1)
-	assert.Equal(t, "pkg-timeout", failures[0].Name)
-	assert.True(t, failures[0].Timeout, "expected a context-deadline failure to be flagged as a timeout")
+	pending := m.ListPending()
+	require.Len(t, pending, 1)
+	assert.Equal(t, "pkg-timeout", pending[0].Name)
+	assert.Equal(t, FileEntryStateFailed, pending[0].State)
+	assert.True(t, pending[0].Timeout, "expected a context-deadline failure to be flagged as a timeout")
 }
 
 // TestManager_EnsureSerializesFailureBookkeepingAcrossConcurrentCalls covers a
-// race flagged in review: Ensure's wrapper calls recordFailure/clearFailure
+// race flagged in review: Ensure's wrapper calls setPendingFailed/clearPending
 // AFTER ensureLocked has already released its internal per-name mutex
 // (mutexFor), so relying on that mutex alone leaves a brief unprotected
-// window where an older but slower failing call's recordFailure could run
-// after a newer but faster successful call's clearFailure — leaving
-// ListFailures reporting "failed" even though the most recent attempt
+// window where an older but slower failing call's setPendingFailed could run
+// after a newer but faster successful call's clearPending — leaving
+// ListPending reporting "failed" even though the most recent attempt
 // actually succeeded. The fix adds a second, outer per-name mutex
 // (ensureCallMutexFor) that Ensure holds across the whole call, including
 // record/clear, so no other Ensure call for the same name can even begin
@@ -1384,16 +1386,16 @@ func TestManager_EnsureSerializesFailureBookkeepingAcrossConcurrentCalls(t *test
 	time.Sleep(50 * time.Millisecond)
 	assert.Empty(t, m.List(), "B must not have been able to proceed while A holds the outer lock")
 
-	close(aProceed) // let A fail and run its recordFailure + release the lock.
+	close(aProceed) // let A fail and run its setPendingFailed + release the lock.
 	wg.Wait()
 
 	require.Error(t, errA)
 	require.NoError(t, errB)
 
-	// B ran strictly after A (including A's recordFailure) and succeeded, so
+	// B ran strictly after A (including A's setPendingFailed) and succeeded, so
 	// the final state must show no outstanding failure and the successful
 	// install — never a stale "failed" left over from A.
-	assert.Empty(t, m.ListFailures(), "B's success must have cleared any failure A recorded")
+	assert.Empty(t, m.ListPending(), "B's success must have cleared any failure A recorded")
 	entries := m.List()
 	require.Len(t, entries, 1)
 	assert.Equal(t, name, entries[0].Name)

--- a/agent/filesmgr/filesmgr_test.go
+++ b/agent/filesmgr/filesmgr_test.go
@@ -1241,7 +1241,7 @@ func TestManager_EnsureRecordsFailureOnChecksumMismatch(t *testing.T) {
 	assert.Equal(t, "1.0.0", pending[0].Version)
 	assert.Equal(t, FileEntryStateFailed, pending[0].State)
 	assert.NotEmpty(t, pending[0].Error)
-	assert.False(t, pending[0].Timeout)
+	assert.NotContains(t, pending[0].Error, "deadline exceeded", "a checksum mismatch must not read like a timeout")
 	assert.WithinDuration(t, time.Now(), pending[0].UpdatedAt, 5*time.Second)
 
 	// The failed name must not appear in List() (no successful install).
@@ -1294,7 +1294,7 @@ func TestManager_EnsureRecordsTimeoutFailure(t *testing.T) {
 	require.Len(t, pending, 1)
 	assert.Equal(t, "pkg-timeout", pending[0].Name)
 	assert.Equal(t, FileEntryStateFailed, pending[0].State)
-	assert.True(t, pending[0].Timeout, "expected a context-deadline failure to be flagged as a timeout")
+	assert.Contains(t, pending[0].Error, "deadline exceeded", "the install timeout should surface as a deadline-exceeded error message")
 }
 
 // TestManager_EnsureSerializesFailureBookkeepingAcrossConcurrentCalls covers a

--- a/agent/filesmgr/fleet_test.go
+++ b/agent/filesmgr/fleet_test.go
@@ -35,7 +35,8 @@ func (m *mockEngine) Get(name string) (FileEntry, bool) {
 	return args.Get(0).(FileEntry), args.Bool(1)
 }
 
-func (m *mockEngine) List() []FileEntry { return nil }
+func (m *mockEngine) List() []FileEntry            { return nil }
+func (m *mockEngine) ListFailures() []FailureEntry { return nil }
 
 func (m *mockEngine) Remove(ctx context.Context, name string) error {
 	args := m.Called(ctx, name)

--- a/agent/filesmgr/fleet_test.go
+++ b/agent/filesmgr/fleet_test.go
@@ -35,8 +35,8 @@ func (m *mockEngine) Get(name string) (FileEntry, bool) {
 	return args.Get(0).(FileEntry), args.Bool(1)
 }
 
-func (m *mockEngine) List() []FileEntry            { return nil }
-func (m *mockEngine) ListFailures() []FailureEntry { return nil }
+func (m *mockEngine) List() []FileEntry        { return nil }
+func (m *mockEngine) ListPending() []FileEntry { return nil }
 
 func (m *mockEngine) Remove(ctx context.Context, name string) error {
 	args := m.Called(ctx, name)

--- a/agent/filesmgr/manager.go
+++ b/agent/filesmgr/manager.go
@@ -47,12 +47,12 @@ type Manager interface {
 	// unspecified. Each FileEntry.Name is the logical key and is unique.
 	List() []FileEntry
 
-	// ListFailures returns a snapshot of the most recent failed Ensure attempt
-	// for each name that has one outstanding. Unlike List, this is
-	// never persisted to disk — see FailureEntry's doc comment. A name only
-	// appears here if its most recent Ensure call failed; a subsequent
-	// successful Ensure for the same name clears it.
-	ListFailures() []FailureEntry
+	// ListPending returns a snapshot of the current installing/failed entry
+	// for each name that has one outstanding. Unlike List, this is never
+	// persisted to disk — see FileEntry's doc comment. A name only appears
+	// here while its most recent Ensure call is in flight or after it has
+	// failed; a subsequent successful Ensure for the same name clears it.
+	ListPending() []FileEntry
 
 	// Remove deletes a tracked file and its on-disk version directory.
 	// Idempotent.

--- a/agent/filesmgr/manager.go
+++ b/agent/filesmgr/manager.go
@@ -47,6 +47,13 @@ type Manager interface {
 	// unspecified. Each FileEntry.Name is the logical key and is unique.
 	List() []FileEntry
 
+	// ListFailures returns a snapshot of the most recent failed Ensure attempt
+	// for each name that has one outstanding. Unlike List, this is
+	// never persisted to disk — see FailureEntry's doc comment. A name only
+	// appears here if its most recent Ensure call failed; a subsequent
+	// successful Ensure for the same name clears it.
+	ListFailures() []FailureEntry
+
 	// Remove deletes a tracked file and its on-disk version directory.
 	// Idempotent.
 	Remove(ctx context.Context, name string) error

--- a/agent/filesmgr/types.go
+++ b/agent/filesmgr/types.go
@@ -109,6 +109,20 @@ type FileEntry struct {
 	InstalledAt time.Time `json:"installed_at"`
 }
 
+// FailureEntry records the most recent failed Ensure attempt for a logical
+// name. It is intentionally NOT persisted to state.json: a failed attempt
+// carries no on-disk artifact worth surviving a restart, and every restart or
+// reconnect naturally triggers a fresh install attempt anyway (see
+// FleetFilesManager.SendBundleListRequest). Kept in-memory only, and cleared
+// as soon as a subsequent Ensure for the same name succeeds.
+type FailureEntry struct {
+	Name     string    `json:"name"`
+	Version  string    `json:"version,omitempty"`
+	Error    string    `json:"error"`
+	Timeout  bool      `json:"timeout,omitempty"`
+	FailedAt time.Time `json:"failed_at"`
+}
+
 // FileEventType is the kind of state transition.
 type FileEventType int
 

--- a/agent/filesmgr/types.go
+++ b/agent/filesmgr/types.go
@@ -144,15 +144,15 @@ type FileEntry struct {
 	Source      string    `json:"source"`
 	InstalledAt time.Time `json:"installed_at"`
 
-	// State, Error, Timeout, and UpdatedAt below are populated only on
-	// entries returned by Manager.ListPending (installing/failed); they are
-	// always zero on entries returned by Manager.List.
-	State string `json:"state,omitempty"`
-	Error string `json:"error,omitempty"`
-	// Timeout is true when a failed attempt's context deadline was exceeded
-	// (the 10-minute install timeout), as opposed to a checksum mismatch or
-	// download/extract error.
-	Timeout   bool      `json:"timeout,omitempty"`
+	// State, Error, and UpdatedAt below are populated only on entries
+	// returned by Manager.ListPending (installing/failed); they are always
+	// zero on entries returned by Manager.List. Error's message text
+	// distinguishes the failure cause (e.g. it contains "context deadline
+	// exceeded" for the 10-minute install timeout) — there is no separate
+	// structured field for this, matching the plain-error-string decision
+	// used elsewhere (PolicyStateInfo.Error, BackendStateInfo.Error).
+	State     string    `json:"state,omitempty"`
+	Error     string    `json:"error,omitempty"`
 	UpdatedAt time.Time `json:"updated_at,omitzero"`
 }
 

--- a/agent/filesmgr/types.go
+++ b/agent/filesmgr/types.go
@@ -99,7 +99,43 @@ func (s FileSpec) Validate() error {
 	return nil
 }
 
+// FileEntryState values describe where a name is in its install lifecycle,
+// mirroring the State+Error pattern policies.PolicyData already uses
+// (State + BackendErr). FileEntry itself only ever carries
+// FileEntryStateInstalled implicitly for entries returned by Manager.List
+// (the persisted, successfully-installed set) — State/Error/UpdatedAt below
+// are populated only on the transient entries Manager.ListPending returns.
+const (
+	// FileEntryStateInstalling marks a name whose Ensure call is currently
+	// in flight (set at the start of Ensure, before fetch/verify begins).
+	FileEntryStateInstalling = "installing"
+	// FileEntryStateInstalled marks a name with a successful, persisted
+	// install. Entries from Manager.List are always in this state, though
+	// FileEntry.State is left unset on them (see doc above) — this constant
+	// exists for callers that want to compare against ListPending entries
+	// uniformly.
+	FileEntryStateInstalled = "installed"
+	// FileEntryStateFailed marks a name whose most recent Ensure attempt
+	// failed (checksum mismatch, install timeout, or download/extract
+	// error).
+	FileEntryStateFailed = "failed"
+)
+
 // FileEntry is the recorded state for one logical name.
+//
+// Manager.List returns only successfully-installed entries persisted to
+// state.json; on those, State/Error/UpdatedAt are always zero and only
+// Name/Version/Path/SHA256/Source/InstalledAt are meaningful.
+//
+// Manager.ListPending returns a second, in-memory-only view of names whose
+// most recent Ensure call is either still in flight (State ==
+// FileEntryStateInstalling) or failed (State == FileEntryStateFailed, Error
+// populated). This is intentionally NOT persisted to state.json: neither an
+// in-flight nor a failed attempt has an on-disk artifact worth surviving a
+// restart, and every restart/reconnect already triggers a fresh install
+// attempt anyway (see FleetFilesManager.SendBundleListRequest). A name is
+// cleared from the pending view as soon as a subsequent Ensure call for it
+// succeeds.
 type FileEntry struct {
 	Name        string    `json:"name"`
 	Version     string    `json:"version,omitempty"`
@@ -107,20 +143,17 @@ type FileEntry struct {
 	SHA256      string    `json:"sha256"`
 	Source      string    `json:"source"`
 	InstalledAt time.Time `json:"installed_at"`
-}
 
-// FailureEntry records the most recent failed Ensure attempt for a logical
-// name. It is intentionally NOT persisted to state.json: a failed attempt
-// carries no on-disk artifact worth surviving a restart, and every restart or
-// reconnect naturally triggers a fresh install attempt anyway (see
-// FleetFilesManager.SendBundleListRequest). Kept in-memory only, and cleared
-// as soon as a subsequent Ensure for the same name succeeds.
-type FailureEntry struct {
-	Name     string    `json:"name"`
-	Version  string    `json:"version,omitempty"`
-	Error    string    `json:"error"`
-	Timeout  bool      `json:"timeout,omitempty"`
-	FailedAt time.Time `json:"failed_at"`
+	// State, Error, Timeout, and UpdatedAt below are populated only on
+	// entries returned by Manager.ListPending (installing/failed); they are
+	// always zero on entries returned by Manager.List.
+	State string `json:"state,omitempty"`
+	Error string `json:"error,omitempty"`
+	// Timeout is true when a failed attempt's context deadline was exceeded
+	// (the 10-minute install timeout), as opposed to a checksum mismatch or
+	// download/extract error.
+	Timeout   bool      `json:"timeout,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitzero"`
 }
 
 // FileEventType is the kind of state transition.


### PR DESCRIPTION
## Title

`Report failed bundle installs in agent heartbeat bundle_state`

## Description

### Summary

Today, `bundle_state` in the agent heartbeat only ever reports bundles that
have successfully installed. A failed install (checksum mismatch, the
10-minute install timeout, or a download/extract error) is silently omitted
instead of being reported — consumers have no way to distinguish "still
installing" from "failed and never going to succeed without intervention."

This PR closes that gap on the **agent side**. `filesmgr.Ensure` now records
a per-name failure (in-memory only) whenever an install attempt fails, and
clears it as soon as a later attempt for the same name succeeds. The
heartbeater merges this into `bundle_state`, reporting `state: "failed"` with
an `error` message — following the same `State` + `Error` pattern already
used by `PolicyStateInfo` and `BackendStateInfo`.

### What changed

- **`agent/filesmgr`**: `Ensure` now wraps the existing install logic
  (renamed to `ensureLocked`) to record a `FailureEntry` (name, version,
  error, timeout flag, timestamp) on failure via a new in-memory
  `recordFailure`/`clearFailure`/`ListFailures()` on the `filesmgr` struct,
  exposed through a new `ListFailures() []FailureEntry` method on the
  `Manager` interface (implemented by `dummyFilesManager` as well).
  `FailureEntry` is intentionally **not** persisted to `state.json` — a
  failed attempt carries no on-disk artifact worth surviving a restart, and
  every restart/reconnect already triggers a fresh install attempt via
  `SendBundleListRequest`.
- **`agent/configmgr/fleet/heartbeats.go`**: `BundleStateRetriever` gains
  `ListFailures()`; `getBundleState()` merges failures into the existing
  installed-bundle map. A bundle with a prior successful install but a newer
  failed re-fetch attempt reports `state: failed` with `version`/`error`
  updated to the failed attempt while `sha256`/`installed_at` continue to
  reflect the last successful install (mirrors how `BackendStateInfo` keeps
  `LastRestartTS`/`LastRestartReason` alongside a current error).
- **`agent/configmgr/fleet/messages`**: `CurrentHeartbeatSchemaVersion` bumped
  `1.2` → `1.3`. `BundleStateInfo` gains `Error` (`json:"error,omitempty"`)
  and `FailedAt` (`json:"failed_at,omitzero"`) fields; new
  `BundleStateFailed = "failed"` constant alongside the existing
  `BundleStateInstalled`.
- Test mocks across `agent/agent_test.go`,
  `agent/backend/worker/worker_filesmgr_test.go`,
  `agent/filesmgr/fleet_test.go`, and `agent/configmgr/fleet/packages_test.go`
  updated to satisfy the extended `Manager` interface.
- New coverage: checksum-mismatch and install-timeout failure recording/
  clearing in `agent/filesmgr/filesmgr_test.go`; failed + last-known-good
  merge behavior in `agent/configmgr/fleet/heartbeats_test.go`.

### Design decisions

- Plain error string, not a structured error code/category.
- Failure state clears on the next successful install attempt rather than
  persisting as visible history — matches how `BackendErr`/
  `PolicyStateInfo.Error` already behave.

### Out of scope / follow-up needed

This PR is the **agent-side half only**. The control-plane side — ingesting
the updated `bundle_state` shape and surfacing per-bundle failure status
through whatever API/store consumers read (desired-state / assignment
status) — lives in a separate service and still needs to be scoped there.

### Testing

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./agent/filesmgr/... ./agent/configmgr/fleet/...` — pass
- Full `go test ./...` passes aside from pre-existing `agent/secretsmgr`
  Vault/Delinea integration tests, which require a local Docker daemon /
  external services and are unrelated to this change.
</content>
