### PR TITLE
feat(device-discovery): configurable stack member name template

### DIFF
--- a/docs/backends/device_discovery/README.md
+++ b/docs/backends/device_discovery/README.md
@@ -95,6 +95,7 @@ Current supported defaults:
 | interface_exclude_patterns | list | Regex patterns to exclude interfaces (and their IPs) from ingestion (see [Interface Exclusion](./interface.md#interface-exclusion-patterns)) |
 | location | str | Device location |
 | rack  | str | Rack name to associate the device with |
+| stack_member_name_template | str | Template for stack / Virtual Chassis member device names. Placeholders: `{name}` (the stack name) and `{id}` (the device-reported member id). Defaults to `{name}-{id}`, which reproduces the legacy naming. See [Switch stacks / Virtual Chassis](#switch-stacks--virtual-chassis). |
 | tenant | str/map | Device tenant |
 | description | str  | General description   |
 | comments   | str  | General comments       |
@@ -319,10 +320,12 @@ In this example:
 When a driver implements stack-member discovery and the target reports 2+ members with serials, device-discovery emits a NetBox `VirtualChassis` plus one `Device` per member, and routes each interface and IP address to the correct member based on the interface name prefix (e.g. `GigabitEthernet1/0/1` → member 1, `GigabitEthernet2/0/12` → member 2). Standalone switches, devices not in stack mode, and members without a serial (which Diode cannot resolve) fall back to the existing single-`Device` path with no change in behaviour.
 
 **Emission shape** (in order):
-1. **Master `Device`** — plain (no `vc_position`, no `virtual_chassis` ref). Named `<hostname>-<id>` where `<hostname>` is the management hostname and `<id>` is the master's stack-member id.
+1. **Master `Device`** — plain (no `vc_position`, no `virtual_chassis` ref). Named from the member-name template (below); by default `<hostname>-<id>`, where `<hostname>` is the management hostname and `<id>` is the master's stack-member id.
 2. **`VirtualChassis`** — named `<hostname>`, with `master` set to the inline matcher block of the master Device.
 3. **N − 1 member `Device` entities** — each carries `vc_position = <member id>` and an inline `virtual_chassis` ref pointing to the same matcher block.
 4. **Interface / IPAddress entities** — routed to the member device whose id matches the interface name prefix. Logical interfaces with no parseable member id (`Vlan*`, `Loopback*`, `Port-channel*`, etc.) land on the master.
+
+**Member naming.** Every member device name — master and non-master — is rendered from `defaults.stack_member_name_template`. The template supports two placeholders: `{name}` (the stack name, i.e. the management hostname) and `{id}` (the device-reported member id). The default `{name}-{id}` reproduces the historical names (`core-sw-1`, `core-sw-2`), so existing deployments are unaffected. Set a custom template when you pre-create member devices under a different convention — e.g. `{name}-css{id}` to match hand-created `core-sw-css1` / `core-sw-css2` — so discovery **updates** those records instead of creating new ones. NetBox matches a member by `name` + `site` (+ `tenant`) ahead of `virtual_chassis` + `vc_position`, so an aligned name only lands on the pre-created device when its site (and tenant) already match; the template does not offer a zero-based offset, so the device-reported ids must equal your numbering (`css1`/`css2` ↔ ids `1`/`2`). An empty, malformed, or otherwise unusable template is ignored with a `WARNING` and the default is used — a bad config never rejects the policy or aborts discovery.
 
 **Master pinning.** The logical master sent to Diode is always the **lowest stack-member id present**, regardless of live role. This is required because the NetBox Diode plugin resolves an existing `VirtualChassis` via its `unique_master` matcher — pinning to the lowest id keeps the master Device stable across StackWise role failovers so re-runs upsert the existing VC instead of creating a new one. The other matcher fields used for VC re-identification (asset_tag, primary_ip4/6, name+site+tenant, and `metadata.source_match`) are carried consistently on both the rich master Device and the inline VC `master` ref so the plugin's matcher cascade resolves through the same record on every cycle.
 
@@ -445,7 +448,7 @@ Only emitted when the driver implements `get_chassis_members()` and the target r
 | `VirtualChassis.name` | `device.hostname` | The management hostname becomes the VC name |
 | `VirtualChassis.master` | Lowest member id present | Pinned to lowest id (not live role) so the master Device is stable across StackWise role failovers |
 | `VirtualChassis.domain` | Driver-supplied (when available) | Optional; only some platforms surface a VC domain id |
-| Member `Device.name` | `<hostname>-<member_id>` | E.g. `core-sw-1`, `core-sw-2` |
+| Member `Device.name` | `stack_member_name_template` | Default `{name}-{id}` → e.g. `core-sw-1`, `core-sw-2`. Configurable — see [Member naming](#switch-stacks--virtual-chassis) |
 | Member `Device.serial` | Per-member from driver | Required — members without a serial are dropped |
 | Member `Device.model` | Per-member from driver | Falls back to chassis model if the driver doesn't surface per-member models |
 | Member `Device.vc_position` | Stack-member id | Preserved exactly (e.g. id=1,2,4 if slot 3 is empty) |

--- a/orb-discovery/device-discovery/device_discovery/policy/models.py
+++ b/orb-discovery/device-discovery/device_discovery/policy/models.py
@@ -2,6 +2,7 @@
 # Copyright 2024 NetBox Labs Inc
 """Device Discovery Policy Models."""
 
+import logging
 import re
 import time
 import uuid
@@ -10,6 +11,13 @@ from typing import Any, Literal
 
 from croniter import CroniterBadCronError, croniter
 from pydantic import BaseModel, Field, field_validator
+
+from device_discovery.stack_naming import (
+    DEFAULT_STACK_MEMBER_TEMPLATE,
+    stack_template_problem,
+)
+
+logger = logging.getLogger(__name__)
 
 
 class Status(Enum):
@@ -151,6 +159,14 @@ class Defaults(BaseModel):
     )
     location: str | None = Field(default=None, description="Location name, optional")
     rack: str | None = Field(default=None, description="Rack name, optional")
+    stack_member_name_template: str = Field(
+        default=DEFAULT_STACK_MEMBER_TEMPLATE,
+        description=(
+            "Template for stack (virtual-chassis) member device names. "
+            "Placeholders: {name} (stack name), {id} (member id). "
+            "Default '{name}-{id}' reproduces the legacy naming."
+        ),
+    )
 
     @field_validator("interface_patterns", "interface_exclude_patterns", mode="before")
     @classmethod
@@ -158,6 +174,30 @@ class Defaults(BaseModel):
         """Treat an empty list as None so override_defaults does not clear the global list."""
         if isinstance(v, list) and len(v) == 0:
             return None
+        return v
+
+    @field_validator("stack_member_name_template", mode="before")
+    @classmethod
+    def _normalize_stack_member_name_template(cls, v: object) -> str:
+        """Fall back to the default template (with a WARN) rather than reject a bad one."""
+        if v is None:
+            return DEFAULT_STACK_MEMBER_TEMPLATE
+        if not isinstance(v, str):
+            logger.warning(
+                "stack_member_name_template must be a string, got %s; using default %r",
+                type(v).__name__,
+                DEFAULT_STACK_MEMBER_TEMPLATE,
+            )
+            return DEFAULT_STACK_MEMBER_TEMPLATE
+        problem = stack_template_problem(v)
+        if problem is not None:
+            logger.warning(
+                "ignoring stack_member_name_template %r (%s); using default %r",
+                v,
+                problem,
+                DEFAULT_STACK_MEMBER_TEMPLATE,
+            )
+            return DEFAULT_STACK_MEMBER_TEMPLATE
         return v
     tenant: str | TenantParameters | None = Field(
         default=None, description="Tenant, optional"

--- a/orb-discovery/device-discovery/device_discovery/stack_naming.py
+++ b/orb-discovery/device-discovery/device_discovery/stack_naming.py
@@ -44,6 +44,14 @@ def stack_template_problem(template: str) -> str | None:
             return f"unknown placeholder {{{tok}}}"
     if "name" not in tokens:
         return "template must include the {name} placeholder"
+    # Stray / unbalanced braces: _PLACEHOLDER_RE only matches balanced {...}
+    # pairs, so a template like "{name}-{id}}" or "{{name}-{id}" passes the
+    # token checks above yet leaves a literal brace after rendering
+    # (e.g. "vc-1}"). Substitute the two allowed placeholders and reject if any
+    # brace remains, so such a template falls back to the default.
+    residual = template.replace("{name}", "").replace("{id}", "")
+    if "{" in residual or "}" in residual:
+        return "template has stray or unbalanced braces"
     if render_stack_member_name(template, "vc", "1") == render_stack_member_name(
         template, "vc", "2"
     ):

--- a/orb-discovery/device-discovery/device_discovery/stack_naming.py
+++ b/orb-discovery/device-discovery/device_discovery/stack_naming.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""
+Stack (virtual-chassis) member name templating.
+
+A bounded token renderer and validator shared by the policy model
+(config-load validation) and the chassis translator (rendering). Uses
+str.replace over a fixed placeholder set — never str.format — so an operator
+template cannot trigger attribute access or format-spec injection and cannot
+raise at render time.
+"""
+
+import re
+
+DEFAULT_STACK_MEMBER_TEMPLATE = "{name}-{id}"
+
+# Placeholders the renderer substitutes. {name} = stack/VC name, {id} =
+# device-reported member id.
+_ALLOWED_PLACEHOLDERS = ("name", "id")
+_PLACEHOLDER_RE = re.compile(r"\{([^{}]*)\}")
+
+
+def render_stack_member_name(template: str, name: str, member_id: object) -> str:
+    """Render a member name from ``template`` using bounded token replacement."""
+    return template.replace("{name}", str(name)).replace("{id}", str(member_id))
+
+
+def stack_template_problem(template: str) -> str | None:
+    """
+    Return a human-readable reason the template is unusable, or None if valid.
+
+    Rejects: empty/whitespace; placeholders that are unknown or contain
+    ``.``/``[``/``:`` (attribute access / format specs); a missing ``{name}``
+    (without it, names collide across stacks in the same site); and templates
+    that do not render distinct names for distinct member ids.
+    """
+    if not template or not template.strip():
+        return "template is empty"
+    tokens = _PLACEHOLDER_RE.findall(template)
+    for tok in tokens:
+        if any(c in tok for c in ".[:"):
+            return f"disallowed placeholder {{{tok}}}"
+        if tok not in _ALLOWED_PLACEHOLDERS:
+            return f"unknown placeholder {{{tok}}}"
+    if "name" not in tokens:
+        return "template must include the {name} placeholder"
+    if render_stack_member_name(template, "vc", "1") == render_stack_member_name(
+        template, "vc", "2"
+    ):
+        return "template does not vary by member {id}"
+    return None

--- a/orb-discovery/device-discovery/device_discovery/translate_chassis.py
+++ b/orb-discovery/device-discovery/device_discovery/translate_chassis.py
@@ -30,6 +30,7 @@ from netboxlabs.diode.sdk.ingester import Entity
 
 from device_discovery.interface import build_interface_entities
 from device_discovery.policy.models import Defaults, Options
+from device_discovery.stack_naming import render_stack_member_name
 from device_discovery.translate_modules import emit_modules_if_requested
 
 logger = logging.getLogger(__name__)
@@ -221,7 +222,9 @@ def _build_member_devices(
 
     def _one(m: dict, *, is_master: bool) -> pb.Device:
         member_info = dict(device_info)
-        member_info["hostname"] = f"{vc_name}-{m['id']}"
+        member_info["hostname"] = render_stack_member_name(
+            defaults.stack_member_name_template, vc_name, m["id"]
+        )
         member_info["serial_number"] = m["serial"]
         if m.get("model"):
             member_info["model"] = m["model"]

--- a/orb-discovery/device-discovery/tests/test_policy_defaults_stack_template.py
+++ b/orb-discovery/device-discovery/tests/test_policy_defaults_stack_template.py
@@ -37,3 +37,9 @@ def test_non_string_falls_back():
     """A non-string template falls back rather than raising a ValidationError."""
     d = Defaults(stack_member_name_template=123)
     assert d.stack_member_name_template == DEFAULT_STACK_MEMBER_TEMPLATE
+
+
+def test_stray_brace_template_falls_back():
+    """A template with an unbalanced brace falls back instead of leaking the brace."""
+    d = Defaults(stack_member_name_template="{name}-{id}}")
+    assert d.stack_member_name_template == DEFAULT_STACK_MEMBER_TEMPLATE

--- a/orb-discovery/device-discovery/tests/test_policy_defaults_stack_template.py
+++ b/orb-discovery/device-discovery/tests/test_policy_defaults_stack_template.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""Tests for Defaults.stack_member_name_template validation/normalization."""
+
+import logging
+
+from device_discovery.policy.models import Defaults
+from device_discovery.stack_naming import DEFAULT_STACK_MEMBER_TEMPLATE
+
+
+def test_default_when_unset():
+    """An unset template defaults to the legacy format."""
+    assert Defaults().stack_member_name_template == DEFAULT_STACK_MEMBER_TEMPLATE
+
+
+def test_valid_custom_template_is_kept():
+    """A well-formed custom template is preserved verbatim."""
+    d = Defaults(stack_member_name_template="{name}-css{id}")
+    assert d.stack_member_name_template == "{name}-css{id}"
+
+
+def test_invalid_template_falls_back_with_warning(caplog):
+    """An unusable template is replaced by the default and logs a WARN (never raises)."""
+    with caplog.at_level(logging.WARNING):
+        d = Defaults(stack_member_name_template="{name}-{id:09d}")
+    assert d.stack_member_name_template == DEFAULT_STACK_MEMBER_TEMPLATE
+    assert any("stack_member_name_template" in r.message for r in caplog.records)
+
+
+def test_missing_name_placeholder_falls_back():
+    """A template without {name} collides across stacks, so it falls back."""
+    d = Defaults(stack_member_name_template="member-{id}")
+    assert d.stack_member_name_template == DEFAULT_STACK_MEMBER_TEMPLATE
+
+
+def test_non_string_falls_back():
+    """A non-string template falls back rather than raising a ValidationError."""
+    d = Defaults(stack_member_name_template=123)
+    assert d.stack_member_name_template == DEFAULT_STACK_MEMBER_TEMPLATE

--- a/orb-discovery/device-discovery/tests/test_stack_naming.py
+++ b/orb-discovery/device-discovery/tests/test_stack_naming.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""Tests for stack member name templating helpers."""
+
+import pytest
+
+from device_discovery.stack_naming import (
+    DEFAULT_STACK_MEMBER_TEMPLATE,
+    render_stack_member_name,
+    stack_template_problem,
+)
+
+
+def test_default_template_reproduces_legacy_name():
+    """The default template renders the historical <name>-<id> form."""
+    assert DEFAULT_STACK_MEMBER_TEMPLATE == "{name}-{id}"
+    assert render_stack_member_name(DEFAULT_STACK_MEMBER_TEMPLATE, "sw-stack", 1) == "sw-stack-1"
+
+
+def test_custom_template_renders():
+    """A custom template substitutes both placeholders."""
+    assert render_stack_member_name("{name}-css{id}", "sw-stack", 2) == "sw-stack-css2"
+
+
+@pytest.mark.parametrize("tmpl", ["{name}-{id}", "{name}-css{id}", "{name}_{id}_unit"])
+def test_valid_templates_have_no_problem(tmpl):
+    """Well-formed templates report no problem."""
+    assert stack_template_problem(tmpl) is None
+
+
+@pytest.mark.parametrize(
+    "tmpl,needle",
+    [
+        ("", "empty"),
+        ("   ", "empty"),
+        ("{id}", "name"),  # missing {name} -> cross-stack collision
+        ("{name}", "vary"),  # no id -> not distinct per member
+        ("{name}-{foo}", "unknown"),  # unknown placeholder
+        ("{name}-{id:09d}", "disallow"),  # ':' format spec
+        ("{name}-{id.real}", "disallow"),  # '.' attribute access
+    ],
+)
+def test_invalid_templates_report_a_problem(tmpl, needle):
+    """Unusable templates report a reason containing the expected keyword."""
+    problem = stack_template_problem(tmpl)
+    assert problem is not None and needle in problem.lower()

--- a/orb-discovery/device-discovery/tests/test_stack_naming.py
+++ b/orb-discovery/device-discovery/tests/test_stack_naming.py
@@ -38,9 +38,19 @@ def test_valid_templates_have_no_problem(tmpl):
         ("{name}-{foo}", "unknown"),  # unknown placeholder
         ("{name}-{id:09d}", "disallow"),  # ':' format spec
         ("{name}-{id.real}", "disallow"),  # '.' attribute access
+        ("{name}-{id}}", "brace"),  # stray trailing brace
+        ("{{name}-{id}", "brace"),  # stray leading brace
+        ("{name}-{id}{", "brace"),  # dangling open brace
     ],
 )
 def test_invalid_templates_report_a_problem(tmpl, needle):
     """Unusable templates report a reason containing the expected keyword."""
     problem = stack_template_problem(tmpl)
     assert problem is not None and needle in problem.lower()
+
+
+def test_stray_brace_template_does_not_leak_into_rendered_name():
+    """A stray-brace template is rejected, so the Defaults validator won't accept it."""
+    # Guards the specific hazard: "{name}-{id}}" renders to "vc-1}" if accepted.
+    assert stack_template_problem("{name}-{id}}") is not None
+    assert render_stack_member_name("{name}-{id}}", "vc", 1) == "vc-1}"

--- a/orb-discovery/device-discovery/tests/test_translate_chassis.py
+++ b/orb-discovery/device-discovery/tests/test_translate_chassis.py
@@ -123,6 +123,43 @@ def test_two_members_emits_master_plain_then_vc_then_member():
     assert not member.virtual_chassis.master.HasField("virtual_chassis")
 
 
+def test_custom_stack_member_name_template_applies_to_master_and_members():
+    """A custom template renames master, member, and the VC master ref."""
+    data = _base_data(_two_member_payload())
+    data["defaults"] = Defaults(stack_member_name_template="{name}-css{id}")
+    entities = list(translate_data(data))
+
+    device_indices = [i for i, e in enumerate(entities) if e.HasField("device")]
+    vc = next(e.virtual_chassis for e in entities if e.HasField("virtual_chassis"))
+    master = entities[device_indices[0]].device
+    member = entities[device_indices[1]].device
+
+    assert master.name == "core-sw-css1"
+    assert member.name == "core-sw-css2"
+    assert vc.name == "core-sw"  # VC name itself is not templated
+    assert vc.master.name == "core-sw-css1"
+    assert member.virtual_chassis.master.name == "core-sw-css1"
+
+
+def test_custom_stack_member_name_template_routes_interfaces():
+    """Interfaces route to the templated member names."""
+    data = _base_data(_two_member_payload())
+    data["defaults"] = Defaults(stack_member_name_template="{name}-css{id}")
+    entities = list(translate_data(data))
+    by_name = {e.interface.name: e.interface for e in entities if e.HasField("interface")}
+    assert by_name["GigabitEthernet1/0/1"].device.name == "core-sw-css1"
+    assert by_name["GigabitEthernet2/0/1"].device.name == "core-sw-css2"
+
+
+def test_bad_stack_member_name_template_falls_back_to_default():
+    """An unusable template is normalized to the default → legacy names, no crash."""
+    data = _base_data(_two_member_payload())
+    data["defaults"] = Defaults(stack_member_name_template="{name}-{id:09d}")
+    entities = list(translate_data(data))
+    names = {e.device.name for e in entities if e.HasField("device")}
+    assert names == {"core-sw-1", "core-sw-2"}
+
+
 def test_interface_routed_to_correct_member():
     """An interface name with a parseable member id routes to that member's Device."""
     data = _base_data(_two_member_payload())


### PR DESCRIPTION
## What

Makes device-discovery's stack / Virtual Chassis **member device names configurable** via a new policy default, `defaults.stack_member_name_template`.

Member device names were built as a hardcoded `f"{vc_name}-{m['id']}"`. Because NetBox matches a member device by `name` + `site` (+ `tenant`) *ahead* of `virtual_chassis` + `vc_position`, an operator who pre-created members under a different convention (e.g. `core-sw-css1` / `core-sw-css2`) got **new** devices created on discovery instead of their existing records updated. There was no way to change the format.

## How

* New field `defaults.stack_member_name_template`, default `"{name}-{id}"` — byte-for-byte identical to the previous output, so existing deployments are unaffected.
* Placeholders: `{name}` (stack name) and `{id}` (device-reported member id). No `{position}` (an ordinal shifts when a member is dropped, which would re-fork the very duplicates this fixes).
* New `device_discovery/stack_naming.py` — a bounded token renderer (`str.replace` over a fixed placeholder set, **never** `str.format`) plus a validator. An operator template therefore cannot inject a format spec / attribute access and cannot raise at the build site.
* The template is validated at policy load (`Defaults` before-validator). An empty, malformed, non-string, or `{name}`-less template is **ignored with a** `WARNING` **and the default is used** — a bad config never rejects the policy or aborts discovery.
* Applied to **all** members including the master (the device-discovery master is already `{name}-{id}`, so the default stays a no-op and the VC `master` ref is derived after the name is finalized).

## Scope / limitations (documented)

* Fixes duplicates only when the pre-created records' **site (and tenant) already match**.
* No zero-based offset knob — device-reported ids must equal the operator's numbering (`css1`/`css2` ↔ ids `1`/`2`).
* snmp-discovery gets the same option in a **separate follow-up PR** (non-master members only there; the snmp master is named from `sysName` and matched via the existing `emit_device_name` feature).

## Testing

* `stack_naming` unit tests (render + validator: empty, unknown/dangerous placeholders, missing `{name}`, non-distinct).
* `Defaults` validator tests (default, valid custom, invalid → fallback + WARN, non-string → fallback).
* End-to-end `translate_chassis` tests (custom template renames master + member + VC master ref + interface routing; bad template falls back to legacy names).
* Full suite: `1841 passed, 161 skipped`; `ruff check .` clean.

Part of netboxlabs/orb-agent#481 (device-discovery half).

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)