### PR TITLE
chore(repo): remove @marc-barry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jajeffries @leoparente @mfiedorowicz @MicahParks @manrodrigues @grant-nbl @paulstuart @marc-barry @samiura @davidlanouette
+* @jajeffries @leoparente @mfiedorowicz @MicahParks @manrodrigues @grant-nbl @paulstuart @samiura @davidlanouette


### PR DESCRIPTION
Removing myself as a code owner here.

I had temporary review access to unblock some cross-org work. That work is complete, so I shouldn't be in this repo's review path any more — right now CODEOWNERS puts me on every PR, which just adds review latency.

No other owners change, so each path keeps its existing reviewers.
