### PR TITLE
fix(snmp-discovery): correct VLANs on Cisco small-business switches

### DIFF
--- a/docs/backends/snmp_discovery/supported_platforms.md
+++ b/docs/backends/snmp_discovery/supported_platforms.md
@@ -94,8 +94,13 @@ Switchport-to-VLAN association discovery is built on standard MIBs with one vend
 |-------|----------------|------------------|
 | **Generic** | Q-BRIDGE-MIB (RFC 4363, `1.3.6.1.2.1.17.7.1.4`) + BRIDGE-MIB `dot1dBasePortIfIndex` | VLAN catalog (`dot1qVlanStaticTable` — names + admin status), per-port PVID (`dot1qPvid`), per-VLAN egress + untagged port masks (`dot1qVlanStatic{Egress,Untagged}Ports`). Required for trunk classification. |
 | **Cisco overlay** | CISCO-VLAN-MEMBERSHIP-MIB `vmMembershipTable`, CISCO-VOICE-VLAN-MIB `vmVoiceVlanId` | Access VLAN refinement on non-trunk ports + voice-VLAN promotion. Walked only when `sysObjectID` falls under enterprise prefix `1.3.6.1.4.1.9.` (Cisco Systems) or `1.3.6.1.4.1.29671.` (Meraki). |
+| **CISCOSB overlay** | CISCOSB private `vlan` group (`1.3.6.1.4.1.9.6.1.101.48`): `vlanAccessPortModeVlanId`, `vlanTrunkPortModeNativeVlanId` | Corrects the untagged VLAN on Cisco small-business switches, where the standard sources are wrong rather than absent. Indexed by `ifIndex` rather than bridge port. Shares the Cisco vendor gate above. |
 
 When a switchport has both Q-BRIDGE membership and the Cisco overlay rows, the overlay layers on top of the generic classification (vmMembership refines the access VLAN for non-trunk ports; vmVoiceVlanId is promoted into the tagged VLAN list per Cisco's voice-on-access semantics). When a device exposes only the Cisco overlay (classic Cisco IOS without Q-BRIDGE), the overlay alone is sufficient to classify access ports — but trunk allowed/native VLANs cannot be reconstructed from `vmMembershipTable` (which is non-trunk by spec).
+
+The CISCOSB overlay is different in kind from the Cisco one: on those switches the generic sources are not merely absent but actively wrong. `dot1qPvid` answers 1 for every port whatever the port is configured for, and the per-VLAN egress/untagged masks come back empty, so Q-BRIDGE alone reports the whole switch as access VLAN 1. Where these private columns are present they therefore take precedence for the untagged VLAN.
+
+The overlay corrects the untagged VLAN only. It does not determine tagged membership or access-vs-trunk mode, so a trunk port on one of these switches is reported as an access port carrying its native VLAN. The private MIB does define per-port egress bitmaps that would supply both, but they are returned empty in practice, leaving no reliable source to derive membership or mode from.
 
 ### Device coverage
 
@@ -105,6 +110,7 @@ When a switchport has both Q-BRIDGE membership and the Cisco overlay rows, the o
 | Classic Cisco IOS (e.g. Catalyst 2960, 2950) | ⚠️ None or partial | ✅ Available | Access classification via `vmMembershipTable`; trunk ports remain unclassified |
 | Cisco IOS-XE (e.g. Catalyst 3850, 9400) | ⚠️ Sometimes empty pre-16.x | ✅ Available | As above; access ports classify, trunks unclassified unless Q-BRIDGE is also present |
 | Cisco NX-OS | ⚠️ Q-BRIDGE present, trunk membership often vendor-only | ✅ Available | Access via overlay; trunks may rely on Q-BRIDGE membership masks |
+| Cisco small business (Catalyst 1200/1300, CBS/SG series) | ❌ Present but wrong: `dot1qPvid` answers 1 on every port, egress/untagged masks empty | ✅ CISCOSB overlay | Correct untagged VLAN per port; mode is not derived, so trunks appear as access on their native VLAN |
 | Pre-ELS Junos | ⚠️ Incomplete | n/a | Limited — defer to a future Junos overlay |
 | Cisco WLC (e.g. 9800), routers, anything without `dot1dBasePortIfIndex` | n/a | n/a | No interface mutations emitted (refused by design — see Bridge-port translation below); VLAN catalog still emitted if `dot1qVlanStaticTable` is present |
 

--- a/orb-discovery/snmp-discovery/mapping/mapping_test.go
+++ b/orb-discovery/snmp-discovery/mapping/mapping_test.go
@@ -2261,3 +2261,41 @@ func TestMapObjectIDsToEntity_VLANIndexCollision(t *testing.T) {
 		t.Errorf("expected VLAN entity for vid 10 (Engineering); got entities=%+v", entities)
 	}
 }
+
+// The CISCOSB overlay only works if these walks are declared. The Go collector
+// matches on OID prefixes, so dropping an entry here would silently stop the
+// rows arriving and send small-business switches back to reporting every port
+// as access VLAN 1 (issue #482), with nothing failing loudly.
+func TestMappingYAML_CiscoSBOverlayEntriesPresent(t *testing.T) {
+	body, err := os.ReadFile("../policy/mapping.yaml")
+	if err != nil {
+		t.Fatalf("read mapping.yaml: %v", err)
+	}
+	var doc config.Mapping
+	if err := yaml.Unmarshal(body, &doc); err != nil {
+		t.Fatalf("yaml: %v", err)
+	}
+	wanted := map[string]bool{
+		".1.3.6.1.4.1.9.6.1.101.48.61.1": false, // vlanTrunkPortModeTable
+		".1.3.6.1.4.1.9.6.1.101.48.62.1": false, // vlanAccessPortModeTable
+	}
+	for _, e := range doc.Entries {
+		if _, want := wanted[e.OID]; !want {
+			continue
+		}
+		wanted[e.OID] = true
+		if e.Vendor != "cisco" {
+			t.Errorf("%s: vendor = %q, want cisco (these devices report sysObjectIDs under ciscoProducts)", e.OID, e.Vendor)
+		}
+		// interface_vlan is what registers the OID as a post-pass prefix, which
+		// keeps these ifIndex-keyed rows out of the ifTable index buckets.
+		if e.Entity != "interface_vlan" {
+			t.Errorf("%s: entity = %q, want interface_vlan", e.OID, e.Entity)
+		}
+	}
+	for oid, found := range wanted {
+		if !found {
+			t.Errorf("mapping.yaml missing CISCOSB-scoped OID %s", oid)
+		}
+	}
+}

--- a/orb-discovery/snmp-discovery/mapping/qbridge/extract_ciscosb.go
+++ b/orb-discovery/snmp-discovery/mapping/qbridge/extract_ciscosb.go
@@ -1,0 +1,100 @@
+package qbridge
+
+import "sort"
+
+// CISCOSB private-MIB VLAN overlay.
+//
+// On Cisco's small-business switches (CISCOSB: Catalyst 1200/1300, CBS/SG
+// series) dot1qPvid is not merely absent but wrong: it answers 1 for every
+// port regardless of the configured VLAN, and the per-VLAN
+// dot1qVlanStaticEgressPorts / UntaggedPorts masks come back empty. A C1200
+// with ports on VLANs 2128/2137/112/1399 therefore reports the whole switch as
+// access VLAN 1 from the standard tables alone (issue #482).
+//
+// The same devices populate a private per-port table with the real untagged
+// VLAN, keyed by ifIndex directly rather than by bridge port:
+//
+//	vlanAccessPortModeVlanId       per-port access VLAN
+//	vlanTrunkPortModeNativeVlanId  per-port trunk native VLAN
+//
+// This overlay corrects the untagged VLAN from those columns.
+//
+// It deliberately does not attempt tagged membership or access-vs-trunk mode.
+// The MIB does expose per-port egress bitmaps (rldot1qPortVlanStaticTable) that
+// would carry both, but they come back empty in practice, so there is nothing to
+// derive them from — and walking that table is expensive, since it is twelve
+// 128-byte columns per port. The other candidate mode signal, vlanPortModeState,
+// does not discriminate: a port configured as a trunk reports the same value as
+// its access neighbours.
+
+// CiscoSBRows carries the CISCOSB per-port VLAN columns, keyed by ifIndex.
+type CiscoSBRows struct {
+	AccessVlan map[int]int
+	NativeVlan map[int]int
+}
+
+// HasData reports whether the walk returned any CISCOSB VLAN rows. These OIDs
+// are walked on every Cisco device because they share the "cisco" vendor gate,
+// so callers use this to skip the overlay entirely on the majority of hosts
+// that do not answer them.
+func (r CiscoSBRows) HasData() bool {
+	return len(r.AccessVlan) > 0 || len(r.NativeVlan) > 0
+}
+
+// IfIndexes returns every ifIndex the rows mention, ascending, so callers
+// visit ports deterministically.
+func (r CiscoSBRows) IfIndexes() []int {
+	seen := map[int]struct{}{}
+	for _, m := range []map[int]int{r.AccessVlan, r.NativeVlan} {
+		for ifx := range m {
+			seen[ifx] = struct{}{}
+		}
+	}
+	out := make([]int, 0, len(seen))
+	for ifx := range seen {
+		out = append(out, ifx)
+	}
+	sort.Ints(out)
+	return out
+}
+
+// ApplyCiscoSB corrects the untagged VLAN of each port from the CISCOSB
+// private-MIB columns.
+//
+// Only ifIndices already present in infos are touched, matching ApplyCisco, so
+// a stale row cannot conjure a port out of nothing. A port with no usable
+// CISCOSB value keeps whatever the generic pass decided, which matters because
+// these OIDs are walked on every Cisco device and most will not answer them.
+//
+// Mode and the tagged VLAN set are deliberately left untouched. These columns
+// say which VLAN a port is untagged on, not whether it is an access port or a
+// trunk; deriving mode from them would demote a correctly classified trunk and
+// drop its tagged VLANs.
+func ApplyCiscoSB(infos map[int]*SwitchportInfo, rows CiscoSBRows) {
+	for _, ifIndex := range rows.IfIndexes() {
+		info, ok := infos[ifIndex]
+		if !ok {
+			continue
+		}
+
+		// CoerceVid rejects the 0 these columns default to, so an unconfigured
+		// column reads as "no opinion" rather than VLAN 0.
+		native := CoerceVid(rows.AccessVlan[ifIndex])
+		if native == nil {
+			if vid := CoerceVid(rows.NativeVlan[ifIndex]); vid != nil &&
+				(*vid != 1 || info.AdminMode == AdminTrunk) {
+				// The trunk-native column reads 1 on a factory-default port,
+				// indistinguishable from unset, so on its own it is not
+				// evidence. Honour it only for a port already known to be a
+				// trunk, or when it names something other than the default.
+				native = vid
+			}
+		}
+		if native == nil {
+			continue
+		}
+
+		info.AccessVlan = native
+		info.NativeVlan = native
+	}
+}

--- a/orb-discovery/snmp-discovery/mapping/qbridge/extract_ciscosb_test.go
+++ b/orb-discovery/snmp-discovery/mapping/qbridge/extract_ciscosb_test.go
@@ -1,0 +1,134 @@
+package qbridge
+
+import (
+	"reflect"
+	"testing"
+)
+
+// genericAccess returns what the standard Q-BRIDGE path produces on a CISCOSB
+// switch: a bridge port whose PVID reads 1 because the device answers 1 for
+// every port, with no membership masks to correct it.
+func genericAccess(pvid int) *SwitchportInfo {
+	return &SwitchportInfo{
+		Enabled:           true,
+		BridgePortPresent: true,
+		AdminMode:         AdminAccess,
+		AccessVlan:        intPtr(pvid),
+		NativeVlan:        intPtr(pvid),
+	}
+}
+
+// genericTrunk returns what the generic pass produces for a working trunk, so
+// tests can prove the overlay does not demote it.
+func genericTrunk(native int, tagged ...int) *SwitchportInfo {
+	return &SwitchportInfo{
+		Enabled:           true,
+		BridgePortPresent: true,
+		AdminMode:         AdminTrunk,
+		NativeVlan:        intPtr(native),
+		AccessVlan:        intPtr(native),
+		AllowedVlans:      AllowedVlans{Vids: tagged},
+	}
+}
+
+func TestApplyCiscoSBCorrectsWrongStandardPvid(t *testing.T) {
+	// Issue #482: dot1qPvid answers 1 for a port really on VLAN 2137.
+	infos := map[int]*SwitchportInfo{2: genericAccess(1)}
+	ApplyCiscoSB(infos, CiscoSBRows{AccessVlan: map[int]int{2: 2137}})
+	got := Classify(*infos[2])
+	if got.Mode != ModeAccess || got.Untagged == nil || *got.Untagged != 2137 {
+		t.Fatalf("got mode=%v untagged=%v want access/2137", got.Mode, deref(got.Untagged))
+	}
+}
+
+func TestApplyCiscoSBDoesNotDemoteATrunk(t *testing.T) {
+	// The access column says which VLAN is untagged, not whether the port is a
+	// trunk. Deriving mode from it would drop the port's tagged VLANs.
+	infos := map[int]*SwitchportInfo{5: genericTrunk(1, 1, 10, 20)}
+	ApplyCiscoSB(infos, CiscoSBRows{AccessVlan: map[int]int{5: 10}})
+	got := Classify(*infos[5])
+	if got.Mode != ModeTrunk {
+		t.Fatalf("got mode=%v want trunk", got.Mode)
+	}
+	if got.Untagged == nil || *got.Untagged != 10 {
+		t.Fatalf("got untagged=%v want 10", deref(got.Untagged))
+	}
+	if want := []int{1, 20}; !reflect.DeepEqual(got.Tagged, want) {
+		t.Fatalf("got tagged=%v want %v", got.Tagged, want)
+	}
+}
+
+func TestApplyCiscoSBLeavesGenericResultWhenNoEvidence(t *testing.T) {
+	// Non-CISCOSB Cisco gear is walked for these OIDs too, so absent or zeroed
+	// columns must not disturb the generic classification.
+	for _, tc := range []struct {
+		name string
+		rows CiscoSBRows
+	}{
+		{"no rows", CiscoSBRows{}},
+		{"zero access vlan", CiscoSBRows{AccessVlan: map[int]int{9: 0}}},
+		{"zero native vlan", CiscoSBRows{NativeVlan: map[int]int{9: 0}}},
+		{"out-of-range access vlan", CiscoSBRows{AccessVlan: map[int]int{9: 4095}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			infos := map[int]*SwitchportInfo{9: genericAccess(50)}
+			ApplyCiscoSB(infos, tc.rows)
+			got := Classify(*infos[9])
+			if got.Untagged == nil || *got.Untagged != 50 {
+				t.Fatalf("got untagged=%v want the generic 50", deref(got.Untagged))
+			}
+		})
+	}
+}
+
+func TestApplyCiscoSBIgnoresUnknownIfIndex(t *testing.T) {
+	// A row for an ifIndex the generic pass never produced must not create one.
+	infos := map[int]*SwitchportInfo{1: genericAccess(1)}
+	ApplyCiscoSB(infos, CiscoSBRows{AccessVlan: map[int]int{999: 2137}})
+	if len(infos) != 1 {
+		t.Fatalf("got %d infos want 1", len(infos))
+	}
+}
+
+func TestApplyCiscoSBFactoryDefaultNativeVlanIsNotEvidence(t *testing.T) {
+	// vlanTrunkPortModeNativeVlanId reads 1 on an unconfigured port, which is
+	// indistinguishable from unset, so on an access port it must not overwrite
+	// the VLAN the generic pass found.
+	infos := map[int]*SwitchportInfo{11: genericAccess(50)}
+	ApplyCiscoSB(infos, CiscoSBRows{NativeVlan: map[int]int{11: 1}})
+	if got := Classify(*infos[11]); got.Untagged == nil || *got.Untagged != 50 {
+		t.Fatalf("got untagged=%v want the generic 50", deref(got.Untagged))
+	}
+
+	// On a port already known to be a trunk it is meaningful.
+	trunk := map[int]*SwitchportInfo{12: genericTrunk(7, 7, 8)}
+	ApplyCiscoSB(trunk, CiscoSBRows{NativeVlan: map[int]int{12: 1}})
+	if got := Classify(*trunk[12]); got.Untagged == nil || *got.Untagged != 1 {
+		t.Fatalf("got untagged=%v want 1 on a trunk", deref(got.Untagged))
+	}
+}
+
+func TestApplyCiscoSBAccessColumnOutranksNativeColumn(t *testing.T) {
+	// Both columns can be populated at once (the reporter's port 2 had 2137 in
+	// each after trying both configurations). The access column wins.
+	infos := map[int]*SwitchportInfo{3: genericAccess(1)}
+	ApplyCiscoSB(infos, CiscoSBRows{
+		AccessVlan: map[int]int{3: 2137},
+		NativeVlan: map[int]int{3: 999},
+	})
+	if got := Classify(*infos[3]); got.Untagged == nil || *got.Untagged != 2137 {
+		t.Fatalf("got untagged=%v want 2137", deref(got.Untagged))
+	}
+}
+
+func TestApplyCiscoSBHasData(t *testing.T) {
+	if (CiscoSBRows{}).HasData() {
+		t.Error("empty rows must not report data")
+	}
+	if !(CiscoSBRows{AccessVlan: map[int]int{1: 10}}).HasData() {
+		t.Error("access-VLAN rows must report data")
+	}
+	if !(CiscoSBRows{NativeVlan: map[int]int{1: 10}}).HasData() {
+		t.Error("native-VLAN rows must report data")
+	}
+}

--- a/orb-discovery/snmp-discovery/mapping/vlan_mapper.go
+++ b/orb-discovery/snmp-discovery/mapping/vlan_mapper.go
@@ -24,6 +24,10 @@ const (
 	// Cisco overlay
 	oidCiscoVMVlan        = ".1.3.6.1.4.1.9.9.68.1.2.2.1.2."
 	oidCiscoVMVoiceVlanID = ".1.3.6.1.4.1.9.9.68.1.5.1.1."
+	// CISCOSB overlay (Cisco small-business: Catalyst 1200/1300, CBS/SG).
+	// Both are indexed by ifIndex, not by bridge port.
+	oidCiscoSBTrunkNativeVlan = ".1.3.6.1.4.1.9.6.1.101.48.61.1.1."
+	oidCiscoSBAccessVlan      = ".1.3.6.1.4.1.9.6.1.101.48.62.1.1."
 )
 
 // ifTypeNumericToString maps a small subset of IANAifType numeric values
@@ -106,6 +110,14 @@ func (m *VlanMapper) PostMap(
 	// and to keep the no-op explicit.
 	if len(cisco.MembershipAccessVlan) > 0 || len(cisco.VoiceVlanByIfIndex) > 0 {
 		qbridge.ApplyCisco(infos, cisco)
+	}
+	// CISCOSB last: on those switches dot1qPvid is actively wrong rather than
+	// absent (it answers 1 on every port), so the private columns have to be
+	// able to overrule whatever the generic pass and the IOS overlay concluded.
+	// The two overlays never both answer in practice, since a device populates
+	// either the IOS vmMembership table or the CISCOSB one.
+	if ciscosb := m.buildCiscoSBRows(allObjectIDs); ciscosb.HasData() {
+		qbridge.ApplyCiscoSB(infos, ciscosb)
 	}
 
 	// Build VLAN entities first — interface refs link to them by VID.
@@ -324,6 +336,32 @@ func (m *VlanMapper) buildGenericRows(all ObjectIDValueMap) qbridge.GenericRows 
 	return rows
 }
 
+// buildCiscoSBRows extracts the CISCOSB private-MIB per-port VLAN columns,
+// keyed by ifIndex.
+func (m *VlanMapper) buildCiscoSBRows(all ObjectIDValueMap) qbridge.CiscoSBRows {
+	rows := qbridge.CiscoSBRows{
+		AccessVlan: map[int]int{},
+		NativeVlan: map[int]int{},
+	}
+	for oid, v := range all {
+		switch {
+		case strings.HasPrefix(oid, oidCiscoSBAccessVlan):
+			ifx, ok1 := atoi(strings.TrimPrefix(oid, oidCiscoSBAccessVlan))
+			vid, ok2 := atoi(v.Value)
+			if ok1 && ok2 {
+				rows.AccessVlan[ifx] = vid
+			}
+		case strings.HasPrefix(oid, oidCiscoSBTrunkNativeVlan):
+			ifx, ok1 := atoi(strings.TrimPrefix(oid, oidCiscoSBTrunkNativeVlan))
+			vid, ok2 := atoi(v.Value)
+			if ok1 && ok2 {
+				rows.NativeVlan[ifx] = vid
+			}
+		}
+	}
+	return rows
+}
+
 // buildCiscoRows extracts Cisco overlay rows.
 func (m *VlanMapper) buildCiscoRows(all ObjectIDValueMap) qbridge.CiscoRows {
 	rows := qbridge.CiscoRows{
@@ -467,6 +505,8 @@ func hasVLANSignal(all ObjectIDValueMap) bool {
 		oidDot1qPvid,
 		oidCiscoVMVlan,
 		oidCiscoVMVoiceVlanID,
+		oidCiscoSBAccessVlan,
+		oidCiscoSBTrunkNativeVlan,
 	}
 	for oid := range all {
 		for _, p := range prefixes {

--- a/orb-discovery/snmp-discovery/mapping/vlan_mapper_test.go
+++ b/orb-discovery/snmp-discovery/mapping/vlan_mapper_test.go
@@ -544,3 +544,138 @@ func TestApplyVLANDefaults_NoGroup_SiteIgnored(t *testing.T) {
 		t.Errorf("Group: got %v, want nil (no group configured)", v.Group)
 	}
 }
+
+// buildCiscoSBFixture models a Cisco Catalyst 1200 as reported in issue #482:
+// dot1qPvid answers 1 for the port even though it is really on accessVid, the
+// per-VLAN egress/untagged masks come back empty, and the private CISCOSB
+// column carries the real VLAN keyed by ifIndex.
+func buildCiscoSBFixture(ifIndex, accessVid int) ObjectIDValueMap {
+	out := ObjectIDValueMap{}
+	put := func(oid, val string, t Asn1BER) { out[oid] = Value{Value: val, Type: t} }
+	idx := strconv.Itoa(ifIndex)
+	vid := strconv.Itoa(accessVid)
+
+	put(".1.3.6.1.2.1.17.1.4.1.2."+idx, idx, Integer)     // bridge port -> ifIndex
+	put(".1.3.6.1.2.1.17.7.1.4.5.1.1."+idx, "1", Integer) // the platform's wrong PVID
+	put(".1.3.6.1.2.1.2.2.1.7."+idx, "1", Integer)
+	put(".1.3.6.1.2.1.2.2.1.3."+idx, "6", Integer)
+
+	// The VLAN exists in the static table but its port masks are all zero.
+	put(".1.3.6.1.2.1.17.7.1.4.3.1.1."+vid, "vlan"+vid, OctetString)
+	put(".1.3.6.1.2.1.17.7.1.4.3.1.2."+vid, string(make([]byte, 126)), OctetString)
+	put(".1.3.6.1.2.1.17.7.1.4.3.1.4."+vid, string(make([]byte, 126)), OctetString)
+	put(".1.3.6.1.2.1.17.7.1.4.3.1.5."+vid, "1", Integer)
+
+	put(".1.3.6.1.4.1.9.6.1.101.48.62.1.1."+idx, vid, Integer)
+	return out
+}
+
+func newVlanTestRegistry(t *testing.T, ifIndex int, name string) (*EntityRegistry, *diode.Interface) {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	registry := NewEntityRegistry(logger)
+	iface := &diode.Interface{Name: StringPtr(name)}
+	if registry.entities[InterfaceEntityType] == nil {
+		registry.entities[InterfaceEntityType] = map[ObjectIDIndex]diode.Entity{}
+	}
+	registry.entities[InterfaceEntityType][ObjectIDIndex(strconv.Itoa(ifIndex))] = iface
+	registry.MarkInterfaceVerified(iface)
+	return registry, iface
+}
+
+// Issue #482: the port must land on the VLAN the private column reports, not on
+// the 1 that dot1qPvid claims.
+func TestVlanMapper_PostMap_CiscoSB_OverridesWrongPvid(t *testing.T) {
+	registry, iface := newVlanTestRegistry(t, 2, "gi2")
+	NewVlanMapper(slog.New(slog.NewTextHandler(os.Stderr, nil)), config.Options{}).
+		PostMap(buildCiscoSBFixture(2, 2137), registry,
+			&config.Defaults{VLAN: config.VLANDefaults{Status: "active"}})
+
+	if iface.Mode == nil || *iface.Mode != "access" {
+		t.Fatalf("Interface.Mode: got %v, want access", iface.Mode)
+	}
+	if iface.UntaggedVlan == nil || iface.UntaggedVlan.Vid == nil {
+		t.Fatalf("Interface.UntaggedVlan: got %+v, want VID 2137", iface.UntaggedVlan)
+	}
+	if got := *iface.UntaggedVlan.Vid; got != 2137 {
+		t.Fatalf("UntaggedVlan.Vid: got %d, want 2137 (dot1qPvid's 1 must not win)", got)
+	}
+}
+
+// Non-CISCOSB Cisco gear is walked for these OIDs too, so a host that does not
+// answer them must classify exactly as before.
+func TestVlanMapper_PostMap_CiscoSB_AbsentLeavesGenericBehaviour(t *testing.T) {
+	registry, iface := newVlanTestRegistry(t, 101, "Ethernet1")
+	NewVlanMapper(slog.New(slog.NewTextHandler(os.Stderr, nil)), config.Options{}).
+		PostMap(buildAccessPortFixture(101, 10), registry,
+			&config.Defaults{VLAN: config.VLANDefaults{Status: "active"}})
+
+	if iface.UntaggedVlan == nil || iface.UntaggedVlan.Vid == nil || *iface.UntaggedVlan.Vid != 10 {
+		t.Fatalf("Interface.UntaggedVlan: got %+v, want VID 10", iface.UntaggedVlan)
+	}
+}
+
+// A port the bridge-port table omits stays untouched even when CISCOSB reports
+// a VLAN for it: the overlay refines ports, it does not create them.
+func TestVlanMapper_PostMap_CiscoSB_DoesNotCreatePorts(t *testing.T) {
+	registry, bridged := newVlanTestRegistry(t, 2, "gi2")
+	omitted := &diode.Interface{Name: StringPtr("gi3")}
+	registry.entities[InterfaceEntityType]["3"] = omitted
+	registry.MarkInterfaceVerified(omitted)
+
+	rows := buildCiscoSBFixture(2, 2137)
+	rows[".1.3.6.1.2.1.2.2.1.7.3"] = Value{Value: "1", Type: Integer}
+	rows[".1.3.6.1.2.1.2.2.1.3.3"] = Value{Value: "6", Type: Integer}
+	rows[".1.3.6.1.4.1.9.6.1.101.48.62.1.1.3"] = Value{Value: "999", Type: Integer}
+
+	NewVlanMapper(slog.New(slog.NewTextHandler(os.Stderr, nil)), config.Options{}).
+		PostMap(rows, registry, &config.Defaults{VLAN: config.VLANDefaults{Status: "active"}})
+
+	if bridged.UntaggedVlan == nil || *bridged.UntaggedVlan.Vid != 2137 {
+		t.Fatalf("bridged port: got %+v, want 2137", bridged.UntaggedVlan)
+	}
+	if omitted.Mode != nil || omitted.UntaggedVlan != nil {
+		t.Fatalf("port omitted from the bridge table was mutated: mode=%v untagged=%+v",
+			omitted.Mode, omitted.UntaggedVlan)
+	}
+}
+
+// The two private columns are not interchangeable. An access column that
+// explicitly reports VLAN 1 is evidence, because the operator configured it;
+// the trunk-native column reading 1 is the factory default and is ignored on an
+// access port. Parsing one into the other's map would silently swap the rules.
+func TestVlanMapper_PostMap_CiscoSB_AccessAndNativeColumnsAreDistinct(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		oid          string
+		wantUntagged int64
+	}{
+		// The access column naming VLAN 1 overrides the generic PVID of 50.
+		{"access column", ".1.3.6.1.4.1.9.6.1.101.48.62.1.1.2", 1},
+		// The native column naming VLAN 1 is indistinguishable from unset on an
+		// access port, so the generic value stands.
+		{"native column", ".1.3.6.1.4.1.9.6.1.101.48.61.1.1.2", 50},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			registry, iface := newVlanTestRegistry(t, 2, "gi2")
+			rows := ObjectIDValueMap{
+				".1.3.6.1.2.1.17.1.4.1.2.2":      Value{Value: "2", Type: Integer},
+				".1.3.6.1.2.1.17.7.1.4.5.1.1.2":  Value{Value: "50", Type: Integer},
+				".1.3.6.1.2.1.17.7.1.4.3.1.1.50": Value{Value: "vlan50", Type: OctetString},
+				".1.3.6.1.2.1.17.7.1.4.3.1.5.50": Value{Value: "1", Type: Integer},
+				".1.3.6.1.2.1.2.2.1.7.2":         Value{Value: "1", Type: Integer},
+				".1.3.6.1.2.1.2.2.1.3.2":         Value{Value: "6", Type: Integer},
+				tc.oid:                           Value{Value: "1", Type: Integer},
+			}
+			NewVlanMapper(slog.New(slog.NewTextHandler(os.Stderr, nil)), config.Options{}).
+				PostMap(rows, registry, &config.Defaults{VLAN: config.VLANDefaults{Status: "active"}})
+
+			if iface.UntaggedVlan == nil || iface.UntaggedVlan.Vid == nil {
+				t.Fatalf("UntaggedVlan: got %+v, want VID %d", iface.UntaggedVlan, tc.wantUntagged)
+			}
+			if got := *iface.UntaggedVlan.Vid; got != tc.wantUntagged {
+				t.Fatalf("UntaggedVlan.Vid: got %d, want %d", got, tc.wantUntagged)
+			}
+		})
+	}
+}

--- a/orb-discovery/snmp-discovery/policy/mapping.yaml
+++ b/orb-discovery/snmp-discovery/policy/mapping.yaml
@@ -234,6 +234,39 @@ entries:
         entity: "interface_vlan"
         field: "vmVoiceVlanId"
 
+  # CISCOSB private vlan group — Cisco small-business switches (Catalyst
+  # 1200/1300, CBS/SG). On these, dot1qPvid is not merely absent but wrong: it
+  # answers 1 on every port whatever the port is configured for, and the
+  # per-VLAN egress/untagged masks come back empty, so Q-BRIDGE alone reports
+  # the whole switch as access VLAN 1. These two columns carry the real
+  # untagged VLAN and are indexed by ifIndex, not bridge port.
+  #
+  # Scoped to the existing cisco vendor gate, which already covers these
+  # devices: they report sysObjectIDs under ciscoProducts
+  # (.1.3.6.1.4.1.9.1.NNNN), so gating on the private .9.6.1 arc would miss
+  # them. Other Cisco platforms simply do not answer.
+  - oid: ".1.3.6.1.4.1.9.6.1.101.48.61.1"
+    entity: "interface_vlan"
+    field: "_id"
+    identifier_size: 1
+    vendor: "cisco"
+    description: "CISCOSB vlanTrunkPortModeTable (per-port trunk native VLAN)"
+    mapping_entries:
+      - oid: ".1.3.6.1.4.1.9.6.1.101.48.61.1.1"
+        entity: "interface_vlan"
+        field: "ciscoSBTrunkNativeVlanId"
+
+  - oid: ".1.3.6.1.4.1.9.6.1.101.48.62.1"
+    entity: "interface_vlan"
+    field: "_id"
+    identifier_size: 1
+    vendor: "cisco"
+    description: "CISCOSB vlanAccessPortModeTable (per-port access VLAN)"
+    mapping_entries:
+      - oid: ".1.3.6.1.4.1.9.6.1.101.48.62.1.1"
+        entity: "interface_vlan"
+        field: "ciscoSBAccessVlanId"
+
   # --- VRF discovery (gated by options.discover_vrfs) ------------------- #
   # Three MIB tiers, resolved in order by mapping.TranslateVrfs: the
   # standards-based MPLS-L3VPN-STD-MIB, the pre-standard MPLS-VPN-MIB


### PR DESCRIPTION
## What

Cisco small-business switches (Catalyst 1200/1300, CBS/SG) report **every port as access VLAN 1**, whatever the ports are actually configured for. Reported in #482 on a C1200-8FP-2G.

## Why

On these switches the standard Q-BRIDGE sources are not merely absent, they are **wrong**. From the reporter's walks:

- `dot1qPvid` returns **1 for all 14 ports**, including a port genuinely on VLAN 2137.
- `dot1qVlanStaticEgressPorts` / `UntaggedPorts` return **all-zero** masks for all 19 VLANs.

So there is nothing for the generic classifier to correct itself with, and it faithfully reports what the device claims.

The same device populates a private per-port table with the real values, keyed by `ifIndex` rather than bridge port:

```
.1.3.6.1.4.1.9.6.1.101.48.62.1.1.<ifIndex>   vlanAccessPortModeVlanId
.1.3.6.1.4.1.9.6.1.101.48.61.1.1.<ifIndex>   vlanTrunkPortModeNativeVlanId
```

Their actual values — `2128, 2137, 2137, 2137, 2137, 112, 1399, 1399, 1, 100, …` — are exactly what NetBox should show.

## How

Walk those two columns on Cisco-matched hosts and use them for the untagged VLAN.

Gating uses the **existing** `vendor: "cisco"` key, which already covers these devices. Worth calling out: they report `sysObjectID` under **ciscoProducts** (`.1.3.6.1.4.1.9.1.3213`), *not* under the private `.9.6.1` arc, so a prefix test on the private arc would have missed the very device being fixed. Other Cisco platforms do not answer these OIDs, so `HasData()` is false and the overlay never runs.

## Scope: untagged VLAN only

The overlay does **not** derive tagged membership or access-vs-trunk mode, so a trunk on one of these switches is still reported as an access port carrying its native VLAN. The docs state this rather than implying full classification.

I implemented that half and then removed it. `rldot1qPortVlanStaticTable` would supply both, but its columns come back empty in practice, so there is nothing to derive membership or mode from — and the table is expensive to walk, at twelve 128-byte columns per port. `vlanPortModeState` is not a substitute either: a port configured as a trunk reports the same value as its access neighbours.

Re-adding it is a small change if firmware that populates the table turns up.

## Behavioural notes

An access column reporting VLAN 1 **is** honoured, because an operator configured it. The trunk-native column reading 1 is the factory default and indistinguishable from unset, so it is ignored on an access port. The two columns are deliberately not interchangeable, and a test pins that.

Mode and the tagged set are never touched, so a correctly classified trunk cannot be demoted. Ports absent from `infos` are never created, matching `ApplyCisco`.

## Testing

- `qbridge` unit tests: the #482 correction, trunk not demoted, factory-default guard, absent/zero/out-of-range columns leaving the generic result alone, unknown ifIndex ignored, access column outranking native.
- Mapper-level tests through the real `PostMap`, on a fixture modelling the device (wrong `dot1qPvid=1`, empty standard masks, correct private column): untagged becomes **2137, not 1**; a non-CISCOSB host is unchanged; a port the bridge table omits is not mutated; and the two columns are proven distinct.
- `mapping.yaml` guard test, since the collector matches on OID prefixes: dropping a walk entry would silently regress to VLAN 1 with nothing failing loudly.
- Full suite green under `-race`; `make fix-lint` clean.
- Mutation-checked in a scratchpad copy: seven semantic mutants including a no-op control, **all seven killed**.

Fixes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)
