### PR TITLE
test(device-discovery): set send_enable on the fake EOS driver

### DIFF
--- a/orb-discovery/device-discovery/tests/custom_drivers/arista_eos/test_driver.py
+++ b/orb-discovery/device-discovery/tests/custom_drivers/arista_eos/test_driver.py
@@ -29,6 +29,14 @@ class TestEOSDriver(BaseDriverTest):
         # which our FakeJsonRpcDevice implements.
         driver = super()._build_driver(mock_dir)
         driver.transport = "https"
+        # napalm >= 5.2 reads self.send_enable on the eAPI path
+        # (kwargs.setdefault("send_enable", self.send_enable)). Both attributes
+        # are only assigned in EOSDriver.__init__, which _build_driver bypasses
+        # via object.__new__, so each one has to be supplied here or
+        # _run_commands raises AttributeError. Our getters catch that broadly
+        # and return None/{}, which surfaces as a confusing equality failure
+        # rather than an error.
+        driver.send_enable = False
         return driver
 
     # Skip inherited NAPALM getters — covered by upstream tests.


### PR DESCRIPTION
## What

Six `arista_eos` tests fail on `develop` with no change to the repo, so **every device-discovery PR is currently red** regardless of what it touches:

```
FAILED tests/custom_drivers/arista_eos/test_driver.py::TestEOSDriver::test_get_modules[normal]
FAILED tests/custom_drivers/arista_eos/test_driver.py::TestEOSDriver::test_get_interfaces_vlans[access_only]
FAILED .../test_get_interfaces_vlans[mixed] [routed] [trunk_all] [trunk_native]
```

## Why

napalm **5.2.0** added a line to the eAPI branch of `EOSDriver._run_commands`:

```python
kwargs.setdefault("send_enable", self.send_enable)   # new in 5.2.0
return self.device.run_commands(commands, **kwargs)
```

`send_enable` is assigned only in `EOSDriver.__init__`, which the test harness bypasses via `object.__new__`, so `_run_commands` raises `AttributeError`. `get_modules()` and `get_interfaces_vlans()` catch broadly and return `None` / `{}`, which surfaces as six confusing equality failures rather than an error.

`pyproject.toml` pins `napalm~=5.0`, so CI resolves 5.2.0 on a fresh install while a longer-lived local venv may still be on 5.1.0 — which is why this passes locally and fails in CI.

## How

One line, next to the existing `driver.transport = "https"` workaround in `TestEOSDriver._build_driver`, which exists for exactly the same reason (both attributes are set only in `__init__`).

## Verification

I could not reproduce this locally, because my venv has napalm 5.1.0 where the bug does not exist. So rather than push and hope, I patched 5.2.0's actual eAPI branch over the local install and ran it both ways:

- **without** this line → the exact six CI failures reproduce
- **with** it → all nine arista tests pass

`pytest tests/custom_drivers/arista_eos/ -q` → 9 passed, 8 skipped. `ruff` clean.

## Follow-up worth considering

`napalm~=5.0` means any napalm minor release can break device-discovery CI with no change on our side. Tightening the floor, or pinning exactly, would prevent a repeat. Not done here to keep this unblocking change minimal.

Split out of #489 so it can merge on its own and unblock other PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
