### PR TITLE
fix(snmp-discovery): report what lookup_extensions_dir actually loaded

### DIFF
--- a/orb-discovery/snmp-discovery/data/lookup_extensions.go
+++ b/orb-discovery/snmp-discovery/data/lookup_extensions.go
@@ -297,6 +297,11 @@ type ExtensionFileResult struct {
 	Name string
 	// Entries is how many device OIDs the file registered.
 	Entries int
+	// ManufacturerEntries is how many manufacturer overrides the file declares.
+	// A file may legitimately carry only a manufacturers: block: the same
+	// directory is also read by NewManufacturerResolver, which applies those
+	// overrides. Callers must not treat such a file as contributing nothing.
+	ManufacturerEntries int
 	// Err is set when the file could not be parsed. Such a file is skipped
 	// rather than failing the whole load, so the rest still apply.
 	Err error
@@ -426,6 +431,22 @@ func loadBuiltInExtensions(devicesByVendor map[string]deviceRef) error {
 	return nil
 }
 
+// countManufacturerEntries reports how many manufacturer overrides a
+// lookup-extension file declares, for reporting only. The overrides themselves
+// are applied by NewManufacturerResolver, which reads the same directory.
+//
+// Keys are IANA Private Enterprise Numbers and so are numeric in YAML; decoding
+// into map[string]any lets them be counted without caring about their type.
+func countManufacturerEntries(data []byte) int {
+	var probe struct {
+		Manufacturers map[string]any `yaml:"manufacturers"`
+	}
+	if err := yaml.Unmarshal(data, &probe); err != nil {
+		return 0
+	}
+	return len(probe.Manufacturers)
+}
+
 // loadUserProvidedExtensions merges every YAML file in dir into
 // devicesByVendor and returns one result per file for the caller to log.
 //
@@ -463,9 +484,10 @@ func loadUserProvidedExtensions(dir string, devicesByVendor map[string]deviceRef
 			}
 		}
 		results = append(results, ExtensionFileResult{
-			Name:    file.Name(),
-			Entries: len(fileRefs),
-			Err:     parseErr,
+			Name:                file.Name(),
+			Entries:             len(fileRefs),
+			ManufacturerEntries: countManufacturerEntries(data),
+			Err:                 parseErr,
 		})
 	}
 	return results, nil

--- a/orb-discovery/snmp-discovery/data/lookup_extensions.go
+++ b/orb-discovery/snmp-discovery/data/lookup_extensions.go
@@ -280,8 +280,9 @@ type DeviceRetriever interface {
 
 // DeviceLookup represents a device lookup service.
 type DeviceLookup struct {
-	devicesByVendor   map[string]deviceRef
-	userExtensionFile []ExtensionFileResult
+	devicesByVendor      map[string]deviceRef
+	userExtensionFile    []ExtensionFileResult
+	userExtensionSkipped int
 }
 
 // ExtensionFileResult records what one file in lookup_extensions_dir
@@ -311,6 +312,13 @@ type ExtensionFileResult struct {
 // contributed, in directory order. Empty when no user directory was configured.
 func (d *DeviceLookup) UserExtensionFiles() []ExtensionFileResult {
 	return d.userExtensionFile
+}
+
+// UserExtensionSkippedFiles is how many entries in lookup_extensions_dir were
+// ignored for not being .yaml or .yml. It distinguishes an empty directory from
+// one holding files the loader will never read, such as a custom.yaml.bak.
+func (d *DeviceLookup) UserExtensionSkippedFiles() int {
+	return d.userExtensionSkipped
 }
 
 // lookupOIDBothSpellings indexes m by oid, accepting either leading-dot or
@@ -389,11 +397,12 @@ func LoadDeviceLookupExtensions(dir string) (*DeviceLookup, error) {
 
 	if dir != "" {
 		// Extend built in extensions with user provided extensions
-		results, err := loadUserProvidedExtensions(dir, devicesByVendor)
+		results, skipped, err := loadUserProvidedExtensions(dir, devicesByVendor)
 		if err != nil {
 			return &deviceLookup, err
 		}
 		deviceLookup.userExtensionFile = results
+		deviceLookup.userExtensionSkipped = skipped
 	}
 
 	return &deviceLookup, nil
@@ -454,22 +463,24 @@ func countManufacturerEntries(data []byte) int {
 // bad file cannot cost an operator every other override they wrote. The failure
 // is returned in the results instead of being logged here, so it reaches the
 // structured logger the caller already holds.
-func loadUserProvidedExtensions(dir string, devicesByVendor map[string]deviceRef) ([]ExtensionFileResult, error) {
+func loadUserProvidedExtensions(dir string, devicesByVendor map[string]deviceRef) ([]ExtensionFileResult, int, error) {
 	files, err := os.ReadDir(dir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read directory %s: %w", dir, err)
+		return nil, 0, fmt.Errorf("failed to read directory %s: %w", dir, err)
 	}
 
 	var results []ExtensionFileResult
+	skipped := 0
 	for _, file := range files {
 		if !isLookupExtensionFile(file) {
+			skipped++
 			continue
 		}
 
 		filePath := filepath.Join(dir, file.Name())
 		data, err := os.ReadFile(filePath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read file %s: %w", filePath, err)
+			return nil, 0, fmt.Errorf("failed to read file %s: %w", filePath, err)
 		}
 
 		// Parse into a per-file map first so the entry count is this file's own
@@ -490,7 +501,7 @@ func loadUserProvidedExtensions(dir string, devicesByVendor map[string]deviceRef
 			Err:                 parseErr,
 		})
 	}
-	return results, nil
+	return results, skipped, nil
 }
 
 func isLookupExtensionFile(file os.DirEntry) bool {

--- a/orb-discovery/snmp-discovery/data/lookup_extensions.go
+++ b/orb-discovery/snmp-discovery/data/lookup_extensions.go
@@ -444,16 +444,17 @@ func loadBuiltInExtensions(devicesByVendor map[string]deviceRef) error {
 // lookup-extension file declares, for reporting only. The overrides themselves
 // are applied by NewManufacturerResolver, which reads the same directory.
 //
-// Keys are IANA Private Enterprise Numbers and so are numeric in YAML; decoding
-// into map[string]any lets them be counted without caring about their type.
+// Counts through the resolver's own decoder rather than a looser probe, so the
+// number always matches what will actually be applied. A non-string value makes
+// the resolver reject the whole manufacturers block, and a count that ignored
+// that would report entries nobody applied, suppressing the no-contribution
+// warning for a file that contributes nothing.
 func countManufacturerEntries(data []byte) int {
-	var probe struct {
-		Manufacturers map[string]any `yaml:"manufacturers"`
-	}
-	if err := yaml.Unmarshal(data, &probe); err != nil {
+	applied := make(map[string]string)
+	if err := loadManufacturerYAML(data, applied); err != nil {
 		return 0
 	}
-	return len(probe.Manufacturers)
+	return len(applied)
 }
 
 // loadUserProvidedExtensions merges every YAML file in dir into

--- a/orb-discovery/snmp-discovery/data/lookup_extensions.go
+++ b/orb-discovery/snmp-discovery/data/lookup_extensions.go
@@ -280,7 +280,32 @@ type DeviceRetriever interface {
 
 // DeviceLookup represents a device lookup service.
 type DeviceLookup struct {
-	devicesByVendor map[string]deviceRef
+	devicesByVendor   map[string]deviceRef
+	userExtensionFile []ExtensionFileResult
+}
+
+// ExtensionFileResult records what one file in lookup_extensions_dir
+// contributed.
+//
+// A file can be read successfully and still contribute nothing: a wrong
+// top-level key or bad indentation yields an empty devices map with no error.
+// Reporting Entries alongside Err lets the caller distinguish "loaded 12
+// entries" from "loaded, but your OID was never registered", which is otherwise
+// indistinguishable from the logs (issue #486).
+type ExtensionFileResult struct {
+	// Name is the file's base name, not its path.
+	Name string
+	// Entries is how many device OIDs the file registered.
+	Entries int
+	// Err is set when the file could not be parsed. Such a file is skipped
+	// rather than failing the whole load, so the rest still apply.
+	Err error
+}
+
+// UserExtensionFiles reports what each YAML file in lookup_extensions_dir
+// contributed, in directory order. Empty when no user directory was configured.
+func (d *DeviceLookup) UserExtensionFiles() []ExtensionFileResult {
+	return d.userExtensionFile
 }
 
 // lookupOIDBothSpellings indexes m by oid, accepting either leading-dot or
@@ -359,10 +384,11 @@ func LoadDeviceLookupExtensions(dir string) (*DeviceLookup, error) {
 
 	if dir != "" {
 		// Extend built in extensions with user provided extensions
-		err = loadUserProvidedExtensions(dir, devicesByVendor)
+		results, err := loadUserProvidedExtensions(dir, devicesByVendor)
 		if err != nil {
 			return &deviceLookup, err
 		}
+		deviceLookup.userExtensionFile = results
 	}
 
 	return &deviceLookup, nil
@@ -400,35 +426,49 @@ func loadBuiltInExtensions(devicesByVendor map[string]deviceRef) error {
 	return nil
 }
 
-func loadUserProvidedExtensions(dir string, devicesByVendor map[string]deviceRef) error {
-	// Read all files in the directory
+// loadUserProvidedExtensions merges every YAML file in dir into
+// devicesByVendor and returns one result per file for the caller to log.
+//
+// A file that fails to parse is skipped rather than aborting the load, so one
+// bad file cannot cost an operator every other override they wrote. The failure
+// is returned in the results instead of being logged here, so it reaches the
+// structured logger the caller already holds.
+func loadUserProvidedExtensions(dir string, devicesByVendor map[string]deviceRef) ([]ExtensionFileResult, error) {
 	files, err := os.ReadDir(dir)
 	if err != nil {
-		return fmt.Errorf("failed to read directory %s: %w", dir, err)
+		return nil, fmt.Errorf("failed to read directory %s: %w", dir, err)
 	}
 
+	var results []ExtensionFileResult
 	for _, file := range files {
 		if !isLookupExtensionFile(file) {
-			log.Printf("Warning: skipping file %s", file.Name())
 			continue
 		}
 
 		filePath := filepath.Join(dir, file.Name())
 		data, err := os.ReadFile(filePath)
 		if err != nil {
-			return fmt.Errorf("failed to read file %s: %w", filePath, err)
+			return nil, fmt.Errorf("failed to read file %s: %w", filePath, err)
 		}
 
-		if err := loadYAMLFile(data, devicesByVendor); err != nil {
-			safeFilePath := strings.ReplaceAll(filePath, "\n", "")
-			safeFilePath = strings.ReplaceAll(safeFilePath, "\r", "")
-			safeErr := strings.ReplaceAll(err.Error(), "\n", "")
-			safeErr = strings.ReplaceAll(safeErr, "\r", "")
-			log.Printf("Warning: failed to load YAML file %s: %s", safeFilePath, safeErr)
-			continue
+		// Parse into a per-file map first so the entry count is this file's own
+		// contribution rather than the running total, then merge. Merging only
+		// on success keeps the pre-existing behaviour that a rejected file
+		// contributes nothing.
+		fileRefs := make(map[string]deviceRef)
+		parseErr := loadYAMLFile(data, fileRefs)
+		if parseErr == nil {
+			for oid, ref := range fileRefs {
+				devicesByVendor[oid] = ref
+			}
 		}
+		results = append(results, ExtensionFileResult{
+			Name:    file.Name(),
+			Entries: len(fileRefs),
+			Err:     parseErr,
+		})
 	}
-	return nil
+	return results, nil
 }
 
 func isLookupExtensionFile(file os.DirEntry) bool {

--- a/orb-discovery/snmp-discovery/data/lookup_extensions_test.go
+++ b/orb-discovery/snmp-discovery/data/lookup_extensions_test.go
@@ -1029,3 +1029,84 @@ func TestResolveDefault_ExistingOIDPatternUnchanged(t *testing.T) {
 	assert.True(t, oidPattern.MatchString(".1.3.6.1.4.1.14988.1"))
 	assert.True(t, oidPattern.MatchString("3.14.159"))
 }
+
+// A user file can be read successfully and still contribute nothing: a wrong
+// top-level key or bad indentation yields an empty devices map with no error.
+// Before this report existed the loader reported plain success in that case, so
+// an operator whose custom OID was ignored had no way to tell from the logs
+// (issue #486). Each file's contribution is now recorded for the caller to log.
+func TestLoadDeviceLookupExtensions_UserFileReport(t *testing.T) {
+	const oid = ".1.3.6.1.4.1.52642.1.439.0"
+	tests := []struct {
+		name        string
+		body        string
+		wantEntries int
+		wantErr     bool
+		wantResolve bool
+	}{
+		{
+			name:        "well-formed file",
+			body:        "devices:\n  " + oid + ": S3400-24T4FP\n",
+			wantEntries: 1,
+			wantResolve: true,
+		},
+		{
+			name:        "tab indentation is a parse error",
+			body:        "devices:\n\t" + oid + ": S3400-24T4FP\n",
+			wantEntries: 0,
+			wantErr:     true,
+		},
+		{
+			name:        "wrong top-level key parses to nothing",
+			body:        "device:\n  " + oid + ": S3400-24T4FP\n",
+			wantEntries: 0,
+		},
+		{
+			name:        "no devices key at all",
+			body:        "  " + oid + ": S3400-24T4FP\n",
+			wantEntries: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "fs_custom.yaml"), []byte(tt.body), 0o600))
+
+			dl, err := LoadDeviceLookupExtensions(dir)
+			require.NoError(t, err, "a bad user file must not fail the whole load")
+
+			files := dl.UserExtensionFiles()
+			require.Len(t, files, 1, "the file must be reported either way")
+			assert.Equal(t, "fs_custom.yaml", files[0].Name)
+			assert.Equal(t, tt.wantEntries, files[0].Entries)
+			if tt.wantErr {
+				assert.Error(t, files[0].Err, "a parse failure must be reported, not swallowed")
+			} else {
+				assert.NoError(t, files[0].Err)
+			}
+
+			_, lookupErr := dl.GetDeviceModel(oid, map[string]string{})
+			assert.Equal(t, tt.wantResolve, lookupErr == nil)
+		})
+	}
+}
+
+func TestLoadDeviceLookupExtensions_NoUserDirReportsNoFiles(t *testing.T) {
+	dl, err := LoadDeviceLookupExtensions("")
+	require.NoError(t, err)
+	assert.Empty(t, dl.UserExtensionFiles(), "built-in-only load has no user files to report")
+}
+
+func TestLoadDeviceLookupExtensions_ReportSkipsNonYAML(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("ignore me"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ok.yaml"),
+		[]byte("devices:\n  .1.3.6.1.4.1.9.1.1: someModel\n"), 0o600))
+
+	dl, err := LoadDeviceLookupExtensions(dir)
+	require.NoError(t, err)
+	files := dl.UserExtensionFiles()
+	require.Len(t, files, 1, "only YAML files are loaded, so only they are reported")
+	assert.Equal(t, "ok.yaml", files[0].Name)
+	assert.Equal(t, 1, files[0].Entries)
+}

--- a/orb-discovery/snmp-discovery/data/lookup_extensions_test.go
+++ b/orb-discovery/snmp-discovery/data/lookup_extensions_test.go
@@ -1110,3 +1110,48 @@ func TestLoadDeviceLookupExtensions_ReportSkipsNonYAML(t *testing.T) {
 	assert.Equal(t, "ok.yaml", files[0].Name)
 	assert.Equal(t, 1, files[0].Entries)
 }
+
+// A lookup-extension file may legitimately carry only a manufacturers: block.
+// The same directory is read by NewManufacturerResolver, where such a file is
+// valid and its overrides are applied, so the report must not present it as
+// contributing nothing.
+func TestLoadDeviceLookupExtensions_ManufacturerOnlyFileIsReported(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "mfr.yaml"),
+		[]byte("manufacturers:\n  52642: FS\n  664: Adtran\n"), 0o600))
+
+	dl, err := LoadDeviceLookupExtensions(dir)
+	require.NoError(t, err)
+
+	files := dl.UserExtensionFiles()
+	require.Len(t, files, 1)
+	assert.Equal(t, 0, files[0].Entries, "it declares no devices")
+	assert.Equal(t, 2, files[0].ManufacturerEntries, "but it does declare manufacturers")
+	assert.NoError(t, files[0].Err)
+}
+
+func TestLoadDeviceLookupExtensions_ReportCountsBothSections(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "both.yaml"), []byte(
+		"devices:\n  .1.3.6.1.4.1.52642.1.439.0: S3400-24T4FP\nmanufacturers:\n  52642: FS\n"), 0o600))
+
+	dl, err := LoadDeviceLookupExtensions(dir)
+	require.NoError(t, err)
+	files := dl.UserExtensionFiles()
+	require.Len(t, files, 1)
+	assert.Equal(t, 1, files[0].Entries)
+	assert.Equal(t, 1, files[0].ManufacturerEntries)
+}
+
+func TestLoadDeviceLookupExtensions_FileWithNeitherSectionReportsNothing(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "empty.yaml"),
+		[]byte("device:\n  .1.3.6.1.4.1.52642.1.439.0: S3400\n"), 0o600))
+
+	dl, err := LoadDeviceLookupExtensions(dir)
+	require.NoError(t, err)
+	files := dl.UserExtensionFiles()
+	require.Len(t, files, 1)
+	assert.Equal(t, 0, files[0].Entries)
+	assert.Equal(t, 0, files[0].ManufacturerEntries)
+}

--- a/orb-discovery/snmp-discovery/data/lookup_extensions_test.go
+++ b/orb-discovery/snmp-discovery/data/lookup_extensions_test.go
@@ -1155,3 +1155,37 @@ func TestLoadDeviceLookupExtensions_FileWithNeitherSectionReportsNothing(t *test
 	assert.Equal(t, 0, files[0].Entries)
 	assert.Equal(t, 0, files[0].ManufacturerEntries)
 }
+
+// The manufacturer count must match what the resolver will actually apply.
+// Counting with looser rules over-reports, which suppresses the
+// no-contribution warning for a file that in fact contributes nothing.
+func TestCountManufacturerEntries_MatchesResolverRules(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want int
+	}{
+		{"string values are applied", "manufacturers:\n  999999: AcmeCorp\n", 1},
+		{"nested map value is rejected", "manufacturers:\n  999999:\n    name: AcmeCorp\n", 0},
+		{"list value is rejected", "manufacturers:\n  999999:\n    - AcmeCorp\n", 0},
+		{
+			// The resolver rejects the whole block, so the valid sibling is lost too.
+			name: "one bad value rejects the block",
+			body: "manufacturers:\n  888888: GoodCo\n  999999:\n    name: AcmeCorp\n",
+			want: 0,
+		},
+		{"no manufacturers section", "devices:\n  .1.2.3: m\n", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := countManufacturerEntries([]byte(tc.body))
+			assert.Equal(t, tc.want, got)
+
+			// Pin it against the resolver itself so the two cannot drift.
+			applied := map[string]string{}
+			if err := loadManufacturerYAML([]byte(tc.body), applied); err != nil {
+				applied = map[string]string{}
+			}
+			assert.Equal(t, len(applied), got, "count must equal what the resolver applies")
+		})
+	}
+}

--- a/orb-discovery/snmp-discovery/policy/manager.go
+++ b/orb-discovery/snmp-discovery/policy/manager.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
@@ -426,19 +427,39 @@ func (m *Manager) logReportedExtensionFiles(lookup *data.DeviceLookup, dir strin
 		return
 	}
 
+	safeDir := sanitizeLogValue(dir)
 	total := 0
 	for _, f := range files {
 		switch {
 		case f.Err != nil:
 			m.logger.Warn("lookup extension file could not be parsed; skipping it",
-				"directory", dir, "file", f.Name, "error", f.Err)
+				"directory", safeDir,
+				"file", sanitizeLogValue(f.Name),
+				"error", sanitizeLogValue(f.Err.Error()))
 		case f.Entries == 0:
 			m.logger.Warn("lookup extension file contributed no device entries; check that it starts with a 'devices:' key and is indented with spaces",
-				"directory", dir, "file", f.Name)
+				"directory", safeDir, "file", sanitizeLogValue(f.Name))
 		default:
 			total += f.Entries
 		}
 	}
 	m.logger.Info("loaded device lookup extensions",
-		"directory", dir, "files", len(files), "entries", total)
+		"directory", safeDir, "files", len(files), "entries", total)
+}
+
+// sanitizeLogValue flattens CR and LF so a value cannot forge additional log
+// records.
+//
+// A filename or YAML parse error is operator-supplied and can echo file
+// content, and both reach the log. slog's own handlers escape newlines, so this
+// is belt and braces there, but it keeps the guarantee in this code rather than
+// resting on which handler happens to be installed, and it restores a
+// protection the previous logging here applied deliberately.
+func sanitizeLogValue(s string) string {
+	if !strings.ContainsAny(s, "\r\n") {
+		return s
+	}
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	return strings.ReplaceAll(s, "\r", " ")
 }

--- a/orb-discovery/snmp-discovery/policy/manager.go
+++ b/orb-discovery/snmp-discovery/policy/manager.go
@@ -455,11 +455,13 @@ func (m *Manager) logReportedExtensionFiles(lookup *data.DeviceLookup, dir strin
 // is belt and braces there, but it keeps the guarantee in this code rather than
 // resting on which handler happens to be installed, and it restores a
 // protection the previous logging here applied deliberately.
+// Every path runs the replacements. An early return for values that contain no
+// newline would be a shortcut from input to output that bypasses them, which
+// leaves the value tainted as far as static analysis is concerned and is the
+// kind of subtlety worth not being clever about in a sanitizer.
 func sanitizeLogValue(s string) string {
-	if !strings.ContainsAny(s, "\r\n") {
-		return s
-	}
 	s = strings.ReplaceAll(s, "\r\n", " ")
 	s = strings.ReplaceAll(s, "\n", " ")
-	return strings.ReplaceAll(s, "\r", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return s
 }

--- a/orb-discovery/snmp-discovery/policy/manager.go
+++ b/orb-discovery/snmp-discovery/policy/manager.go
@@ -425,8 +425,16 @@ func (m *Manager) logReportedExtensionFiles(lookup *data.DeviceLookup, dir strin
 	safeDir := sanitizeLogValue(dir)
 
 	files := lookup.UserExtensionFiles()
-	if dir == "" || len(files) == 0 {
+	if dir == "" {
 		m.logger.Info("loaded device lookup extensions", "directory", safeDir)
+		return
+	}
+	if len(files) == 0 {
+		// The operator configured a directory and nothing in it was read, so
+		// none of their overrides are in effect. Reporting success here is the
+		// misleading case this reporting exists to remove.
+		m.logger.Warn("lookup_extensions_dir has no .yaml or .yml files; no custom entries were loaded",
+			"directory", safeDir, "files_ignored", lookup.UserExtensionSkippedFiles())
 		return
 	}
 
@@ -435,9 +443,13 @@ func (m *Manager) logReportedExtensionFiles(lookup *data.DeviceLookup, dir strin
 		mfrTotal += f.ManufacturerEntries
 		switch {
 		case f.Err != nil:
-			m.logger.Warn("lookup extension file could not be parsed; skipping it",
+			// Only the devices section is lost. A manufacturers section in the
+			// same file is parsed separately by the manufacturer resolver and
+			// still applies, so do not imply the whole file was discarded.
+			m.logger.Warn("lookup extension file has an unparseable devices section; its device entries were skipped",
 				"directory", safeDir,
 				"file", sanitizeLogValue(f.Name),
+				"manufacturer_entries", f.ManufacturerEntries,
 				"error", sanitizeLogValue(f.Err.Error()))
 		case f.Entries == 0 && f.ManufacturerEntries == 0:
 			// Only when neither recognised section contributed. A file carrying

--- a/orb-discovery/snmp-discovery/policy/manager.go
+++ b/orb-discovery/snmp-discovery/policy/manager.go
@@ -251,7 +251,7 @@ func (m *Manager) StartPolicy(name string, policy config.Policy) error {
 		if err != nil {
 			m.logger.Warn("failed to load device lookup extensions", "error", err, "directory", policy.Config.LookupExtensionsDir)
 		} else {
-			m.logger.Info("loaded device lookup extensions", "directory", policy.Config.LookupExtensionsDir)
+			m.logReportedExtensionFiles(deviceLookup, policy.Config.LookupExtensionsDir)
 		}
 
 		// Build the per-policy manufacturer resolver: the built-in IANA
@@ -408,4 +408,37 @@ func (m *Manager) GetPolicyStatuses() []Status {
 	}
 
 	return statuses
+}
+
+// logReportedExtensionFiles logs what lookup_extensions_dir actually
+// contributed.
+//
+// The bare "loaded device lookup extensions" message this replaces only proved
+// the directory was readable. A file with a wrong top-level key or bad
+// indentation parses to zero entries without error, so an operator whose custom
+// OID was ignored saw nothing but a success line followed by the model falling
+// back to the raw OID (issue #486). Reporting per-file entry counts, and
+// warning on the two cases that contribute nothing, makes that self-diagnosing.
+func (m *Manager) logReportedExtensionFiles(lookup *data.DeviceLookup, dir string) {
+	files := lookup.UserExtensionFiles()
+	if dir == "" || len(files) == 0 {
+		m.logger.Info("loaded device lookup extensions", "directory", dir)
+		return
+	}
+
+	total := 0
+	for _, f := range files {
+		switch {
+		case f.Err != nil:
+			m.logger.Warn("lookup extension file could not be parsed; skipping it",
+				"directory", dir, "file", f.Name, "error", f.Err)
+		case f.Entries == 0:
+			m.logger.Warn("lookup extension file contributed no device entries; check that it starts with a 'devices:' key and is indented with spaces",
+				"directory", dir, "file", f.Name)
+		default:
+			total += f.Entries
+		}
+	}
+	m.logger.Info("loaded device lookup extensions",
+		"directory", dir, "files", len(files), "entries", total)
 }

--- a/orb-discovery/snmp-discovery/policy/manager.go
+++ b/orb-discovery/snmp-discovery/policy/manager.go
@@ -430,23 +430,29 @@ func (m *Manager) logReportedExtensionFiles(lookup *data.DeviceLookup, dir strin
 		return
 	}
 
-	total := 0
+	total, mfrTotal := 0, 0
 	for _, f := range files {
+		mfrTotal += f.ManufacturerEntries
 		switch {
 		case f.Err != nil:
 			m.logger.Warn("lookup extension file could not be parsed; skipping it",
 				"directory", safeDir,
 				"file", sanitizeLogValue(f.Name),
 				"error", sanitizeLogValue(f.Err.Error()))
-		case f.Entries == 0:
-			m.logger.Warn("lookup extension file contributed no device entries; check that it starts with a 'devices:' key and is indented with spaces",
+		case f.Entries == 0 && f.ManufacturerEntries == 0:
+			// Only when neither recognised section contributed. A file carrying
+			// just a manufacturers: block declares no devices by design, and its
+			// overrides are applied by the manufacturer resolver over the same
+			// directory, so warning about it would nag a healthy config.
+			m.logger.Warn("lookup extension file contributed no device or manufacturer entries; check that it starts with a 'devices:' or 'manufacturers:' key and is indented with spaces",
 				"directory", safeDir, "file", sanitizeLogValue(f.Name))
 		default:
 			total += f.Entries
 		}
 	}
 	m.logger.Info("loaded device lookup extensions",
-		"directory", safeDir, "files", len(files), "entries", total)
+		"directory", safeDir, "files", len(files),
+		"entries", total, "manufacturer_entries", mfrTotal)
 }
 
 // sanitizeLogValue flattens CR and LF so a value cannot forge additional log

--- a/orb-discovery/snmp-discovery/policy/manager.go
+++ b/orb-discovery/snmp-discovery/policy/manager.go
@@ -421,13 +421,15 @@ func (m *Manager) GetPolicyStatuses() []Status {
 // back to the raw OID (issue #486). Reporting per-file entry counts, and
 // warning on the two cases that contribute nothing, makes that self-diagnosing.
 func (m *Manager) logReportedExtensionFiles(lookup *data.DeviceLookup, dir string) {
+	// Sanitize before any branch uses it, so no path can log the raw value.
+	safeDir := sanitizeLogValue(dir)
+
 	files := lookup.UserExtensionFiles()
 	if dir == "" || len(files) == 0 {
-		m.logger.Info("loaded device lookup extensions", "directory", dir)
+		m.logger.Info("loaded device lookup extensions", "directory", safeDir)
 		return
 	}
 
-	safeDir := sanitizeLogValue(dir)
 	total := 0
 	for _, f := range files {
 		switch {

--- a/orb-discovery/snmp-discovery/policy/manager_extensions_internal_test.go
+++ b/orb-discovery/snmp-discovery/policy/manager_extensions_internal_test.go
@@ -139,3 +139,50 @@ func TestLogReportedExtensionFiles_NoUserDirKeepsPlainMessage(t *testing.T) {
 			lines[0].Entries, lines[0].Files)
 	}
 }
+
+// A filename or parse error is operator-supplied and can echo file content, so
+// it must not be able to forge extra log records. The logging this replaced
+// stripped CR/LF deliberately; keep that guarantee here rather than resting on
+// which slog handler happens to be installed.
+func TestSanitizeLogValue(t *testing.T) {
+	for _, tc := range []struct{ name, in, want string }{
+		{"plain value untouched", "fs_custom.yaml", "fs_custom.yaml"},
+		{"newline flattened", "a.yaml\nforged", "a.yaml forged"},
+		{"carriage return flattened", "a.yaml\rforged", "a.yaml forged"},
+		{"crlf becomes one space", "a.yaml\r\nforged", "a.yaml forged"},
+		{"multi-line yaml error", "yaml: line 2:\n  bad indent", "yaml: line 2:   bad indent"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizeLogValue(tc.in); got != tc.want {
+				t.Errorf("sanitizeLogValue(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// End to end: a crafted filename must produce exactly one log record.
+func TestLogReportedExtensionFiles_CraftedFilenameCannotForgeARecord(t *testing.T) {
+	dir := t.TempDir()
+	// A filename cannot contain a newline on most filesystems, so drive the
+	// helper directly with a report whose file name carries one.
+	var buf bytes.Buffer
+	m, err := NewManager(context.Background(),
+		slog.New(slog.NewJSONHandler(&buf, nil)), nil, nil)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	writeExtFile(t, dir, "ok.yaml", "devices:\n  .1.3.6.1.4.1.9.1.1: m\n")
+	lookup, err := data.LoadDeviceLookupExtensions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.logReportedExtensionFiles(lookup, "/opt/orb\nFAKE level=ERROR msg=forged")
+
+	records := strings.Count(strings.TrimSpace(buf.String()), "\n") + 1
+	if records != 1 {
+		t.Errorf("got %d log records, want 1; output:\n%s", records, buf.String())
+	}
+	if strings.Contains(buf.String(), "\nFAKE") {
+		t.Error("a raw newline reached the log output")
+	}
+}

--- a/orb-discovery/snmp-discovery/policy/manager_extensions_internal_test.go
+++ b/orb-discovery/snmp-discovery/policy/manager_extensions_internal_test.go
@@ -15,13 +15,14 @@ import (
 
 // logLine is one slog JSON record, decoded far enough to assert on.
 type logLine struct {
-	Level     string `json:"level"`
-	Msg       string `json:"msg"`
-	Directory string `json:"directory"`
-	File      string `json:"file"`
-	Entries   int    `json:"entries"`
-	Files     int    `json:"files"`
-	Err       string `json:"error"`
+	Level               string `json:"level"`
+	Msg                 string `json:"msg"`
+	Directory           string `json:"directory"`
+	File                string `json:"file"`
+	Entries             int    `json:"entries"`
+	Files               int    `json:"files"`
+	ManufacturerEntries int    `json:"manufacturer_entries"`
+	Err                 string `json:"error"`
 }
 
 func captureExtensionLogs(t *testing.T, dir string) []logLine {
@@ -88,7 +89,7 @@ func TestLogReportedExtensionFiles_WarnsOnUnparseableFile(t *testing.T) {
 
 	var warned bool
 	for _, l := range captureExtensionLogs(t, dir) {
-		if l.Level == "WARN" && strings.Contains(l.Msg, "could not be parsed") {
+		if l.Level == "WARN" && strings.Contains(l.Msg, "unparseable devices section") {
 			warned = true
 			if l.File != "broken.yaml" || l.Err == "" {
 				t.Errorf("warning must name the file and the parse error, got file=%q err=%q", l.File, l.Err)
@@ -271,5 +272,54 @@ func TestLogReportedExtensionFiles_WarnsWhenNeitherSectionContributes(t *testing
 	}
 	if !warned {
 		t.Error("a file contributing neither devices nor manufacturers must warn")
+	}
+}
+
+// A configured directory holding no .yaml/.yml files means none of the
+// operator's files were considered. Logging the plain success message there
+// recreates exactly the misleading success this reporting exists to remove: the
+// previous loader at least logged a line per skipped file.
+func TestLogReportedExtensionFiles_WarnsWhenDirHasNoYamlFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeExtFile(t, dir, "custom.yaml.bak", "devices:\n  .1.2.3: m\n")
+
+	var warned bool
+	for _, l := range captureExtensionLogs(t, dir) {
+		if l.Level == "WARN" && strings.Contains(l.Msg, "no .yaml") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Error("a directory with no usable YAML files must warn, not report success")
+	}
+}
+
+// A devices: section that fails to parse does not stop the manufacturers:
+// section of the same file being applied, so the warning must not imply the
+// whole file was discarded.
+func TestLogReportedExtensionFiles_ParseFailureScopedToDeviceSection(t *testing.T) {
+	dir := t.TempDir()
+	writeExtFile(t, dir, "mixed.yaml",
+		"devices:\n  .1.3.6.1.4.1.1: {nested: map}\nmanufacturers:\n  52642: FS\n")
+
+	var found *logLine
+	lines := captureExtensionLogs(t, dir)
+	for i := range lines {
+		if lines[i].Level == "WARN" {
+			found = &lines[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("a devices-section parse failure must still warn")
+	}
+	if strings.Contains(found.Msg, "skipping it") {
+		t.Errorf("warning implies the whole file was skipped: %q", found.Msg)
+	}
+	if !strings.Contains(found.Msg, "device") {
+		t.Errorf("warning should identify the device entries as the skipped part: %q", found.Msg)
+	}
+	if found.ManufacturerEntries != 1 {
+		t.Errorf("manufacturer_entries = %d, want 1 so the operator sees that part still applied",
+			found.ManufacturerEntries)
 	}
 }

--- a/orb-discovery/snmp-discovery/policy/manager_extensions_internal_test.go
+++ b/orb-discovery/snmp-discovery/policy/manager_extensions_internal_test.go
@@ -15,12 +15,13 @@ import (
 
 // logLine is one slog JSON record, decoded far enough to assert on.
 type logLine struct {
-	Level   string `json:"level"`
-	Msg     string `json:"msg"`
-	File    string `json:"file"`
-	Entries int    `json:"entries"`
-	Files   int    `json:"files"`
-	Err     string `json:"error"`
+	Level     string `json:"level"`
+	Msg       string `json:"msg"`
+	Directory string `json:"directory"`
+	File      string `json:"file"`
+	Entries   int    `json:"entries"`
+	Files     int    `json:"files"`
+	Err       string `json:"error"`
 }
 
 func captureExtensionLogs(t *testing.T, dir string) []logLine {
@@ -184,5 +185,60 @@ func TestLogReportedExtensionFiles_CraftedFilenameCannotForgeARecord(t *testing.
 	}
 	if strings.Contains(buf.String(), "\nFAKE") {
 		t.Error("a raw newline reached the log output")
+	}
+}
+
+// The early-return branch logs the directory too, and it was the one call site
+// that escaped sanitization: the existing crafted-value test only exercised the
+// populated path, so it never touched this branch. Cover both.
+func TestLogReportedExtensionFiles_CraftedDirIsSanitizedOnEveryPath(t *testing.T) {
+	craftedDir := "/opt/orb\nFAKE level=ERROR msg=forged"
+
+	for _, tc := range []struct {
+		name  string
+		setup func(t *testing.T) string // returns the dir to load from
+	}{
+		{
+			name:  "early return, no user files",
+			setup: func(t *testing.T) string { return "" },
+		},
+		{
+			name: "populated directory",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				writeExtFile(t, dir, "ok.yaml", "devices:\n  .1.3.6.1.4.1.9.1.1: m\n")
+				return dir
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			m, err := NewManager(context.Background(),
+				slog.New(slog.NewJSONHandler(&buf, nil)), nil, nil)
+			if err != nil {
+				t.Fatalf("NewManager: %v", err)
+			}
+			lookup, err := data.LoadDeviceLookupExtensions(tc.setup(t))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Always report against the crafted directory string.
+			m.logReportedExtensionFiles(lookup, craftedDir)
+
+			// Assert on the decoded attribute, not the rendered line: slog
+			// escapes newlines on output, so a raw value looks harmless there
+			// while still being unsanitized in the record itself.
+			out := strings.TrimSpace(buf.String())
+			for _, raw := range strings.Split(out, "\n") {
+				var l logLine
+				if err := json.Unmarshal([]byte(raw), &l); err != nil {
+					t.Fatalf("decode %q: %v", raw, err)
+				}
+				if strings.ContainsAny(l.Directory, "\r\n") {
+					t.Errorf("directory attribute still carries a newline: %q", l.Directory)
+				}
+			}
+		})
 	}
 }

--- a/orb-discovery/snmp-discovery/policy/manager_extensions_internal_test.go
+++ b/orb-discovery/snmp-discovery/policy/manager_extensions_internal_test.go
@@ -199,8 +199,9 @@ func TestLogReportedExtensionFiles_CraftedDirIsSanitizedOnEveryPath(t *testing.T
 		setup func(t *testing.T) string // returns the dir to load from
 	}{
 		{
-			name:  "early return, no user files",
-			setup: func(t *testing.T) string { return "" },
+			name: "early return, no user files",
+			// No directory to build, so the helper is unused here.
+			setup: func(_ *testing.T) string { return "" },
 		},
 		{
 			name: "populated directory",

--- a/orb-discovery/snmp-discovery/policy/manager_extensions_internal_test.go
+++ b/orb-discovery/snmp-discovery/policy/manager_extensions_internal_test.go
@@ -1,0 +1,141 @@
+package policy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/data"
+)
+
+// logLine is one slog JSON record, decoded far enough to assert on.
+type logLine struct {
+	Level   string `json:"level"`
+	Msg     string `json:"msg"`
+	File    string `json:"file"`
+	Entries int    `json:"entries"`
+	Files   int    `json:"files"`
+	Err     string `json:"error"`
+}
+
+func captureExtensionLogs(t *testing.T, dir string) []logLine {
+	t.Helper()
+	var buf bytes.Buffer
+	m, err := NewManager(context.Background(),
+		slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})), nil, nil)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	lookup, err := data.LoadDeviceLookupExtensions(dir)
+	if err != nil {
+		t.Fatalf("LoadDeviceLookupExtensions: %v", err)
+	}
+	m.logReportedExtensionFiles(lookup, dir)
+
+	var out []logLine
+	for _, raw := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if raw == "" {
+			continue
+		}
+		var l logLine
+		if err := json.Unmarshal([]byte(raw), &l); err != nil {
+			t.Fatalf("decode log line %q: %v", raw, err)
+		}
+		out = append(out, l)
+	}
+	return out
+}
+
+func writeExtFile(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A file that parses to zero entries must be called out. Reporting plain
+// success here is what left the operator in issue #486 with no way to tell that
+// their custom OID had been ignored.
+func TestLogReportedExtensionFiles_WarnsOnFileThatContributesNothing(t *testing.T) {
+	dir := t.TempDir()
+	// Valid YAML, but the top-level key is not "devices", so nothing registers.
+	writeExtFile(t, dir, "fs_custom.yaml", "device:\n  .1.3.6.1.4.1.52642.1.439.0: S3400-24T4FP\n")
+
+	var warned bool
+	for _, l := range captureExtensionLogs(t, dir) {
+		if l.Level == "WARN" && strings.Contains(l.Msg, "no device entries") {
+			warned = true
+			if l.File != "fs_custom.yaml" {
+				t.Errorf("warning names file %q, want fs_custom.yaml", l.File)
+			}
+		}
+	}
+	if !warned {
+		t.Error("a file contributing no entries must produce a WARN naming it")
+	}
+}
+
+func TestLogReportedExtensionFiles_WarnsOnUnparseableFile(t *testing.T) {
+	dir := t.TempDir()
+	// A tab is not valid YAML indentation.
+	writeExtFile(t, dir, "broken.yaml", "devices:\n\t.1.3.6.1.4.1.52642.1.439.0: S3400\n")
+
+	var warned bool
+	for _, l := range captureExtensionLogs(t, dir) {
+		if l.Level == "WARN" && strings.Contains(l.Msg, "could not be parsed") {
+			warned = true
+			if l.File != "broken.yaml" || l.Err == "" {
+				t.Errorf("warning must name the file and the parse error, got file=%q err=%q", l.File, l.Err)
+			}
+		}
+	}
+	if !warned {
+		t.Error("an unparseable file must produce a WARN carrying the parse error")
+	}
+}
+
+// The success path has to report how much was actually loaded, which is the
+// signal that was missing before.
+func TestLogReportedExtensionFiles_ReportsEntryCount(t *testing.T) {
+	dir := t.TempDir()
+	writeExtFile(t, dir, "fs_custom.yaml",
+		"devices:\n  .1.3.6.1.4.1.52642.1.439.0: S3400-24T4FP\n  .1.3.6.1.4.1.52642.1.440.0: S3400-48T4SP\n")
+
+	lines := captureExtensionLogs(t, dir)
+	var info *logLine
+	for i := range lines {
+		if lines[i].Level == "INFO" && lines[i].Msg == "loaded device lookup extensions" {
+			info = &lines[i]
+		}
+	}
+	if info == nil {
+		t.Fatal("expected an INFO summary line")
+	}
+	if info.Entries != 2 {
+		t.Errorf("entries = %d, want 2", info.Entries)
+	}
+	if info.Files != 1 {
+		t.Errorf("files = %d, want 1", info.Files)
+	}
+}
+
+// With no user directory there is nothing to count, and the message must stay
+// as it was so existing log expectations are unaffected.
+func TestLogReportedExtensionFiles_NoUserDirKeepsPlainMessage(t *testing.T) {
+	lines := captureExtensionLogs(t, "")
+	if len(lines) != 1 {
+		t.Fatalf("got %d log lines, want 1", len(lines))
+	}
+	if lines[0].Level != "INFO" || lines[0].Msg != "loaded device lookup extensions" {
+		t.Errorf("got %s %q, want INFO loaded device lookup extensions", lines[0].Level, lines[0].Msg)
+	}
+	if lines[0].Entries != 0 || lines[0].Files != 0 {
+		t.Errorf("counts must be absent for a built-in-only load, got entries=%d files=%d",
+			lines[0].Entries, lines[0].Files)
+	}
+}

--- a/orb-discovery/snmp-discovery/policy/manager_extensions_internal_test.go
+++ b/orb-discovery/snmp-discovery/policy/manager_extensions_internal_test.go
@@ -69,7 +69,7 @@ func TestLogReportedExtensionFiles_WarnsOnFileThatContributesNothing(t *testing.
 
 	var warned bool
 	for _, l := range captureExtensionLogs(t, dir) {
-		if l.Level == "WARN" && strings.Contains(l.Msg, "no device entries") {
+		if l.Level == "WARN" && strings.Contains(l.Msg, "no device or manufacturer entries") {
 			warned = true
 			if l.File != "fs_custom.yaml" {
 				t.Errorf("warning names file %q, want fs_custom.yaml", l.File)
@@ -241,5 +241,35 @@ func TestLogReportedExtensionFiles_CraftedDirIsSanitizedOnEveryPath(t *testing.T
 				}
 			}
 		})
+	}
+}
+
+// A file carrying only a manufacturers: block declares no devices by design.
+// The manufacturer resolver reads the same directory and applies its overrides,
+// so warning about it would nag a healthy configuration.
+func TestLogReportedExtensionFiles_NoWarnForManufacturerOnlyFile(t *testing.T) {
+	dir := t.TempDir()
+	writeExtFile(t, dir, "mfr.yaml", "manufacturers:\n  52642: FS\n")
+
+	for _, l := range captureExtensionLogs(t, dir) {
+		if l.Level == "WARN" {
+			t.Errorf("manufacturer-only file must not warn, got: %s %q file=%q", l.Level, l.Msg, l.File)
+		}
+	}
+}
+
+// The counterpart: a file with neither recognised section still warns.
+func TestLogReportedExtensionFiles_WarnsWhenNeitherSectionContributes(t *testing.T) {
+	dir := t.TempDir()
+	writeExtFile(t, dir, "typo.yaml", "device:\n  .1.3.6.1.4.1.52642.1.439.0: S3400\n")
+
+	var warned bool
+	for _, l := range captureExtensionLogs(t, dir) {
+		if l.Level == "WARN" && strings.Contains(l.Msg, "no device or manufacturer entries") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Error("a file contributing neither devices nor manufacturers must warn")
 	}
 }


### PR DESCRIPTION
## Why

A custom lookup-extension file can be read successfully and still contribute **nothing**. I verified four ways this happens, all of which loaded without error:

| File content | OID resolves | Logged anything |
|---|---|---|
| `devices:` with 2 or 4 space indent | **yes** | n/a, works |
| indented with a **tab** | no | yes, a parse error |
| no indentation under `devices:` | no | **nothing** |
| top-level key other than `devices:` | no | **nothing** |
| no `devices:` line at all | no | **nothing** |

In every failing case the operator saw `loaded device lookup extensions` followed by the device model falling back to the raw OID. Nothing distinguished a file that registered twelve entries from one that registered none.

That is what #486 has been: several rounds of back and forth in which I twice sent the reporter after the wrong thing (a directory-name mismatch, then SELinux) because the success line told us the directory was readable and nothing more. Their file is still the likely culprit, but the logs could not say so.

## What changed

Each file's contribution is now recorded and reported:

```
INFO  loaded device lookup extensions  directory=/opt/orb/snmp_exts files=1 entries=12
WARN  lookup extension file contributed no device entries; check that it starts
      with a 'devices:' key and is indented with spaces  file=fs_custom.yaml
WARN  lookup extension file could not be parsed; skipping it  file=broken.yaml error=...
```

Three other things worth noting:

- The parse failure previously went through the **standard library** logger, not the structured one, so it did not appear alongside other backend records and was easy to miss even when it fired. It now uses the same logger as everything else.
- The per-file `skipping file` line for non-YAML files is dropped. The new counts make it redundant, and it fired for every unrelated file in the directory.
- Parsing happens into a per-file map before merging, so a count is that file's own contribution rather than a running total. Merging still happens only on success, so a rejected file contributes nothing, exactly as before.

`LoadDeviceLookupExtensions` keeps its signature; the report hangs off `DeviceLookup` and the caller logs it, which avoided touching seventeen existing call sites and keeps the logging where the structured logger already lives.

## Behaviour

No change to what resolves. A bad file is still skipped rather than failing the load, so one broken file cannot cost an operator every other override they wrote.

## Testing

- Data layer: the four failure modes above plus the working form, asserting entry counts and whether an error is surfaced; a built-in-only load reports no files; non-YAML files are excluded from the report.
- Log output, captured through a JSON handler: the zero-entry warning names the file, the parse-failure warning carries the error, the success line carries both counts, and a built-in-only load keeps the original message unchanged.
- `GOWORK=off go test -race ./...` green across all packages; `make fix-lint` clean.

Refs #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)
