### PR TITLE
fix(device-discovery): omit unset device name from nested entity stubs

### DIFF
--- a/orb-discovery/device-discovery/device_discovery/proto_presence.py
+++ b/orb-discovery/device-discovery/device_discovery/proto_presence.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""
+Presence-safe helpers for populating Diode ingester protos.
+
+MOST optional scalars on the ingester protos declare explicit presence (``optional`` in
+proto3) — as a rule, everything except the fields NetBox requires. ``Device`` alone has
+eight such string fields (``name``, ``serial``, ``asset_tag``, ``face``, ``status``,
+``airflow``, ``description``, ``comments``), and ``Interface``, ``IPAddress``,
+``Prefix``, ``VRF``, ``Module`` and ``ModuleBay`` all carry their own. Do NOT work from
+a memorised list: check ``DESCRIPTOR.fields_by_name[name].has_presence``.
+
+For a presence-bearing field, "unset" and "set to the empty string" are DISTINCT on the
+wire, and the Diode NetBox plugin treats them very differently. Unset means "leave this
+field alone"; an explicit empty value is a real value the plugin diffs against NetBox
+and — from plugin v1.14.1 on — writes as a deliberate clear.
+
+The exceptions are the required matcher fields (``Site.name``, ``Interface.name``,
+``DeviceType.model``, ``Manufacturer.name``, ``MACAddress.mac_address``,
+``IPAddress.address``, ``VRF.name``, ...), which have no presence: for them empty and
+unset serialize identically and neither helper here changes anything.
+
+Reading an unset scalar through the normal attribute accessor yields the proto3 default
+(``""``), so the natural-looking ``pb.Device(name=d.name)`` silently launders absence
+into an explicit empty string. See ``copy_scalar_if_set``.
+"""
+
+from google.protobuf.message import Message
+
+
+def copy_scalar_if_set(dst: Message, src: Message, *fields: str) -> None:
+    """
+    Copy scalar ``fields`` from ``src`` to ``dst`` without laundering absence into presence.
+
+    Use this instead of passing accessor reads into a message constructor
+    (``pb.Device(name=d.name)``). When ``d.name`` is unset that expression yields ``""``
+    and the constructor marks the field PRESENT, turning "we discovered no hostname"
+    into "the hostname is empty".
+
+    That laundering is a real reported failure: nested device stubs built by
+    ``prune_nested_refs`` carried ``name: ""`` even when discovery had correctly reported
+    no hostname. On diode plugin v1.13.0 the plugin counted the empty value as a change
+    but stripped it from the payload it actually wrote, so Assurance raised a deviation
+    claiming one change with an empty diff — it applied with no effect and came back on
+    the next discovery. On v1.14.1 the same payload instead erases the device name.
+
+    Fields that declare explicit presence are copied only when set on ``src``. Fields
+    without presence are copied unconditionally, since for them empty and unset are
+    indistinguishable on the wire; they are accepted here so callers need not track
+    which is which.
+
+    Args:
+    ----
+        dst: Message to copy onto.
+        src: Message to copy from.
+        *fields: Names of scalar fields to copy.
+
+    """
+    descriptor = src.DESCRIPTOR
+    for field in fields:
+        if descriptor.fields_by_name[field].has_presence and not src.HasField(field):
+            continue
+        setattr(dst, field, getattr(src, field))

--- a/orb-discovery/device-discovery/device_discovery/stubs.py
+++ b/orb-discovery/device-discovery/device_discovery/stubs.py
@@ -14,6 +14,7 @@ from netboxlabs.diode.sdk.diode.v1 import ingester_pb2 as pb
 from netboxlabs.diode.sdk.ingester import Entity
 
 from custom_napalm._modules import MAX_BAY_DEPTH
+from device_discovery.proto_presence import copy_scalar_if_set
 
 logger = logging.getLogger(__name__)
 
@@ -179,7 +180,11 @@ def _device_match_stub(
     defaults.device.asset_tag — kept on the stub so the rich entity and stub never resolve
     via different matchers.
     """
-    stub = pb.Device(name=d.name)
+    # copy_scalar_if_set, not pb.Device(name=d.name): Device.name declares proto
+    # presence, so reading an unset name as "" and passing it to the constructor
+    # would mark the field PRESENT and send an explicit empty name.
+    stub = pb.Device()
+    copy_scalar_if_set(stub, d, "name")
     _copy_device_relations(
         stub, d, keep_primary_ip4=keep_primary_ip4, keep_primary_ip6=keep_primary_ip6
     )
@@ -253,12 +258,12 @@ def _module_match_stub(rich: pb.Module, dev_stub: pb.Device) -> pb.Module:
     Interface entities does not duplicate the running-config-bearing
     Device proto per port.
     """
-    stub = pb.Module(serial=rich.serial)
+    stub = pb.Module()
+    copy_scalar_if_set(stub, rich, "serial")
     stub.device.CopyFrom(dev_stub)
     if rich.HasField("module_bay"):
-        bay_stub = pb.ModuleBay(
-            name=rich.module_bay.name, position=rich.module_bay.position,
-        )
+        bay_stub = pb.ModuleBay(name=rich.module_bay.name)
+        copy_scalar_if_set(bay_stub, rich.module_bay, "position")
         bay_stub.device.CopyFrom(dev_stub)
         stub.module_bay.CopyFrom(bay_stub)
     return stub

--- a/orb-discovery/device-discovery/device_discovery/translate_chassis.py
+++ b/orb-discovery/device-discovery/device_discovery/translate_chassis.py
@@ -30,6 +30,7 @@ from netboxlabs.diode.sdk.ingester import Entity
 
 from device_discovery.interface import build_interface_entities
 from device_discovery.policy.models import Defaults, Options
+from device_discovery.proto_presence import copy_scalar_if_set
 from device_discovery.stack_naming import render_stack_member_name
 from device_discovery.translate_modules import emit_modules_if_requested
 
@@ -114,7 +115,12 @@ def _master_device_ref(master_dev: pb.Device) -> pb.Device:
     and device.primary_ip4 is a circular reference the plugin can only resolve in
     the single change set that also assigns the IP to its interface.
     """
-    stub = pb.Device(name=master_dev.name, serial=master_dev.serial)
+    # Defensive: the master name is currently always non-empty (hostname or
+    # target_hostname or "unknown") and member serials are validated non-empty, so
+    # neither field can be blank today. Routed through copy_scalar_if_set anyway so
+    # this stub cannot regress into emitting an explicit empty matcher value.
+    stub = pb.Device()
+    copy_scalar_if_set(stub, master_dev, "name", "serial")
     _copy_master_ref_fields(stub, master_dev)
     if master_dev.asset_tag:
         stub.asset_tag = master_dev.asset_tag

--- a/orb-discovery/device-discovery/tests/test_stub_presence.py
+++ b/orb-discovery/device-discovery/tests/test_stub_presence.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""
+NetBox Labs - presence tests for nested entity stubs.
+
+Most optional scalars on the ingester protos declare explicit proto presence (including
+``Device.name``), so "unset" and "set to the empty string" are distinct on the wire. The Diode NetBox plugin reads an
+explicit empty value as a real value: on plugin v1.13.0 it counted as a change but was
+stripped from the payload actually written (a deviation claiming one change with an
+empty diff, applying with no effect, recreated on every discovery), and on v1.14.1 it
+is written as a deliberate field clear.
+
+Reading an unset scalar yields the proto3 default ``""``, so ``pb.Device(name=d.name)``
+laundered absence into presence. These tests pin that down.
+"""
+
+from netboxlabs.diode.sdk.diode.v1 import ingester_pb2 as pb
+
+from device_discovery.policy.models import Defaults
+from device_discovery.proto_presence import copy_scalar_if_set
+from device_discovery.stubs import _device_match_stub, prune_nested_refs
+from device_discovery.translate import translate_data
+
+
+def test_device_match_stub_does_not_launder_unset_name():
+    """An unset name on the rich Device stays unset on the stub instead of becoming ""."""
+    rich = pb.Device(serial="ABC123")
+    rich.site.CopyFrom(pb.Site(name="site-1"))
+    assert not rich.HasField("name")
+
+    stub = _device_match_stub(rich)
+
+    assert not stub.HasField("name"), "unset device name laundered into an empty string"
+
+
+def test_device_match_stub_preserves_a_real_name():
+    """A set name is still copied onto the stub."""
+    stub = _device_match_stub(pb.Device(name="rtr-1"))
+    assert stub.HasField("name")
+    assert stub.name == "rtr-1"
+
+
+def test_nested_device_stub_omits_name_when_hostname_undiscovered():
+    """Nested device refs must not carry name:"" when no hostname was discovered."""
+    entities = list(
+        translate_data(
+            {
+                "device": {
+                    "hostname": None,
+                    "vendor": "MikroTik",
+                    "model": "CCR1036-8G-2S+",
+                    "serial_number": "ABC123",
+                    "interface_list": ["management"],
+                },
+                "interface": {
+                    "management": {
+                        "is_up": True,
+                        "is_enabled": True,
+                        "description": "uplink",
+                        "mtu": 1500,
+                        "speed": -1.0,
+                        "mac_address": "08:55:31:10:47:8D",
+                        "last_flapped": -1.0,
+                    }
+                },
+                "defaults": Defaults(site="site-1", role="router"),
+                "netbox_id": 1,
+            }
+        )
+    )
+    prune_nested_refs(entities)
+
+    devices = [e.device for e in entities if e.HasField("device")]
+    interfaces = [e.interface for e in entities if e.HasField("interface")]
+    assert devices and interfaces
+
+    assert not devices[0].HasField("name")
+    for iface in interfaces:
+        assert not iface.device.HasField(
+            "name"
+        ), "nested device stub laundered the absent hostname into name:''"
+
+
+def test_copy_scalar_if_set_skips_unset_presence_field():
+    """A presence-bearing field that is unset on the source is not copied."""
+    dst = pb.Device()
+    copy_scalar_if_set(dst, pb.Device(), "name", "serial")
+    assert not dst.HasField("name")
+    assert not dst.HasField("serial")
+
+
+def test_copy_scalar_if_set_copies_explicit_empty_when_source_set_it():
+    """An explicitly-set empty value is still copied — the helper only guards absence."""
+    dst = pb.Device()
+    copy_scalar_if_set(dst, pb.Device(name=""), "name")
+    assert dst.HasField("name")
+    assert dst.name == ""
+
+
+def test_copy_scalar_if_set_handles_fields_without_presence():
+    """Fields without explicit presence are copied unconditionally, not rejected."""
+    dst = pb.Site()
+    copy_scalar_if_set(dst, pb.Site(name="site-1"), "name")
+    assert dst.name == "site-1"
+
+
+def test_master_device_ref_does_not_launder_unset_name():
+    """The virtual-chassis master ref must not launder an unset name/serial either."""
+    from device_discovery.translate_chassis import _master_device_ref
+
+    master = pb.Device()
+    master.site.CopyFrom(pb.Site(name="site-1"))
+    assert not master.HasField("name")
+    assert not master.HasField("serial")
+
+    ref = _master_device_ref(master)
+
+    assert not ref.HasField("name")
+    assert not ref.HasField("serial")
+    assert ref.site.name == "site-1"


### PR DESCRIPTION
`prune_nested_refs` built nested reference stubs by passing accessor reads into the message constructor: `pb.Device(name=d.name)`. `Device.name` declares explicit proto presence, and reading it while unset yields the proto3 default `""`, which the constructor then records as PRESENT. So a device whose hostname was never discovered was emitted with `name` correctly omitted at top level but `name: ""` on every nested device reference.

The Diode NetBox plugin reads an explicit empty value as a real value. On plugin v1.13.0 it counts as "this field changed" but is stripped from the payload actually written, which is exactly the reported symptom: a deviation claiming one change, showing an empty diff, applying with no effect, and reappearing on the next discovery because nothing was ever written. On v1.14.1 the same payload instead erases the device name in NetBox.

Add `proto_presence.copy_scalar_if_set` and route the presence-bearing scalars through it: `Device.name` in `_device_match_stub`, `Module.serial`, `ModuleBay.position`, and `Device.name`/`serial` on the virtual-chassis master ref in translate_chassis (defensive there — neither can be blank today). Fields without explicit presence stay on the constructor path, since for them empty and unset are indistinguishable on the wire.

