### PR TITLE
fix(device-discovery): omit blank values instead of sending empty strings

### DIFF
--- a/orb-discovery/device-discovery/custom_napalm/nokia_sros.py
+++ b/orb-discovery/device-discovery/custom_napalm/nokia_sros.py
@@ -929,7 +929,13 @@ class SROSDriver(_napalm_base.NetworkDriver):
         """Return general device facts via NETCONF state tree."""
         try:
             result = _parse_xml(self.conn.get(filter=_FILTER_FACTS).data_xml)
-            hostname = _find_txt(result, "state_ns:state/state_ns:system/state_ns:oper-name")
+            # ``_find_txt`` returns "" when the XPath misses, and an empty hostname
+            # becomes an empty Device.name on the wire. Every other driver falls back
+            # to the target host or "Unknown"; do the same here.
+            hostname = (
+                _find_txt(result, "state_ns:state/state_ns:system/state_ns:oper-name")
+                or self.hostname
+            )
             uptime_ms_str = _find_txt(result, "state_ns:state/state_ns:system/state_ns:up-time")
             # Nokia YANG up-time is milliseconds (integer string)
             uptime = convert(float, uptime_ms_str, default=0.0) / 1000.0 if uptime_ms_str else 0.0

--- a/orb-discovery/device-discovery/device_discovery/interface.py
+++ b/orb-discovery/device-discovery/device_discovery/interface.py
@@ -13,6 +13,7 @@ from netboxlabs.diode.sdk.ingester import Device, Entity, Interface, IPAddress, 
 from device_discovery.defaults import DEFAULT_INTERFACE_PATTERNS
 from device_discovery.interface_types import VALID_INTERFACE_TYPES
 from device_discovery.policy.models import Defaults, Options
+from device_discovery.proto_presence import blank_to_none
 
 logger = logging.getLogger(__name__)
 
@@ -251,12 +252,14 @@ def translate_interface(
         tags.extend(defaults.interface.tags or [])
         description = defaults.interface.description
 
-    description = interface_info.get("description", description)
-    mac_address = (
-        interface_info.get("mac_address")
-        if interface_info.get("mac_address") != ""
-        else None
-    )
+    # NAPALM uses "" for "not available", and 17 of the custom drivers hardcode
+    # `"description": ""` without ever reading a description off the box. A blank
+    # driver value must therefore neither override the policy default nor reach the
+    # wire, where the plugin would treat it as an explicit clear.
+    driver_description = blank_to_none(interface_info.get("description"))
+    if driver_description is not None:
+        description = driver_description
+    mac_address = blank_to_none(interface_info.get("mac_address"))
 
     # Determine interface type by descending priority:
     # 1. Subinterface (has parent) -> "virtual" (structural)

--- a/orb-discovery/device-discovery/device_discovery/proto_presence.py
+++ b/orb-discovery/device-discovery/device_discovery/proto_presence.py
@@ -25,6 +25,8 @@ Reading an unset scalar through the normal attribute accessor yields the proto3 
 into an explicit empty string. See ``copy_scalar_if_set``.
 """
 
+from typing import Any
+
 from google.protobuf.message import Message
 
 
@@ -61,3 +63,35 @@ def copy_scalar_if_set(dst: Message, src: Message, *fields: str) -> None:
         if descriptor.fields_by_name[field].has_presence and not src.HasField(field):
             continue
         setattr(dst, field, getattr(src, field))
+
+
+def blank_to_none(value: Any) -> Any:
+    """
+    Map a blank NAPALM string to ``None`` so the field is omitted rather than sent empty.
+
+    NAPALM's getter contract uses ``""`` for "this value is not available", not for
+    "this value is empty on the device" — 17 of the custom drivers hardcode
+    ``"description": ""`` in ``get_interfaces`` without ever reading a description off
+    the box. Passing that straight through sets a presence-bearing proto field to an
+    explicit empty string, which the plugin reads as a real value: a no-op deviation
+    that reapplies forever on plugin v1.13.0, and an actual field clear on v1.14.1.
+
+    Whitespace-only values are treated as blank too, since they only ever come from a
+    parser that matched nothing. Non-blank values are returned unchanged and unstripped,
+    so genuine content is never rewritten. ``str`` and ``bytes`` are both handled; any
+    other type passes straight through.
+
+    Args:
+    ----
+        value: A value from a NAPALM getter, or anything else (returned unchanged).
+
+    Returns:
+    -------
+        ``None`` when ``value`` is a blank string, otherwise ``value`` unchanged.
+
+    """
+    # bytes as well as str: translate_device deliberately lets a bytes serial through
+    # its type normalisation, so b"" must be blanked too.
+    if isinstance(value, str | bytes) and not value.strip():
+        return None
+    return value

--- a/orb-discovery/device-discovery/device_discovery/translate.py
+++ b/orb-discovery/device-discovery/device_discovery/translate.py
@@ -32,6 +32,7 @@ from device_discovery.policy.models import (
     TenantParameters,
     VrfParameters,
 )
+from device_discovery.proto_presence import blank_to_none
 from device_discovery.translate_chassis import (
     translate_as_stack,
     validate_chassis_payload,
@@ -72,7 +73,10 @@ def translate_vrf(
     if isinstance(vrf, VrfParameters):
         return VRF(
             name=vrf.name,
-            rd=vrf.rd,
+            # VRF.rd declares presence, and stubs.py omits a falsy rd — a policy
+            # supplying rd="" would otherwise make the rich VRF and its stub resolve
+            # via different matchers.
+            rd=blank_to_none(vrf.rd),
             comments=vrf.comments,
             description=vrf.description,
             tags=vrf.tags,
@@ -141,6 +145,9 @@ def translate_device(
                 serial_number = str(serial_number[0])
     elif serial_number is not None and not isinstance(serial_number, str | bytes):
         serial_number = str(serial_number)
+    # Device.serial declares proto presence too, so a blank serial must be omitted
+    # rather than sent as an explicit empty value.
+    serial_number = blank_to_none(serial_number)
 
     device_config = None
     if config_info and options:
@@ -148,12 +155,19 @@ def translate_device(
 
     # Build Device parameters
     device_params = {
-        "name": device_info.get("hostname"),
+        # A driver that discovered no hostname must OMIT device.name. An explicit
+        # empty name is a real value to the Diode plugin, not an omission.
+        "name": blank_to_none(device_info.get("hostname")),
         "device_type": DeviceType(model=model, manufacturer=manufacturer),
         "platform": Platform(name=platform, manufacturer=manufacturer),
         "role": defaults.role,
         "serial": serial_number,
-        "asset_tag": defaults.device.asset_tag if defaults.device else None,
+        # asset_tag is the highest-precedence dcim.device matcher and comes straight
+        # from policy. Blanking it here keeps the rich entity consistent with the
+        # nested stub, which omits a falsy asset_tag.
+        "asset_tag": blank_to_none(defaults.device.asset_tag)
+        if defaults.device
+        else None,
         "status": "active",
         "site": defaults.site,
         "tags": tags,

--- a/orb-discovery/device-discovery/device_discovery/translate_modules.py
+++ b/orb-discovery/device-discovery/device_discovery/translate_modules.py
@@ -27,6 +27,7 @@ from netboxlabs.diode.sdk.ingester import Entity, Module, ModuleBay, ModuleType
 
 from device_discovery.metrics import get_metric
 from device_discovery.policy.models import Options
+from device_discovery.proto_presence import blank_to_none
 
 logger = logging.getLogger(__name__)
 
@@ -262,7 +263,10 @@ def _emit_bay_recursive(
     bay = ModuleBay(
         device=device,
         name=bay_data["name"],
-        position=bay_data.get("position") or bay_data["name"],
+        # ModuleBay.position and Module.serial declare presence. custom_napalm
+        # normally drops blank-serial bays, but a driver assembling the envelope
+        # without to_payload must not be able to emit an explicit empty value.
+        position=blank_to_none(bay_data.get("position") or bay_data["name"]),
     )
     entities.append(Entity(module_bay=bay))
     _bump("module_bays_emitted", 1, {"vendor": manufacturer.name})
@@ -275,7 +279,7 @@ def _emit_bay_recursive(
         "device": device,
         "module_bay": bay,
         "module_type": module_type,
-        "serial": module_data["serial"],
+        "serial": blank_to_none(module_data["serial"]),
     }
     if module_data.get("description"):
         module_kwargs["description"] = module_data["description"]

--- a/orb-discovery/device-discovery/tests/custom_drivers/nokia_sros/mock_data/test_get_facts/missing_oper_name/expected_result.json
+++ b/orb-discovery/device-discovery/tests/custom_drivers/nokia_sros/mock_data/test_get_facts/missing_oper_name/expected_result.json
@@ -1,0 +1,15 @@
+{
+  "hostname": "test-host",
+  "vendor": "Nokia",
+  "model": "7750 SR-12",
+  "os_version": "TiMOS-B-21.10.R2",
+  "serial_number": "NS1921F1814",
+  "uptime": 3802044.41,
+  "fqdn": "test-host",
+  "interface_list": [
+    "1/1/1",
+    "management/management",
+    "system",
+    "to_RTR-01"
+  ]
+}

--- a/orb-discovery/device-discovery/tests/custom_drivers/nokia_sros/mock_data/test_get_facts/missing_oper_name/response.xml
+++ b/orb-discovery/device-discovery/tests/custom_drivers/nokia_sros/mock_data/test_get_facts/missing_oper_name/response.xml
@@ -1,0 +1,34 @@
+<data xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+    <state xmlns="urn:nokia.com:sros:ns:yang:sr:state">
+        <chassis>
+            <hardware-data>
+                <serial-number>NS1921F1814</serial-number>
+            </hardware-data>
+        </chassis>
+        <port>
+            <port-id>1/1/1</port-id>
+        </port>
+        <router>
+            <router-name>Base</router-name>
+            <interface>
+                <interface-name>system</interface-name>
+            </interface>
+            <interface>
+                <interface-name>to_RTR-01</interface-name>
+            </interface>
+        </router>
+        <router>
+            <router-name>management</router-name>
+            <interface>
+                <interface-name>management</interface-name>
+            </interface>
+        </router>
+        <system>
+            <platform>7750 SR-12</platform>
+            <up-time>3802044410</up-time>
+            <version>
+                <version-number>TiMOS-B-21.10.R2</version-number>
+            </version>
+        </system>
+    </state>
+</data>

--- a/orb-discovery/device-discovery/tests/test_blank_napalm_values.py
+++ b/orb-discovery/device-discovery/tests/test_blank_napalm_values.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""
+NetBox Labs - tests that blank NAPALM values are omitted, not sent empty.
+
+NAPALM uses ``""`` to mean "this value is not available". Several presence-bearing
+proto fields are fed directly from NAPALM getters, so passing a blank value through
+sets the field to an explicit empty string — which the Diode NetBox plugin reads as a
+real value rather than an omission.
+"""
+
+import pytest
+from netboxlabs.diode.sdk.diode.v1 import ingester_pb2 as pb
+from netboxlabs.diode.sdk.ingester import Entity
+
+from device_discovery.policy.models import Defaults, ObjectParameters
+from device_discovery.proto_presence import blank_to_none
+from device_discovery.stubs import prune_nested_refs
+from device_discovery.translate import translate_data
+
+BASE_DEVICE = {
+    "hostname": "rtr-1",
+    "vendor": "MikroTik",
+    "model": "CCR1036-8G-2S+",
+    "serial_number": "ABC123",
+    "os_version": "7.1",
+    "interface_list": ["management"],
+}
+BASE_INTERFACE = {
+    "is_up": True,
+    "is_enabled": True,
+    "description": "uplink to core",
+    "mtu": 1500,
+    "speed": -1.0,
+    "mac_address": "08:55:31:10:47:8D",
+    "last_flapped": -1.0,
+}
+
+
+def _is_repeated(field) -> bool:
+    """
+    Report whether a field is repeated, portably across protobuf versions.
+
+    ``FieldDescriptor.is_repeated`` landed in protobuf 5.27; ``.label`` was removed in
+    protobuf 6. protobuf is unpinned here (transitively via grpcio-status), so probe for
+    the modern attribute and fall back to the legacy one.
+    """
+    if hasattr(field, "is_repeated"):
+        return field.is_repeated
+    return field.label == field.LABEL_REPEATED
+
+
+def _present_but_blank(msg: pb.Device, path: str = "") -> list[str]:
+    """
+    Return dotted paths of every presence-bearing string field that is present but blank.
+
+    Blank means empty OR whitespace-only: a field set to "   " is just as much a real
+    value to the plugin as one set to "", so both must be caught.
+    """
+    found: list[str] = []
+    for field, value in msg.ListFields():
+        where = f"{path}.{field.name}" if path else field.name
+        repeated = _is_repeated(field)
+        if field.type == field.TYPE_STRING and not repeated:
+            if field.has_presence and not value.strip():
+                found.append(where)
+        elif field.type == field.TYPE_MESSAGE and repeated:
+            for i, item in enumerate(value):
+                if hasattr(item, "ListFields"):
+                    found.extend(_present_but_blank(item, f"{where}[{i}]"))
+        elif field.type == field.TYPE_MESSAGE and hasattr(value, "ListFields"):
+            found.extend(_present_but_blank(value, where))
+    return found
+
+
+def _emit(device_overrides=None, interface_overrides=None, defaults=None) -> list[Entity]:
+    """Translate + prune a single-device payload, returning the emitted entities."""
+    entities = list(
+        translate_data(
+            {
+                "device": {**BASE_DEVICE, **(device_overrides or {})},
+                "interface": {
+                    "management": {**BASE_INTERFACE, **(interface_overrides or {})}
+                },
+                "defaults": defaults or Defaults(site="site-1", role="router"),
+                "netbox_id": 1,
+            }
+        )
+    )
+    prune_nested_refs(entities)
+    return entities
+
+
+@pytest.mark.parametrize(
+    ("label", "device_overrides", "interface_overrides"),
+    [
+        ("hostname undiscovered", {"hostname": None}, None),
+        ("hostname empty", {"hostname": ""}, None),
+        ("hostname whitespace", {"hostname": "   "}, None),
+        ("serial empty", {"serial_number": ""}, None),
+        ("serial whitespace", {"serial_number": " "}, None),
+        ("serial blank in a list", {"serial_number": [""]}, None),
+        ("serial bytes blank", {"serial_number": b""}, None),
+        ("description empty", None, {"description": ""}),
+        ("description whitespace", None, {"description": "  "}),
+        ("mac empty", None, {"mac_address": ""}),
+        (
+            "everything blank",
+            {"hostname": "", "serial_number": ""},
+            {"description": "", "mac_address": ""},
+        ),
+    ],
+)
+def test_no_present_but_blank_fields_on_the_wire(
+    label, device_overrides, interface_overrides
+):
+    """No emitted entity may carry a presence-bearing string field that is blank."""
+    offenders: list[str] = []
+    for entity in _emit(device_overrides, interface_overrides):
+        which = entity.WhichOneof("entity")
+        offenders.extend(
+            f"{which}.{p}" for p in _present_but_blank(getattr(entity, which))
+        )
+    assert offenders == [], f"{label}: present-but-blank fields emitted: {offenders}"
+
+
+def test_baseline_payload_still_carries_real_values():
+    """The blank-value handling must not strip genuinely discovered values."""
+    entities = _emit()
+    device = next(e.device for e in entities if e.HasField("device"))
+    iface = next(e.interface for e in entities if e.HasField("interface"))
+
+    assert device.name == "rtr-1"
+    assert device.serial == "ABC123"
+    assert iface.description == "uplink to core"
+    assert iface.primary_mac_address.mac_address == "08:55:31:10:47:8D"
+    assert iface.device.name == "rtr-1"
+
+
+def test_blank_driver_description_falls_back_to_policy_default():
+    """A blank driver description must not override a policy-supplied default."""
+    entities = _emit(
+        interface_overrides={"description": ""},
+        defaults=Defaults(
+            site="site-1",
+            role="router",
+            interface=ObjectParameters(description="from policy"),
+        ),
+    )
+    iface = next(e.interface for e in entities if e.HasField("interface"))
+    assert iface.description == "from policy"
+
+
+def test_real_driver_description_still_overrides_policy_default():
+    """A non-blank driver description keeps precedence over the policy default."""
+    entities = _emit(
+        interface_overrides={"description": "from device"},
+        defaults=Defaults(
+            site="site-1",
+            role="router",
+            interface=ObjectParameters(description="from policy"),
+        ),
+    )
+    iface = next(e.interface for e in entities if e.HasField("interface"))
+    assert iface.description == "from device"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("", None),
+        ("   ", None),
+        ("\t\n", None),
+        ("x", "x"),
+        (" padded ", " padded "),
+        (None, None),
+        (0, 0),
+        (False, False),
+    ],
+)
+def test_blank_to_none(value, expected):
+    """Blank strings become None; every other value passes through untouched."""
+    assert blank_to_none(value) == expected
+
+
+def test_blank_policy_asset_tag_is_omitted():
+    """A policy asset_tag of "" must not reach the wire: it is the top device matcher."""
+    from device_discovery.policy.models import DeviceParameters
+
+    entities = _emit(
+        defaults=Defaults(
+            site="site-1", role="router", device=DeviceParameters(asset_tag="")
+        )
+    )
+    device = next(e.device for e in entities if e.HasField("device"))
+    assert not device.HasField("asset_tag")
+
+
+def test_blank_policy_asset_tag_keeps_rich_entity_and_stub_consistent():
+    """The rich Device and its nested stub must agree on whether asset_tag is set."""
+    from device_discovery.policy.models import DeviceParameters
+
+    entities = _emit(
+        defaults=Defaults(
+            site="site-1", role="router", device=DeviceParameters(asset_tag="")
+        )
+    )
+    device = next(e.device for e in entities if e.HasField("device"))
+    iface = next(e.interface for e in entities if e.HasField("interface"))
+    assert device.HasField("asset_tag") == iface.device.HasField("asset_tag")
+
+
+def test_blank_policy_vrf_rd_is_omitted():
+    """A policy VRF rd of "" must not reach the wire."""
+    from device_discovery.policy.models import IpamParameters, VrfParameters
+
+    entities = list(
+        translate_data(
+            {
+                "device": BASE_DEVICE,
+                "interface": {"management": BASE_INTERFACE},
+                "interface_ip": {
+                    "management": {"ipv4": {"192.0.2.1": {"prefix_length": 24}}}
+                },
+                "defaults": Defaults(
+                    site="site-1",
+                    role="router",
+                    ipaddress=IpamParameters(vrf=VrfParameters(name="mgmt", rd="")),
+                ),
+            }
+        )
+    )
+    prune_nested_refs(entities)
+    vrf_bearing = [
+        e.ip_address
+        for e in entities
+        if e.HasField("ip_address") and e.ip_address.HasField("vrf")
+    ]
+    assert vrf_bearing, "expected at least one IP carrying a VRF"
+    for ip in vrf_bearing:
+        assert not ip.vrf.HasField("rd")
+
+
+@pytest.mark.parametrize("field", ["model", "vendor"])
+def test_non_presence_fields_are_untouched(field):
+    """Fields without proto presence are unaffected: empty and unset are the same wire."""
+    entities = _emit({field: None})
+    device = next(e.device for e in entities if e.HasField("device"))
+    assert device.HasField("device_type")


### PR DESCRIPTION
Follows #495, which landed the `copy_scalar_if_set` half. Two commits: the blank-value handling, and the nokia_sros fallback Leo asked for in review.

## Problem

Two sources feed blank strings onto presence-bearing proto fields, where the Diode plugin reads them as real values rather than omissions.

**Drivers.** NAPALM's getter contract uses `""` for *"this value is not available"*, not for *"this value is empty on the device"*. 17 of the custom drivers hardcode `"description": ""` in `get_interfaces` without ever reading a description off the box:

```
$ grep -rl '"description": ""' custom_napalm/ | wc -l
17
```

A driver that cannot determine a hostname or serial can likewise return `""` rather than `None`.

**Policy.** A policy may legitimately be written with an empty `asset_tag` or VRF `rd`.

## Why the policy fields matter more than the empty diff

`asset_tag` is the **highest-precedence** `dcim.device` matcher. And the nested stubs already omit a falsy `asset_tag` / `rd` (`stubs.py:191`, `stubs.py:31`) while the rich entity carried the empty value — so a blank policy value made the rich entity and its own stub resolve through **different matchers**. That directly violates the invariant `_device_match_stub`'s docstring declares:

> `asset_tag` is the highest-precedence matcher and is populated when the policy sets `defaults.device.asset_tag` — kept on the stub so the rich entity and stub never resolve via different matchers.

There is a test for exactly this consistency property.

## Change

Adds `proto_presence.blank_to_none` and applies it where driver or policy values reach presence-bearing fields:

| field | source | file |
|---|---|---|
| `Device.name` | driver `hostname` | `translate.py` |
| `Device.serial` | driver `serial_number` | `translate.py` |
| `Device.asset_tag` | policy | `translate.py` |
| `VRF.rd` | policy | `translate.py` |
| `Interface.description` | driver | `interface.py` |
| `Interface.mac_address` | driver | `interface.py` |
| `Module.serial`, `ModuleBay.position` | driver payload | `translate_modules.py` |

Details worth a look in review:

- The `serial_number` call sits **after** the existing list/tuple normalisation, so `[""]` is caught too. Placing it earlier would miss that case.
- Blank means blank-or-whitespace. Whitespace-only values only ever come from a parser that matched nothing. Non-blank values pass through **unstripped**, so genuine content is never rewritten.
- `bytes` is handled alongside `str`, because `translate_device` deliberately lets a `bytes` serial through its type normalisation.
- The pre-existing `mac_address != ""` special case becomes a call to the shared helper — same behaviour, plus whitespace.
- `Module.serial` / `ModuleBay.position` are defensive: `custom_napalm/_modules.py` drops blank-serial bays today, so these only fire if a driver assembles the envelope without `to_payload`.

## Two deliberate behaviour changes — please confirm these are the calls you want

**1. Discovery can no longer clear a description an operator set in NetBox.** Under NAPALM's contract a blank getter value is not evidence the field should be cleared, and on plugin v1.13.0 such writes were stripped anyway — so this matches current effective behaviour. But on v1.14.1 it forgoes a capability the plugin now offers.

**2. A policy setting `defaults.interface.description` now applies on the 17 drivers that hardcode a blank description**, where previously the blank won and overrode the policy default with `""`.

Open question: would you rather the description handling be opt-in via a policy option than a blanket rule? I went with the blanket rule because a per-driver audit of which drivers genuinely read descriptions is a much larger change, but it is a product call.

One further silent change, smaller: a driver returning `"description": None` previously overrode the policy default with `None`; it now keeps the default.

## Testing

`tests/test_blank_napalm_values.py` — 20 tests, including a parametrised sweep asserting that **no** emitted entity carries a presence-bearing string field that is present but blank, across 11 input shapes (blank/whitespace/None hostname, blank/whitespace/list/bytes serial, blank/whitespace description, blank MAC, everything-at-once).

Against unmodified `develop`, 14 of the tests in this file fail. The sweep's blank check is `not value.strip()` rather than `== ""` specifically so the whitespace cases actually bite — with an equality check they passed both before and after and were worthless.

Full backend suite: 1880 passed, 161 skipped. `ruff check .` clean.

## Risk

Moderate, concentrated in the two behaviour changes above. Everything else replaces a payload the plugin either could not apply or applied destructively.

`_present_but_blank` in the test file probes for `FieldDescriptor.is_repeated` and falls back to `.label`, since `is_repeated` landed in protobuf 5.27 and `.label` was removed in protobuf 6 — the backend does not pin protobuf, and CI runs Python 3.11–3.14.


**nokia_sros fallback** (second commit) — `get_facts` used `_find_txt(...)` directly, which returns `""` on an XPath miss, so a NETCONF reply without `state/system/oper-name` gave a blank hostname and a blank `fqdn`. Now falls back to `self.hostname`, matching the other 40 drivers. New `missing_oper_name` get_facts scenario — the existing mock with `<oper-name>` removed — fails without the change.