### PR TITLE
chore(device-discovery): drop internal ticket reference from a test

### DIFF
--- a/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/test_driver.py
+++ b/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/test_driver.py
@@ -52,7 +52,7 @@ class TestIOSDriver(BaseDriverTest):
         """
         ``Fi*`` short-form expands to FiveGigabitEthernet, not FiftyGigabitEthernet.
 
-        Regression for ENGHLP-1279: netutils.BASE_INTERFACES maps ``"Fi"`` to
+        Regression test: netutils.BASE_INTERFACES maps ``"Fi"`` to
         ``"FiftyGigabitEthernet"``, which is wrong for Cisco IOS Catalyst
         multigig hardware. Without the IOS-specific ``addl_name_map`` override,
         every ``Fi*`` port returned by ``show interfaces switchport`` ended up


### PR DESCRIPTION


The IOS multigig VLAN regression test cited an internal support-ticket ID in its docstring. This repo is public, so a support ticket ID leaks the existence of a specific customer escalation without adding anything a reader outside the company can act on.

The docstring already explains the bug in full — the ``"Fi"`` short-form mapping to FiftyGigabitEthernet instead of FiveGigabitEthernet — so dropping the identifier loses no information.

Comment-only; no test behaviour changes.