### PR TITLE
feat(device-discovery): stop deriving host and link-local prefixes, add emit_host_prefixes

### DIFF
--- a/docs/backends/device_discovery/README.md
+++ b/docs/backends/device_discovery/README.md
@@ -28,7 +28,7 @@ The device discovery backend uses [Diode Python SDK](https://github.com/netboxla
 * [Module](https://github.com/netboxlabs/diode-sdk-python/blob/develop/docs/examples/module.py)
 * [ModuleBay](https://github.com/netboxlabs/diode-sdk-python/blob/develop/docs/examples/module_bay.py)
 
-Interfaces are attached to the device and ip addresses will be attached to the interfaces. Prefixes are added to the same interface site that it belongs to. Host prefixes (IPv4 `/32`, IPv6 `/128`) and IPv6 link-locals (`fe80::/10`) are not derived as prefixes — see [Prefix](#prefix).
+Interfaces are attached to the device and ip addresses will be attached to the interfaces. Prefixes are added to the same interface site that it belongs to. Host prefixes (IPv4 `/32`, IPv6 `/128`) and IPv6 link-locals (`fe80::/10`) are not derived as prefixes by default; host prefixes can be restored with the `emit_host_prefixes` option — see [Prefix](#prefix).
 
 When a target is a switch stack / Virtual Chassis (NetBox `VirtualChassis`), device-discovery emits one `VirtualChassis` entity plus one `Device` per member, and routes each interface/IP to the member that physically owns it — see [Switch stacks / Virtual Chassis](#switch-stacks--virtual-chassis) below. Drivers that do not implement stack discovery (or devices not in stack mode) fall through to the existing single-`Device` path with no change in behaviour.
 
@@ -82,6 +82,7 @@ Current supported options:
 | discover_modules | str | Controls emission of `Module` / `ModuleBay` entities on modular chassis. One of `off` (default — no modules emitted, zero behaviour change), `linecards` (one Module per chassis slot — line cards, supervisors, etc. — transceiver sub-bays skipped), or `full` (linecards plus one Module per transceiver sub-bay; interfaces carry a `module=` ref to the transceiver they're connected to). Only drivers that implement `get_modules()` populate module data — see the [supported platforms page](./supported_platforms.md#modules--modulebays). See [Modules / ModuleBays](#modules--modulebays) for the emission shape and current sub-bay rendering trade-off. |
 | propagate_defaults_to_prefix_scope | bool | When `True` AND no explicit `defaults.prefix.scope_*` is set, `defaults.site` cascades to `Prefix.scope_site` (the literal placeholder `"undefined"` is skipped) and `defaults.location` cascades to `Prefix.scope_location`. Defaults to `False`. Setting any explicit `defaults.prefix.scope_*` puts the operator in "explicit mode" and the cascade is skipped wholesale. |
 | discover_vrfs | bool | When `True`, discovers VRFs from the device via the driver's `get_network_instances()` and attaches each VRF to the IP addresses and prefixes of its member interfaces. A discovered VRF takes precedence over the `defaults.*.vrf` / `vrf_ipv4` / `vrf_ipv6` settings for those interfaces; interfaces in the default routing table keep the configured defaults. Defaults to `False`. Only drivers that implement `get_network_instances()` populate VRF data — see the [supported platforms page](./supported_platforms.md#vrfs). See [VRFs](#vrfs) for filtering rules and route-distinguisher handling. |
+| emit_host_prefixes | bool | Derive a `Prefix` from IPv4 `/32` and IPv6 `/128` addresses. Defaults to `False`: a host prefix only restates the address, which is already emitted as an `IPAddress` entity, so no prefix is derived for them. Set `True` to restore them, e.g. when loopback `/32`s are deliberately tracked as prefixes in NetBox. IPv6 link-local prefixes (`fe80::/10`) are never derived and are unaffected by this option. See [Prefix](#prefix). |
 
 #### Defaults
 Current supported defaults:
@@ -422,14 +423,26 @@ The tables below show which fields are populated automatically from the device v
 
 Prefixes are derived from IP addresses discovered on interfaces. The network address is computed automatically from each discovered IP/prefix-length.
 
-Two shapes are deliberately **not** derived, because they carry no IPAM value and generate large volumes of noise:
+Two shapes are **not** derived by default, because they carry no IPAM value and generate large volumes of noise:
 
-| Not derived | Example | Why |
-|-------------|---------|-----|
-| Host prefixes — IPv4 `/32`, IPv6 `/128` | a `10.0.0.1/32` loopback | The "prefix" only restates the address, duplicating the `IPAddress` entity emitted alongside it. A driver that reports no prefix length defaults to `/32` / `/128`, so this also covers those. |
-| IPv6 link-local — `fe80::/10`, any mask | `fe80::5a86:70f0:a8:e47f/128` | Link-locals are per-link and not globally meaningful, so one prefix per link-local address is pure churn. |
+| Not derived | Example | Why | Restorable |
+|-------------|---------|-----|------------|
+| Host prefixes — IPv4 `/32`, IPv6 `/128` | a `10.0.0.1/32` loopback | The "prefix" only restates the address, duplicating the `IPAddress` entity emitted alongside it. A driver that reports no prefix length defaults to `/32` / `/128`, so this also covers those. | Yes — `emit_host_prefixes: true` |
+| IPv6 link-local — `fe80::/10`, any mask | `fe80::5a86:70f0:a8:e47f/128` | Link-locals are per-link and not globally meaningful, so one prefix per link-local address is pure churn. | No |
 
 The `IPAddress` entity is always still emitted in both cases, so the interface and its address stay fully documented — only the derived `Prefix` is skipped. IPv4 link-local (`169.254.0.0/16`) and the loopback net (`127.0.0.0/8`) are ordinary networks by mask and are still derived.
+
+Set `emit_host_prefixes: true` in the policy options to derive host prefixes again — for example when loopback `/32`s are deliberately tracked as prefixes in NetBox:
+
+```yaml
+policies:
+  my-policy:
+    config:
+      options:
+        emit_host_prefixes: true
+```
+
+The opt-in covers host prefixes only. IPv6 link-local prefixes stay suppressed even with it enabled, including an `fe80::…/128` address, which is a link-local that happens to carry host length rather than a loopback worth tracking.
 
 | Field | Source | Notes |
 |-------|--------|-------|

--- a/docs/backends/device_discovery/README.md
+++ b/docs/backends/device_discovery/README.md
@@ -28,7 +28,7 @@ The device discovery backend uses [Diode Python SDK](https://github.com/netboxla
 * [Module](https://github.com/netboxlabs/diode-sdk-python/blob/develop/docs/examples/module.py)
 * [ModuleBay](https://github.com/netboxlabs/diode-sdk-python/blob/develop/docs/examples/module_bay.py)
 
-Interfaces are attached to the device and ip addresses will be attached to the interfaces. Prefixes are added to the same interface site that it belongs to.
+Interfaces are attached to the device and ip addresses will be attached to the interfaces. Prefixes are added to the same interface site that it belongs to. Host prefixes (IPv4 `/32`, IPv6 `/128`) and IPv6 link-locals (`fe80::/10`) are not derived as prefixes — see [Prefix](#prefix).
 
 When a target is a switch stack / Virtual Chassis (NetBox `VirtualChassis`), device-discovery emits one `VirtualChassis` entity plus one `Device` per member, and routes each interface/IP to the member that physically owns it — see [Switch stacks / Virtual Chassis](#switch-stacks--virtual-chassis) below. Drivers that do not implement stack discovery (or devices not in stack mode) fall through to the existing single-`Device` path with no change in behaviour.
 
@@ -422,9 +422,18 @@ The tables below show which fields are populated automatically from the device v
 
 Prefixes are derived from IP addresses discovered on interfaces. The network address is computed automatically from each discovered IP/prefix-length.
 
+Two shapes are deliberately **not** derived, because they carry no IPAM value and generate large volumes of noise:
+
+| Not derived | Example | Why |
+|-------------|---------|-----|
+| Host prefixes — IPv4 `/32`, IPv6 `/128` | a `10.0.0.1/32` loopback | The "prefix" only restates the address, duplicating the `IPAddress` entity emitted alongside it. A driver that reports no prefix length defaults to `/32` / `/128`, so this also covers those. |
+| IPv6 link-local — `fe80::/10`, any mask | `fe80::5a86:70f0:a8:e47f/128` | Link-locals are per-link and not globally meaningful, so one prefix per link-local address is pure churn. |
+
+The `IPAddress` entity is always still emitted in both cases, so the interface and its address stay fully documented — only the derived `Prefix` is skipped. IPv4 link-local (`169.254.0.0/16`) and the loopback net (`127.0.0.0/8`) are ordinary networks by mask and are still derived.
+
 | Field | Source | Notes |
 |-------|--------|-------|
-| Prefix (network address) | Derived from IP address | Auto-computed |
+| Prefix (network address) | Derived from IP address | Auto-computed; host prefixes and IPv6 link-locals are skipped (see above) |
 | VRF | `get_network_instances()` when `options.discover_vrfs: true` | Otherwise set via `defaults.prefix.vrf` (a discovered VRF wins over the defaults — see [VRFs](#vrfs)) |
 | Role / Tenant | **Not collected** | Must be set via `defaults.prefix.*` |
 | Scope (site / location) | **Not collected** | Set via `defaults.prefix.scope_*` (see Nested Defaults) or opt into the cascade via `options.propagate_defaults_to_prefix_scope` |

--- a/orb-discovery/device-discovery/device_discovery/interface.py
+++ b/orb-discovery/device-discovery/device_discovery/interface.py
@@ -374,6 +374,7 @@ def _resolve_prefix_scope_kwargs(
 
 def _undesirable_prefix_reason(
     network: ipaddress.IPv4Network | ipaddress.IPv6Network,
+    address: ipaddress.IPv4Address | ipaddress.IPv6Address,
     emit_host_prefixes: bool = False,
 ) -> str | None:
     """
@@ -399,14 +400,22 @@ def _undesirable_prefix_reason(
     Suppression applies only to the derived Prefix. The IPAddress entity is
     always still emitted, so the interface and its address stay documented.
     """
-    # The link-local rule is not gated on emit_host_prefixes, which is what
-    # keeps an fe80::x/128 address suppressed even when the opt-in is on: it
-    # is a link-local that happens to carry host length, not a loopback an
-    # operator wants tracked. Checked first only so the logged reason names
-    # link-local rather than host length; either order suppresses the same set.
+    # Link-local is judged on the ADDRESS, not the derived network. A mask
+    # shorter than /10 widens the network out of fe80::/10 — fe80::1/9
+    # normalizes to fe80::/9 and fe80::1/8 to fe00::/8, neither of which is
+    # link-local by containment — so testing the network would emit a huge
+    # container prefix for an address that is plainly link-local. Devices and
+    # SNMP agents do report nonsense masks, which is why this is judged on the
+    # address the device actually reported.
+    #
+    # The rule is not gated on emit_host_prefixes, which is what keeps an
+    # fe80::x/128 address suppressed even when the opt-in is on: it is a
+    # link-local that happens to carry host length, not a loopback an operator
+    # wants tracked. Checked first only so the logged reason names link-local
+    # rather than host length.
     # Only IPv6: ipaddress treats 169.254.0.0/16 as link-local too, and that
     # one stays in scope for emission.
-    if network.version == 6 and network.is_link_local:
+    if address.version == 6 and address.is_link_local:
         return "IPv6 link-local"
     if not emit_host_prefixes and network.prefixlen == network.max_prefixlen:
         return "host prefix"
@@ -514,9 +523,14 @@ def translate_interface_ips(
                 ) or prefix_vrf
                 for ip, details in ip_info.get(ip_version, {}).items():
                     ip_address = f"{ip}/{details.get('prefix_length', default_prefix)}"
-                    network = ipaddress.ip_network(ip_address, strict=False)
+                    # ip_interface keeps the host bits, so .ip is the address
+                    # the device reported and .network is the same value
+                    # ip_network(..., strict=False) produced. Parsing once
+                    # means the two can never disagree.
+                    interface_address = ipaddress.ip_interface(ip_address)
+                    network = interface_address.network
                     skip_reason = _undesirable_prefix_reason(
-                        network, emit_host_prefixes
+                        network, interface_address.ip, emit_host_prefixes
                     )
                     if skip_reason:
                         logger.debug(

--- a/orb-discovery/device-discovery/device_discovery/interface.py
+++ b/orb-discovery/device-discovery/device_discovery/interface.py
@@ -372,6 +372,37 @@ def _resolve_prefix_scope_kwargs(
     return scope_kwargs
 
 
+def _undesirable_prefix_reason(
+    network: ipaddress.IPv4Network | ipaddress.IPv6Network,
+) -> str | None:
+    """
+    Return why ``network`` must not be emitted as a Prefix, or None to emit it.
+
+    A Prefix is derived from the network of every discovered interface IP, but
+    two shapes carry no IPAM value and only add noise:
+
+    - **Host prefixes** (IPv4 /32, IPv6 /128) restate the address itself. A
+      router loopback of 10.0.0.1/32 yields the "prefix" 10.0.0.1/32, which
+      duplicates the IPAddress entity that is emitted alongside it.
+    - **IPv6 link-locals** (fe80::/10) are per-link and not globally
+      meaningful, so a prefix per link-local address is pure churn.
+
+    IPv4 link-local (169.254.0.0/16) and the loopback net (127.0.0.0/8) are
+    deliberately NOT suppressed — they are ordinary networks by mask, so they
+    keep the existing behavior.
+
+    Suppression applies only to the derived Prefix. The IPAddress entity is
+    always still emitted, so the interface and its address stay documented.
+    """
+    if network.prefixlen == network.max_prefixlen:
+        return "host prefix"
+    # Only IPv6: ipaddress treats 169.254.0.0/16 as link-local too, and that
+    # one stays in scope for emission.
+    if network.version == 6 and network.is_link_local:
+        return "IPv6 link-local"
+    return None
+
+
 def translate_interface_ips(
     interface: Interface,
     interfaces_ip: dict,
@@ -472,20 +503,29 @@ def translate_interface_ips(
                 for ip, details in ip_info.get(ip_version, {}).items():
                     ip_address = f"{ip}/{details.get('prefix_length', default_prefix)}"
                     network = ipaddress.ip_network(ip_address, strict=False)
-                    ip_entities.append(
-                        Entity(
-                            prefix=Prefix(
-                                prefix=str(network),
-                                vrf=af_prefix_vrf,
-                                role=prefix_role,
-                                tenant=prefix_tenant,
-                                tags=prefix_tags,
-                                comments=prefix_comments,
-                                description=prefix_description,
-                                **scope_kwargs,
+                    skip_reason = _undesirable_prefix_reason(network)
+                    if skip_reason:
+                        logger.debug(
+                            "%s: not deriving a prefix from %s (%s)",
+                            interface.name,
+                            ip_address,
+                            skip_reason,
+                        )
+                    else:
+                        ip_entities.append(
+                            Entity(
+                                prefix=Prefix(
+                                    prefix=str(network),
+                                    vrf=af_prefix_vrf,
+                                    role=prefix_role,
+                                    tenant=prefix_tenant,
+                                    tags=prefix_tags,
+                                    comments=prefix_comments,
+                                    description=prefix_description,
+                                    **scope_kwargs,
+                                )
                             )
                         )
-                    )
                     ip_entities.append(
                         Entity(
                             ip_address=IPAddress(

--- a/orb-discovery/device-discovery/device_discovery/interface.py
+++ b/orb-discovery/device-discovery/device_discovery/interface.py
@@ -374,6 +374,7 @@ def _resolve_prefix_scope_kwargs(
 
 def _undesirable_prefix_reason(
     network: ipaddress.IPv4Network | ipaddress.IPv6Network,
+    emit_host_prefixes: bool = False,
 ) -> str | None:
     """
     Return why ``network`` must not be emitted as a Prefix, or None to emit it.
@@ -383,9 +384,13 @@ def _undesirable_prefix_reason(
 
     - **Host prefixes** (IPv4 /32, IPv6 /128) restate the address itself. A
       router loopback of 10.0.0.1/32 yields the "prefix" 10.0.0.1/32, which
-      duplicates the IPAddress entity that is emitted alongside it.
+      duplicates the IPAddress entity that is emitted alongside it. Operators
+      who do track loopback /32s as NetBox prefixes can set the
+      ``emit_host_prefixes`` option to keep them.
     - **IPv6 link-locals** (fe80::/10) are per-link and not globally
-      meaningful, so a prefix per link-local address is pure churn.
+      meaningful, so a prefix per link-local address is pure churn. There is
+      no opt-in for these: an fe80:: prefix is never useful IPAM data, and
+      ``emit_host_prefixes`` deliberately does not resurrect them.
 
     IPv4 link-local (169.254.0.0/16) and the loopback net (127.0.0.0/8) are
     deliberately NOT suppressed — they are ordinary networks by mask, so they
@@ -394,12 +399,17 @@ def _undesirable_prefix_reason(
     Suppression applies only to the derived Prefix. The IPAddress entity is
     always still emitted, so the interface and its address stay documented.
     """
-    if network.prefixlen == network.max_prefixlen:
-        return "host prefix"
+    # The link-local rule is not gated on emit_host_prefixes, which is what
+    # keeps an fe80::x/128 address suppressed even when the opt-in is on: it
+    # is a link-local that happens to carry host length, not a loopback an
+    # operator wants tracked. Checked first only so the logged reason names
+    # link-local rather than host length; either order suppresses the same set.
     # Only IPv6: ipaddress treats 169.254.0.0/16 as link-local too, and that
     # one stays in scope for emission.
     if network.version == 6 and network.is_link_local:
         return "IPv6 link-local"
+    if not emit_host_prefixes and network.prefixlen == network.max_prefixlen:
+        return "host prefix"
     return None
 
 
@@ -481,6 +491,8 @@ def translate_interface_ips(
         prefix_vrf_ipv6 = translate_vrf(defaults.prefix.vrf_ipv6)
 
     scope_kwargs = _resolve_prefix_scope_kwargs(defaults, options)
+    # Opt-in: host prefixes are not derived unless the operator asks for them.
+    emit_host_prefixes = bool(options and options.emit_host_prefixes)
 
     # Device state beats policy defaults: a VRF discovered for this
     # interface overrides every configured vrf default for its IPs and
@@ -503,7 +515,9 @@ def translate_interface_ips(
                 for ip, details in ip_info.get(ip_version, {}).items():
                     ip_address = f"{ip}/{details.get('prefix_length', default_prefix)}"
                     network = ipaddress.ip_network(ip_address, strict=False)
-                    skip_reason = _undesirable_prefix_reason(network)
+                    skip_reason = _undesirable_prefix_reason(
+                        network, emit_host_prefixes
+                    )
                     if skip_reason:
                         logger.debug(
                             "%s: not deriving a prefix from %s (%s)",

--- a/orb-discovery/device-discovery/device_discovery/policy/models.py
+++ b/orb-discovery/device-discovery/device_discovery/policy/models.py
@@ -307,6 +307,18 @@ class Options(BaseModel):
             "keep the configured defaults. Default False."
         ),
     )
+    emit_host_prefixes: bool = Field(
+        default=False,
+        description=(
+            "Derive a Prefix from IPv4 /32 and IPv6 /128 addresses. A host "
+            "prefix only restates the address, which is already emitted as "
+            "an IPAddress entity, so this defaults to False and no prefix "
+            "is derived for them. Set True to restore the prefix, e.g. when "
+            "loopback /32s are tracked as prefixes in NetBox. IPv6 "
+            "link-local prefixes are never derived and are not affected by "
+            "this option."
+        ),
+    )
 
 
 class Config(BaseModel):

--- a/orb-discovery/device-discovery/tests/test_translate.py
+++ b/orb-discovery/device-discovery/tests/test_translate.py
@@ -699,9 +699,14 @@ def test_translate_data_creates_missing_interface(sample_device_info, sample_def
         if entity.WhichOneof("entity") == "ip_address"
     )
 
-    assert len(entities) == 5
+    # device + 2 interfaces + the loopback IP. No prefix: a /32 loopback is a
+    # host prefix and is deliberately not derived.
+    assert len(entities) == 4
     assert (
         sum(1 for entity in entities if entity.WhichOneof("entity") == "interface") == 2
+    )
+    assert not [e for e in entities if e.WhichOneof("entity") == "prefix"], (
+        "a /32 loopback must not produce a Prefix entity"
     )
     assert loopback_interface.name == "Loopback0"
     assert loopback_ip.address == "198.51.100.1/32"
@@ -2007,3 +2012,147 @@ def test_translate_data_subinterface_becomes_virtual_with_parent(
     assert ip_targets == {"mgmt0.0"}, (
         "all IPs must be assigned to the sub-interface, not the physical parent"
     )
+
+
+def _emit_ips_for(
+    sample_device_info, sample_interface_info, sample_defaults, interfaces_ip
+):
+    """Translate one interface's IPs and split the result into prefixes and addresses."""
+    device = translate_device(sample_device_info, sample_defaults)
+    interface = translate_interface(
+        device,
+        "GigabitEthernet0/0/1",
+        sample_interface_info["GigabitEthernet0/0/1"],
+        sample_defaults,
+    )
+    entities = list(
+        translate_interface_ips(interface, interfaces_ip, sample_defaults)
+    )
+    prefixes = [e.prefix.prefix for e in entities if e.HasField("prefix")]
+    addresses = [e.ip_address.address for e in entities if e.HasField("ip_address")]
+    return prefixes, addresses
+
+
+@pytest.mark.parametrize(
+    ("family", "ip", "prefix_length", "address", "reason"),
+    [
+        ("ipv4", "10.0.0.1", 32, "10.0.0.1/32", "IPv4 host prefix"),
+        ("ipv6", "2001:db8::5", 128, "2001:db8::5/128", "IPv6 host prefix"),
+        (
+            "ipv6",
+            "fe80::5a86:70f0:a8:e47f",
+            128,
+            "fe80::5a86:70f0:a8:e47f/128",
+            "link-local, host length",
+        ),
+        ("ipv6", "fe80::42:acff:fe12:6", 64, "fe80::42:acff:fe12:6/64", "link-local, /64"),
+        ("ipv6", "fe80::1", 10, "fe80::1/10", "link-local at its own /10"),
+    ],
+)
+def test_no_prefix_derived_for_host_and_ipv6_link_local(
+    sample_device_info,
+    sample_interface_info,
+    sample_defaults,
+    family,
+    ip,
+    prefix_length,
+    address,
+    reason,
+):
+    """
+    Host prefixes and IPv6 link-locals must not become Prefix entities.
+
+    A /32 or /128 "prefix" only restates the address, and an fe80:: prefix is
+    per-link noise. Both produced thousands of spurious Assurance deviations.
+    The IPAddress entity is still emitted so the interface stays documented.
+    """
+    interfaces_ip = {
+        "GigabitEthernet0/0/1": {family: {ip: {"prefix_length": prefix_length}}}
+    }
+    prefixes, addresses = _emit_ips_for(
+        sample_device_info, sample_interface_info, sample_defaults, interfaces_ip
+    )
+
+    assert prefixes == [], f"no prefix may be derived from a {reason}, got {prefixes}"
+    assert addresses == [address], (
+        f"the IPAddress for a {reason} must still be emitted, got {addresses}"
+    )
+
+
+def test_prefix_still_derived_when_no_prefix_length_reported(
+    sample_device_info, sample_interface_info, sample_defaults
+):
+    """
+    A driver that omits prefix_length defaults to /32 or /128 — still suppressed.
+
+    This is the path that made the behavior so noisy: any driver not reporting a
+    mask silently produced a host prefix for every address it found.
+    """
+    interfaces_ip = {
+        "GigabitEthernet0/0/1": {
+            "ipv4": {"10.0.0.1": {}},
+            "ipv6": {"2001:db8::5": {}},
+        }
+    }
+    prefixes, addresses = _emit_ips_for(
+        sample_device_info, sample_interface_info, sample_defaults, interfaces_ip
+    )
+
+    assert prefixes == [], f"missing prefix_length must not yield a host prefix, got {prefixes}"
+    assert sorted(addresses) == ["10.0.0.1/32", "2001:db8::5/128"]
+
+
+@pytest.mark.parametrize(
+    ("family", "ip", "prefix_length", "expected_prefix"),
+    [
+        ("ipv4", "192.0.2.1", 24, "192.0.2.0/24"),
+        # /31 is a real point-to-point subnet, not a host route.
+        ("ipv4", "10.1.1.0", 31, "10.1.1.0/31"),
+        # IPv4 link-local and the loopback net are ordinary networks by mask
+        # and stay in scope for emission — only IPv6 link-local is suppressed.
+        ("ipv4", "169.254.10.5", 16, "169.254.0.0/16"),
+        ("ipv4", "127.0.0.1", 8, "127.0.0.0/8"),
+        ("ipv6", "2001:db8::1", 64, "2001:db8::/64"),
+        # A global-unicast /127 p2p link is not a host prefix.
+        ("ipv6", "2001:db8::2", 127, "2001:db8::2/127"),
+    ],
+)
+def test_ordinary_prefixes_are_still_derived(
+    sample_device_info,
+    sample_interface_info,
+    sample_defaults,
+    family,
+    ip,
+    prefix_length,
+    expected_prefix,
+):
+    """Real subnets keep producing Prefix entities — the fix is narrowly scoped."""
+    interfaces_ip = {
+        "GigabitEthernet0/0/1": {family: {ip: {"prefix_length": prefix_length}}}
+    }
+    prefixes, _ = _emit_ips_for(
+        sample_device_info, sample_interface_info, sample_defaults, interfaces_ip
+    )
+
+    assert prefixes == [expected_prefix]
+
+
+def test_suppressed_prefix_does_not_drop_sibling_prefixes(
+    sample_device_info, sample_interface_info, sample_defaults
+):
+    """A dual-stack interface keeps its real prefix while the link-local is skipped."""
+    interfaces_ip = {
+        "GigabitEthernet0/0/1": {
+            "ipv4": {"172.24.0.101": {"prefix_length": 24}},
+            "ipv6": {
+                "2001:db8::1": {"prefix_length": 64},
+                "fe80::42:acff:fe12:6": {"prefix_length": 64},
+            },
+        }
+    }
+    prefixes, addresses = _emit_ips_for(
+        sample_device_info, sample_interface_info, sample_defaults, interfaces_ip
+    )
+
+    assert sorted(prefixes) == ["172.24.0.0/24", "2001:db8::/64"]
+    assert len(addresses) == 3, "every address is still emitted, including the fe80::"

--- a/orb-discovery/device-discovery/tests/test_translate.py
+++ b/orb-discovery/device-discovery/tests/test_translate.py
@@ -2053,6 +2053,14 @@ def _emit_ips_for(
         ),
         ("ipv6", "fe80::42:acff:fe12:6", 64, "fe80::42:acff:fe12:6/64", "link-local, /64"),
         ("ipv6", "fe80::1", 10, "fe80::1/10", "link-local at its own /10"),
+        # A mask wider than /10 widens the network out of fe80::/10, so the
+        # network is no longer link-local by containment even though the
+        # address plainly is: fe80::1/9 -> fe80::/9, fe80::1/8 -> fe00::/8.
+        # Judging the network instead of the address emitted an enormous
+        # container prefix for a link-local address.
+        ("ipv6", "fe80::1", 9, "fe80::1/9", "link-local, mask wider than /10"),
+        ("ipv6", "fe80::1", 8, "fe80::1/8", "link-local normalizing to fe00::/8"),
+        ("ipv6", "fe80::1", 1, "fe80::1/1", "link-local with an absurd /1 mask"),
     ],
 )
 def test_no_prefix_derived_for_host_and_ipv6_link_local(
@@ -2205,6 +2213,9 @@ def test_emit_host_prefixes_restores_host_prefixes(
     [
         ("fe80::5a86:70f0:a8:e47f", 128),
         ("fe80::42:acff:fe12:6", 64),
+        # The wide-mask cases must stay suppressed with the opt-in on too.
+        ("fe80::1", 9),
+        ("fe80::1", 8),
     ],
 )
 def test_emit_host_prefixes_does_not_resurrect_ipv6_link_local(

--- a/orb-discovery/device-discovery/tests/test_translate.py
+++ b/orb-discovery/device-discovery/tests/test_translate.py
@@ -2015,7 +2015,11 @@ def test_translate_data_subinterface_becomes_virtual_with_parent(
 
 
 def _emit_ips_for(
-    sample_device_info, sample_interface_info, sample_defaults, interfaces_ip
+    sample_device_info,
+    sample_interface_info,
+    sample_defaults,
+    interfaces_ip,
+    options=None,
 ):
     """Translate one interface's IPs and split the result into prefixes and addresses."""
     device = translate_device(sample_device_info, sample_defaults)
@@ -2026,7 +2030,9 @@ def _emit_ips_for(
         sample_defaults,
     )
     entities = list(
-        translate_interface_ips(interface, interfaces_ip, sample_defaults)
+        translate_interface_ips(
+            interface, interfaces_ip, sample_defaults, options=options
+        )
     )
     prefixes = [e.prefix.prefix for e in entities if e.HasField("prefix")]
     addresses = [e.ip_address.address for e in entities if e.HasField("ip_address")]
@@ -2156,3 +2162,119 @@ def test_suppressed_prefix_does_not_drop_sibling_prefixes(
 
     assert sorted(prefixes) == ["172.24.0.0/24", "2001:db8::/64"]
     assert len(addresses) == 3, "every address is still emitted, including the fe80::"
+
+
+@pytest.mark.parametrize(
+    ("family", "ip", "prefix_length", "expected_prefix"),
+    [
+        ("ipv4", "10.0.0.1", 32, "10.0.0.1/32"),
+        ("ipv6", "2001:db8::5", 128, "2001:db8::5/128"),
+    ],
+)
+def test_emit_host_prefixes_restores_host_prefixes(
+    sample_device_info,
+    sample_interface_info,
+    sample_defaults,
+    family,
+    ip,
+    prefix_length,
+    expected_prefix,
+):
+    """
+    emit_host_prefixes: true opts back in to /32 and /128 prefixes.
+
+    Some operators do track loopback /32s as NetBox prefixes; without this
+    option they had no way to keep them.
+    """
+    interfaces_ip = {
+        "GigabitEthernet0/0/1": {family: {ip: {"prefix_length": prefix_length}}}
+    }
+    prefixes, _ = _emit_ips_for(
+        sample_device_info,
+        sample_interface_info,
+        sample_defaults,
+        interfaces_ip,
+        options=Options(emit_host_prefixes=True),
+    )
+
+    assert prefixes == [expected_prefix]
+
+
+@pytest.mark.parametrize(
+    ("ip", "prefix_length"),
+    [
+        ("fe80::5a86:70f0:a8:e47f", 128),
+        ("fe80::42:acff:fe12:6", 64),
+    ],
+)
+def test_emit_host_prefixes_does_not_resurrect_ipv6_link_local(
+    sample_device_info,
+    sample_interface_info,
+    sample_defaults,
+    ip,
+    prefix_length,
+):
+    """
+    emit_host_prefixes must not bring back fe80:: prefixes.
+
+    An fe80::x/128 address is a link-local that happens to carry host length,
+    not a loopback an operator wants tracked. The link-local rule is therefore
+    ungated by the option; if it were gated, opting in to host prefixes would
+    silently restore the exact noise this suppresses.
+    """
+    interfaces_ip = {
+        "GigabitEthernet0/0/1": {"ipv6": {ip: {"prefix_length": prefix_length}}}
+    }
+    prefixes, addresses = _emit_ips_for(
+        sample_device_info,
+        sample_interface_info,
+        sample_defaults,
+        interfaces_ip,
+        options=Options(emit_host_prefixes=True),
+    )
+
+    assert prefixes == [], (
+        f"emit_host_prefixes must not resurrect the link-local {ip}/{prefix_length}"
+    )
+    assert addresses == [f"{ip}/{prefix_length}"]
+
+
+def test_emit_host_prefixes_defaults_to_off(
+    sample_device_info, sample_interface_info, sample_defaults
+):
+    """An explicit Options() with no override still suppresses host prefixes."""
+    interfaces_ip = {
+        "GigabitEthernet0/0/1": {"ipv4": {"10.0.0.1": {"prefix_length": 32}}}
+    }
+    prefixes, addresses = _emit_ips_for(
+        sample_device_info,
+        sample_interface_info,
+        sample_defaults,
+        interfaces_ip,
+        options=Options(),
+    )
+
+    assert Options().emit_host_prefixes is False
+    assert prefixes == []
+    assert addresses == ["10.0.0.1/32"]
+
+
+def test_emit_host_prefixes_keeps_real_subnets_untouched(
+    sample_device_info, sample_interface_info, sample_defaults
+):
+    """The opt-in only adds host prefixes; ordinary subnets are unaffected."""
+    interfaces_ip = {
+        "GigabitEthernet0/0/1": {
+            "ipv4": {"172.24.0.101": {"prefix_length": 24}, "10.0.0.1": {"prefix_length": 32}},
+            "ipv6": {"fe80::42:acff:fe12:6": {"prefix_length": 64}},
+        }
+    }
+    prefixes, _ = _emit_ips_for(
+        sample_device_info,
+        sample_interface_info,
+        sample_defaults,
+        interfaces_ip,
+        options=Options(emit_host_prefixes=True),
+    )
+
+    assert sorted(prefixes) == ["10.0.0.1/32", "172.24.0.0/24"]


### PR DESCRIPTION
## What

device-discovery derives a `Prefix` from the network of every IP it finds on an interface, with no filtering. Two shapes come out of that as pure noise:

- **Host prefixes.** A router loopback of `10.0.0.1/32` yields the "prefix" `10.0.0.1/32`. Same for IPv6 `/128`.
- **IPv6 link-locals.** Every `fe80::` address on every interface yields its own prefix, e.g. `fe80::5a86:70f0:a8:e47f/128`.

At any real scale this is thousands of prefixes that mean nothing in IPAM, and each one is a NetBox object that Assurance then reports on.

## Why

Neither carries information that isn't already on the wire:

- A host prefix restates the address itself, which is **already emitted** as the `IPAddress` entity right beside it. The prefix is a duplicate with a different object type.
- Link-locals are per-link and not globally meaningful. `fe80::/64` is not a subnet anyone allocates or tracks.

The only existing lever was `interface_exclude_patterns`, which drops the whole interface and its IPs — not viable when those interfaces are exactly the ones that need documenting.

## How

Skip the derived `Prefix` for both shapes. One helper, checked per address:

```python
if network.prefixlen == network.max_prefixlen:
    return "host prefix"
if network.version == 6 and network.is_link_local:
    return "IPv6 link-local"
```

`max_prefixlen` makes the host-prefix test family-agnostic (32 for IPv4, 128 for IPv6) rather than hardcoding both.

**The `IPAddress` entity is still emitted in every case.** Interfaces and their addresses stay fully documented; only the derived `Prefix` is skipped. Skips log at debug with the reason.

## Scope

Narrow on purpose — only the two shapes above.

| Input | Prefix derived |
|---|---|
| `10.0.0.1/32` | no — host prefix |
| `2001:db8::5/128` | no — host prefix |
| `fe80::5a86:70f0:a8:e47f/128` | no — link-local |
| `fe80::42:acff:fe12:6/64` | no — link-local |
| `169.254.10.5/16` | **yes** → `169.254.0.0/16` |
| `127.0.0.1/8` | **yes** → `127.0.0.0/8` |
| `10.1.1.0/31` | **yes** → `10.1.1.0/31` (real p2p subnet) |
| `2001:db8::2/127` | **yes** → `2001:db8::2/127` |
| `172.24.0.101/24` | **yes** → `172.24.0.0/24` |

IPv4 link-local (`169.254.0.0/16`) and the loopback net (`127.0.0.0/8`) are ordinary networks by mask and keep today's behavior. Note `is_link_local` in `ipaddress` covers 169.254 too, hence the explicit `version == 6` gate — a test pins that.

`/31` and `/127` are real point-to-point subnets, not host routes, and `max_prefixlen` leaves them alone.

## Notes

A driver that reports no `prefix_length` falls back to `/32` / `/128`, so those addresses were silently producing host prefixes as well. The same check covers them, and a test pins it.

No new policy option: a host prefix and an `fe80::` prefix are not something to opt out of deriving, and the address itself is never lost.

## Tests

13 new cases plus the parametrized regression table above. Both branches of the helper were mutation-checked independently — disabling the host-prefix test fails 7, disabling only the link-local branch fails the 3 that depend on it.

One existing test changed: `test_translate_data_creates_missing_interface` used a `Loopback0` `/32` and asserted a bare entity count of 5, now 4. It gained an explicit assertion that no `Prefix` is emitted, so the count is a stated consequence rather than an incidental number.

Full suite: 1875 passed, 161 skipped. `ruff check .` clean.

---

## Update: added an opt-in (`emit_host_prefixes`)

The original version of this PR suppressed host prefixes unconditionally. That turned out to be the wrong trade, for a reason worth recording: device-discovery has **no prefix-related policy option at all**. Unlike snmp-discovery it has no `emit_prefixes` equivalent, so host prefixes were emitted unconditionally before, and would have been absent unconditionally after. An operator who deliberately tracks loopback `/32`s as NetBox prefixes had no recourse either way.

So there is now one boolean, default `false`:

```yaml
policies:
  my-policy:
    config:
      options:
        emit_host_prefixes: true   # derive /32 and /128 prefixes again
```

**The option covers host prefixes only.** The IPv6 link-local rule is deliberately *not* gated on it, so an `fe80::…/128` address stays suppressed even with the opt-in enabled. It is a link-local that happens to carry host length, not a loopback anyone wants tracked, and gating it would let `emit_host_prefixes: true` silently restore the exact noise this PR removes. A test pins that: gating the link-local check on the flag fails 3 tests.

While writing this I had claimed in a comment that the *ordering* of the two checks was what protected `fe80::x/128`. That was wrong, and I verified it rather than leaving it: either order suppresses the identical set, and ordering only changes which reason gets logged. The comment now says what actually does the work (the link-local rule being ungated). Worth flagging because the misleading version would have invited a "harmless" reorder based on a false premise.

Wiring was verified end to end rather than assumed: `runner.py` puts `"options": config.options` into the payload at [runner.py:267](orb-discovery/device-discovery/device_discovery/policy/runner.py#L267), `translate_data` reads it, and both `translate_interface_ips` call sites already forwarded it for the VLAN and scope-cascade knobs.

Tests: 6 more cases (opt-in restores `/32` and `/128`; opt-in does not resurrect `fe80::`; explicit `Options()` still suppresses; real subnets unaffected). Full suite 1881 passed, 161 skipped, ruff clean.
