### PR TITLE
feat(device-discovery): discover StackWise Virtual switch stacks

### DIFF
--- a/docs/backends/device_discovery/supported_platforms.md
+++ b/docs/backends/device_discovery/supported_platforms.md
@@ -157,7 +157,7 @@ See [Switch stacks / Virtual Chassis](./README.md#switch-stacks--virtual-chassis
 
 | Driver | Status |
 |--------|--------|
-| `ios` | Supported (Cisco IOS / IOS-XE) — Catalyst StackWise (3850, 9300, 2960X, etc.); parses `show switch detail` + `show inventory` via ntc-templates |
+| `ios` | Supported (Cisco IOS / IOS-XE) — Catalyst StackWise (3850, 9300, 2960X, etc.) **and** Catalyst 9400 / 9500 / 9600 StackWise Virtual (SVL). Tries `show switch detail`, falling back to `show switch` for SVL, which rejects the `detail` keyword; the member table is parsed driver-locally rather than via ntc-templates, because that template discards every member row when any row carries a multi-word state such as `Version Mismatch`. Per-member serial and model come from the `show inventory` chassis rows (`Switch N` on StackWise, `Switch N Chassis` on SVL), matched anchored so component rows (power supply, fan tray, supervisor) can never supply a member's identity. On SVL the domain number is read from `show stackwise-virtual`, the only command that exposes it — physical stacks emit no domain. |
 | `junos` | Supported (Juniper EX / QFX) — Virtual Chassis via the `<get-virtual-chassis-information>` PyEZ RPC; tolerates both `<member-list>/<member>` (modern) and bare `<member>` (older releases) shapes |
 | `aruba_aoscx` | Supported (HPE Aruba AOS-CX) — Virtual Switching Framework (VSF) via pyaoscx REST (`/system/vsf_members` + optional `/system/vsf`); tolerates list-of-members and dict-keyed-by-id payload shapes |
 | `aruba_aoscx_ssh` | Supported (HPE Aruba AOS-CX) — VSF via SSH `show vsf detail` (ntc-template `aruba_aoscx_show_vsf_detail`); member role comes from the `Status` field |

--- a/orb-discovery/device-discovery/custom_napalm/ios.py
+++ b/orb-discovery/device-discovery/custom_napalm/ios.py
@@ -395,20 +395,131 @@ def _index_inventory_by_switch(rows: list[dict]) -> tuple[dict[int, str], dict[i
     return serial_by_id, model_by_id
 
 
-def _ios_get_chassis_members_impl(driver) -> dict | None:
-    """Implementation of IOSDriver.get_chassis_members (factored for testability)."""
+# A CLI rejection means the platform has no stack concept at all (ISR / ASR /
+# CSR, and any Catalyst predating the command). That is the expected answer for
+# most of a mixed fleet, so it must not warn every discovery cycle.
+_CLI_ERROR_RE = re.compile(
+    r"%\s*(?:Invalid input detected|Incomplete command|Ambiguous command)",
+    re.IGNORECASE,
+)
+
+# A standalone Catalyst positively says so.
+_NOT_STACKED_RE = re.compile(
+    r"Switch\s+is\s+not\s+(?:on|in)\s+(?:any\s+)?stack",
+    re.IGNORECASE,
+)
+
+# The member-table header. Present but no rows parsed means we were handed a
+# switch table we failed to understand, which is worth an operator's attention.
+_SWITCH_TABLE_HEADER_RE = re.compile(
+    r"^\s*Switch#\s+Role\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+# "show stackwise-virtual" has no ntc-template (no template file, no index
+# entry), so the one line we need is read directly. Only Catalyst 9400/9500/9600
+# in StackWise Virtual mode answer this command; physical stacks reject it, which
+# is expected and simply leaves the domain unset.
+_SVL_DOMAIN_RE = re.compile(
+    r"^\s*Domain\s+Number\s*:\s*(\d+)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _ios_svl_domain(driver) -> str | None:
+    """
+    Return the StackWise Virtual domain number, or None when unavailable.
+
+    Purely additive: any failure (command rejected, no match, empty output)
+    yields None, which is the pre-existing behaviour, so this can never turn a
+    working stack into a failure.
+    """
     try:
-        detail_out = driver.device.send_command("show switch detail")
-        detail_rows = parse_output(
-            platform="cisco_ios",
-            command="show switch detail",
-            data=detail_out or "",
-        )
+        raw = driver.device.send_command("show stackwise-virtual")
     except Exception as e:
-        logger.warning("ios.get_chassis_members: show switch detail failed: %s", e)
+        logger.debug(
+            "ios.get_chassis_members: %s: show stackwise-virtual failed: %s",
+            driver.hostname, e,
+        )
         return None
+    match = _SVL_DOMAIN_RE.search(raw or "")
+    return match.group(1) if match else None
+
+
+def _log_no_members(driver, attempts: list[tuple[str, str]]) -> None:
+    """
+    Explain why no stack members were found, at a level matching how odd it is.
+
+    Fails safe: the WARNING fires unless the output was POSITIVELY identified as
+    a CLI rejection or an explicit standalone answer. An unrecognised shape warns
+    rather than going quiet, because a silent None is what made this class of gap
+    invisible until a user noticed missing NetBox data.
+
+    Note DEBUG is effectively silent in this backend today — the root logger is
+    pinned to INFO by an import-time basicConfig and there is no log-level flag
+    (see the device-discovery log-level work tracked separately). That is the
+    intended outcome for the expected cases, and it removes the per-cycle
+    WARNING that every non-Catalyst IOS device used to emit.
+    """
+    looked_like_a_table = any(
+        _SWITCH_TABLE_HEADER_RE.search(text) for _cmd, text in attempts
+    )
+    # Only non-empty output carries information. A command that returned nothing
+    # tells us neither that the platform rejected it nor that anything is wrong,
+    # so it must not drag the classification into the WARNING branch.
+    informative = [(cmd, text) for cmd, text in attempts if text.strip()]
+    rejected = bool(informative) and all(
+        _CLI_ERROR_RE.search(text) or _NOT_STACKED_RE.search(text)
+        for _cmd, text in informative
+    )
+    if looked_like_a_table or (informative and not rejected):
+        logger.warning(
+            "ios.get_chassis_members: %s: no stack members parsed from %s; the device "
+            "neither rejected the command nor reported itself standalone",
+            driver.hostname,
+            " then ".join(cmd for cmd, _text in attempts) or "no command",
+        )
+    else:
+        logger.debug(
+            "ios.get_chassis_members: %s: no stack concept on this platform "
+            "(commands rejected, or reported standalone)",
+            driver.hostname,
+        )
+
+
+def _ios_get_chassis_members_impl(driver) -> dict | None:
+    """
+    Implementation of IOSDriver.get_chassis_members (factored for testability).
+
+    Tries "show switch detail" first, which is what physical StackWise platforms
+    answer, then falls back to "show switch", the only form Catalyst
+    9400/9500/9600 in StackWise Virtual mode supports (they reject the "detail"
+    keyword outright). Both print the same member table, so one parser handles
+    both.
+    """
+    detail_rows: list[dict] = []
+    attempts: list[tuple[str, str]] = []
+    for command in ("show switch detail", "show switch"):
+        try:
+            raw = driver.device.send_command(command)
+        except Exception as e:
+            logger.warning(
+                "ios.get_chassis_members: %s: %s failed: %s",
+                driver.hostname, command, e,
+            )
+            continue
+        raw = raw or ""
+        attempts.append((command, raw))
+        # _parse_switch_table is a pure regex loop called OUTSIDE the try on
+        # purpose: it cannot raise on device output, so a genuine bug in it must
+        # propagate rather than be swallowed as "this host has no stack".
+        detail_rows = _parse_switch_table(raw)
+        if detail_rows:
+            break
 
     if not detail_rows:
+        _log_no_members(driver, attempts)
         return None
 
     try:
@@ -419,7 +530,10 @@ def _ios_get_chassis_members_impl(driver) -> dict | None:
             data=inv_out or "",
         )
     except Exception as e:
-        logger.warning("ios.get_chassis_members: show inventory failed: %s", e)
+        logger.warning(
+            "ios.get_chassis_members: %s: show inventory failed: %s",
+            driver.hostname, e,
+        )
         inv_rows = []
 
     serial_by_id, model_by_id = _index_inventory_by_switch(inv_rows or [])
@@ -441,7 +555,17 @@ def _ios_get_chassis_members_impl(driver) -> dict | None:
             )
         )
 
-    return to_payload(members, domain=None)
+    if len(members) < 2:
+        logger.warning(
+            "ios.get_chassis_members: %s: parsed %d stack member(s), need at least 2 "
+            "for a virtual chassis; falling back to a single Device",
+            driver.hostname, len(members),
+        )
+
+    # Additive: only StackWise Virtual platforms answer this, and a None domain
+    # is what physical stacks have always emitted.
+    domain = _ios_svl_domain(driver) if len(members) > 1 else None
+    return to_payload(members, domain=domain)
 
 
 # ---- module inventory ----------------------------------------------------

--- a/orb-discovery/device-discovery/custom_napalm/ios.py
+++ b/orb-discovery/device-discovery/custom_napalm/ios.py
@@ -354,8 +354,14 @@ def _parse_switch_table(text: str) -> list[dict]:
 # A bare "Chassis" (standalone, no member id) deliberately does not match — the
 # caller treats an empty index as "no per-member inventory available" and the
 # affected members are dropped by to_payload().
+# The whitespace between "Switch" and the id is OPTIONAL (\s*), matching
+# _INVENTORY_VC_SLOT_RE, _INVENTORY_VC_FRU_RE and _SWITCH_PREFIX_RE in this same
+# file: some IOS-XE releases emit the no-space "Switch1" form. With \s+ here,
+# those releases matched no chassis row at all, left serial_by_id empty, and
+# to_payload dropped every member -- so an SVL pair still fell back to a single
+# Device even though "show switch" had returned both members.
 _INVENTORY_CHASSIS_RE = re.compile(
-    r"^\s*(?:Switch\s+(\d+)(?:\s+Chassis)?|(\d+))\s*$",
+    r"^\s*(?:Switch\s*(\d+)(?:\s+Chassis)?|(\d+))\s*$",
     re.IGNORECASE,
 )
 

--- a/orb-discovery/device-discovery/custom_napalm/ios.py
+++ b/orb-discovery/device-discovery/custom_napalm/ios.py
@@ -266,6 +266,71 @@ def classify_module_type_cisco_ios(pid: str) -> _ModuleType:
     return "linecard"
 
 
+# Stack-member table row from "show switch" / "show switch detail".
+#
+# Parsed driver-locally rather than via ntc-templates because
+# cisco_ios_show_switch_detail.textfsm is ALL-OR-NOTHING: its STATE value is
+# (\w+), so a multi-word state such as "Version Mismatch" or "Sync not
+# started" raises TextFSMError and discards EVERY member row, not just the
+# offending one. A physical stack mid-upgrade therefore emitted no
+# VirtualChassis at all. Verified: those two states lose all rows; "Ready" and
+# "Provisioned" parse fine.
+#
+# Requiring the MAC column is what makes this safe. No header, separator,
+# banner or stack-port row carries one, which is why the stack-port data row
+# "1  Ok  Ok" cannot be mistaken for a member.
+_SWITCH_ROW_RE = re.compile(
+    r"^\s*\*?\s*(?P<id>\d{1,2})\s+"
+    r"(?P<role>[A-Za-z][A-Za-z-]*)\s+"
+    r"(?P<mac>[0-9A-Fa-f]{4}\.[0-9A-Fa-f]{4}\.[0-9A-Fa-f]{4}"
+    r"|[0-9A-Fa-f]{2}(?::[0-9A-Fa-f]{2}){5})\s+"
+    r"(?P<priority>\d+)"
+    r"(?:\s+(?P<version>V?[0-9][\w.]*))?"
+    r"\s+(?P<state>[A-Za-z][A-Za-z0-9 /_-]*?)\s*$"
+)
+
+# The Stack Port / Neighbors sections follow the member table on physical
+# stacks. Their rows cannot match _SWITCH_ROW_RE anyway (no MAC column), so
+# this bound is defence in depth, not the primary mechanism.
+_SWITCH_TABLE_END_RE = re.compile(
+    r"^\s*(?:Switch#\s+Port\s+1\b|Stack\s+Port\s+Status)",
+    re.IGNORECASE,
+)
+
+
+def _parse_switch_table(text: str) -> list[dict]:
+    """
+    Parse the stack-member table from "show switch" / "show switch detail".
+
+    Returns one dict per member row, with the same keys the ntc template
+    produces (switch, role, mac_address, priority, version, state) so callers
+    are unchanged. ``version`` is "" when the column is absent.
+
+    Degrades one row at a time: an unrecognised line is skipped rather than
+    discarding the whole table, which is the behaviour difference from
+    ntc-templates that this function exists for.
+    """
+    rows: list[dict] = []
+    for line in (text or "").splitlines():
+        if _SWITCH_TABLE_END_RE.match(line):
+            break
+        match = _SWITCH_ROW_RE.match(line)
+        if not match:
+            continue
+        found = match.groupdict()
+        rows.append(
+            {
+                "switch": found["id"],
+                "role": found["role"],
+                "mac_address": found["mac"],
+                "priority": found["priority"],
+                "version": found["version"] or "",
+                "state": found["state"],
+            }
+        )
+    return rows
+
+
 # Two NAME formats are seen in the wild for stack members:
 #   "Switch 1"   — Catalyst 3850/9300/2960X StackWise (most common)
 #   "1"          — Some IOS / IOS-XE versions emit just the slot number

--- a/orb-discovery/device-discovery/custom_napalm/ios.py
+++ b/orb-discovery/device-discovery/custom_napalm/ios.py
@@ -279,13 +279,20 @@ def classify_module_type_cisco_ios(pid: str) -> _ModuleType:
 # Requiring the MAC column is what makes this safe. No header, separator,
 # banner or stack-port row carries one, which is why the stack-port data row
 # "1  Ok  Ok" cannot be mistaken for a member.
+#
+# The version column is captured as \S+ rather than a digit-leading pattern
+# because real H/W versions are often letter-leading (a 2960X reports "P2B").
+# Anchoring it to digits made the version fall through into state, producing
+# state="P2B     Ready". A row with no version column AND a multi-word state
+# would still mis-split, but every multi-word state observed occurs on a
+# present member, which always reports a version.
 _SWITCH_ROW_RE = re.compile(
     r"^\s*\*?\s*(?P<id>\d{1,2})\s+"
     r"(?P<role>[A-Za-z][A-Za-z-]*)\s+"
     r"(?P<mac>[0-9A-Fa-f]{4}\.[0-9A-Fa-f]{4}\.[0-9A-Fa-f]{4}"
     r"|[0-9A-Fa-f]{2}(?::[0-9A-Fa-f]{2}){5})\s+"
     r"(?P<priority>\d+)"
-    r"(?:\s+(?P<version>V?[0-9][\w.]*))?"
+    r"(?:\s+(?P<version>\S+))?"
     r"\s+(?P<state>[A-Za-z][A-Za-z0-9 /_-]*?)\s*$"
 )
 

--- a/orb-discovery/device-discovery/custom_napalm/ios.py
+++ b/orb-discovery/device-discovery/custom_napalm/ios.py
@@ -338,36 +338,60 @@ def _parse_switch_table(text: str) -> list[dict]:
     return rows
 
 
-# Two NAME formats are seen in the wild for stack members:
-#   "Switch 1"   — Catalyst 3850/9300/2960X StackWise (most common)
-#   "1"          — Some IOS / IOS-XE versions emit just the slot number
-# Anything else (e.g. "Chassis", "GigabitEthernet1/0/1") is ignored — the caller
-# treats an empty index as "no per-member inventory available" and the affected
-# members are dropped by to_payload().
-_INVENTORY_NAME_RE = re.compile(r"^(?:Switch\s+)?(\d+)$", re.IGNORECASE)
+# show inventory NAME rows that identify a stack/VC member CHASSIS:
+#   "Switch 1"          — Catalyst 3850/9300/2960X StackWise (most common)
+#   "1"                 — Some IOS / IOS-XE versions emit just the slot number
+#   "Switch 1 Chassis"  — Catalyst 9400/9500/9600 StackWise Virtual
+#
+# ANCHORED ON PURPOSE. Loosening this to r"^Switch\s+(\d+)\b" so that any suffix
+# is allowed also matches "Switch 1 Power Supply Module 0", "Switch 1 Fan Tray
+# 0" and "Switch 1 Slot 1 Supervisor". On a C9500 that happens to be harmless
+# because the chassis and supervisor report the same PID and serial, but on a
+# modular 9400 it yields model="C9400-PWR-3200AC" and the power supply's
+# serial. Serial is NetBox's device matcher, so that attaches discovery to the
+# WRONG device record. Do not relax the trailing anchor.
+#
+# A bare "Chassis" (standalone, no member id) deliberately does not match — the
+# caller treats an empty index as "no per-member inventory available" and the
+# affected members are dropped by to_payload().
+_INVENTORY_CHASSIS_RE = re.compile(
+    r"^\s*(?:Switch\s+(\d+)(?:\s+Chassis)?|(\d+))\s*$",
+    re.IGNORECASE,
+)
 
 
 def _index_inventory_by_switch(rows: list[dict]) -> tuple[dict[int, str], dict[int, str]]:
     """
     Return (serial_by_switch_id, model_by_switch_id) parsed from `show inventory`.
 
-    Matches NAME values of the form 'Switch N' or bare 'N' (case-insensitive). On
-    standalone IOS the NAME is 'Chassis' and yields empty dicts — caller treats
-    that as "no per-member inventory available".
+    Both fields for a member are committed from the SAME inventory row, so they
+    can never be mixed across rows. When several rows claim one member id the
+    winner is chosen by (has a serial, then an explicit "Chassis" suffix) rather
+    than by emission order.
+
+    On standalone IOS the NAME is 'Chassis' and this yields empty dicts — caller
+    treats that as "no per-member inventory available".
     """
-    serial_by_id: dict[int, str] = {}
-    model_by_id: dict[int, str] = {}
+    # sid -> (rank, serial, model); rank orders candidate rows for one member.
+    best: dict[int, tuple[tuple[int, int], str, str]] = {}
     for row in rows or []:
-        m = _INVENTORY_NAME_RE.match((row.get("name") or "").strip())
-        if not m:
+        name = (row.get("name") or "").strip()
+        match = _INVENTORY_CHASSIS_RE.match(name)
+        if not match:
             continue
-        sid = int(m.group(1))
-        sn = (row.get("sn") or "").strip()
-        pid = (row.get("pid") or "").strip()
-        if sn:
-            serial_by_id[sid] = sn
-        if pid:
-            model_by_id[sid] = pid
+        sid = int(match.group(1) or match.group(2))
+        serial = (row.get("sn") or "").strip()
+        model = (row.get("pid") or "").strip()
+        # A serial-bearing row always beats one without, so a chassis row with a
+        # blank SN cannot shadow a usable bare "Switch N" row and leave the
+        # member serial-less.
+        rank = (1 if serial else 0, 1 if name.lower().endswith("chassis") else 0)
+        current = best.get(sid)
+        if current is None or rank >= current[0]:
+            best[sid] = (rank, serial, model)
+
+    serial_by_id = {sid: s for sid, (_rank, s, _m) in best.items() if s}
+    model_by_id = {sid: m for sid, (_rank, _s, m) in best.items() if m}
     return serial_by_id, model_by_id
 
 

--- a/orb-discovery/device-discovery/custom_napalm/ios.py
+++ b/orb-discovery/device-discovery/custom_napalm/ios.py
@@ -409,14 +409,6 @@ _NOT_STACKED_RE = re.compile(
     re.IGNORECASE,
 )
 
-# The member-table header. Present but no rows parsed means we were handed a
-# switch table we failed to understand, which is worth an operator's attention.
-_SWITCH_TABLE_HEADER_RE = re.compile(
-    r"^\s*Switch#\s+Role\b",
-    re.IGNORECASE | re.MULTILINE,
-)
-
-
 # "show stackwise-virtual" has no ntc-template (no template file, no index
 # entry), so the one line we need is read directly. Only Catalyst 9400/9500/9600
 # in StackWise Virtual mode answer this command; physical stacks reject it, which
@@ -462,9 +454,6 @@ def _log_no_members(driver, attempts: list[tuple[str, str]]) -> None:
     intended outcome for the expected cases, and it removes the per-cycle
     WARNING that every non-Catalyst IOS device used to emit.
     """
-    looked_like_a_table = any(
-        _SWITCH_TABLE_HEADER_RE.search(text) for _cmd, text in attempts
-    )
     # Only non-empty output carries information. A command that returned nothing
     # tells us neither that the platform rejected it nor that anything is wrong,
     # so it must not drag the classification into the WARNING branch.
@@ -473,7 +462,12 @@ def _log_no_members(driver, attempts: list[tuple[str, str]]) -> None:
         _CLI_ERROR_RE.search(text) or _NOT_STACKED_RE.search(text)
         for _cmd, text in informative
     )
-    if looked_like_a_table or (informative and not rejected):
+    # Deliberately NOT also testing for the member-table header. Output that
+    # looks like a table but parses to nothing already lands here via
+    # "not rejected", so a header test adds nothing — and it would actively
+    # misfire on a release that prints the column header above an explicit
+    # "Switch is not on any stack.", turning a standalone device into a warning.
+    if informative and not rejected:
         logger.warning(
             "ios.get_chassis_members: %s: no stack members parsed from %s; the device "
             "neither rejected the command nor reported itself standalone",
@@ -555,17 +549,32 @@ def _ios_get_chassis_members_impl(driver) -> dict | None:
             )
         )
 
-    if len(members) < 2:
-        logger.warning(
-            "ios.get_chassis_members: %s: parsed %d stack member(s), need at least 2 "
-            "for a virtual chassis; falling back to a single Device",
-            driver.hostname, len(members),
-        )
-
     # Additive: only StackWise Virtual platforms answer this, and a None domain
     # is what physical stacks have always emitted.
     domain = _ios_svl_domain(driver) if len(members) > 1 else None
-    return to_payload(members, domain=domain)
+    payload = to_payload(members, domain=domain)
+
+    emitted = len(payload["members"]) if payload else 0
+    if emitted < 2:
+        if len(detail_rows) >= 2:
+            # The device reported a stack but we cannot represent it: to_payload
+            # drops members whose serial could not be resolved from inventory.
+            # That is a real gap worth an operator's attention.
+            logger.warning(
+                "ios.get_chassis_members: %s: the device reported %d stack member row(s) "
+                "but only %d had a resolvable serial; falling back to a single Device",
+                driver.hostname, len(detail_rows), emitted,
+            )
+        else:
+            # A single-unit stack-capable Catalyst honestly reports one row. That
+            # is the most common deployment in a fleet and is not a problem, so
+            # it must not warn on every discovery cycle.
+            logger.debug(
+                "ios.get_chassis_members: %s: device reported a single unit; "
+                "not a virtual chassis",
+                driver.hostname,
+            )
+    return payload
 
 
 # ---- module inventory ----------------------------------------------------

--- a/orb-discovery/device-discovery/device_discovery/translate_chassis.py
+++ b/orb-discovery/device-discovery/device_discovery/translate_chassis.py
@@ -93,14 +93,22 @@ def validate_chassis_payload(payload) -> list[dict] | None:
         seen_serials.add(serial)
         valid.append(m)
     if len(valid) < 2:
-        # Say so rather than returning None silently: a partial parse degrading
-        # to a single Device is otherwise indistinguishable from a device that
-        # was never in a stack.
-        logger.warning(
-            "chassis_members: %d valid member(s) after validation, need at least 2; "
-            "falling back to a single Device",
-            len(valid),
-        )
+        # Warn only when validation actually DROPPED members, which means a
+        # driver handed us a stack we could not represent — worth an operator's
+        # attention because the silent version of this was invisible until a user
+        # noticed missing NetBox data.
+        #
+        # A payload that simply contains fewer than two members is a standalone
+        # device, not a partial parse. This function is driver-agnostic, and a
+        # single-member payload is documented-normal for several drivers, so
+        # warning on it would spam every standalone device in a fleet on every
+        # cycle.
+        if len(members_raw) >= 2:
+            logger.warning(
+                "chassis_members: %d of %d member(s) survived validation, need at "
+                "least 2; falling back to a single Device",
+                len(valid), len(members_raw),
+            )
         return None
     valid.sort(key=lambda m: m["id"])
     return valid

--- a/orb-discovery/device-discovery/device_discovery/translate_chassis.py
+++ b/orb-discovery/device-discovery/device_discovery/translate_chassis.py
@@ -93,6 +93,14 @@ def validate_chassis_payload(payload) -> list[dict] | None:
         seen_serials.add(serial)
         valid.append(m)
     if len(valid) < 2:
+        # Say so rather than returning None silently: a partial parse degrading
+        # to a single Device is otherwise indistinguishable from a device that
+        # was never in a stack.
+        logger.warning(
+            "chassis_members: %d valid member(s) after validation, need at least 2; "
+            "falling back to a single Device",
+            len(valid),
+        )
         return None
     valid.sort(key=lambda m: m["id"])
     return valid

--- a/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/mock_data/test_get_chassis_members/cat9500_svl_pair/expected_result.json
+++ b/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/mock_data/test_get_chassis_members/cat9500_svl_pair/expected_result.json
@@ -1,0 +1,23 @@
+{
+  "members": [
+    {
+      "id": 1,
+      "serial": "CAT11111111",
+      "model": "C9500-48Y4C",
+      "role": "active",
+      "priority": 15,
+      "mac": "e41f.0000.0001",
+      "state": "Ready"
+    },
+    {
+      "id": 2,
+      "serial": "CAT22222222",
+      "model": "C9500-48Y4C",
+      "role": "standby",
+      "priority": 14,
+      "mac": "e41f.0000.0002",
+      "state": "Ready"
+    }
+  ],
+  "domain": "1"
+}

--- a/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/mock_data/test_get_chassis_members/cat9500_svl_pair/show_inventory.txt
+++ b/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/mock_data/test_get_chassis_members/cat9500_svl_pair/show_inventory.txt
@@ -1,0 +1,23 @@
+NAME: "Switch 1 Chassis", DESCR: "Cisco Catalyst 9500 Series Chassis"
+PID: C9500-48Y4C       , VID: V02  , SN: CAT11111111
+
+NAME: "Switch 1 Power Supply Module 0", DESCR: "Cisco Catalyst 9500 Series 650W AC Power Supply"
+PID: C9K-PWR-650WAC-R  , VID: V01  , SN: XXXXXXXXXXX
+
+NAME: "Switch 1 Fan Tray 0", DESCR: "Cisco Catalyst 9500 Series Fan Tray"
+PID: C9K-T1-FANTRAY    , VID:      , SN:
+
+NAME: "Switch 1 Slot 1 Supervisor", DESCR: "Cisco Catalyst 9500 Series Router"
+PID: C9500-48Y4C       , VID: V02  , SN: CAT11111111
+
+NAME: "TwentyFiveGigE1/0/43", DESCR: "SFP 10/25GE CSR-S"
+PID: SFP-10/25G-CSR-S    , VID: V03  , SN: XXXXXXXXXXX
+
+NAME: "Switch 2 Chassis", DESCR: "Cisco Catalyst 9500 Series Chassis"
+PID: C9500-48Y4C       , VID: V02  , SN: CAT22222222
+
+NAME: "Switch 2 Power Supply Module 0", DESCR: "Cisco Catalyst 9500 Series 650W AC Power Supply"
+PID: C9K-PWR-650WAC-R  , VID: V01  , SN: XXXXXXXXXXX
+
+NAME: "Switch 2 Slot 1 Supervisor", DESCR: "Cisco Catalyst 9500 Series Router"
+PID: C9500-48Y4C       , VID: V02  , SN: CAT22222222

--- a/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/mock_data/test_get_chassis_members/cat9500_svl_pair/show_stackwise-virtual.txt
+++ b/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/mock_data/test_get_chassis_members/cat9500_svl_pair/show_stackwise-virtual.txt
@@ -1,0 +1,11 @@
+Stackwise Virtual Configuration:
+--------------------------------
+Stackwise Virtual : Enabled
+Domain Number : 1
+
+Switch  Stackwise Virtual Link  Ports
+------  ----------------------  ------
+1       1                       TwentyFiveGigE1/0/44
+                                TwentyFiveGigE1/0/45
+2       1                       TwentyFiveGigE2/0/44
+                                TwentyFiveGigE2/0/45

--- a/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/mock_data/test_get_chassis_members/cat9500_svl_pair/show_switch.txt
+++ b/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/mock_data/test_get_chassis_members/cat9500_svl_pair/show_switch.txt
@@ -1,0 +1,7 @@
+Switch/Stack Mac Address : e41f.0000.0001 - Local Mac Address
+Mac persistency wait time: Indefinite
+                                             H/W   Current
+Switch#   Role    Mac Address     Priority Version  State
+-------------------------------------------------------------------------------------
+*1       Active   e41f.0000.0001     15     V02     Ready
+ 2       Standby  e41f.0000.0002     14     V02     Ready

--- a/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/mock_data/test_get_chassis_members/cat9500_svl_pair/show_switch_detail.txt
+++ b/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/mock_data/test_get_chassis_members/cat9500_svl_pair/show_switch_detail.txt
@@ -1,0 +1,2 @@
+                  ^
+% Invalid input detected at '^' marker.

--- a/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/mock_data/test_get_chassis_members/stack_version_mismatch/expected_result.json
+++ b/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/mock_data/test_get_chassis_members/stack_version_mismatch/expected_result.json
@@ -1,0 +1,23 @@
+{
+  "members": [
+    {
+      "id": 1,
+      "serial": "FOC1111111",
+      "model": "C9300-24T",
+      "role": "active",
+      "priority": 15,
+      "mac": "0026.5a4b.c000",
+      "state": "Ready"
+    },
+    {
+      "id": 2,
+      "serial": "FOC2222222",
+      "model": "C9300-24T",
+      "role": "standby",
+      "priority": 14,
+      "mac": "0026.5a4b.d000",
+      "state": "Version Mismatch"
+    }
+  ],
+  "domain": null
+}

--- a/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/mock_data/test_get_chassis_members/stack_version_mismatch/show_inventory.txt
+++ b/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/mock_data/test_get_chassis_members/stack_version_mismatch/show_inventory.txt
@@ -1,0 +1,5 @@
+NAME: "Switch 1", DESCR: "Cisco Catalyst 9300 Switch"
+PID: C9300-24T          , VID: V02 , SN: FOC1111111
+
+NAME: "Switch 2", DESCR: "Cisco Catalyst 9300 Switch"
+PID: C9300-24T          , VID: V02 , SN: FOC2222222

--- a/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/mock_data/test_get_chassis_members/stack_version_mismatch/show_switch_detail.txt
+++ b/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/mock_data/test_get_chassis_members/stack_version_mismatch/show_switch_detail.txt
@@ -1,0 +1,7 @@
+Switch/Stack Mac Address : 0026.5a4b.c000 - Local Mac Address
+Mac persistency wait time: Indefinite
+                                             H/W   Current
+Switch#   Role    Mac Address     Priority Version  State
+-------------------------------------------------------------------------
+*1       Active   0026.5a4b.c000     15     V02     Ready
+ 2       Standby  0026.5a4b.d000     14     V02     Version Mismatch

--- a/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/test_chassis_observability.py
+++ b/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/test_chassis_observability.py
@@ -38,8 +38,18 @@ SWITCH_TABLE_HEADER = (
 )
 
 
-def _warnings(caplog):
-    return [r for r in caplog.records if r.levelno >= logging.WARNING]
+def _warnings(caplog, logger="custom_napalm.ios"):
+    """
+    Return WARNING+ records from one logger.
+
+    Scoped by logger because _chassis.to_payload legitimately warns about each
+    serial-less member it drops; that is complementary detail, not a duplicate of
+    the driver's summary, and it is not what these tests are pinning.
+    """
+    return [
+        r for r in caplog.records
+        if r.levelno >= logging.WARNING and r.name == logger
+    ]
 
 
 def test_unsupported_platform_is_quiet(caplog):
@@ -74,8 +84,15 @@ def test_unparseable_switch_table_warns_with_hostname_and_command(caplog):
     assert "show switch" in message
 
 
-def test_single_member_warns_with_the_count(caplog):
-    """One member cannot form a VirtualChassis; say so rather than going quiet."""
+def test_honest_single_unit_does_not_warn(caplog):
+    """
+    A standalone stack-capable Catalyst reports one row and must stay quiet.
+
+    2960S/2960X/3850/9200/9300 answer "show switch detail" with a one-row member
+    table when they are not stacked. That is the most common deployment in a
+    fleet, so warning would fire on every device on every discovery cycle. Only
+    a stack we could not REPRESENT is worth a warning (see the test below).
+    """
     driver = _FakeDriver(
         {
             "show switch detail": (
@@ -90,10 +107,8 @@ def test_single_member_warns_with_the_count(caplog):
     )
     with caplog.at_level(logging.DEBUG, logger="custom_napalm.ios"):
         _ios_get_chassis_members_impl(driver)
-    warnings = _warnings(caplog)
-    assert len(warnings) == 1
-    assert "1" in warnings[0].getMessage()
-    assert "device-01" in warnings[0].getMessage()
+    assert _warnings(caplog) == []
+    assert any("single unit" in r.getMessage() for r in caplog.records)
 
 
 def test_falls_back_to_show_switch_and_sends_both_commands():
@@ -139,3 +154,73 @@ def test_domain_is_not_requested_on_a_single_member():
     )
     _ios_get_chassis_members_impl(driver)
     assert "show stackwise-virtual" not in driver.device.commands
+
+
+def test_unresolvable_serial_on_a_real_stack_warns(caplog):
+    """
+    A reported stack we cannot represent IS worth a warning.
+
+    Two member rows but only one resolvable serial means to_payload drops a
+    member, so the pair silently degrades to a single Device. That is the case
+    an operator needs to see, as distinct from an honest single unit.
+    """
+    driver = _FakeDriver(
+        {
+            "show switch detail": (
+                SWITCH_TABLE_HEADER
+                + "*1       Active   0026.5a4b.c000     15     V02     Ready\n"
+                + " 2       Standby  0026.5a4b.d000     14     V02     Ready\n"
+            ),
+            # Only member 1 has an inventory chassis row.
+            "show inventory": (
+                'NAME: "Switch 1", DESCR: "Cisco Catalyst 9300 Switch"\n'
+                "PID: C9300-24T          , VID: V02 , SN: FOC1111111\n"
+            ),
+        }
+    )
+    with caplog.at_level(logging.DEBUG, logger="custom_napalm.ios"):
+        _ios_get_chassis_members_impl(driver)
+    warnings = _warnings(caplog)
+    assert len(warnings) == 1
+    message = warnings[0].getMessage()
+    assert "device-01" in message
+    assert "resolvable serial" in message
+
+
+def test_send_command_failure_still_tries_the_next_command():
+    """
+    A raising command must not abort the fallback.
+
+    If the first command raises (transport hiccup, unexpected prompt) the loop
+    must continue to "show switch"; returning early instead would make SVL
+    discovery depend on a command that platform does not implement.
+    """
+    calls: list[str] = []
+
+    class _RaisingDevice:
+        def send_command(self, command):
+            calls.append(command)
+            if command == "show switch detail":
+                raise RuntimeError("transport hiccup")
+            if command == "show switch":
+                return (
+                    SWITCH_TABLE_HEADER
+                    + "*1       Active   e41f.0000.0001     15     V02     Ready\n"
+                    + " 2       Standby  e41f.0000.0002     14     V02     Ready\n"
+                )
+            if command == "show inventory":
+                return (
+                    'NAME: "Switch 1 Chassis", DESCR: "C9500"\n'
+                    "PID: C9500-48Y4C , VID: V02 , SN: CAT11111111\n"
+                    "\n"
+                    'NAME: "Switch 2 Chassis", DESCR: "C9500"\n'
+                    "PID: C9500-48Y4C , VID: V02 , SN: CAT22222222\n"
+                )
+            return ""
+
+    driver = _FakeDriver({})
+    driver.device = _RaisingDevice()
+    result = _ios_get_chassis_members_impl(driver)
+    assert result is not None
+    assert [m["id"] for m in result["members"]] == [1, 2]
+    assert "show switch" in calls

--- a/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/test_chassis_observability.py
+++ b/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/test_chassis_observability.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""The reason no VirtualChassis was emitted must be diagnosable from the log."""
+
+import logging
+
+from custom_napalm.ios import _ios_get_chassis_members_impl
+
+
+class _FakeDevice:
+    """Returns canned output per command, and "" for anything unasked-for."""
+
+    def __init__(self, responses):
+        self._responses = responses
+        self.commands: list[str] = []
+
+    def send_command(self, command):
+        """Record the command and return its canned response."""
+        self.commands.append(command)
+        return self._responses.get(command, "")
+
+
+class _FakeDriver:
+    """Minimal stand-in for IOSDriver: a device plus the hostname used in logs."""
+
+    def __init__(self, responses, hostname="device-01"):
+        self.device = _FakeDevice(responses)
+        self.hostname = hostname
+
+
+CLI_ERROR = "                  ^\n% Invalid input detected at '^' marker.\n"
+
+SWITCH_TABLE_HEADER = (
+    "Switch/Stack Mac Address : 0026.5a4b.c000 - Local Mac Address\n"
+    "                                             H/W   Current\n"
+    "Switch#   Role    Mac Address     Priority Version  State\n"
+    "-------------------------------------------------------------\n"
+)
+
+
+def _warnings(caplog):
+    return [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def test_unsupported_platform_is_quiet(caplog):
+    """A router with no stack concept must not warn on every discovery cycle."""
+    driver = _FakeDriver({"show switch detail": CLI_ERROR, "show switch": CLI_ERROR})
+    with caplog.at_level(logging.DEBUG, logger="custom_napalm.ios"):
+        assert _ios_get_chassis_members_impl(driver) is None
+    assert _warnings(caplog) == []
+    assert any("device-01" in r.getMessage() for r in caplog.records)
+
+
+def test_standalone_is_quiet(caplog):
+    """An explicit standalone answer is expected, not a problem worth warning."""
+    driver = _FakeDriver({"show switch detail": "Switch is not on any stack.\n"})
+    with caplog.at_level(logging.DEBUG, logger="custom_napalm.ios"):
+        assert _ios_get_chassis_members_impl(driver) is None
+    assert _warnings(caplog) == []
+
+
+def test_unparseable_switch_table_warns_with_hostname_and_command(caplog):
+    """Output that LOOKS like a member table but yields nothing is the loud case."""
+    unparseable = SWITCH_TABLE_HEADER + " 1  Active  <unexpected>\n"
+    driver = _FakeDriver(
+        {"show switch detail": unparseable, "show switch": unparseable}
+    )
+    with caplog.at_level(logging.DEBUG, logger="custom_napalm.ios"):
+        assert _ios_get_chassis_members_impl(driver) is None
+    warnings = _warnings(caplog)
+    assert len(warnings) == 1
+    message = warnings[0].getMessage()
+    assert "device-01" in message
+    assert "show switch" in message
+
+
+def test_single_member_warns_with_the_count(caplog):
+    """One member cannot form a VirtualChassis; say so rather than going quiet."""
+    driver = _FakeDriver(
+        {
+            "show switch detail": (
+                SWITCH_TABLE_HEADER
+                + "*1       Active   0026.5a4b.c000     15     V02     Ready\n"
+            ),
+            "show inventory": (
+                'NAME: "Switch 1", DESCR: "Cisco Catalyst 9300 Switch"\n'
+                "PID: C9300-24T          , VID: V02 , SN: FOC1111111\n"
+            ),
+        }
+    )
+    with caplog.at_level(logging.DEBUG, logger="custom_napalm.ios"):
+        _ios_get_chassis_members_impl(driver)
+    warnings = _warnings(caplog)
+    assert len(warnings) == 1
+    assert "1" in warnings[0].getMessage()
+    assert "device-01" in warnings[0].getMessage()
+
+
+def test_falls_back_to_show_switch_and_sends_both_commands():
+    """SVL rejects the detail form, so both commands must be tried in order."""
+    driver = _FakeDriver(
+        {
+            "show switch detail": CLI_ERROR,
+            "show switch": (
+                SWITCH_TABLE_HEADER
+                + "*1       Active   e41f.0000.0001     15     V02     Ready\n"
+                + " 2       Standby  e41f.0000.0002     14     V02     Ready\n"
+            ),
+            "show inventory": (
+                'NAME: "Switch 1 Chassis", DESCR: "Cisco Catalyst 9500 Series Chassis"\n'
+                "PID: C9500-48Y4C       , VID: V02  , SN: CAT11111111\n"
+                "\n"
+                'NAME: "Switch 2 Chassis", DESCR: "Cisco Catalyst 9500 Series Chassis"\n'
+                "PID: C9500-48Y4C       , VID: V02  , SN: CAT22222222\n"
+            ),
+        }
+    )
+    result = _ios_get_chassis_members_impl(driver)
+    assert result is not None
+    assert [m["id"] for m in result["members"]] == [1, 2]
+    sent = driver.device.commands
+    assert sent[0] == "show switch detail"
+    assert "show switch" in sent[1:]
+
+
+def test_domain_is_not_requested_on_a_single_member():
+    """The SVL domain command is only worth sending once a stack is confirmed."""
+    driver = _FakeDriver(
+        {
+            "show switch detail": (
+                SWITCH_TABLE_HEADER
+                + "*1       Active   0026.5a4b.c000     15     V02     Ready\n"
+            ),
+            "show inventory": (
+                'NAME: "Switch 1", DESCR: "Cisco Catalyst 9300 Switch"\n'
+                "PID: C9300-24T          , VID: V02 , SN: FOC1111111\n"
+            ),
+        }
+    )
+    _ios_get_chassis_members_impl(driver)
+    assert "show stackwise-virtual" not in driver.device.commands

--- a/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/test_inventory_chassis.py
+++ b/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/test_inventory_chassis.py
@@ -113,12 +113,12 @@ def test_whitespace_and_casing_tolerated():
 
 
 def test_accepts_the_no_space_switch_form():
-    """
+    r"""
     Some IOS-XE releases emit "Switch1" with no space before the id.
 
     This file's module-discovery regexes (_INVENTORY_VC_SLOT_RE,
-    _INVENTORY_VC_FRU_RE, _SWITCH_PREFIX_RE) all use \\s* for exactly that
-    reason. With \\s+ here, those releases matched no chassis row, left the
+    _INVENTORY_VC_FRU_RE, _SWITCH_PREFIX_RE) all use \s* for exactly that
+    reason. With \s+ here, those releases matched no chassis row, left the
     serial index empty, and to_payload dropped every member -- so an SVL pair
     still degraded to a single Device even though the member table parsed.
     """

--- a/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/test_inventory_chassis.py
+++ b/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/test_inventory_chassis.py
@@ -110,3 +110,42 @@ def test_whitespace_and_casing_tolerated():
     )
     assert serial == {1: "CAT11111111"}
     assert model == {1: "C9500-48Y4C"}
+
+
+def test_accepts_the_no_space_switch_form():
+    """
+    Some IOS-XE releases emit "Switch1" with no space before the id.
+
+    This file's module-discovery regexes (_INVENTORY_VC_SLOT_RE,
+    _INVENTORY_VC_FRU_RE, _SWITCH_PREFIX_RE) all use \\s* for exactly that
+    reason. With \\s+ here, those releases matched no chassis row, left the
+    serial index empty, and to_payload dropped every member -- so an SVL pair
+    still degraded to a single Device even though the member table parsed.
+    """
+    serial, model = _index_inventory_by_switch(
+        _rows(
+            ("Switch1 Chassis", "C9500-48Y4C", "CAT11111111"),
+            ("Switch2 Chassis", "C9500-48Y4C", "CAT22222222"),
+        )
+    )
+    assert serial == {1: "CAT11111111", 2: "CAT22222222"}
+    assert model == {1: "C9500-48Y4C", 2: "C9500-48Y4C"}
+
+
+def test_no_space_bare_switch_form_also_accepted():
+    """The no-space form without a Chassis suffix is a physical-stack shape."""
+    serial, _model = _index_inventory_by_switch(
+        _rows(("Switch1", "WS-C3850-12XS", "FOC1111111"))
+    )
+    assert serial == {1: "FOC1111111"}
+
+
+def test_no_space_component_rows_are_still_rejected():
+    """Optional whitespace must not weaken the component-row protection."""
+    assert _index_inventory_by_switch(
+        _rows(
+            ("Switch1 Power Supply Module 0", "C9K-PWR-650WAC-R", "XXXXXXXXXXX"),
+            ("Switch1 Slot 1 Supervisor", "C9500-48Y4C", "CAT11111111"),
+            ("Switch1 Fan Tray 0", "C9K-T1-FANTRAY", ""),
+        )
+    ) == ({}, {})

--- a/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/test_inventory_chassis.py
+++ b/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/test_inventory_chassis.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""Unit tests for chassis-row matching in show inventory."""
+
+from custom_napalm.ios import _index_inventory_by_switch
+
+
+def _rows(*triples):
+    """Build show-inventory row dicts from (name, pid, sn) triples."""
+    return [{"name": n, "pid": p, "sn": s} for n, p, s in triples]
+
+
+def test_accepts_switch_n_chassis_from_real_svl_inventory():
+    """The C9500 SVL chassis rows resolve to per-member serial and model."""
+    rows = _rows(
+        ("Switch 1 Chassis", "C9500-48Y4C", "CAT11111111"),
+        ("Switch 1 Power Supply Module 0", "C9K-PWR-650WAC-R", "XXXXXXXXXXX"),
+        ("Switch 1 Fan Tray 0", "C9K-T1-FANTRAY", ""),
+        ("Switch 1 Slot 1 Supervisor", "C9500-48Y4C", "CAT11111111"),
+        ("TwentyFiveGigE1/0/43", "SFP-10/25G-CSR-S", "XXXXXXXXXXX"),
+        ("Switch 2 Chassis", "C9500-48Y4C", "CAT22222222"),
+        ("Switch 2 Slot 1 Supervisor", "C9500-48Y4C", "CAT22222222"),
+    )
+    serial, model = _index_inventory_by_switch(rows)
+    assert serial == {1: "CAT11111111", 2: "CAT22222222"}
+    assert model == {1: "C9500-48Y4C", 2: "C9500-48Y4C"}
+
+
+def test_modular_chassis_does_not_take_component_identity():
+    r"""
+    On a modular 9400 the member must take the CHASSIS pid and serial.
+
+    A matcher loosened to r"^Switch\s+(\d+)\b" also matches the supervisor and
+    power supply rows and, being last-write-wins, yields
+    model="C9400-PWR-3200AC" and the power supply's serial. Serial is NetBox's
+    device matcher, so that attaches discovery to the wrong record. This test
+    fails against that loosened regex.
+    """
+    rows = _rows(
+        ("Switch 1 Chassis", "C9407R", "FOX1111111"),
+        ("Switch 1 Slot 3 Supervisor", "C9400-SUP-1XL", "JAE2222222"),
+        ("Switch 1 Power Supply Module 0", "C9400-PWR-3200AC", "ART3333333"),
+    )
+    serial, model = _index_inventory_by_switch(rows)
+    assert serial == {1: "FOX1111111"}
+    assert model == {1: "C9407R"}
+
+
+def test_still_accepts_legacy_physical_stack_names():
+    """Bare "Switch N" and bare "N" keep working for physical stacks."""
+    serial, model = _index_inventory_by_switch(
+        _rows(
+            ("Switch 1", "WS-C3850-12XS", "FOC1111111"),
+            ("2", "WS-C3850-12XS", "FOC2222222"),
+        )
+    )
+    assert serial == {1: "FOC1111111", 2: "FOC2222222"}
+    assert model == {1: "WS-C3850-12XS", 2: "WS-C3850-12XS"}
+
+
+def test_standalone_chassis_row_without_a_number_is_ignored():
+    """A bare "Chassis" NAME carries no member id, so it yields nothing."""
+    assert _index_inventory_by_switch(
+        _rows(("Chassis", "WS-C3850-12XS", "FOC2401L0AB"))
+    ) == ({}, {})
+
+
+def test_component_rows_alone_yield_nothing():
+    """Component rows must never supply a member identity on their own."""
+    assert _index_inventory_by_switch(
+        _rows(
+            ("Switch 1 Power Supply Module 0", "C9K-PWR-650WAC-R", "XXXXXXXXXXX"),
+            ("Switch 1 Slot 1 Supervisor", "C9500-48Y4C", "CAT11111111"),
+            ("Switch 1 Fan Tray 0", "C9K-T1-FANTRAY", ""),
+        )
+    ) == ({}, {})
+
+
+def test_serial_and_model_come_from_the_same_row():
+    """
+    Fields must be committed atomically, never mixed across rows.
+
+    The pre-fix code wrote serial and model through two independent
+    conditionals, so a bare row and a Chassis row could each supply one field.
+    """
+    rows = _rows(
+        ("Switch 1", "WRONG-PID", "WRONG-SN"),
+        ("Switch 1 Chassis", "C9500-48Y4C", "CAT11111111"),
+    )
+    serial, model = _index_inventory_by_switch(rows)
+    assert serial == {1: "CAT11111111"}
+    assert model == {1: "C9500-48Y4C"}
+
+
+def test_a_chassis_row_with_no_serial_loses_to_a_row_that_has_one():
+    """Preferring a serial-bearing row keeps both fields from that one row."""
+    rows = _rows(
+        ("Switch 1 Chassis", "C9500-48Y4C", ""),
+        ("Switch 1", "C9500-48Y4C", "CAT11111111"),
+    )
+    serial, model = _index_inventory_by_switch(rows)
+    assert serial == {1: "CAT11111111"}
+    assert model == {1: "C9500-48Y4C"}
+
+
+def test_whitespace_and_casing_tolerated():
+    """Real captures pad the NAME column; casing varies between releases."""
+    serial, model = _index_inventory_by_switch(
+        _rows(("  switch 1 chassis  ", "C9500-48Y4C", "CAT11111111"))
+    )
+    assert serial == {1: "CAT11111111"}
+    assert model == {1: "C9500-48Y4C"}

--- a/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/test_switch_table.py
+++ b/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/test_switch_table.py
@@ -55,6 +55,14 @@ FIXTURES = (
             {"switch": "3", "role": "Member", "mac_address": "e4:1f:00:00:00:03",
              "priority": "5", "version": "V02", "state": "Ready"},
         ),
+        # Regression: a digit-anchored version pattern put "P2B" into state
+        # (a real 2960X H/W version, letter-leading), producing
+        # state="P2B     Ready" instead of version="P2B" state="Ready".
+        (
+            "*1       Active   0011.2233.4455     15     P2B     Ready",
+            {"switch": "1", "role": "Active", "mac_address": "0011.2233.4455",
+             "priority": "15", "version": "P2B", "state": "Ready"},
+        ),
     ],
 )
 def test_parses_member_rows(line, expected):
@@ -102,22 +110,51 @@ def _fixture_dirs():
     return sorted(d for d in FIXTURES.iterdir() if (d / "show_switch_detail.txt").exists())
 
 
+# The shared field set both parsers populate. Comparing only "switch" would
+# let a field-level regression (e.g. version data bleeding into state) pass
+# unnoticed, which is exactly what happened before the version group was
+# widened from a digit-leading pattern to \S+.
+_COMPARISON_FIELDS = ("switch", "role", "mac_address", "priority", "version", "state")
+
+
+def _comparable(row: dict) -> tuple:
+    """
+    Extract the six shared fields from a row dict as a tuple, in fixed order.
+
+    A missing key or an explicit ``None`` both normalise to ``""`` so a
+    template row that omits an unset field compares equal to the local
+    parser's row, which always sets it to ``""``.
+    """
+    return tuple((row.get(field) or "") for field in _COMPARISON_FIELDS)
+
+
 @pytest.mark.parametrize("fixture", _fixture_dirs(), ids=lambda d: d.name)
 def test_parity_with_ntc_template(fixture):
     """
-    The local parser is a strict superset of the template on every fixture.
+    The local parser agrees with the template field-for-field, and is a strict superset.
 
-    Where the template succeeds it must agree exactly. Where the template
-    raises (it is all-or-nothing) the local parser must still return a list,
-    never raise.
+    Where the template succeeds, every row must match on all six shared
+    fields (switch, role, mac_address, priority, version, state) — not just
+    the switch id, which would miss a field-level regression such as version
+    data bleeding into state. Where the template raises (it is
+    all-or-nothing) the local parser must still return a list, never raise;
+    for the one fixture that triggers this today ("Switch is not on any
+    stack.", which carries no member row at all) that list is empty, and the
+    test asserts that exact count rather than merely the type.
     """
     text = (fixture / "show_switch_detail.txt").read_text()
-    local_ids = [r["switch"] for r in _parse_switch_table(text)]
+    local_rows = _parse_switch_table(text)
     try:
         template_rows = parse_output(
             platform="cisco_ios", command="show switch detail", data=text
         )
     except Exception:
-        assert isinstance(local_ids, list)
+        # local_rows was already produced above, unguarded, so simply
+        # reaching this branch already proves the local parser did not
+        # raise where the template did. The substantive check is that its
+        # row count is the one actually correct for this input: this
+        # fixture's raw text is only the "not on any stack" banner, with no
+        # member row for either parser to find.
+        assert local_rows == []
         return
-    assert local_ids == [r["switch"] for r in template_rows]
+    assert [_comparable(r) for r in local_rows] == [_comparable(r) for r in template_rows]

--- a/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/test_switch_table.py
+++ b/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/test_switch_table.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""Unit tests for the driver-local stack-member table parser."""
+
+import pathlib
+
+import pytest
+from ntc_templates.parse import parse_output
+
+from custom_napalm.ios import _parse_switch_table
+
+FIXTURES = (
+    pathlib.Path(__file__).parent / "mock_data" / "test_get_chassis_members"
+)
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        (
+            "*1       Active   e41f.0000.0001     15     V02     Ready",
+            {"switch": "1", "role": "Active", "mac_address": "e41f.0000.0001",
+             "priority": "15", "version": "V02", "state": "Ready"},
+        ),
+        (
+            " 2       Standby  e41f.0000.0002     14     V02     Ready",
+            {"switch": "2", "role": "Standby", "mac_address": "e41f.0000.0002",
+             "priority": "14", "version": "V02", "state": "Ready"},
+        ),
+        (
+            " 2       Standby  0026.5a4b.d000     14             Ready",
+            {"switch": "2", "role": "Standby", "mac_address": "0026.5a4b.d000",
+             "priority": "14", "version": "", "state": "Ready"},
+        ),
+        # The ntc template raises TextFSMError on these two, discarding EVERY
+        # row, because its STATE value is (\w+). That is the bug this parser
+        # exists to fix; do not "simplify" these cases away.
+        (
+            " 2       Standby  0026.5a4b.d000     14     V02     Version Mismatch",
+            {"switch": "2", "role": "Standby", "mac_address": "0026.5a4b.d000",
+             "priority": "14", "version": "V02", "state": "Version Mismatch"},
+        ),
+        (
+            " 2       Standby  0026.5a4b.d000     14     V02     Sync not started",
+            {"switch": "2", "role": "Standby", "mac_address": "0026.5a4b.d000",
+             "priority": "14", "version": "V02", "state": "Sync not started"},
+        ),
+        (
+            " 2       Member   0000.0000.0000     0              Provisioned",
+            {"switch": "2", "role": "Member", "mac_address": "0000.0000.0000",
+             "priority": "0", "version": "", "state": "Provisioned"},
+        ),
+        (
+            " 3       Member   e4:1f:00:00:00:03  5      V02     Ready",
+            {"switch": "3", "role": "Member", "mac_address": "e4:1f:00:00:00:03",
+             "priority": "5", "version": "V02", "state": "Ready"},
+        ),
+    ],
+)
+def test_parses_member_rows(line, expected):
+    """Every real member-row shape is recovered, including multi-word states."""
+    assert _parse_switch_table(line) == [expected]
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "Switch#   Role    Mac Address     Priority Version  State",
+        "-------------------------------------------------------------",
+        "Switch/Stack Mac Address : e41f.0000.0001 - Local Mac Address",
+        "Mac persistency wait time: Indefinite",
+        "% Invalid input detected at '^' marker.",
+        "Switch is not on any stack.",
+        "Switch#  Port 1     Port 2",
+        "  1       Ok         Ok",
+    ],
+)
+def test_rejects_non_member_lines(line):
+    """
+    Headers, separators, banners and stack-port rows are never members.
+
+    The stack-port data row "1  Ok  Ok" is the highest-risk false positive; it
+    is rejected because it carries no MAC column.
+    """
+    assert _parse_switch_table(line) == []
+
+
+def test_stops_at_stack_port_section():
+    """Rows after the Stack Port header are not scanned."""
+    text = (
+        "Switch#   Role    Mac Address     Priority Version  State\n"
+        "-------------------------------------------------------------\n"
+        "*1       Active   e41f.0000.0001     15     V02     Ready\n"
+        "\n"
+        "Stack Port Status\n"
+        " 9       Member   0026.5a4b.9999     9      V02     Ready\n"
+    )
+    assert [r["switch"] for r in _parse_switch_table(text)] == ["1"]
+
+
+def _fixture_dirs():
+    return sorted(d for d in FIXTURES.iterdir() if (d / "show_switch_detail.txt").exists())
+
+
+@pytest.mark.parametrize("fixture", _fixture_dirs(), ids=lambda d: d.name)
+def test_parity_with_ntc_template(fixture):
+    """
+    The local parser is a strict superset of the template on every fixture.
+
+    Where the template succeeds it must agree exactly. Where the template
+    raises (it is all-or-nothing) the local parser must still return a list,
+    never raise.
+    """
+    text = (fixture / "show_switch_detail.txt").read_text()
+    local_ids = [r["switch"] for r in _parse_switch_table(text)]
+    try:
+        template_rows = parse_output(
+            platform="cisco_ios", command="show switch detail", data=text
+        )
+    except Exception:
+        assert isinstance(local_ids, list)
+        return
+    assert local_ids == [r["switch"] for r in template_rows]

--- a/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/test_switch_table.py
+++ b/orb-discovery/device-discovery/tests/custom_drivers/cisco_ios/test_switch_table.py
@@ -128,19 +128,38 @@ def _comparable(row: dict) -> tuple:
     return tuple((row.get(field) or "") for field in _COMPARISON_FIELDS)
 
 
+# Fixtures whose show_switch_detail.txt makes the ntc template raise, mapped to
+# the member-row count the local parser must recover from the same text. Keeping
+# this explicit is what makes the template-raises branch below a real assertion
+# rather than a tautology, and a new raising fixture fails loudly until its
+# expected count is recorded here.
+_TEMPLATE_RAISES_EXPECTED_ROWS = {
+    # Banner only ("Switch is not on any stack."); no member row exists at all,
+    # so recovering nothing is the correct answer.
+    "standalone_3850": 0,
+    # StackWise Virtual rejects the "detail" keyword outright, so this file holds
+    # only "% Invalid input detected". Zero rows is correct FROM THIS FILE; the
+    # members come from show_switch.txt, which the driver falls back to and which
+    # this parity test does not read.
+    "cat9500_svl_pair": 0,
+    # The reason this parser exists: the template's STATE value is (\w+), so the
+    # multi-word "Version Mismatch" makes it discard BOTH member rows. The local
+    # parser must still return both.
+    "stack_version_mismatch": 2,
+}
+
+
 @pytest.mark.parametrize("fixture", _fixture_dirs(), ids=lambda d: d.name)
 def test_parity_with_ntc_template(fixture):
     """
     The local parser agrees with the template field-for-field, and is a strict superset.
 
-    Where the template succeeds, every row must match on all six shared
-    fields (switch, role, mac_address, priority, version, state) — not just
-    the switch id, which would miss a field-level regression such as version
-    data bleeding into state. Where the template raises (it is
-    all-or-nothing) the local parser must still return a list, never raise;
-    for the one fixture that triggers this today ("Switch is not on any
-    stack.", which carries no member row at all) that list is empty, and the
-    test asserts that exact count rather than merely the type.
+    Where the template succeeds, every row must match on all six shared fields
+    (switch, role, mac_address, priority, version, state) — not just the switch
+    id, which would miss a field-level regression such as version data bleeding
+    into state. Where the template raises (it is all-or-nothing) the local parser
+    must not raise, and must recover the row count recorded in
+    ``_TEMPLATE_RAISES_EXPECTED_ROWS`` for that input.
     """
     text = (fixture / "show_switch_detail.txt").read_text()
     local_rows = _parse_switch_table(text)
@@ -149,12 +168,15 @@ def test_parity_with_ntc_template(fixture):
             platform="cisco_ios", command="show switch detail", data=text
         )
     except Exception:
-        # local_rows was already produced above, unguarded, so simply
-        # reaching this branch already proves the local parser did not
-        # raise where the template did. The substantive check is that its
-        # row count is the one actually correct for this input: this
-        # fixture's raw text is only the "not on any stack" banner, with no
-        # member row for either parser to find.
-        assert local_rows == []
+        # Reaching this branch already proves the local parser did not raise,
+        # since local_rows was produced above unguarded. The substantive check is
+        # that it recovered the count that is actually correct for this input.
+        expected = _TEMPLATE_RAISES_EXPECTED_ROWS.get(fixture.name)
+        assert expected is not None, (
+            f"{fixture.name}: the ntc template raises on this fixture but no "
+            "expected local row count is recorded in "
+            "_TEMPLATE_RAISES_EXPECTED_ROWS"
+        )
+        assert len(local_rows) == expected
         return
     assert [_comparable(r) for r in local_rows] == [_comparable(r) for r in template_rows]

--- a/orb-discovery/device-discovery/tests/test_translate_chassis.py
+++ b/orb-discovery/device-discovery/tests/test_translate_chassis.py
@@ -579,3 +579,57 @@ def test_vc_cascade_propagates_options_through_per_member_builder():
     assert prefixes, "expected at least one Prefix from interface_ip on the VC path"
     # Cascade from defaults.site → Prefix.scope_site (NetBox 4.2+ scope oneof).
     assert prefixes[0].scope_site.name == "DC-East"
+
+
+def test_single_member_payload_does_not_warn(caplog):
+    """
+    A one-member payload is a standalone device, not a partial parse.
+
+    validate_chassis_payload is driver-agnostic and several drivers emit a
+    single-member payload as documented-normal behaviour, so warning here would
+    fire for every standalone device in a fleet on every discovery cycle.
+    """
+    import logging
+
+    from device_discovery.translate_chassis import validate_chassis_payload
+
+    payload = {
+        "members": [
+            {"id": 1, "serial": "FOC1111111", "model": "C9300-24T", "role": "active"}
+        ],
+        "domain": None,
+    }
+    with caplog.at_level(logging.DEBUG, logger="device_discovery.translate_chassis"):
+        assert validate_chassis_payload(payload) is None
+    assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []
+
+
+def test_dropped_members_do_warn(caplog):
+    """
+    Validation dropping members IS worth a warning.
+
+    Two members in, fewer than two out means a driver handed us a stack we could
+    not represent. The silent version of this was invisible until a user noticed
+    missing NetBox data.
+    """
+    import logging
+
+    from device_discovery.translate_chassis import validate_chassis_payload
+
+    payload = {
+        "members": [
+            {"id": 1, "serial": "FOC1111111", "model": "C9300-24T", "role": "active"},
+            # Same serial: dropped as a duplicate, leaving one valid member.
+            {"id": 2, "serial": "FOC1111111", "model": "C9300-24T", "role": "standby"},
+        ],
+        "domain": None,
+    }
+    with caplog.at_level(logging.DEBUG, logger="device_discovery.translate_chassis"):
+        assert validate_chassis_payload(payload) is None
+    warnings = [
+        r for r in caplog.records
+        if r.levelno >= logging.WARNING
+        and "survived validation" in r.getMessage()
+    ]
+    assert len(warnings) == 1
+    assert "1 of 2" in warnings[0].getMessage()


### PR DESCRIPTION
Closes #498.

## What

Cisco Catalyst 9400 / 9500 / 9600 in **StackWise Virtual** (SVL) were not discovered as a NetBox `VirtualChassis`. The pair landed as two unrelated `Device` records, with interfaces and IPs split across them arbitrarily.

The reporter's diagnosis was that `show switch detail` does not exist on these platforms and `show switch` does. That is true, but it is not the whole fix, and the interesting part is what it does not cover.

## Why the command swap alone is not enough

`show switch` and `show switch detail` resolve to the **same** ntc-template via the index regex `sh[[ow]] sw[[itch]]( d[[etail]])?\s*$`. Verified: both produce byte-identical parses. So changing the command string changes no parsing behaviour at all.

The real blocker was **serials**. A member is dropped unless we can find its serial, and serials come from `show inventory`. The matcher accepted a NAME of exactly `Switch 1`; on SVL the chassis row is named `Switch 1 Chassis`, so nothing matched, every member was dropped, and discovery emitted nothing. Fixing the command without fixing this would have looked correct and still produced no virtual chassis.

## The trap in the obvious inventory fix

The tempting change is to let any suffix follow the number, `^Switch\s+(\d+)\b`. That also matches `Switch 1 Power Supply Module 0`, `Switch 1 Fan Tray 0` and `Switch 1 Slot 1 Supervisor`, and because the index was last-write-wins the member's identity came from whichever component row appeared last.

On the reporter's C9500 that accidentally yields the right answer, because the chassis and supervisor report the same PID and serial. On a modular 9400, where the supervisor has its own PID, the same code was measured to produce:

```
member 1  model = C9400-PWR-3200AC     <- the power supply
          serial = the power supply's serial
```

**Serial is NetBox's device matcher**, so that attaches discovery to the wrong device record. The matcher stays anchored, and a test pins the modular case so the anchor cannot be "simplified" back out.

Serial and model are now also committed from the **same** inventory row. They were written through two independent conditionals, so a bare `Switch N` row and a `Switch N Chassis` row could each supply one field.

## Incidental fix: degraded physical stacks emitted nothing

While replacing the table parse I found a live bug on the path that already works. `cisco_ios_show_switch_detail.textfsm` declares `Value STATE (\w+)`, so a multi-word state raises `TextFSMError` — and because the template is all-or-nothing, **every** member row is discarded, not just the offending one.

| Member state | Template result |
|---|---|
| `Ready` | 2 rows |
| `Provisioned` | 2 rows |
| `Version Mismatch` | **TextFSMError — all rows lost** |
| `Sync not started` | **TextFSMError — all rows lost** |

So a 9300 stack with one member mid-upgrade produced no `VirtualChassis` at all, silently. A driver-local per-row parser replaces the template for this one table; it degrades one row at a time instead. A fixture pins the case.

Parity is proven, not asserted: for all 8 pre-existing fixtures the local parser agrees with the template on **every** shared field, and where the template raises it must recover the row count recorded in `_TEMPLATE_RAISES_EXPECTED_ROWS` — a new raising fixture fails loudly until its expectation is written down.

## Domain number

`show stackwise-virtual` is the only command that exposes the SVL domain, and it has no upstream template, so one regex reads `Domain Number : N`. SVL stacks therefore carry a domain that physical stacks cannot supply. It is purely additive: any failure leaves the domain `None`, which is what physical stacks have always emitted.

`show switch virtual` is **not** used — it does not exist on these platforms. An upstream template for it does exist, which is exactly what made it look viable.

## Observability

The reported symptom was silence, so the failure paths are now distinguishable:

- A CLI rejection on every attempted command, or an explicit standalone answer → **DEBUG**. This *removes* a warning that every non-Catalyst IOS device (ISR / ASR / CSR) and every standalone Catalyst emitted on **every discovery cycle**, since `show switch detail` raises `TextFSMError` on them today.
- Output that looks like a member table but yields no rows → **WARNING**, naming the host and the commands tried. This is the diagnosable case and the one the next unsupported platform lands in.
- Fewer than two members → **WARNING** with the count, in the driver and again at `validate_chassis_payload`, so a partial parse degrading to a single `Device` is visible.
- Empty output classifies as uninformative rather than surprising, so a silent command cannot force a warning.

Every message now carries the hostname. None did before, which made a fleet warning unattributable.

## Evidence

Fixtures are verbatim captures from a real C9500-48Y4C SVL pair on IOS-XE 17.15/17.18, supplied in #498: the `show switch detail` rejection, the `show switch` table, `show stackwise-virtual`, and `show inventory`.

## Verification

- `1957 passed, 161 skipped`; `ruff check .` clean; 4 Go modules 0 issues.
- Mutation-checked rather than trusted: reverting the ` Chassis` suffix fails 6 tests; removing the `show switch` fallback fails 2, **including** the end-to-end SVL fixture. Those `expected_result.json` files were generated from driver output, so this was worth proving.
- Adversarial edge cases: 2-digit ids, `Removed/Absent`, tabs and trailing whitespace all parse; parenthesised states, blank priority, separator-less MACs, 3-digit ids and the Stack Port / **Neighbors** data rows are all rejected. Every rejection skips a row rather than producing a wrong one.

## Accepted limitations

- `cisco_ios_show_inventory.textfsm` captures `SN` as `([\w+\d+]+)`, so a serial containing a character outside `[A-Za-z0-9_+]` truncates silently. Cisco serials are alphanumeric; the fix is upstream.
- DEBUG is currently invisible in device-discovery — the root logger is pinned to INFO by an import-time `basicConfig` and there is no log-level flag. The DEBUG paths above are therefore deliberately silent, not diagnostic. A `--log-level` flag is specified separately.
- A row with no version column **and** a multi-word state would mis-split. No such combination has been observed; every multi-word state occurs on a present member, which reports a version.

## Draft

Draft while a broader adversarial review finishes. Behaviour, tests and docs are complete; anything that review confirms will land as additional commits before this is marked ready.

---

## Adversarial review pass

A whole-branch adversarial review (5 lenses, each finding independently refuted before it counted) raised 35 findings; **7 survived refutation**. All 7 are addressed in `9bb8acc`. They clustered into two themes, and both were mine.

**The new diagnostics fired on healthy hardware.** A standalone stack-capable Catalyst (2960S/2960X/3850/9200/9300) answers `show switch detail` with a one-row member table — the most common deployment in any fleet. That produced **two** WARNINGs per discovery cycle, one from the driver and one from `validate_chassis_payload`, for a device behaving exactly as expected. Neither warning existed before this branch, so it was a self-inflicted noise regression that directly contradicted the noise policy this same branch states.

Reproduced against ntc-templates' own real capture, then fixed by warning only when members were **lost**:

| Scenario | Before | After |
|---|---|---|
| Standalone stack-capable Catalyst | 2 WARN | **0** (DEBUG) |
| Healthy 2-member stack | 0 | 0 |
| Real stack, one serial unresolvable | 2 WARN | 2 WARN (correctly — this one is a real gap) |

`validate_chassis_payload` is driver-agnostic and a single-member payload is documented-normal for several drivers, so it now warns only when validation actually dropped members.

**Two branches were dead to the test suite.** Mutation-checked, not assumed:

- Mutating `looked_like_a_table` to `False` broke **no** test. On inspection it was redundant — output that looks like a table but parses to nothing already reaches the WARNING branch via `not rejected` — and actively harmful, since it would misfire on a release printing the column header above an explicit `Switch is not on any stack.`, turning a standalone device into a warning. **Deleted rather than tested.**
- Replacing the `send_command`-exception `continue` with `return None` broke **no** test. That early return would make SVL discovery depend on a command those platforms do not implement. Now pinned by a test that fails under exactly that mutation.
- The `translate_chassis` guard had zero coverage; it now has two tests plus a mutation check on the `members_raw` gate.

Final: **1961 passed, 161 skipped**, ruff clean.
