### PR TITLE
fix(device-discovery): emit one warning per unreachable target and add --log-level

### DIFF
--- a/orb-discovery/device-discovery/device_discovery/client.py
+++ b/orb-discovery/device-discovery/device_discovery/client.py
@@ -15,6 +15,7 @@ from netboxlabs.diode.sdk import (
 )
 
 from device_discovery.entity_metadata import apply_run_id_to_entities
+from device_discovery.log_config import configure_default_logging
 from device_discovery.stubs import prune_nested_refs
 from device_discovery.translate import translate_data
 from device_discovery.version import version_semver
@@ -24,7 +25,7 @@ APP_VERSION = version_semver()
 MAX_MESSAGE_SIZE_BYTES = 3 * 1024 * 1024  # 3MB threshold for chunking
 
 # Set up logging
-logging.basicConfig(level=logging.INFO)
+configure_default_logging()
 logger = logging.getLogger(__name__)
 
 

--- a/orb-discovery/device-discovery/device_discovery/discovery.py
+++ b/orb-discovery/device-discovery/device_discovery/discovery.py
@@ -12,10 +12,12 @@ from typing import Any
 from napalm import get_network_driver
 from napalm.base.base import NetworkDriver
 
+from device_discovery.log_config import configure_default_logging
+
 _DRIVER_MISMATCH_MARKERS = ["%", "Invalid input", "^"]
 
 # Set up logging
-logging.basicConfig(level=logging.INFO)
+configure_default_logging()
 logger = logging.getLogger(__name__)
 
 
@@ -184,11 +186,11 @@ def discover_device_driver(info: dict, drivers: list[str] | None = None) -> str 
                         "Hostname %s: '%s' driver did not work", info.hostname, driver
                     )
                     continue
-                set_napalm_logs_level(logging.INFO)
+                set_napalm_logs_level(logging.getLogger().getEffectiveLevel())
                 return driver
         except Exception as e:
             logger.info(
                 "Hostname %s: '%s' driver did not work. Exception: %s", info.hostname, driver, str(e)
             )
-    set_napalm_logs_level(logging.INFO)
+    set_napalm_logs_level(logging.getLogger().getEffectiveLevel())
     return None

--- a/orb-discovery/device-discovery/device_discovery/log_config.py
+++ b/orb-discovery/device-discovery/device_discovery/log_config.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""
+Logging configuration for the device-discovery backend.
+
+Centralises the root-logger setup that used to be five independent
+``logging.basicConfig`` calls, and provides the ``--log-level`` plumbing.
+
+Two things here are load-bearing and easy to undo by accident:
+
+1. ``LOG_FORMAT`` is byte-identical to ``logging.BASIC_FORMAT``. The emitted
+   shape is a wire contract with ``normalizeDeviceDiscoveryLine`` in
+   ``agent/backend/devicediscovery/device_discovery.go``, which parses
+   ``LEVEL:module:message``, and with operator grep habits. Changing it buys
+   nothing and breaks both.
+2. ``configure_logging`` passes ``force=True``. Every module in this package
+   configures logging at import time, so by the time ``main()`` runs a root
+   handler already exists and a plain ``basicConfig`` is a silent no-op --
+   which is exactly the "accepted and ignored" defect ``--log-level`` exists
+   to fix. Prior art: ``orb-discovery/worker/worker/main.py``.
+"""
+
+import logging
+
+# Byte-identical to logging.BASIC_FORMAT. See the module docstring.
+LOG_FORMAT = "%(levelname)s:%(name)s:%(message)s"
+
+DEFAULT_LEVEL = logging.INFO
+
+# Mirrors parseDeviceDiscoveryLevel in
+# agent/backend/devicediscovery/device_discovery.go so that every token the
+# agent can forward resolves here instead of silently falling back to INFO.
+#
+# Deliberately an explicit dict rather than logging.getLevelNamesMapping()
+# (3.11+, while pyproject declares requires-python = ">=3.10") or
+# logging.getLevelName(), which returns the string "Level TRACE" for trace,
+# err and exception -- setLevel raises on those.
+_LEVEL_ALIASES = {
+    "trace": logging.DEBUG,
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warn": logging.WARNING,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+    "err": logging.ERROR,
+    "exception": logging.ERROR,
+    "critical": logging.CRITICAL,
+    "fatal": logging.CRITICAL,
+}
+
+
+def flatten_message(value: object) -> str:
+    """
+    Collapse a value's string form onto a single physical line.
+
+    Not cosmetic. netmiko builds its timeout and authentication messages as
+    ten-line f-strings, and the agent splits the backend's stderr on every
+    newline and assigns ERROR by pipe rather than by content
+    (agent/backend/process.go and device_discovery.go). An unflattened
+    message therefore becomes one WARNING plus nine ERROR records.
+    """
+    return " ".join(str(value).split())
+
+
+def resolve_log_level(value: object) -> tuple[int, str | None]:
+    """
+    Resolve a log-level value to a logging level, never raising.
+
+    Tolerates non-str input on purpose: the argparse namespace is a MagicMock
+    under test, and a YAML ``log_level: 3`` reaches us as an int.
+
+    Args:
+    ----
+        value: the raw log-level value, of any type.
+
+    Returns:
+    -------
+        tuple[int, str | None]: the resolved level, and a warning message when
+        the value was unrecognised (so a degraded setting is visible rather
+        than silent) or None when it was understood.
+
+    """
+    normalized = str(value).strip().lower()
+    level = _LEVEL_ALIASES.get(normalized)
+    if level is None:
+        return DEFAULT_LEVEL, f"unrecognised log level {value!r}, falling back to INFO"
+    return level, None
+
+
+def configure_logging(value: object) -> int:
+    """
+    Configure root logging from a --log-level value, replacing any existing setup.
+
+    ``force=True`` is required: the import-time ``configure_default_logging``
+    calls have already installed a root handler by the time this runs, and
+    ``basicConfig`` without ``force`` would be a silent no-op.
+
+    Args:
+    ----
+        value: the raw --log-level value.
+
+    Returns:
+    -------
+        int: the logging level that was applied.
+
+    """
+    level, warning = resolve_log_level(value)
+    logging.basicConfig(level=level, format=LOG_FORMAT, force=True)
+    if warning:
+        logging.getLogger(__name__).warning(warning)
+    return level
+
+
+def configure_default_logging() -> None:
+    """
+    Configure root logging at the package default of INFO, if not already configured.
+
+    Called at import time by the modules that used to call ``basicConfig``
+    directly. Behaviour is unchanged -- the first call still wins and it is
+    still INFO -- but the format is now stated once instead of being five
+    implicit copies of an unchecked wire contract.
+
+    Not removable: these modules are imported standalone by the test suite and
+    by the FastAPI app, and without this the root logger is left unconfigured
+    and INFO records vanish under ``logging.lastResort``.
+    """
+    logging.basicConfig(level=DEFAULT_LEVEL, format=LOG_FORMAT)

--- a/orb-discovery/device-discovery/device_discovery/main.py
+++ b/orb-discovery/device-discovery/device_discovery/main.py
@@ -11,6 +11,7 @@ import netboxlabs.diode.sdk.version as SdkVersion
 import uvicorn
 
 from device_discovery.client import Client
+from device_discovery.log_config import configure_logging
 from device_discovery.metrics import setup_metrics_export
 from device_discovery.server import app
 from device_discovery.version import version_semver
@@ -35,11 +36,15 @@ def resolve_env_var(value: str) -> str:
     return value
 
 
-def main():
+def build_parser() -> argparse.ArgumentParser:
     """
-    Main entry point for the Agent CLI.
+    Build the CLI argument parser.
 
-    Parses command-line arguments and starts the backend.
+    Extracted from main() so a test can feed it the exact argument vector the
+    Go agent's buildArgs emits, pinning both sides of that boundary without a
+    subprocess. See agent/backend/devicediscovery/device_discovery.go.
+
+    Returns the configured argparse.ArgumentParser.
     """
     parser = argparse.ArgumentParser(description="Orb Device Discovery Backend")
     parser.add_argument(
@@ -129,8 +134,37 @@ def main():
         required=False,
     )
 
+    # Long flag only: -d is --dry-run, and -s -p -t -c -k -a -o -V are taken.
+    #
+    # Deliberately no choices=. A typo in the agent's YAML would make argparse
+    # exit(2), and the backend would crash-loop and never pass readiness --
+    # the same class of defect as #494, inverted. Unrecognised values fall
+    # back to INFO and warn instead.
+    parser.add_argument(
+        "--log-level",
+        help="Log level: trace/debug/info/warn/error/critical (default: INFO)",
+        type=str,
+        default="INFO",
+        required=False,
+    )
+
+    return parser
+
+
+def main():
+    """
+    Main entry point for the Agent CLI.
+
+    Parses command-line arguments and starts the backend.
+    """
+    parser = build_parser()
+
     try:
         args = parser.parse_args()
+        # Before the dry-run validation and before setup_metrics_export,
+        # Client() and uvicorn.run: basicConfig(force=True) replaces the root
+        # handlers installed at import time.
+        configure_logging(args.log_level)
         if not args.dry_run:
             missing = [
                 name

--- a/orb-discovery/device-discovery/device_discovery/metrics.py
+++ b/orb-discovery/device-discovery/device_discovery/metrics.py
@@ -12,10 +12,11 @@ from opentelemetry.sdk.metrics.export import (
     PeriodicExportingMetricReader,
 )
 
+from device_discovery.log_config import configure_default_logging
 from device_discovery.version import version_semver
 
 # Set up logging
-logging.basicConfig(level=logging.INFO)
+configure_default_logging()
 logger = logging.getLogger(__name__)
 
 # Global variables to store the provider and meter

--- a/orb-discovery/device-discovery/device_discovery/policy/manager.py
+++ b/orb-discovery/device-discovery/device_discovery/policy/manager.py
@@ -7,12 +7,13 @@ import os
 
 import yaml
 
+from device_discovery.log_config import configure_default_logging
 from device_discovery.policy.models import Policy, PolicyRequest, PolicyStatus
 from device_discovery.policy.run import RunStore
 from device_discovery.policy.runner import PolicyRunner
 
 # Set up logging
-logging.basicConfig(level=logging.INFO)
+configure_default_logging()
 logger = logging.getLogger(__name__)
 
 

--- a/orb-discovery/device-discovery/device_discovery/policy/run.py
+++ b/orb-discovery/device-discovery/device_discovery/policy/run.py
@@ -8,6 +8,7 @@ import threading
 import time
 from typing import Any
 
+from device_discovery.log_config import flatten_message
 from device_discovery.policy.models import Run, RunStatus
 
 # Maximum number of runs to keep per target
@@ -165,7 +166,9 @@ class RunStore:
                     run.updated_at = time.time_ns()
 
                     if error:
-                        run.reason = str(error)
+                        # Flattened so the string in the JSON /api/v1/status
+                        # response is byte-identical to the log line.
+                        run.reason = flatten_message(error)
                     else:
                         run.reason = ""  # Clear reason when no error
 

--- a/orb-discovery/device-discovery/device_discovery/policy/runner.py
+++ b/orb-discovery/device-discovery/device_discovery/policy/runner.py
@@ -4,6 +4,7 @@
 
 import logging
 import time
+import traceback
 import uuid
 from datetime import datetime, timedelta
 from typing import Any
@@ -13,9 +14,12 @@ from apscheduler.triggers.base import BaseTrigger
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
 from napalm import get_network_driver
+from napalm.base.exceptions import ConnectionException
+from netmiko.exceptions import NetmikoAuthenticationException
 
 from device_discovery.client import Client
 from device_discovery.discovery import discover_device_driver, supported_drivers
+from device_discovery.log_config import configure_default_logging, flatten_message
 from device_discovery.metrics import get_metric
 from device_discovery.policy.models import Config, Defaults, Napalm, Options, Status
 from device_discovery.policy.portscan import (
@@ -25,8 +29,45 @@ from device_discovery.policy.portscan import (
 from device_discovery.policy.run import RunStatus, RunStore
 
 # Set up logging
-logging.basicConfig(level=logging.INFO)
+configure_default_logging()
 logger = logging.getLogger(__name__)
+
+# Per-target failures that are routine in a discovery sweep rather than bugs:
+# a host that is alive on the scanned port but is not a manageable device.
+# These log as ONE WARNING with no traceback; everything else keeps ERROR plus
+# full exc_info so real defects stay diagnosable.
+#
+# Both entries are required. Do not collapse this tuple:
+#   * napalm's NetworkDriver._netmiko_open (napalm/base/base.py) catches ONLY
+#     NetMikoTimeoutException and re-raises ConnectionException. Nothing there
+#     catches authentication failure.
+#   * netmiko declares NetmikoAuthenticationException on paramiko's
+#     AuthenticationException (netmiko/exceptions.py), so it is not a
+#     NapalmException at all -- issubclass(..., ConnectionException) is False.
+# A rejected credential therefore propagates raw, and dropping the second
+# entry restores the full ~63-record traceback wall for exactly the case
+# reported in #494 ("unable to log into the device with the provided
+# credentials").
+#
+# ConnectionException already subsumes ConnectAuthError, ConnectTimeoutError,
+# ConnectionClosedException and UnsupportedVersion, so they are not listed.
+# Builtin TimeoutError / ConnectionError / socket.gaierror are deliberately
+# EXCLUDED: Client().ingest runs inside the same catch-all, so widening this
+# would relabel a dead Diode endpoint as a per-host connection failure and
+# send the operator hunting devices while ingestion is down.
+_EXPECTED_TARGET_FAILURES = (ConnectionException, NetmikoAuthenticationException)
+
+
+def _is_expected_target_failure(error: BaseException) -> bool:
+    """
+    Report whether a per-target failure is an expected unreachable/unauthenticated host.
+
+    Evaluated on the raised object only. The ``__cause__`` / ``__context__``
+    chain is deliberately NOT walked: a driver bug that surfaces while a
+    connection error is being handled must stay UNEXPECTED and keep its
+    traceback.
+    """
+    return isinstance(error, _EXPECTED_TARGET_FAILURES)
 
 
 def _deep_merge(base: dict, override: dict) -> dict:
@@ -204,7 +245,7 @@ class PolicyRunner:
             scope.driver = discover_device_driver(scope, drivers=discovery_drivers)
             if scope.driver is None:
                 self.status = Status.FAILED
-                logger.error(
+                logger.warning(
                     f"Policy {self.name}, Hostname {sanitized_hostname}: Not able to discover device driver"
                 )
                 return False
@@ -375,6 +416,49 @@ class PolicyRunner:
                 f"Error getting network instances: {e}. "
                 "Continuing without VRF data."
             )
+
+    def _log_target_failure(self, sanitized_hostname: str, error: Exception) -> None:
+        """
+        Log a per-target discovery failure at a level matching how odd it is.
+
+        Expected transport and authentication failures emit exactly ONE
+        physical line at WARNING with the message flattened and no traceback --
+        the agent splits stderr per newline, so one logical record must be one
+        line. Their traceback is still recoverable at DEBUG, as a single
+        newline-escaped line.
+
+        Anything unexpected keeps ERROR with full exc_info. Diagnosability of
+        real bugs must not regress in service of quieting a routine condition.
+        The discipline matches custom_napalm/junos.py and aruba_aoscx.py:
+        expected signal goes quiet, unexpected stays loud.
+
+        Args:
+        ----
+            sanitized_hostname: target the failure belongs to.
+            error: the exception that reached the per-target catch-all.
+
+        """
+        message = (
+            f"Policy {self.name}, Hostname {sanitized_hostname}: "
+            f"{flatten_message(error)}"
+        )
+
+        if not _is_expected_target_failure(error):
+            # exc_info takes the instance, not True, so this helper does not
+            # depend on being called inside an active except block.
+            logger.error(message, exc_info=error)
+            return
+
+        logger.warning(message)
+        if logger.isEnabledFor(logging.DEBUG):
+            formatted = "".join(
+                traceback.format_exception(type(error), error, error.__traceback__)
+            )
+            # One physical line: newlines escaped, so the agent's per-line
+            # stderr split cannot fan this back out. Un-escape with
+            #   printf '%b\n' "<the traceback: value>"
+            escaped = formatted.replace("\\", "\\\\").replace("\n", "\\n")
+            logger.debug(f"{message} | traceback: {escaped}")
 
     def run_scan(
         self, hostnames: list[str], trigger: BaseTrigger, scope: Napalm, config: Config
@@ -562,9 +646,7 @@ class PolicyRunner:
             discovery_failure = get_metric("discovery_failure")
             if discovery_failure:
                 discovery_failure.add(1, {"policy": self.name})
-            logger.error(
-                f"Policy {self.name}, Hostname {sanitized_hostname}: {e}", exc_info=True
-            )
+            self._log_target_failure(sanitized_hostname, e)
             # Still record discovery duration on failure
             discovery_latency = get_metric("discovery_latency")
             if discovery_latency:
@@ -672,9 +754,7 @@ class PolicyRunner:
             discovery_failure = get_metric("discovery_failure")
             if discovery_failure:
                 discovery_failure.add(1, {"policy": self.name})
-            logger.error(
-                f"Policy {self.name}, Hostname {sanitized_hostname}: {e}", exc_info=True
-            )
+            self._log_target_failure(sanitized_hostname, e)
             # Still record discovery duration on failure
             discovery_latency = get_metric("discovery_latency")
             if discovery_latency:

--- a/orb-discovery/device-discovery/tests/conftest.py
+++ b/orb-discovery/device-discovery/tests/conftest.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""Shared fixtures for the device-discovery test suite."""
+
+import logging
+
+import pytest
+
+_LIBRARY_LOGGERS = ("napalm", "ncclient", "paramiko", "pyeapi")
+
+
+@pytest.fixture
+def preserve_root_logging():
+    """
+    Snapshot and restore process-global logging state.
+
+    ``basicConfig(force=True)`` and ``set_napalm_logs_level`` both mutate
+    process-global state, so without this the "exactly one record" and
+    "exactly one line" assertions become order-dependent flakes.
+    """
+    root = logging.getLogger()
+    saved_level = root.level
+    saved_handlers = root.handlers[:]
+    saved_library = {name: logging.getLogger(name).level for name in _LIBRARY_LOGGERS}
+
+    yield
+
+    root.handlers[:] = saved_handlers
+    root.setLevel(saved_level)
+    for name, level in saved_library.items():
+        logging.getLogger(name).setLevel(level)

--- a/orb-discovery/device-discovery/tests/policy/test_runner.py
+++ b/orb-discovery/device-discovery/tests/policy/test_runner.py
@@ -261,7 +261,7 @@ def test_run_discovered_driver_error(
         patch(
             "device_discovery.policy.runner.discover_device_driver", return_value=None
         ) as mock_discover,
-        patch("device_discovery.policy.runner.logger.error") as mock_logger_error,
+        patch("device_discovery.policy.runner.logger.warning") as mock_logger_warning,
     ):
         # Set up run_store
         policy_runner.run_store = run_store
@@ -271,8 +271,8 @@ def test_run_discovered_driver_error(
         policy_runner.run("test_id", sample_scopes[0], sample_config)
 
         mock_discover.assert_called_once_with(sample_scopes[0], drivers=None)
-        mock_logger_error.assert_called_once()
-        assert "Not able to discover device driver" in mock_logger_error.call_args[0][0]
+        mock_logger_warning.assert_called_once()
+        assert "Not able to discover device driver" in mock_logger_warning.call_args[0][0]
         assert policy_runner.status == Status.FAILED
         failed_run = run_store.get_runs_for_policy(policy_runner.name)[0]
         assert failed_run.driver is None

--- a/orb-discovery/device-discovery/tests/policy/test_target_errors.py
+++ b/orb-discovery/device-discovery/tests/policy/test_target_errors.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""NetBox Labs - Per-target failure classification unit tests."""
+
+import pytest
+from napalm.base.exceptions import (
+    CommandErrorException,
+    CommandTimeoutException,
+    ConnectAuthError,
+    ConnectionClosedException,
+    ConnectionException,
+    ConnectTimeoutError,
+    NapalmException,
+    UnsupportedVersion,
+    ValidationException,
+)
+from netmiko.exceptions import NetmikoAuthenticationException, NetmikoTimeoutException
+
+from device_discovery.policy.runner import (
+    _EXPECTED_TARGET_FAILURES,
+    _is_expected_target_failure,
+)
+
+
+def test_tuple_membership_is_a_conscious_choice():
+    """
+    Pin the tuple so widening or narrowing it must be a deliberate test edit.
+
+    Collapsing it to the ConnectionException anchor alone restores the full
+    traceback wall for rejected credentials, which is the reported case.
+    """
+    assert _EXPECTED_TARGET_FAILURES == (
+        ConnectionException,
+        NetmikoAuthenticationException,
+    )
+
+
+def test_netmiko_auth_is_not_reachable_via_the_anchor():
+    """
+    The reason the second entry exists.
+
+    netmiko roots NetmikoAuthenticationException in paramiko, not napalm, so a
+    rejected credential propagates past napalm's timeout-only except clause.
+    """
+    assert not issubclass(NetmikoAuthenticationException, ConnectionException)
+    assert not issubclass(NetmikoAuthenticationException, NapalmException)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        ConnectionException("Cannot connect to 10.0.0.5"),
+        ConnectAuthError("auth"),
+        ConnectTimeoutError("timeout"),
+        ConnectionClosedException("closed"),
+        UnsupportedVersion("version"),
+        NetmikoAuthenticationException("Authentication to device failed."),
+    ],
+)
+def test_expected_failures(error):
+    """Routine unreachable/unauthenticated hosts classify as expected."""
+    assert _is_expected_target_failure(error) is True
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        NapalmException("bare napalm"),
+        CommandErrorException("bad command"),
+        CommandTimeoutException("command timed out"),
+        ValidationException("invalid"),
+        NetmikoTimeoutException("normalized upstream, should not be listed"),
+        KeyError("missing"),
+        ValueError("bad value"),
+        NotImplementedError("driver gap"),
+        # Stand-in for a diode transport failure: Client().ingest runs inside
+        # the same catch-all, and a dead ingest endpoint must NOT be reported
+        # as a per-host connection failure.
+        ConnectionResetError("diode endpoint reset"),
+        TimeoutError("builtin timeout"),
+        OSError("dns"),
+    ],
+)
+def test_unexpected_failures(error):
+    """Everything else keeps ERROR and its traceback."""
+    assert _is_expected_target_failure(error) is False
+
+
+def test_the_exception_chain_is_deliberately_not_walked():
+    """
+    A driver bug raised while handling a connection error stays UNEXPECTED.
+
+    Proves the chain exists and is ignored on purpose, rather than the test
+    passing because no chain was built.
+    """
+    try:
+        try:
+            raise ConnectionException("Cannot connect to 10.0.0.5")
+        except ConnectionException:
+            raise KeyError("driver bug")
+    except KeyError as error:
+        assert _is_expected_target_failure(error) is False
+        assert isinstance(error.__context__, ConnectionException)

--- a/orb-discovery/device-discovery/tests/policy/test_target_failure_logging.py
+++ b/orb-discovery/device-discovery/tests/policy/test_target_failure_logging.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""NetBox Labs - Per-target failure logging behaviour unit tests."""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+from napalm.base.exceptions import ConnectionException
+from netmiko.exceptions import NetmikoAuthenticationException
+
+from device_discovery.policy.models import Config, Defaults, Napalm, Status
+from device_discovery.policy.run import RunStatus, RunStore
+from device_discovery.policy.runner import PolicyRunner
+
+RUNNER_LOGGER = "device_discovery.policy.runner"
+
+# The real ten-line message netmiko builds for a rejected credential.
+AUTH_MESSAGE = """Authentication to device failed.
+
+Common causes of this problem are:
+1. Invalid username and password
+2. Incorrect SSH-key file
+3. Connecting to the wrong device
+
+Device settings: cisco_ios 10.0.0.5:22
+
+Authentication failed."""
+
+
+@pytest.fixture
+def runner():
+    """A PolicyRunner wired to a real RunStore."""
+    instance = PolicyRunner()
+    instance.name = "test_policy"
+    instance.run_store = RunStore()
+    return instance
+
+
+@pytest.fixture
+def scope():
+    """A scope with the driver pinned, so driver discovery is skipped."""
+    return Napalm(
+        driver="ios", hostname="10.0.0.5", username="admin", password="password"
+    )
+
+
+@pytest.fixture
+def config():
+    """A minimal policy config."""
+    return Config(schedule="0 * * * *", defaults=Defaults(site="Lab"))
+
+
+def _invoke(runner, entry_point, scope, config):
+    if entry_point == "run":
+        runner.run("test_id", scope, config)
+    else:
+        runner.run_with_parent("test_id", scope, config, "10.0.0.0/24")
+
+
+ENTRY_POINTS = ["run", "run_with_parent"]
+
+
+@pytest.mark.parametrize("entry_point", ENTRY_POINTS)
+@pytest.mark.parametrize(
+    "error",
+    [
+        ConnectionException("Cannot connect to 10.0.0.5"),
+        NetmikoAuthenticationException(AUTH_MESSAGE),
+    ],
+)
+def test_expected_failure_is_one_flat_warning(
+    runner, scope, config, entry_point, error, caplog
+):
+    """One WARNING, no traceback, no embedded newline -- on both entry points."""
+    with (
+        patch.object(PolicyRunner, "_collect_device_data", side_effect=error),
+        caplog.at_level(logging.INFO, logger=RUNNER_LOGGER),
+    ):
+        _invoke(runner, entry_point, scope, config)
+
+    records = [r for r in caplog.records if r.name == RUNNER_LOGGER and r.levelno >= logging.WARNING]
+    assert len(records) == 1
+    record = records[0]
+    assert record.levelno == logging.WARNING
+    assert record.exc_info is None
+    assert record.exc_text is None
+    assert "\n" not in record.getMessage()
+    assert "10.0.0.5" in record.getMessage()
+
+
+@pytest.mark.parametrize("entry_point", ENTRY_POINTS)
+def test_expected_failure_keeps_traceback_at_debug(
+    runner, scope, config, entry_point, caplog
+):
+    """At DEBUG the traceback is recoverable, still on a single physical line."""
+    error = ConnectionException("Cannot connect to 10.0.0.5")
+    with (
+        patch.object(PolicyRunner, "_collect_device_data", side_effect=error),
+        caplog.at_level(logging.DEBUG, logger=RUNNER_LOGGER),
+    ):
+        _invoke(runner, entry_point, scope, config)
+
+    relevant = [
+        r
+        for r in caplog.records
+        if r.name == RUNNER_LOGGER and r.levelno in (logging.WARNING, logging.DEBUG)
+    ]
+    assert [r.levelno for r in relevant] == [logging.WARNING, logging.DEBUG]
+    debug_message = relevant[1].getMessage()
+    assert "Traceback" in debug_message
+    assert "\n" not in debug_message
+
+
+@pytest.mark.parametrize("entry_point", ENTRY_POINTS)
+def test_unexpected_failure_keeps_error_and_exc_info(
+    runner, scope, config, entry_point, caplog
+):
+    """The decision-3 guard: real bugs must not lose their traceback."""
+    error = RuntimeError("boom")
+    with (
+        patch.object(PolicyRunner, "_collect_device_data", side_effect=error),
+        caplog.at_level(logging.INFO, logger=RUNNER_LOGGER),
+    ):
+        _invoke(runner, entry_point, scope, config)
+
+    errors = [r for r in caplog.records if r.name == RUNNER_LOGGER and r.levelno == logging.ERROR]
+    warnings = [r for r in caplog.records if r.name == RUNNER_LOGGER and r.levelno == logging.WARNING]
+    assert len(errors) == 1
+    assert errors[0].exc_info is not None
+    assert errors[0].exc_info[1] is error
+    assert warnings == []
+
+
+@pytest.mark.parametrize("entry_point", ENTRY_POINTS)
+def test_non_log_behaviour_is_unchanged(runner, scope, config, entry_point):
+    """Run status, reason, and the failure metrics must be untouched."""
+    error = NetmikoAuthenticationException(AUTH_MESSAGE)
+    with patch.object(PolicyRunner, "_collect_device_data", side_effect=error):
+        _invoke(runner, entry_point, scope, config)
+
+    runs = runner.run_store.get_runs_for_policy("test_policy")
+    assert runs
+    run = runs[0]
+    assert run.status is RunStatus.FAILED
+    # run.reason is flattened too -- a multi-line string inside the JSON
+    # /api/v1/status response is a defect on its own.
+    assert "\n" not in run.reason
+    assert "Authentication to device failed." in run.reason
+
+
+@pytest.mark.parametrize("entry_point", ENTRY_POINTS)
+def test_both_entry_points_route_through_the_shared_emitter(
+    runner, scope, config, entry_point
+):
+    """The failure rule must not be able to drift between run and run_with_parent."""
+    error = ConnectionException("Cannot connect to 10.0.0.5")
+    with (
+        patch.object(PolicyRunner, "_collect_device_data", side_effect=error),
+        patch.object(PolicyRunner, "_log_target_failure") as emitter,
+    ):
+        _invoke(runner, entry_point, scope, config)
+
+    assert emitter.call_count == 1
+
+
+def test_driver_discovery_failure_warns_rather_than_errors(runner, scope, config, caplog):
+    """
+    runner.py:207 is the same expected-failure class on the auto-discovery path.
+
+    Status.FAILED is deliberately left alone -- see the follow-up issue.
+    """
+    scope.driver = None
+    with (
+        patch("device_discovery.policy.runner.discover_device_driver", return_value=None),
+        caplog.at_level(logging.INFO, logger=RUNNER_LOGGER),
+    ):
+        runner.run("test_id", scope, config)
+
+    matching = [
+        r
+        for r in caplog.records
+        if "Not able to discover device driver" in r.getMessage()
+    ]
+    assert len(matching) == 1
+    assert matching[0].levelno == logging.WARNING
+    assert runner.status == Status.FAILED

--- a/orb-discovery/device-discovery/tests/test_log_amplification.py
+++ b/orb-discovery/device-discovery/tests/test_log_amplification.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""
+NetBox Labs - Log amplification regression tests.
+
+Measured in PHYSICAL STDERR LINES, not log records, and that is the point.
+The agent's go-cmd stream splits stderr on every newline and assigns ERROR by
+pipe rather than by content (agent/backend/process.go:83-103 and
+devicediscovery/device_discovery.go:172-176). That amplifier is deliberately
+out of scope for #494, so the Python side has to hold the one-record ==
+one-line invariant permanently. Record-count assertions alone would not catch
+a regression that reintroduces embedded newlines.
+"""
+
+import io
+import logging
+
+import pytest
+from napalm.base.exceptions import ConnectionException
+from netmiko.exceptions import NetmikoAuthenticationException
+
+from device_discovery.log_config import LOG_FORMAT
+from device_discovery.policy.run import RunStore
+from device_discovery.policy.runner import PolicyRunner
+
+AUTH_MESSAGE = """Authentication to device failed.
+
+Common causes of this problem are:
+1. Invalid username and password
+2. Incorrect SSH-key file
+3. Connecting to the wrong device
+
+Device settings: cisco_ios 10.0.0.5:22
+
+Authentication failed."""
+
+
+@pytest.fixture
+def stderr_capture():
+    """Attach a formatted stream handler to the runner logger, as the backend does."""
+    buffer = io.StringIO()
+    logger = logging.getLogger("device_discovery.policy.runner")
+    handler = logging.StreamHandler(buffer)
+    handler.setFormatter(logging.Formatter(LOG_FORMAT))
+
+    saved_handlers = logger.handlers[:]
+    saved_propagate = logger.propagate
+    saved_level = logger.level
+
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.INFO)
+
+    yield buffer, logger
+
+    logger.handlers = saved_handlers
+    logger.propagate = saved_propagate
+    logger.setLevel(saved_level)
+
+
+def _emit(logger, error):
+    runner = PolicyRunner()
+    runner.name = "test_policy"
+    runner.run_store = RunStore()
+    runner._log_target_failure("10.0.0.5", error)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        ConnectionException("Cannot connect to 10.0.0.5"),
+        NetmikoAuthenticationException(AUTH_MESSAGE),
+    ],
+)
+def test_expected_failure_is_exactly_one_physical_line(stderr_capture, error):
+    """
+    The headline of #494: one line per unreachable target, not ~63.
+
+    The auth case is the one that matters most -- dropping exc_info without
+    flattening leaves ten lines, nine of which the agent labels ERROR.
+    """
+    buffer, logger = stderr_capture
+    _emit(logger, error)
+    output = buffer.getvalue()
+    assert output.count("\n") == 1
+    assert "Traceback" not in output
+
+
+def test_a_sweep_emits_one_line_per_host(stderr_capture):
+    """The reported symptom, at the reported scale: a /24 of unreachable hosts."""
+    buffer, logger = stderr_capture
+    for octet in range(1, 255):
+        _emit(logger, ConnectionException(f"Cannot connect to 10.0.0.{octet}"))
+    assert buffer.getvalue().count("\n") == 254
+
+
+def test_debug_adds_exactly_one_more_line(stderr_capture):
+    """The escaped traceback is recoverable at DEBUG and still one line."""
+    buffer, logger = stderr_capture
+    logger.setLevel(logging.DEBUG)
+    try:
+        raise ConnectionException("Cannot connect to 10.0.0.5")
+    except ConnectionException as error:
+        _emit(logger, error)
+    output = buffer.getvalue()
+    assert output.count("\n") == 2
+    assert "Traceback" in output
+
+
+def test_unexpected_failure_still_gets_a_real_traceback(stderr_capture):
+    """Quiet must not have been bought by destroying diagnosability."""
+    buffer, logger = stderr_capture
+    try:
+        raise ValueError("boom")
+    except ValueError as error:
+        _emit(logger, error)
+    output = buffer.getvalue()
+    assert "Traceback" in output
+    assert output.count("\n") > 1
+
+
+def test_emitted_line_matches_the_shape_the_agent_parses(stderr_capture):
+    """
+    The format is a wire contract.
+
+    normalizeDeviceDiscoveryLine (device_discovery.go:325-368) splits on the
+    first two colons to recover LEVEL and module. If this shape changes, the
+    agent silently falls back to assigning level by pipe.
+    """
+    buffer, logger = stderr_capture
+    _emit(logger, ConnectionException("Cannot connect to 10.0.0.5"))
+    line = buffer.getvalue().rstrip("\n")
+    level, module, _ = line.split(":", 2)
+    assert level == "WARNING"
+    assert module == "device_discovery.policy.runner"

--- a/orb-discovery/device-discovery/tests/test_log_config.py
+++ b/orb-discovery/device-discovery/tests/test_log_config.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""NetBox Labs - Log configuration unit tests."""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from device_discovery.log_config import (
+    _LEVEL_ALIASES,
+    LOG_FORMAT,
+    configure_logging,
+    flatten_message,
+    resolve_log_level,
+)
+
+
+def test_log_format_is_logging_basic_format():
+    """The emitted shape is a wire contract with the Go-side normalizer."""
+    assert LOG_FORMAT == logging.BASIC_FORMAT
+
+
+def test_alias_vocabulary_matches_the_go_side():
+    """
+    Mirrors parseDeviceDiscoveryLevel in device_discovery.go.
+
+    If the Go switch gains a token, this assertion is the thing that notices.
+    """
+    assert set(_LEVEL_ALIASES) == {
+        "trace",
+        "debug",
+        "info",
+        "warn",
+        "warning",
+        "error",
+        "err",
+        "exception",
+        "critical",
+        "fatal",
+    }
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("trace", logging.DEBUG),
+        ("debug", logging.DEBUG),
+        ("DEBUG", logging.DEBUG),
+        ("  Debug  ", logging.DEBUG),
+        ("info", logging.INFO),
+        ("warn", logging.WARNING),
+        ("warning", logging.WARNING),
+        ("WARNING", logging.WARNING),
+        ("error", logging.ERROR),
+        ("err", logging.ERROR),
+        ("exception", logging.ERROR),
+        ("critical", logging.CRITICAL),
+        ("fatal", logging.CRITICAL),
+    ],
+)
+def test_resolve_known_levels(value, expected):
+    """Every accepted token resolves without a warning."""
+    level, warning = resolve_log_level(value)
+    assert level == expected
+    assert warning is None
+
+
+@pytest.mark.parametrize("value", [None, "", "verbose", 3, MagicMock()])
+def test_resolve_unknown_levels_fall_back_and_warn(value):
+    """
+    An unusable value degrades to INFO and says so.
+
+    Must never raise: argparse has no choices= (a YAML typo would exit(2) and
+    crash-loop the backend), and every existing main() test patches parse_args
+    to return a MagicMock.
+    """
+    level, warning = resolve_log_level(value)
+    assert level == logging.INFO
+    assert warning is not None
+    assert "falling back to INFO" in warning
+
+
+def test_configure_logging_overrides_import_time_basicconfig(preserve_root_logging):
+    """
+    The load-bearing test: this FAILS on pre-#494 code.
+
+    Importing device_discovery.client runs the import-time basicConfig, after
+    which a plain basicConfig is a silent no-op. Without force=True the root
+    level stays INFO and --log-level is accepted and ignored -- the exact
+    defect this work exists to kill.
+    """
+    import device_discovery.client  # noqa: F401 - imported for its import-time side effect
+
+    configure_logging("debug")
+
+    root = logging.getLogger()
+    assert root.level == logging.DEBUG
+    assert root.handlers
+    assert any(
+        handler.formatter is not None and handler.formatter._fmt == LOG_FORMAT
+        for handler in root.handlers
+    )
+
+
+def test_configure_logging_returns_applied_level(preserve_root_logging):
+    """configure_logging reports what it applied."""
+    assert configure_logging("error") == logging.ERROR
+    assert logging.getLogger().level == logging.ERROR
+
+
+def test_flatten_message_collapses_multiline_exceptions():
+    """Netmiko messages are ten physical lines; one record must be one line."""
+    error = ValueError("line one\n\nline two\n   line three")
+    flattened = flatten_message(error)
+    assert "\n" not in flattened
+    assert flattened == "line one line two line three"

--- a/orb-discovery/device-discovery/tests/test_no_error_traceback_regression.py
+++ b/orb-discovery/device-discovery/tests/test_no_error_traceback_regression.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""
+NetBox Labs - Structural guard against reintroducing ERROR-level tracebacks.
+
+The generic Go stderr amplifier stays in place by decision, so nothing
+downstream will ever catch a reintroduced ``exc_info=True`` on a routine
+condition. This test is the backstop.
+"""
+
+import ast
+import pathlib
+
+RUNNER = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "device_discovery"
+    / "policy"
+    / "runner.py"
+)
+
+
+def _calls(tree):
+    return [node for node in ast.walk(tree) if isinstance(node, ast.Call)]
+
+
+def _emitter_line_range(tree):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_log_target_failure":
+            return range(node.lineno, (node.end_lineno or node.lineno) + 1)
+    return range(0)
+
+
+def _attribute_path(func):
+    parts = []
+    while isinstance(func, ast.Attribute):
+        parts.append(func.attr)
+        func = func.value
+    if isinstance(func, ast.Name):
+        parts.append(func.id)
+    return ".".join(reversed(parts))
+
+
+def test_no_logger_error_carries_exc_info():
+    """
+    logger.error(..., exc_info=...) belongs only inside _log_target_failure.
+
+    Anywhere else it means a routine per-target condition is emitting a full
+    chained traceback again, which the agent fans out into ~63 ERROR records.
+    """
+    tree = ast.parse(RUNNER.read_text())
+    offenders = []
+    for call in _calls(tree):
+        if _attribute_path(call.func) != "logger.error":
+            continue
+        if any(keyword.arg == "exc_info" for keyword in call.keywords):
+            offenders.append(call.lineno)
+
+    allowed = _emitter_line_range(tree)
+    unexpected = [line for line in offenders if line not in allowed]
+    assert unexpected == [], (
+        f"logger.error(..., exc_info=...) outside _log_target_failure at lines {unexpected}"
+    )
+
+
+def test_the_emitter_exists_so_this_cannot_pass_vacuously():
+    """A guard that passes because the thing it guards was deleted is not a guard."""
+    tree = ast.parse(RUNNER.read_text())
+    names = {
+        node.name for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    }
+    assert "_log_target_failure" in names
+
+    source = RUNNER.read_text()
+    assert source.count("self._log_target_failure(") == 2, (
+        "expected exactly two call sites: run() and run_with_parent()"
+    )


### PR DESCRIPTION
Closes #494.

A host that is alive on the scanned port but is not a manageable device now produces **one WARNING** per discovery attempt instead of a full chained traceback, and `log_level` becomes a real lever for device-discovery instead of a silently-ignored key.

Python side only. The Go `log_level` wiring and the docs follow in separate PRs — the Python side has to accept `--log-level` *before* the agent emits it, or the backend `exit(2)`s and never passes readiness.

## The two problems

The reported ~61 ERROR records come from two independent causes, and only the first is fixed here.

The **defect** is `exc_info=True` on a routine condition, at `policy/runner.py:565` and `:675`. stdlib logging appends the whole chained traceback to a single record. The **amplifier** is generic to every backend: `agent/backend/process.go` splits stderr on every newline and `device_discovery.go:172-176` assigns ERROR by *pipe* rather than by content, so each traceback line becomes its own ERROR record. Fixing only the defect is enough.

Measured on the real code path, against a listener that accepts TCP and never speaks SSH:

| | before | after |
|---|---|---|
| failure record | 1 ERROR rendering as **66 physical lines** | **1 WARNING, 1 line** |
| whole `run()` | 68 lines | 3 lines (2 INFO + 1 WARNING) |

(The reporter pasted ~61; the exact count moves with Python version and where the connection fails.)

## What changed

**Classification.** One module constant, `_EXPECTED_TARGET_FAILURES = (ConnectionException, NetmikoAuthenticationException)`, evaluated with `isinstance` on the raised object only — the `__cause__`/`__context__` chain is deliberately not walked. Expected → one WARNING, flattened, no traceback. Everything else → unchanged ERROR with full `exc_info`.

**Both entries are required.** napalm's `_netmiko_open` catches *only* `NetMikoTimeoutException` and re-raises `ConnectionException`; nothing there catches auth. netmiko roots `NetmikoAuthenticationException` in paramiko's `AuthenticationException`, so `issubclass(NetmikoAuthenticationException, ConnectionException)` is `False` and it is not a `NapalmException` at all. A rejected credential propagates raw — which is precisely the reporter's case. Collapsing the tuple to the anchor alone restores the full wall for bad passwords. There's a comment on the constant saying so.

**Flattening is not cosmetic.** netmiko builds both its timeout and auth messages as ten-line f-strings. Dropping `exc_info` alone leaves the credential path at 1 WARNING + 9 ERROR continuation lines. `run.reason` is flattened by the same helper, so the string at `/api/v1/status` is byte-identical to the log line — a multi-line string inside a JSON response was a defect on its own.

**`log_level` actually works now.** It was accepted and ignored: every module in the package calls `basicConfig` at import time, so by the time `main()` runs the first call has won and any later `basicConfig` is a silent no-op. New `log_config.py` centralises this, `configure_logging` uses `force=True`, and the ten accepted level tokens mirror `parseDeviceDiscoveryLevel` in `device_discovery.go`. `LOG_FORMAT` is pinned byte-identical to `logging.BASIC_FORMAT` because the emitted shape is a wire contract with `normalizeDeviceDiscoveryLine`.

`discovery.py` also stopped clobbering the napalm/ncclient/paramiko/pyeapi levels back to a hardcoded INFO after every auto-discovery pass, which broke `log_level` in both directions.

`runner.py:207` goes ERROR → WARNING: same expected-failure class on the auto-discovery path. `Status.FAILED` at `:206` is left alone (see follow-ups).

## Honest residue

napalm's `NetworkDriver.__exit__` `print`s a two-line "NAPALM didn't catch this exception" epilog to **stdout** for any exception whose name is not in `dir(napalm.base.exceptions)`. `NetmikoAuthenticationException` is not, so this fires on exactly the auth path, and stdout's fallback level is INFO. Not fixable from our code:

| path | before | after |
|---|---|---|
| timeout | ~66 ERROR | **1 WARN** |
| auth rejected | ~66 ERROR + 2 INFO | **1 WARN + 2 INFO** |

**Accepted cost:** a driver bug wrapped into `ConnectionException` is now treated as expected — one WARNING, no traceback. Real sites exist (`custom_napalm/aruba_aoscx.py`, `aruba_osswitch.py`, `cisco_asa.py`, `paloalto_panos.py` all wrap broadly). Mitigated by the DEBUG traceback carrying the chained cause, and by `run.reason` at `/api/v1/status`.

**Not a gap:** netmiko's third message literal, the paramiko `SSHException` branch, raises `NetmikoTimeoutException`, which napalm normalizes to `ConnectionException`. Already covered; no third tuple entry needed.

## Deliberately out of scope

The generic Go stderr amplifier stays. That is why the Python side must hold the one-record-equals-one-physical-line invariant permanently, and why the tests assert **line counts** and include an AST guard rather than relying on record counts alone.

Also not done: no new traceback/`exc_info` option, no `--log-format`, no `WarnUnknownConfigKeys`, no de-duplication of `run`/`run_with_parent`, no custom exception taxonomy.

## Tests

64 new tests; full suite 2028 passed / 161 skipped, up from a 1964 baseline, with zero existing tests broken. `ruff check` clean under the pinned 0.15.10. Verified on Python 3.11 and 3.13.

Covers: the classification table both ways including diode-transport stand-ins, a guard proving the exception chain exists and is ignored on purpose, behaviour parametrised over both `run` and `run_with_parent`, physical-line counts (including a 254-host sweep), the AST guard against reintroducing `exc_info`, and the `log_config` test that **fails on pre-#494 code** — which is the proof the `basicConfig` half actually landed.

## Follow-ups (not folded in)

1. Drivers using `raise ... from None` (`custom_napalm/cisco_fxos.py:318`) destroy the cause chain and should preserve it.
2. An unrecognised level maps to `slog.LevelDebug` in `orb-discovery/network-discovery/config/logger.go`, so a typo makes three backends maximally verbose.
3. `runner.py:206` marks a whole policy FAILED because one host in a sweep failed.
4. The port-scan gate never speaks the protocol (`policy/portscan.py:70-76`), which is the structural reason non-devices enter the discovery path at all. snmp-discovery's `probeTarget` does a real Connect + Walk; device-discovery could do an SSH banner check.