### PR TITLE
fix(device-discovery): keep module_type on nested Module references

### DIFF
--- a/orb-discovery/device-discovery/device_discovery/stubs.py
+++ b/orb-discovery/device-discovery/device_discovery/stubs.py
@@ -250,17 +250,36 @@ def _module_match_stub(rich: pb.Module, dev_stub: pb.Device) -> pb.Module:
     """
     Build a matcher-only Module for use as a nested reference.
 
-    Keeps just the fields Diode needs to resolve a Module — the chassis
-    device (matcher-stubbed) and the serial — plus a positional
-    module_bay reference (device-stubbed) when the rich Module carries
-    one. Drops module_type, description, asset_tag, status, and any
-    rich device fields, so that copying this stub into hundreds of
-    Interface entities does not duplicate the running-config-bearing
-    Device proto per port.
+    ``dcim.module`` resolves on ``module_bay`` (its only unique field
+    besides asset_tag), so the positional module_bay reference —
+    device-stubbed — is the load-bearing part of this stub, not the
+    serial. Serial is carried for create fidelity only; it matches
+    nothing. Drops description, asset_tag, status, and any rich device
+    fields, so that copying this stub into hundreds of Interface
+    entities does not duplicate the running-config-bearing Device proto
+    per port.
+
+    ``module_type`` is retained even though it plays no part in matching:
+    when a nested reference does not resolve, Diode falls back to
+    creating the Module, and NetBox rejects a Module without one
+    (``Field module_type is required``). Dropping it cost 48 failed
+    plans per run on a 6-linecard chassis, and those failures take every
+    other entity in the same batch down with them. Only the
+    ``(manufacturer, model)`` pair is copied — the complete matcher for
+    ``dcim.moduletype`` — rather than the rich ModuleType, so the
+    reference cannot grow as drivers start populating part_number,
+    attributes or profile.
     """
     stub = pb.Module()
     copy_scalar_if_set(stub, rich, "serial")
     stub.device.CopyFrom(dev_stub)
+    if rich.HasField("module_type"):
+        stub.module_type.CopyFrom(
+            pb.ModuleType(
+                model=rich.module_type.model,
+                manufacturer=pb.Manufacturer(name=rich.module_type.manufacturer.name),
+            ),
+        )
     if rich.HasField("module_bay"):
         bay_stub = pb.ModuleBay(name=rich.module_bay.name)
         copy_scalar_if_set(bay_stub, rich.module_bay, "position")

--- a/orb-discovery/device-discovery/tests/test_stubs.py
+++ b/orb-discovery/device-discovery/tests/test_stubs.py
@@ -384,7 +384,9 @@ def test_prune_nested_refs_stubs_interface_module_reference():
     the slot. Without stubbing, a 48-port linecard duplicates that rich
     subtree 48 times in the ingest payload. The stub keeps only the
     fields Diode needs to resolve the module — device, serial, and a
-    positional module_bay shell — so per-interface wire cost is bounded.
+    positional module_bay shell — plus module_type, which NetBox requires
+    if the reference has to be created rather than matched — so
+    per-interface wire cost is bounded.
     """
     rich_dev = pb.Device(name="sw1", serial="FCW123", status="active")
     rich_dev.device_type.CopyFrom(
@@ -398,7 +400,13 @@ def test_prune_nested_refs_stubs_interface_module_reference():
     rich_module.device.CopyFrom(rich_dev)
     rich_module.module_bay.CopyFrom(bay)
     rich_module.module_type.CopyFrom(
-        pb.ModuleType(model="C9400-LC-48U", manufacturer=pb.Manufacturer(name="Cisco")),
+        pb.ModuleType(
+            model="C9400-LC-48U",
+            manufacturer=pb.Manufacturer(name="Cisco", slug="cisco", description="vendor"),
+            part_number="C9400-LC-48U-A",
+            description="48 port UPOE+ line card",
+            comments="rich field a driver may start populating",
+        ),
     )
 
     iface = pb.Interface(name="GigabitEthernet2/0/1", type="1000base-t")
@@ -413,7 +421,17 @@ def test_prune_nested_refs_stubs_interface_module_reference():
     assert pruned_iface.HasField("module")
     assert pruned_iface.module.serial == "JAE2401LC02"
     assert pruned_iface.module.description == ""
-    assert not pruned_iface.module.HasField("module_type")
+    # module_type is retained: a nested ref that fails to match is created
+    # instead, and NetBox rejects a Module without one.
+    assert pruned_iface.module.module_type.model == "C9400-LC-48U"
+    assert pruned_iface.module.module_type.manufacturer.name == "Cisco"
+    # ...but only the (manufacturer, model) matcher pair, so the reference cannot
+    # grow as drivers start populating the richer ModuleType fields.
+    assert pruned_iface.module.module_type.part_number == ""
+    assert pruned_iface.module.module_type.description == ""
+    assert pruned_iface.module.module_type.comments == ""
+    assert pruned_iface.module.module_type.manufacturer.slug == ""
+    assert pruned_iface.module.module_type.manufacturer.description == ""
     # Nested device on the module ref is also a stub.
     assert pruned_iface.module.device.name == "sw1"
     assert pruned_iface.module.device.serial == ""


### PR DESCRIPTION
## What

`_module_match_stub` dropped `module_type` from nested Module references. That is right for *matching* — `dcim.module` resolves on `module_bay`, and `module_type` is not a matcher — but a nested reference that fails to resolve is **created** rather than matched, and NetBox rejects a Module without one:

```
ERR_OPS_GENERATE_DIFF - {"dcim.module":{"module_type":["Field module_type is required"]}}
```

On a 6-linecard chassis that is **48 failed plans per run**, every run.

## Why it costs more than 48 modules

`bulk-plan-apply` batches plans, and a failed plan takes its **whole batch** down. So these failures also lost interfaces that had nothing wrong with them. That is the mechanism behind a report of interfaces "missing across the modules" on a 432-interface chassis.

Replaying that reported payload against NetBox 4.5.5 + the diode plugin, counting interfaces absent after reconciliation settled (fresh device/site/VLAN-group per run, so each pays first-run creation cost):

| | interfaces missing / 432 |
|---|---|
| before | 36, 49 |
| after | **14, 14** |

The nested ref in that payload carried `device`, `module_bay` and `serial` but no `module_type`, across 167 interfaces — so this reproduces from real data, not a synthetic case.

## Why only `(manufacturer, model)` is copied

`stub.module_type.CopyFrom(rich.module_type)` would work, but this stub is duplicated into **every interface on the linecard**, so it must not grow when drivers start populating `part_number`, `attributes`, `profile`, or `Manufacturer.slug/tags`. `(manufacturer, model)` is the complete `dcim.moduletype` matcher and the only pair required on create, so nothing is lost. This also matches how every other retained field in this function is rebuilt, and how the sibling `_device_type_match_stub` already behaves. A test asserts the richer fields do **not** survive.

## Docstring correction

The docstring claimed the stub keeps "the fields Diode needs to resolve a Module — the chassis device and the serial". That is wrong: per the plugin's matcher table `dcim.module` has no logical matcher and resolves on `module_bay` (precedence 1) then `asset_tag` (2). `serial` matches nothing and is carried for create fidelity only. Left as-is, the next person trimming this stub for wire size would keep `serial` and drop the `module_bay` branch as decorative, regenerating exactly this cascade.

## Verification

- 2028 passed, 161 skipped; `ruff check` clean.
- Mutation-tested: removing the copy fails the test, and so does reverting to the unbounded `CopyFrom`.
- End-to-end on the reported payload, twice per arm (numbers above).
- Adversarial review (5 independent lenses, each finding put to 2 independent skeptics). Two of its findings are applied here: the bounded copy and the docstring correction.

## Not in this PR, deliberately

A second bug surfaced in the same investigation: a VLAN group created through Diode ends up permitting only **1-4093**, so VID 4094 is rejected for the group's lifetime, and that rejection poisons batches too. Fixing both took the same payload to **0/432 missing**.

I am not shipping the agent-side workaround for it. Setting `vid_ranges` on the emitted group overwrites an operator's deliberately narrowed range, silently, on the next discovery run:

| | group range after our ingest |
|---|---|
| today (field omitted) | `[[1, 1000]]` preserved |
| with the workaround | `[[1, 4094]]` — overwritten |

NetBox's own default is correctly `[[1, 4094]]`; a group created via the NetBox API directly gets it. Only groups created *through Diode* come out `1-4093`, so this belongs upstream, where it costs nothing and destroys no operator intent.

Raised as **netboxlabs/diode-netbox-plugin#197** — `harmonize_formats` assumed every range was Postgres-canonical half-open, which silently dropped the top of NetBox's inclusive `default_vid_ranges()`. With that fix loaded and **only this PR's `module_type` change** on the agent side, the same payload reaches **432/432 interfaces, twice** — no `vid_ranges` written by the agent, and an operator-narrowed group left untouched.

Companion PRs (one per backend, per repo convention):

- **#511** — the identical `ModuleType` defect in `snmp-discovery`, which has the same stub shape.
- **netboxlabs/diode-netbox-plugin#197** — the plugin-side `vid_ranges` fix described above.

`gnmi-discovery` needs no equivalent: it never attaches a Module to an Interface (its only reference to the field sets it to nil).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
