### PR TITLE
feat(agent): pass log_level through to the device-discovery backend

### DIFF
--- a/agent/backend/devicediscovery/device_discovery.go
+++ b/agent/backend/devicediscovery/device_discovery.go
@@ -49,6 +49,7 @@ type deviceDiscoveryBackend struct {
 	diodeTargetFromOtel  bool
 	diodeDryRun          bool
 	diodeDryRunOutputDir string
+	diodeLogLevel        string
 
 	startTime  time.Time
 	proc       backend.Commander
@@ -87,6 +88,21 @@ func (d *deviceDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Po
 	d.diodeAppNamePrefix = backend.ConfigValueOrDefault(config, "agent_name", common.Diode.AgentName)
 	d.diodeDryRun = backend.ConfigValueOrDefault(config, "dry_run", common.Diode.DryRun)
 	d.diodeDryRunOutputDir = backend.ConfigValueOrDefault(config, "dry_run_output_dir", common.Diode.DryRunOutputDir)
+
+	// Mirrors networkdiscovery/network_discovery.go so the four backends stay
+	// greppably identical for the open de-duplication work. Precedence:
+	// explicit log_level > per-backend debug: true > the agent already running
+	// at debug (-d or orb.debug.enable, which cmd/main.go applies to the shared
+	// LevelVar before agent.New). Uses the logger parameter rather than
+	// d.logger, exactly as the sibling does. A non-string log_level (YAML
+	// `log_level: 3`) falls through the type assertion and cannot panic.
+	if logLevel, prs := config["log_level"].(string); prs {
+		d.diodeLogLevel = logLevel
+	} else if debug, prs := config["debug"].(bool); prs && debug {
+		d.diodeLogLevel = "debug"
+	} else if logger.Enabled(context.Background(), slog.LevelDebug) {
+		d.diodeLogLevel = "debug"
+	}
 
 	if common.Otlp.Grpc != "" {
 		d.diodeOtelEndpoint = common.Otlp.Grpc
@@ -134,6 +150,12 @@ func (d *deviceDiscoveryBackend) buildArgs() []string {
 			)
 		}
 		dOptions = append(opts, dOptions...)
+	}
+
+	if d.diodeLogLevel != "" {
+		dOptions = append(dOptions, "--log-level", d.diodeLogLevel)
+		d.logger.Info("device-discovery using log level",
+			"log_level", d.diodeLogLevel)
 	}
 
 	if d.diodeOtelEndpoint != "" {

--- a/agent/backend/devicediscovery/device_discovery.go
+++ b/agent/backend/devicediscovery/device_discovery.go
@@ -89,18 +89,31 @@ func (d *deviceDiscoveryBackend) Configure(logger *slog.Logger, repo policies.Po
 	d.diodeDryRun = backend.ConfigValueOrDefault(config, "dry_run", common.Diode.DryRun)
 	d.diodeDryRunOutputDir = backend.ConfigValueOrDefault(config, "dry_run_output_dir", common.Diode.DryRunOutputDir)
 
-	// Mirrors networkdiscovery/network_discovery.go so the four backends stay
-	// greppably identical for the open de-duplication work. Precedence:
-	// explicit log_level > per-backend debug: true > the agent already running
-	// at debug (-d or orb.debug.enable, which cmd/main.go applies to the shared
-	// LevelVar before agent.New). Uses the logger parameter rather than
-	// d.logger, exactly as the sibling does. A non-string log_level (YAML
+	// Precedence: explicit log_level > per-backend debug: true > the agent
+	// itself running in debug mode. A non-string log_level (YAML
 	// `log_level: 3`) falls through the type assertion and cannot panic.
+	//
+	// The third branch deliberately reads common.Debug rather than
+	// logger.Enabled(ctx, slog.LevelDebug), which is what the other three
+	// discovery backends currently do. logger.Enabled is not a reliable proxy
+	// for debug mode here: when orb.backends.common.otlp.grpc is set,
+	// agent.go:165-166 replaces the agent logger with a telemetry.multiHandler
+	// wrapping both the console handler and the otelslog handler. multiHandler
+	// ORs Enabled across its handlers (telemetry/logs.go:52-59) and the
+	// otelslog handler applies no level filter, so Enabled(Debug) is true
+	// whenever OTLP log export is enabled -- with or without -d. That would
+	// silently start device-discovery at DEBUG and export the full traceback
+	// plus napalm/netmiko/paramiko/ncclient chatter to the collector.
+	//
+	// common.Debug is the explicit state: agent.go:160 sets it from a.debug,
+	// which cmd/main.go:95 derives as debugFlag || cfg.OrbAgent.Debug.Enable.
+	// The same fix is owed to networkdiscovery, snmpdiscovery and
+	// gnmidiscovery; tracked separately.
 	if logLevel, prs := config["log_level"].(string); prs {
 		d.diodeLogLevel = logLevel
 	} else if debug, prs := config["debug"].(bool); prs && debug {
 		d.diodeLogLevel = "debug"
-	} else if logger.Enabled(context.Background(), slog.LevelDebug) {
+	} else if common.Debug {
 		d.diodeLogLevel = "debug"
 	}
 

--- a/agent/backend/devicediscovery/device_discovery_test.go
+++ b/agent/backend/devicediscovery/device_discovery_test.go
@@ -88,6 +88,8 @@ func TestDeviceDiscoveryBackendStart(t *testing.T) {
 		assert.Contains(t, args, "device-secret", "Expected args to contain diode client secret")
 		assert.Contains(t, args, "--diode-app-name-prefix", "Expected args to contain diode app name prefix flag")
 		assert.Contains(t, args, "device-agent", "Expected args to contain diode app name prefix")
+		assert.Contains(t, args, "--log-level", "Expected args to contain log level flag")
+		assert.Contains(t, args, "debug", "Expected args to contain log level value")
 		assert.Contains(t, args, "--otel-endpoint", "Expected args to contain otel endpoint flag")
 		assert.Contains(t, args, "collector:4317", "Expected args to contain otel endpoint value")
 	})
@@ -116,6 +118,7 @@ func TestDeviceDiscoveryBackendStart(t *testing.T) {
 		"agent_name":         "device-agent",
 		"dry_run":            false,
 		"dry_run_output_dir": "/tmp/device",
+		"log_level":          "debug",
 	}, commons, nil)
 	require.NoError(t, err)
 

--- a/agent/backend/devicediscovery/log_level_test.go
+++ b/agent/backend/devicediscovery/log_level_test.go
@@ -1,6 +1,7 @@
 package devicediscovery
 
 import (
+	"context"
 	"io"
 	"log/slog"
 	"testing"
@@ -11,17 +12,30 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/config"
 )
 
-// levelLogger builds a discarding logger pinned at the given level, standing in
-// for the shared LevelVar that cmd/main.go raises for -d or orb.debug.enable.
-func levelLogger(level slog.Level) *slog.Logger {
-	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: level}))
+// discardLogger is a plain Info-level logger; the level is irrelevant to the
+// precedence chain now that it keys off common.Debug rather than the handler.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo}))
+}
+
+// otlpLikeHandler mimics the otelslog handler that
+// telemetry.BuildOTLPLogExporter merges into the agent logger: no level filter,
+// so Enabled always reports true. telemetry.multiHandler ORs Enabled across its
+// handlers, which is why an OTLP-wrapped agent logger claims Debug is enabled
+// even when the agent was never started with -d.
+type otlpLikeHandler struct {
+	slog.Handler
+}
+
+func (otlpLikeHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func otlpWrappedLogger() *slog.Logger {
+	return slog.New(otlpLikeHandler{Handler: slog.NewTextHandler(io.Discard, nil)})
 }
 
 // flagValue returns the argument immediately following flag. Asserting on
 // adjacency is strictly stronger than two separate assert.Contains calls, which
 // would pass even if the flag and its value were separated by another option.
-// The Python side pins the other half of this boundary in
-// orb-discovery/device-discovery/tests/test_cli_parity.py.
 func flagValue(t *testing.T, args []string, flag string) (string, bool) {
 	t.Helper()
 	for i, arg := range args {
@@ -35,70 +49,108 @@ func flagValue(t *testing.T, args []string, flag string) (string, bool) {
 
 func TestConfigureLogLevelPrecedence(t *testing.T) {
 	tests := []struct {
-		name     string
-		config   map[string]any
-		logger   *slog.Logger
-		expected string
+		name       string
+		config     map[string]any
+		agentDebug bool
+		expected   string
 	}{
 		{
 			name:     "explicit log_level wins",
 			config:   map[string]any{"log_level": "error"},
-			logger:   levelLogger(slog.LevelInfo),
 			expected: "error",
 		},
 		{
 			name:     "explicit log_level beats per-backend debug",
 			config:   map[string]any{"log_level": "error", "debug": true},
-			logger:   levelLogger(slog.LevelInfo),
 			expected: "error",
+		},
+		{
+			name:       "explicit log_level beats agent debug",
+			config:     map[string]any{"log_level": "error"},
+			agentDebug: true,
+			expected:   "error",
 		},
 		{
 			name:     "per-backend debug implies debug",
 			config:   map[string]any{"debug": true},
-			logger:   levelLogger(slog.LevelInfo),
 			expected: "debug",
 		},
 		{
 			name:     "per-backend debug false does not imply debug",
 			config:   map[string]any{"debug": false},
-			logger:   levelLogger(slog.LevelInfo),
 			expected: "",
 		},
 		{
-			name:     "agent already at debug implies debug",
-			config:   map[string]any{},
-			logger:   levelLogger(slog.LevelDebug),
-			expected: "debug",
+			name:       "agent debug implies debug",
+			config:     map[string]any{},
+			agentDebug: true,
+			expected:   "debug",
 		},
 		{
 			name:     "nothing set leaves it empty",
 			config:   map[string]any{},
-			logger:   levelLogger(slog.LevelInfo),
 			expected: "",
 		},
 		{
 			// YAML `log_level: 3` must fall through the type assertion.
 			name:     "non-string log_level does not panic",
 			config:   map[string]any{"log_level": 3},
-			logger:   levelLogger(slog.LevelInfo),
 			expected: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			commons := config.BackendCommons{}
+			commons.Debug = tt.agentDebug
+
 			d := &deviceDiscoveryBackend{apiProtocol: "http"}
 			require.NotPanics(t, func() {
-				require.NoError(t, d.Configure(tt.logger, nil, tt.config, config.BackendCommons{}, nil))
+				require.NoError(t, d.Configure(discardLogger(), nil, tt.config, commons, nil))
 			})
 			assert.Equal(t, tt.expected, d.diodeLogLevel)
 		})
 	}
 }
 
+// TestConfigureDoesNotTreatOtlpExportAsDebug is the regression guard for the
+// review finding on PR #510. Enabling OTLP log export must not, by itself, put
+// the backend into debug.
+func TestConfigureDoesNotTreatOtlpExportAsDebug(t *testing.T) {
+	logger := otlpWrappedLogger()
+	require.True(t, logger.Enabled(context.Background(), slog.LevelDebug),
+		"precondition: an OTLP-wrapped agent logger reports Debug as enabled")
+
+	commons := config.BackendCommons{}
+	commons.Otlp.Grpc = "collector:4317"
+	commons.Debug = false // no -d, no orb.debug.enable
+
+	d := &deviceDiscoveryBackend{apiProtocol: "http"}
+	require.NoError(t, d.Configure(logger, nil, map[string]any{}, commons, nil))
+
+	assert.Empty(t, d.diodeLogLevel,
+		"OTLP log export alone must not enable debug — see telemetry/logs.go:52-59")
+
+	_, found := flagValue(t, d.buildArgs(), "--log-level")
+	assert.False(t, found, "expected no --log-level when only OTLP export is configured")
+}
+
+// TestConfigureOtlpPlusAgentDebugStillEnablesDebug is the other half: the fix
+// must not have broken the legitimate case.
+func TestConfigureOtlpPlusAgentDebugStillEnablesDebug(t *testing.T) {
+	commons := config.BackendCommons{}
+	commons.Otlp.Grpc = "collector:4317"
+	commons.Debug = true
+
+	d := &deviceDiscoveryBackend{apiProtocol: "http"}
+	require.NoError(t, d.Configure(otlpWrappedLogger(), nil, map[string]any{}, commons, nil))
+
+	assert.Equal(t, "debug", d.diodeLogLevel)
+}
+
 func TestBuildArgsIncludesLogLevel(t *testing.T) {
 	d := &deviceDiscoveryBackend{apiProtocol: "http"}
-	require.NoError(t, d.Configure(levelLogger(slog.LevelInfo), nil,
+	require.NoError(t, d.Configure(discardLogger(), nil,
 		map[string]any{"log_level": "debug"}, config.BackendCommons{}, nil))
 
 	args := d.buildArgs()
@@ -113,7 +165,7 @@ func TestBuildArgsOmitsLogLevelWhenUnset(t *testing.T) {
 	// debug anywhere, the arguments must be exactly what they were before this
 	// change. That is what bounds the blast radius.
 	d := &deviceDiscoveryBackend{apiProtocol: "http"}
-	require.NoError(t, d.Configure(levelLogger(slog.LevelInfo), nil,
+	require.NoError(t, d.Configure(discardLogger(), nil,
 		map[string]any{}, config.BackendCommons{}, nil))
 
 	args := d.buildArgs()
@@ -129,7 +181,7 @@ func TestBuildArgsLogLevelPrecedesOtelEndpoint(t *testing.T) {
 	commons.Otlp.Grpc = "collector:4317"
 
 	d := &deviceDiscoveryBackend{apiProtocol: "http"}
-	require.NoError(t, d.Configure(levelLogger(slog.LevelInfo), nil,
+	require.NoError(t, d.Configure(discardLogger(), nil,
 		map[string]any{"log_level": "warn"}, commons, nil))
 
 	args := d.buildArgs()

--- a/agent/backend/devicediscovery/log_level_test.go
+++ b/agent/backend/devicediscovery/log_level_test.go
@@ -1,0 +1,144 @@
+package devicediscovery
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/config"
+)
+
+// levelLogger builds a discarding logger pinned at the given level, standing in
+// for the shared LevelVar that cmd/main.go raises for -d or orb.debug.enable.
+func levelLogger(level slog.Level) *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: level}))
+}
+
+// flagValue returns the argument immediately following flag. Asserting on
+// adjacency is strictly stronger than two separate assert.Contains calls, which
+// would pass even if the flag and its value were separated by another option.
+// The Python side pins the other half of this boundary in
+// orb-discovery/device-discovery/tests/test_cli_parity.py.
+func flagValue(t *testing.T, args []string, flag string) (string, bool) {
+	t.Helper()
+	for i, arg := range args {
+		if arg == flag {
+			require.Less(t, i+1, len(args), "flag %s has no value following it", flag)
+			return args[i+1], true
+		}
+	}
+	return "", false
+}
+
+func TestConfigureLogLevelPrecedence(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   map[string]any
+		logger   *slog.Logger
+		expected string
+	}{
+		{
+			name:     "explicit log_level wins",
+			config:   map[string]any{"log_level": "error"},
+			logger:   levelLogger(slog.LevelInfo),
+			expected: "error",
+		},
+		{
+			name:     "explicit log_level beats per-backend debug",
+			config:   map[string]any{"log_level": "error", "debug": true},
+			logger:   levelLogger(slog.LevelInfo),
+			expected: "error",
+		},
+		{
+			name:     "per-backend debug implies debug",
+			config:   map[string]any{"debug": true},
+			logger:   levelLogger(slog.LevelInfo),
+			expected: "debug",
+		},
+		{
+			name:     "per-backend debug false does not imply debug",
+			config:   map[string]any{"debug": false},
+			logger:   levelLogger(slog.LevelInfo),
+			expected: "",
+		},
+		{
+			name:     "agent already at debug implies debug",
+			config:   map[string]any{},
+			logger:   levelLogger(slog.LevelDebug),
+			expected: "debug",
+		},
+		{
+			name:     "nothing set leaves it empty",
+			config:   map[string]any{},
+			logger:   levelLogger(slog.LevelInfo),
+			expected: "",
+		},
+		{
+			// YAML `log_level: 3` must fall through the type assertion.
+			name:     "non-string log_level does not panic",
+			config:   map[string]any{"log_level": 3},
+			logger:   levelLogger(slog.LevelInfo),
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &deviceDiscoveryBackend{apiProtocol: "http"}
+			require.NotPanics(t, func() {
+				require.NoError(t, d.Configure(tt.logger, nil, tt.config, config.BackendCommons{}, nil))
+			})
+			assert.Equal(t, tt.expected, d.diodeLogLevel)
+		})
+	}
+}
+
+func TestBuildArgsIncludesLogLevel(t *testing.T) {
+	d := &deviceDiscoveryBackend{apiProtocol: "http"}
+	require.NoError(t, d.Configure(levelLogger(slog.LevelInfo), nil,
+		map[string]any{"log_level": "debug"}, config.BackendCommons{}, nil))
+
+	args := d.buildArgs()
+
+	value, found := flagValue(t, args, "--log-level")
+	require.True(t, found, "expected --log-level in %v", args)
+	assert.Equal(t, "debug", value, "--log-level must be immediately followed by its value")
+}
+
+func TestBuildArgsOmitsLogLevelWhenUnset(t *testing.T) {
+	// Pins the byte-identical default command line: with no log_level and no
+	// debug anywhere, the arguments must be exactly what they were before this
+	// change. That is what bounds the blast radius.
+	d := &deviceDiscoveryBackend{apiProtocol: "http"}
+	require.NoError(t, d.Configure(levelLogger(slog.LevelInfo), nil,
+		map[string]any{}, config.BackendCommons{}, nil))
+
+	args := d.buildArgs()
+
+	_, found := flagValue(t, args, "--log-level")
+	assert.False(t, found, "expected no --log-level in %v", args)
+}
+
+func TestBuildArgsLogLevelPrecedesOtelEndpoint(t *testing.T) {
+	// Order matters only in that both must survive; this catches an append that
+	// accidentally replaces rather than extends.
+	commons := config.BackendCommons{}
+	commons.Otlp.Grpc = "collector:4317"
+
+	d := &deviceDiscoveryBackend{apiProtocol: "http"}
+	require.NoError(t, d.Configure(levelLogger(slog.LevelInfo), nil,
+		map[string]any{"log_level": "warn"}, commons, nil))
+
+	args := d.buildArgs()
+
+	logLevel, foundLevel := flagValue(t, args, "--log-level")
+	require.True(t, foundLevel)
+	assert.Equal(t, "warn", logLevel)
+
+	endpoint, foundEndpoint := flagValue(t, args, "--otel-endpoint")
+	require.True(t, foundEndpoint)
+	assert.Equal(t, "collector:4317", endpoint)
+}

--- a/agent/backend/devicediscovery/normalize_test.go
+++ b/agent/backend/devicediscovery/normalize_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseDeviceDiscoveryLevel(t *testing.T) {
@@ -38,6 +39,36 @@ func TestParseDeviceDiscoveryLevel(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNormalizeDeviceDiscoveryLine_ExpectedTargetFailureWarning(t *testing.T) {
+	// The verbatim line the Python backend now emits for an unreachable target
+	// (device_discovery/policy/runner.py, _log_target_failure). If this stops
+	// parsing, the agent silently falls back to assigning level by pipe and the
+	// #494 fix regresses from the operator's point of view.
+	line := "WARNING:device_discovery.policy.runner:Policy lab_mgmt_device_policy, " +
+		"Hostname 10.0.0.5: Cannot connect to 10.0.0.5"
+
+	msg, attrs, level, ok := normalizeDeviceDiscoveryLine(line, slog.LevelError)
+
+	assert.True(t, ok)
+	assert.Equal(t, slog.LevelWarn, level)
+	require.Len(t, attrs, 1)
+	assert.Equal(t, "module", attrs[0].Key)
+	assert.Equal(t, "device_discovery.policy.runner", attrs[0].Value.String())
+	assert.Contains(t, msg, "Cannot connect to 10.0.0.5")
+}
+
+func TestNormalizeDeviceDiscoveryLine_ContinuationStillFallsBackToStderrLevel(t *testing.T) {
+	// Known remaining behaviour, recorded as a test rather than left implicit.
+	// A traceback continuation line has no LEVEL: prefix, so it keeps the
+	// caller's fallback -- which logLineAdapter sets to ERROR for stderr. The
+	// generic per-line stderr amplifier is deliberately out of scope for #494;
+	// the Python side avoids it by emitting exactly one physical line.
+	_, _, level, ok := normalizeDeviceDiscoveryLine("    self._open()", slog.LevelError)
+
+	assert.False(t, ok)
+	assert.Equal(t, slog.LevelError, level)
 }
 
 func TestNormalizeDeviceDiscoveryLine_Valid(t *testing.T) {

--- a/docs/backends/device_discovery/README.md
+++ b/docs/backends/device_discovery/README.md
@@ -96,10 +96,6 @@ to go *quieter* than INFO. Note that DEBUG also raises napalm, netmiko, paramiko
 ncclient verbosity considerably (ncclient dumps multi-line XML), so point it at one
 target rather than a subnet.
 
-For a machine-readable per-target census instead of grepping logs, query
-`GET http://<host>:<port>/api/v1/status`. It keeps the last 3 runs per target, in memory
-only.
-
 ## Policy
 Device discovery policies are broken down into two subsections: `config` and `scope`. 
 

--- a/docs/backends/device_discovery/README.md
+++ b/docs/backends/device_discovery/README.md
@@ -37,7 +37,7 @@ When a target is a modular chassis and the `discover_modules` policy option is e
 When the `discover_vrfs` policy option is enabled, device-discovery emits a `VRF` entity for each VRF configured on the device and attaches it to the IP addresses and prefixes of the interfaces inside that VRF — see [VRFs](#vrfs) below. Defaults to `false`, so existing operators see zero behaviour change.
 
 ## Configuration
-The `device_discovery` backend does not require any special configuration, though overriding `host` and `port` values can be specified. The backend will use the `diode` settings specified in the `common` subsection to forward discovery results.
+The `device_discovery` backend does not require any special configuration, though overriding `host`, `port` and `log_level` values can be specified. The backend will use the `diode` settings specified in the `common` subsection to forward discovery results.
 
 
 ```yaml
@@ -52,8 +52,53 @@ orb:
     device_discovery:
       host: 192.168.5.11 # default 0.0.0.0
       port: 8857 # default 8072
+      log_level: ERROR # default INFO
 
 ```
+
+| Parameter | Type | Required | Description |
+|:---------:|:----:|:--------:|:-----------:|
+| host | str | no | REST API host (default `0.0.0.0`) |
+| port | int | no | REST API port (default `8072`) |
+| log_level | str | no | Log level (default `INFO`) - see [Log level and troubleshooting](#log-level-and-troubleshooting) |
+
+### Log level and troubleshooting
+
+`log_level` accepts `trace`, `debug`, `info`, `warn`/`warning`, `error`/`err`/`exception`
+and `critical`/`fatal`, case-insensitively. The default is `INFO`. An unrecognised value
+falls back to `INFO` and logs a warning rather than failing to start.
+
+Precedence, highest first: an explicit `log_level`, then `debug: true` on the backend,
+then the agent already running at debug (`-d` or `orb.debug.enable`).
+
+**A host that is reachable but not a manageable device logs exactly one record.** When
+a target answers on the scanned port but cannot be logged into, device-discovery emits a
+single WARNING per target per run, with no traceback:
+
+```
+WARNING:device_discovery.policy.runner:Policy my_policy, Hostname 10.0.0.5: Cannot connect to 10.0.0.5
+```
+
+Stable phrases to alert or grep on: `Cannot connect to` and `Authentication to device failed`.
+A sweep over unreachable address space produces one line per host, not one per traceback frame.
+
+Tracebacks for these expected failures are emitted only at DEBUG, on a single line with
+newlines escaped as `\n`. To read one back:
+
+```bash
+printf '%b\n' "<the traceback: value>"
+```
+
+**`log_level: DEBUG` alone is not enough to see debug output.** The agent maps the
+backend's `DEBUG:` lines to its own debug level and its root handler drops them at Info.
+Use `orb.debug.enable` or `-d` as the single troubleshooting switch; use `log_level` only
+to go *quieter* than INFO. Note that DEBUG also raises napalm, netmiko, paramiko and
+ncclient verbosity considerably (ncclient dumps multi-line XML), so point it at one
+target rather than a subnet.
+
+For a machine-readable per-target census instead of grepping logs, query
+`GET http://<host>:<port>/api/v1/status`. It keeps the last 3 runs per target, in memory
+only.
 
 ## Policy
 Device discovery policies are broken down into two subsections: `config` and `scope`. 

--- a/docs/backends/device_discovery/README.md
+++ b/docs/backends/device_discovery/README.md
@@ -50,7 +50,7 @@ orb:
         client_secret: ${DIODE_CLIENT_SECRET}
         agent_name: agent01
     device_discovery:
-      host: 192.168.5.11 # default 0.0.0.0
+      host: 192.168.5.11 # default localhost
       port: 8857 # default 8072
       log_level: ERROR # default INFO
 
@@ -58,7 +58,7 @@ orb:
 
 | Parameter | Type | Required | Description |
 |:---------:|:----:|:--------:|:-----------:|
-| host | str | no | REST API host (default `0.0.0.0`) |
+| host | str | no | REST API host (default `localhost`) |
 | port | int | no | REST API port (default `8072`) |
 | log_level | str | no | Log level (default `INFO`) - see [Log level and troubleshooting](#log-level-and-troubleshooting) |
 


### PR DESCRIPTION
Follow-up to #508, which closed #494.

#508 taught the device-discovery Python backend to accept `--log-level`, but nothing was passing it. This wires the agent side, so `log_level` under `orb.backends.device_discovery` finally does something:

```yaml
orb:
  backends:
    device_discovery:
      log_level: ERROR # default INFO
```

## The change

Three hunks in `agent/backend/devicediscovery/device_discovery.go`:

1. A `diodeLogLevel string` field on the backend struct.
2. A precedence conditional in `Configure`.
3. An append in `buildArgs`, guarded by `!= ""`.

Precedence, highest first:

1. explicit `log_level` on the backend
2. `debug: true` on the backend
3. the agent itself running in debug mode

A non-string value (`log_level: 3`) falls through the type assertion and is ignored; it cannot panic.

**With nothing configured the command line is byte-for-byte unchanged**, which is what bounds the blast radius. `TestBuildArgsOmitsLogLevelWhenUnset` pins that.

## Divergence from the sibling backends

The struct field and the `buildArgs` append are copied from `agent/backend/networkdiscovery/network_discovery.go`. The `Configure` branch **deliberately diverges** from it, following review.

The sibling's third branch tests `logger.Enabled(ctx, slog.LevelDebug)`. That is not a reliable proxy for debug mode: when `orb.backends.common.otlp.grpc` is set, `agent.go:165-166` replaces the agent logger with a `telemetry.multiHandler` wrapping both the console handler and the otelslog handler. `multiHandler.Enabled` ORs across its handlers (`telemetry/logs.go:52-59`) and otelslog applies no level filter, so `Enabled(Debug)` is true whenever OTLP log export is on — with or without `-d`. Enabling log export would silently start device-discovery at DEBUG and ship the full traceback plus napalm/netmiko/paramiko/ncclient chatter to the collector.

Reproduced against the first push of this branch:

```
OTLP export ON, agent debug OFF  ->  diodeLogLevel = "debug"
buildArgs = [... --log-level debug --otel-endpoint collector:4317]
```

This branch now reads `common.Debug`, which `agent.go:160` sets from `a.debug`, which `cmd/main.go:95` derives as `debugFlag || cfg.OrbAgent.Debug.Enable` — the explicit state, unaffected by handler composition.

`networkdiscovery`, `snmpdiscovery` and `gnmidiscovery` all still have the original branch and are affected today. Fixing them is out of scope here and will follow as a separate `fix(agent)` PR.

## Why this had to come second

The Dockerfile builds the agent binary and pip-installs the device-discovery wheel from the same commit. Had this merged before #508, any agent started with `-d` or `orb.debug.enable` would have emitted `--log-level` to a wheel that rejects it — argparse exits 2 and device_discovery crash-loops before passing readiness. With #508 in `develop`, that window is closed.

## Tests

- `TestConfigureLogLevelPrecedence` — 8 cases covering the full chain plus the non-string no-panic case.
- `TestConfigureDoesNotTreatOtlpExportAsDebug` — the regression guard for the finding above: OTLP export alone must not enable debug.
- `TestConfigureOtlpPlusAgentDebugStillEnablesDebug` — the other half, so the fix cannot over-correct and suppress a legitimate debug run.
- `TestBuildArgsIncludesLogLevel` — asserts the flag and its value are **adjacent**, via a `flagValue` helper. Stronger than `network_discovery_test.go:91-92`, which uses two separate `Contains` calls and would pass even if they were separated.
- `TestBuildArgsOmitsLogLevelWhenUnset`, `TestBuildArgsLogLevelPrecedesOtelEndpoint`.
- Two `normalize_test.go` cases: the verbatim WARNING line #508 now emits parses to `slog.LevelWarn` with the right `module` attribute, and the known-remaining continuation-line ERROR fallback is pinned as a test so the out-of-scope decision is recorded rather than implicit.
- `log_level` added to the existing `Configure` map and args assertions.

`go test -race ./agent/backend/devicediscovery/...` green, full `./agent/... ./cmd/...` green, `gofmt` and `go vet` clean, golangci-lint 0 issues.

## Docs

`docs/backends/device_discovery/README.md` gains the `log_level` key, the parameter table the page lacked, and a troubleshooting section covering accepted values, the precedence chain, the one-WARNING-per-unreachable-target behaviour with grep-stable phrases, and how to un-escape the DEBUG traceback.

It also documents the trap: `log_level: DEBUG` alone is **not** enough to see debug output, because the agent's own handler drops debug records at Info. `orb.debug.enable` / `-d` is the troubleshooting switch; `log_level` is for going quieter.

## Not included

The Python-side CLI parity test (feeding `buildArgs`' literal argument vector to `build_parser()`) lives under `orb-discovery/device-discovery/`, and semantic-release selects by path — including it here would cut a spurious **minor** bump of the PyPI package for a test-only change. It'll follow as `test(device-discovery)`, which releases nothing.