### PR TITLE
fix(snmp-discovery): keep ModuleType on nested Module references

### DIFF
--- a/orb-discovery/snmp-discovery/mapping/stubs.go
+++ b/orb-discovery/snmp-discovery/mapping/stubs.go
@@ -349,31 +349,36 @@ func PruneNestedRefs(entities []diode.Entity, currentDevice *diode.Device, prima
 				e.Lag = stubForIface(e.Lag)
 			}
 			if e.Module != nil {
-				// Reduce nested Interface.Module to a matcher-only ref:
-				// chassis Device stub + Serial (if known) + ModuleBay
-				// matcher (if known). The top-level Module entity
-				// carries the full record (module_type, description,
-				// status, etc.); this nested form lets the Diode
-				// reconciler resolve the ref to that top-level row via
-				// the (Device, ModuleBay) or (Device, Serial) match
-				// paths without re-creating it.
+				// Reduce nested Interface.Module to a matcher-only ref: chassis
+				// Device stub + ModuleBay matcher + ModuleType, plus Serial when
+				// known. The top-level Module entity carries the full record
+				// (description, status, etc.).
 				//
-				// Shape mirrors device-discovery's _module_match_stub
-				// (device-discovery/device_discovery/stubs.py
-				// `_module_match_stub`): emit Device unconditionally,
-				// then conditionally copy Serial and ModuleBay matcher
-				// fields when present on the rich Module. Vendors that
-				// omit transceiver serial in ENTITY-MIB (some Aruba
-				// and low-end OEMs) still populate the bay, so the
-				// (Device, ModuleBay) path alone must keep the ref
-				// resolvable.
+				// ModuleBay is the load-bearing part: it is dcim.module's only
+				// unique matcher besides asset_tag. Serial is carried for create
+				// fidelity only — dcim.module has no serial matcher, so a
+				// serial-only stub resolves nothing. Vendors that omit transceiver
+				// serial in ENTITY-MIB (some Aruba and low-end OEMs) still populate
+				// the bay, so the bay alone must keep the ref resolvable.
 				//
-				// Only when BOTH Serial AND ModuleBay are unusable do
-				// we drop the ref entirely — at that point the stub
-				// carries no identifier and the reconciler would fall
-				// into creation mode and fail the
-				// "module_bay required, module_type required"
-				// validation (we also strip ModuleType).
+				// ModuleType is retained even though it matches nothing. A ref only
+				// resolves once the referenced ModuleBay row exists; until then
+				// Diode falls back to CREATING the Module, and NetBox rejects a
+				// Module without a module_type. Emitting module entities ahead of
+				// interfaces does not prevent that: bulk-plan-apply batches plans
+				// and applies them independently, so payload order is not
+				// reconciliation order, and one failed plan takes its whole batch
+				// down — including unrelated interfaces. Only the
+				// (Manufacturer, Model) pair is copied, which is the complete
+				// dcim.moduletype matcher, so the ref cannot grow as drivers
+				// populate richer ModuleType fields.
+				//
+				// Mirrors device-discovery's _module_match_stub
+				// (device-discovery/device_discovery/stubs.py).
+				//
+				// Only when BOTH Serial AND ModuleBay are unusable do we drop the
+				// ref entirely: it then carries no identifier, and creating it
+				// would fail anyway because NetBox requires module_bay.
 				devStub := stubFor(e.Module.Device)
 				stub := &diode.Module{Device: devStub}
 				if e.Module.Serial != nil && *e.Module.Serial != "" {
@@ -384,6 +389,14 @@ func PruneNestedRefs(entities []diode.Entity, currentDevice *diode.Device, prima
 						Device:   devStub,
 						Name:     e.Module.ModuleBay.Name,
 						Position: e.Module.ModuleBay.Position,
+					}
+				}
+				if mt := e.Module.ModuleType; mt != nil {
+					stub.ModuleType = &diode.ModuleType{Model: mt.Model}
+					if mt.Manufacturer != nil {
+						stub.ModuleType.Manufacturer = &diode.Manufacturer{
+							Name: mt.Manufacturer.Name,
+						}
 					}
 				}
 				if stub.Serial == nil && stub.ModuleBay == nil {

--- a/orb-discovery/snmp-discovery/mapping/stubs_test.go
+++ b/orb-discovery/snmp-discovery/mapping/stubs_test.go
@@ -603,16 +603,19 @@ func TestPruneNestedRefs_StubsModuleBayAndInterfaceModule(t *testing.T) {
 	assert.Nil(t, bay.Device.Status, "ModuleBay.Device status stripped on stub")
 
 	// Interface.Module reduced to a matcher-only ref: Device stub + Serial
-	// + ModuleBay matcher (name+position+device stub). Mirrors
-	// device-discovery's _module_match_stub so the Diode reconciler
-	// resolves the ref to the existing top-level Module instead of
-	// trying to create one and failing the "module_bay/module_type
-	// required" validation. ModuleType / Description / Status etc. stay
-	// dropped so the wire payload stays bounded.
+	// + ModuleBay matcher (name+position+device stub) + ModuleType.
+	// Mirrors device-discovery's _module_match_stub. ModuleType is not a
+	// matcher, but a ref that has not yet resolved is CREATED instead, and
+	// NetBox rejects a Module without one; only the (Manufacturer, Model)
+	// matcher pair is copied so the ref stays bounded. Description /
+	// Status etc. stay dropped.
 	require.NotNil(t, iface.Module)
 	assert.Equal(t, "FNS24010TR1", strDerefSafe(iface.Module.Serial))
-	assert.Nil(t, iface.Module.ModuleType,
-		"Interface.Module stub must not carry ModuleType (drops large nested manufacturer)")
+	require.NotNil(t, iface.Module.ModuleType,
+		"Interface.Module stub must carry ModuleType: NetBox requires it when the ref is created")
+	assert.Equal(t, "SFP-10G-LR", strDerefSafe(iface.Module.ModuleType.Model))
+	require.NotNil(t, iface.Module.ModuleType.Manufacturer)
+	assert.Equal(t, "Cisco", strDerefSafe(iface.Module.ModuleType.Manufacturer.Name))
 	assert.Nil(t, iface.Module.Description,
 		"Interface.Module stub must not carry Description")
 
@@ -675,7 +678,8 @@ func TestPruneNestedRefs_InterfaceModuleSurvivesWhenSerialNilButBayPresent(t *te
 	assert.Equal(t, "TenGigabitEthernet1/0/1", strDerefSafe(iface.Module.ModuleBay.Name))
 	assert.Equal(t, "1", strDerefSafe(iface.Module.ModuleBay.Position))
 	assert.Nil(t, iface.Module.Serial, "serial stays nil — matcher uses Device + Bay")
-	assert.Nil(t, iface.Module.ModuleType, "ModuleType still dropped per Python parity")
+	require.NotNil(t, iface.Module.ModuleType,
+		"ModuleType retained per Python parity: required when the ref is created")
 	require.NotNil(t, iface.Module.Device, "Interface.Module.Device must be a chassis stub")
 	assert.Equal(t, "sw1", strDerefSafe(iface.Module.Device.Name))
 	assert.Nil(t, iface.Module.Device.Status, "Module.Device must be stubbed (no rich Status)")
@@ -714,17 +718,64 @@ func TestPruneNestedRefs_InterfaceModuleStubDegradesToSerialOnly(t *testing.T) {
 	require.NotNil(t, iface.Module, "must not be cleared when serial is present")
 	assert.Equal(t, "FNS00000001", strDerefSafe(iface.Module.Serial))
 	assert.Nil(t, iface.Module.ModuleBay, "no bay was set on input, stays nil")
-	assert.Nil(t, iface.Module.ModuleType, "ModuleType still dropped per Python parity")
+	require.NotNil(t, iface.Module.ModuleType,
+		"ModuleType retained per Python parity: required when the ref is created")
 	require.NotNil(t, iface.Module.Device)
 	assert.Equal(t, "sw1", strDerefSafe(iface.Module.Device.Name))
+}
+
+// TestPruneNestedRefs_InterfaceModuleTypeCopyIsBounded — the nested ref keeps
+// ModuleType because NetBox requires it when the ref is created, but only the
+// (Manufacturer, Model) matcher pair is copied. This stub is duplicated into
+// every interface on a linecard, so it must not grow as drivers start
+// populating the richer ModuleType fields.
+func TestPruneNestedRefs_InterfaceModuleTypeCopyIsBounded(t *testing.T) {
+	rich := &diode.Device{
+		Name:   strPtr("sw1"),
+		Site:   &diode.Site{Name: strPtr("dc1")},
+		Serial: strPtr("FCW123"),
+	}
+	bay := &diode.ModuleBay{Device: rich, Name: strPtr("Gi1/0/1"), Position: strPtr("1")}
+	mod := &diode.Module{
+		Device:    rich,
+		ModuleBay: bay,
+		Serial:    strPtr("FNS24010TR1"),
+		ModuleType: &diode.ModuleType{
+			Model:       strPtr("SFP-10G-LR"),
+			PartNumber:  strPtr("SFP-10G-LR-S"),
+			Description: strPtr("10G LR optic"),
+			Comments:    strPtr("a field a driver may start populating"),
+			Manufacturer: &diode.Manufacturer{
+				Name:        strPtr("Cisco"),
+				Slug:        strPtr("cisco"),
+				Description: strPtr("vendor"),
+			},
+		},
+	}
+	iface := &diode.Interface{Name: strPtr("Gi1/0/1"), Device: rich, Module: mod}
+
+	PruneNestedRefs([]diode.Entity{rich, bay, mod, iface}, rich, nil)
+
+	require.NotNil(t, iface.Module)
+	require.NotNil(t, iface.Module.ModuleType)
+	mt := iface.Module.ModuleType
+	assert.Equal(t, "SFP-10G-LR", strDerefSafe(mt.Model))
+	require.NotNil(t, mt.Manufacturer)
+	assert.Equal(t, "Cisco", strDerefSafe(mt.Manufacturer.Name))
+	// everything outside the matcher pair must be absent
+	assert.Nil(t, mt.PartNumber, "PartNumber must not ride along")
+	assert.Nil(t, mt.Description, "ModuleType.Description must not ride along")
+	assert.Nil(t, mt.Comments, "ModuleType.Comments must not ride along")
+	assert.Nil(t, mt.Manufacturer.Slug, "Manufacturer.Slug must not ride along")
+	assert.Nil(t, mt.Manufacturer.Description, "Manufacturer.Description must not ride along")
 }
 
 // TestPruneNestedRefs_InterfaceModuleClearedWhenSerialAndBayBothMissing —
 // the only legitimate clear path. Without Serial AND without
 // ModuleBay, no matcher field can resolve the ref. Shipping such a
-// stub would force the reconciler into creation mode and fail
-// validation ("module_bay required, module_type required") because
-// the stub also strips ModuleType.
+// stub would force the reconciler into creation mode, which fails
+// because NetBox requires module_bay. Retaining ModuleType does not
+// rescue this case, so the ref is dropped instead.
 func TestPruneNestedRefs_InterfaceModuleClearedWhenSerialAndBayBothMissing(t *testing.T) {
 	rich := &diode.Device{
 		Name:   strPtr("sw1"),


### PR DESCRIPTION
## What

`PruneNestedRefs` stripped `ModuleType` from the nested `Interface.Module` ref. That is right for *matching* — `dcim.module` resolves on `module_bay`, its only unique matcher besides `asset_tag` — but a nested reference that has not yet resolved is **created** rather than matched, and NetBox rejects a Module without one:

```
ERR_OPS_GENERATE_DIFF - {"dcim.module":{"module_type":["Field module_type is required"]}}
```

Companion to #509, which fixes the identical defect in device-discovery.

## Why emitting modules first does not already cover this

The old comment reasoned that the ref would resolve because module entities are spliced ahead of interfaces. That does not hold: **`bulk-plan-apply` batches plans and applies them independently, so payload order is not reconciliation order.** I measured this separately while investigating the device-discovery case — reordering a payload so VLANs preceded the interfaces referencing them changed nothing (44 missing vs 36-49 baseline); only a real barrier between two ingests helped, and the agent cannot observe reconciliation completion.

And the blast radius is not confined to the module: a failed plan takes its whole batch down, including unrelated interfaces. In device-discovery this cost 48 failed plans per run on a 6-linecard chassis and **36-49 of 432 interfaces**; fixing it took that to 14, and to 0 combined with the plugin-side fix. This backend has the same stub shape and had simply never been measured on a modular chassis.

## Why only `(Manufacturer, Model)` is copied

`stub.ModuleType = mt` would work, but this stub is duplicated into **every interface on the linecard**, so it must not grow as drivers start populating `part_number`, `description`, `comments`, or `Manufacturer.slug`. `(Manufacturer, Model)` is the complete `dcim.moduletype` matcher and the only pair required on create, so nothing is lost. Matches how the rest of this stub is built field-by-field, and mirrors #509.

## Two comment corrections

Both were factually wrong and would mislead the next person trimming this stub:

- It claimed the ref resolves via *"the (Device, ModuleBay) or (Device, Serial) match paths"*. Per the plugin's matcher table, `dcim.module` has **no serial matcher** — `serial` resolves nothing and is carried for create fidelity only. `module_bay` is the load-bearing field.
- The clear-path comment justified dropping the ref because *"we also strip ModuleType"*. The actual reason is that NetBox requires `module_bay`, which retaining `ModuleType` does not supply. The drop stays correct, for the correct reason.

## gnmi-discovery deliberately not included

Checked, and it needs no equivalent change: gnmi **never attaches a Module to an Interface**. Its only reference to the field is `ifaceCopy.Module = nil` in `translate_ip.go:269`, and there is no assignment anywhere that sets it. Its top-level `Module` entities already carry a manufacturer-bearing `ModuleType` (`translate.go:601`), and its own `case *diode.Module` in `stubs.go` only stubs the nested Device, never touching ModuleType. So there is no nested module ref to fix.

(One PR per backend, per repo convention, hence separate from #509.)

## Verification

- Full snmp-discovery suite green across all 12 packages; `gofmt` clean; `golangci-lint` (v2.11.4 config) **0 issues**.
- Mutation-tested, both caught:

| mutant | caught by |
|---|---|
| ModuleType copy removed entirely | 4 tests, incl. `StubsModuleBayAndInterfaceModule` |
| unbounded `stub.ModuleType = mt` | `InterfaceModuleTypeCopyIsBounded` |

- New test `TestPruneNestedRefs_InterfaceModuleTypeCopyIsBounded` pins that `part_number`, `description`, `comments` and `Manufacturer.slug`/`description` do **not** ride along.
- The three existing assertions that pinned `ModuleType == nil` are inverted, and their prose updated to say why it is retained.

Not verified end-to-end against a live modular chassis over SNMP — I have no such capture. The device-discovery equivalent was validated e2e on a real 432-interface payload; this is the same defect in the same stub shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
