### PR TITLE
feat(snmp-discovery): support SNMPv3 context name

### DIFF
--- a/docs/backends/snmp_discovery/README.md
+++ b/docs/backends/snmp_discovery/README.md
@@ -180,10 +180,11 @@ Each target in the `targets` list can include:
 | auth_passphrase | string | no | SNMPv3 authentication passphrase |
 | priv_protocol | string | no | SNMPv3 privacy protocol (see [SNMPv3 auth/priv protocols](#snmpv3-authpriv-protocols)) |
 | priv_passphrase | string | no | SNMPv3 privacy passphrase |
+| context_name | string | no | SNMPv3 context name (equivalent to `snmpwalk -n`). Required by devices that expose MIB data in a named context; such devices return an empty walk when it is omitted. Rejected for SNMPv1/v2c. |
 
 *Required for SNMPv1/v2c, optional for SNMPv3
 
-**Note:** Authentication can be specified at the policy level (under `scope.authentication`) as a fallback, or per-target (under each target's `authentication` field). Targets without authentication use the policy-level authentication. Environment variables are supported using `${VAR}` syntax for `community`, `username`, `auth_passphrase`, and `priv_passphrase` fields.
+**Note:** Authentication can be specified at the policy level (under `scope.authentication`) as a fallback, or per-target (under each target's `authentication` field). Targets without authentication use the policy-level authentication — this is a wholesale replacement, not a field-level merge: a target with its own `authentication` block does not inherit any individual field, such as `context_name`, from the policy-level block. Environment variables are supported using `${VAR}` syntax for `community`, `username`, `auth_passphrase`, `priv_passphrase`, and `context_name` fields.
 
 #### SNMPv3 auth/priv protocols
 Values are case-sensitive and must be passed as one of the strings in the tables below.

--- a/docs/config_samples.md
+++ b/docs/config_samples.md
@@ -513,6 +513,7 @@ orb:
             # auth_passphrase: "auth-password" # Also supports resolving values from environment variables eg ${SNMP_AUTH_PASSPHRASE}
             # priv_protocol: "AES"
             # priv_passphrase: "priv-password"# Also supports resolving values from environment variables eg ${SNMP_PRIV_PASSPHRASE}
+            # context_name: "mfpdirect" # SNMPv3 context name (snmpwalk -n); required by devices whose MIB data lives in a named context. Rejected for SNMPv1/v2c.
       discover_once: # will run only once
         scope:
           targets:
@@ -536,6 +537,7 @@ orb:
 - `username`
 - `auth_passphrase`
 - `priv_passphrase`
+- `context_name`
 
 ### Device Model Lookup
 The `lookup_extensions_dir` specifies a directory containing device data YAML files that map SNMP device ObjectIDs (from querying `.1.3.6.1.2.1.1.2.0`) to human-readable device names. This allows snmp-discovery to provide meaningful device identification instead of raw ObjectID values. This only needs to be set if additional or modified files are being provided beyond the ones bundled with orb-agent (under `orb-discovery/snmp-discovery/data/lookup_extensions`).

--- a/docs/configs/agent_yaml.md
+++ b/docs/configs/agent_yaml.md
@@ -317,7 +317,7 @@ Values can reference environment variables using `${VAR_NAME}` syntax. Resolutio
 | Vault secrets manager `auth_args` | All fields | Go agent at startup |
 | CyberArk secrets manager | `url`, `app_id`, `reason`, `ca_bundle`, `client_cert`, `client_key` | Go agent at startup |
 | `device_discovery` policy (all fields) | Any string value in `scope` and `defaults` | Python backend at policy execution |
-| `snmp_discovery` policy authentication | `community`, `username`, `auth_passphrase`, `priv_passphrase` | Go SNMP backend at policy execution |
+| `snmp_discovery` policy authentication | `community`, `username`, `auth_passphrase`, `priv_passphrase`, `context_name` | Go SNMP backend at policy execution |
 
 ```yaml
 # Git config (resolved by Go agent)

--- a/orb-discovery/snmp-discovery/config/config.go
+++ b/orb-discovery/snmp-discovery/config/config.go
@@ -155,6 +155,11 @@ type Authentication struct {
 	AuthPassphrase  string `yaml:"auth_passphrase"`
 	PrivProtocol    string `yaml:"priv_protocol"`
 	PrivPassphrase  string `yaml:"priv_passphrase"`
+	// ContextName is the SNMPv3 context name (snmpwalk -n). Devices that expose
+	// their MIB data in a named context return nothing for the default context,
+	// so an absent value looks like a successful empty walk. Rejected for
+	// v1/v2c, which have no context concept.
+	ContextName string `yaml:"context_name,omitempty"`
 }
 
 // IPAddressDefaults represents default values for a specific entity type

--- a/orb-discovery/snmp-discovery/config/config_test.go
+++ b/orb-discovery/snmp-discovery/config/config_test.go
@@ -439,6 +439,41 @@ func TestTargetNetboxID_optional(t *testing.T) {
 	assert.Nil(t, target.NetboxID)
 }
 
+func TestAuthentication_ContextName_ParsesFromScopeAndTarget(t *testing.T) {
+	input := `
+targets:
+  - host: "10.3.2.20"
+    authentication:
+      protocol_version: "3"
+      username: "umsnmp"
+      auth_protocol: "SHA"
+      auth_passphrase: "secret"
+      priv_protocol: "AES"
+      priv_passphrase: "secret"
+      context_name: "mfpdirect"
+authentication:
+  protocol_version: "3"
+  username: "policyuser"
+  context_name: "policycontext"
+`
+	var scope Scope
+	err := yaml.Unmarshal([]byte(input), &scope)
+	require.NoError(t, err)
+
+	assert.Equal(t, "policycontext", scope.Authentication.ContextName)
+	require.Len(t, scope.Targets, 1)
+	require.NotNil(t, scope.Targets[0].Authentication)
+	assert.Equal(t, "mfpdirect", scope.Targets[0].Authentication.ContextName)
+}
+
+func TestAuthentication_ContextName_Optional(t *testing.T) {
+	input := `protocol_version: "3"`
+	var auth Authentication
+	err := yaml.Unmarshal([]byte(input), &auth)
+	require.NoError(t, err)
+	assert.Empty(t, auth.ContextName)
+}
+
 func TestMappingEntry_IndexKind(t *testing.T) {
 	yamlBody := []byte(`
 entries:

--- a/orb-discovery/snmp-discovery/policy/manager.go
+++ b/orb-discovery/snmp-discovery/policy/manager.go
@@ -152,6 +152,11 @@ func (m *Manager) validateAuthentication(auth *config.Authentication, context st
 		return fmt.Errorf("%s: unsupported protocol version", context)
 	}
 
+	if auth.ContextName != "" && auth.ProtocolVersion != snmp.ProtocolVersion3 {
+		return fmt.Errorf("%s: context_name is only valid for SNMPv3 (got %q)",
+			context, auth.ProtocolVersion)
+	}
+
 	if auth.ProtocolVersion == "SNMPv2c" || auth.ProtocolVersion == "SNMPv1" {
 		if auth.Community == "" {
 			return fmt.Errorf("%s: missing community", context)
@@ -200,6 +205,15 @@ func (m *Manager) validatePolicy(policy config.Policy) error {
 		if err := m.validateAuthentication(&policy.Scope.Authentication, "policy-level"); err != nil {
 			return err
 		}
+	} else if policy.Scope.Authentication.ContextName != "" {
+		// A scope.authentication block with a context_name but no
+		// protocol_version skips the check above entirely (hasPolicyAuth is
+		// false), yet it is still env-resolved and then silently discarded
+		// for any target with its own authentication block. Catch it here
+		// rather than letting it disappear the same way the missing-context
+		// bug this ticket exists to fix did.
+		return fmt.Errorf("policy-level: context_name is only valid for SNMPv3 (got %q)",
+			policy.Scope.Authentication.ProtocolVersion)
 	}
 
 	// Validate each target's authentication
@@ -326,6 +340,7 @@ func (m *Manager) resolveAuthenticationEnvVarsForAuth(auth *config.Authenticatio
 		{&auth.Username, "username"},
 		{&auth.AuthPassphrase, "auth_passphrase"},
 		{&auth.PrivPassphrase, "priv_passphrase"},
+		{&auth.ContextName, "context_name"},
 	}
 
 	// Iterate over the fields and resolve environment variables

--- a/orb-discovery/snmp-discovery/policy/manager_test.go
+++ b/orb-discovery/snmp-discovery/policy/manager_test.go
@@ -419,6 +419,152 @@ func TestManagerParsePolicies(t *testing.T) {
 	})
 }
 
+func TestManagerParsePolicies_ContextName(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
+	manager, err := policy.NewManager(context.Background(), logger, nil, nil)
+	assert.NoError(t, err)
+
+	t.Run("Environment Variable Resolution - context_name", func(t *testing.T) {
+		err := os.Setenv("SNMP_CONTEXT_NAME", "mfpdirect")
+		require.NoError(t, err)
+		defer func() {
+			_ = os.Unsetenv("SNMP_CONTEXT_NAME")
+		}()
+
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              lookup_extensions_dir: /tmp/extensions
+            scope:
+              targets:
+                - host: 192.168.1.1
+              authentication:
+                protocol_version: SNMPv3
+                security_level: noAuthNoPriv
+                username: testuser
+                context_name: ${SNMP_CONTEXT_NAME}
+       `)
+
+		policies, err := manager.ParsePolicies(yamlData)
+		assert.NoError(t, err)
+		assert.Contains(t, policies, "policy1")
+		assert.Equal(t, "mfpdirect", policies["policy1"].Scope.Authentication.ContextName)
+	})
+
+	t.Run("Environment Variable Resolution - Missing context_name Environment Variable", func(t *testing.T) {
+		err := os.Unsetenv("MISSING_SNMP_CONTEXT_NAME")
+		require.NoError(t, err)
+
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              lookup_extensions_dir: /tmp/extensions
+            scope:
+              targets:
+                - host: 192.168.1.1
+              authentication:
+                protocol_version: SNMPv3
+                security_level: noAuthNoPriv
+                username: testuser
+                context_name: ${MISSING_SNMP_CONTEXT_NAME}
+       `)
+
+		_, err = manager.ParsePolicies(yamlData)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "policy1 : failed to resolve environment variables")
+		assert.Contains(t, err.Error(), "failed to resolve context_name environment variable")
+		assert.Contains(t, err.Error(), "environment variable MISSING_SNMP_CONTEXT_NAME is not set")
+	})
+
+	t.Run("Rejects context_name on SNMPv2c policy-level auth", func(t *testing.T) {
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              lookup_extensions_dir: /tmp/extensions
+            scope:
+              targets:
+                - host: 192.168.1.1
+              authentication:
+                protocol_version: SNMPv2c
+                community: public
+                context_name: mfpdirect
+       `)
+
+		_, err := manager.ParsePolicies(yamlData)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "policy-level: context_name is only valid for SNMPv3")
+	})
+
+	t.Run("Rejects context_name on SNMPv2c per-target auth", func(t *testing.T) {
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              lookup_extensions_dir: /tmp/extensions
+            scope:
+              targets:
+                - host: 192.168.1.1
+                  authentication:
+                    protocol_version: SNMPv2c
+                    community: public
+                    context_name: mfpdirect
+       `)
+
+		_, err := manager.ParsePolicies(yamlData)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "target 192.168.1.1: context_name is only valid for SNMPv3")
+	})
+
+	t.Run("Rejects context_name in scope.authentication with no protocol_version", func(t *testing.T) {
+		// hasPolicyAuth is false here (ProtocolVersion is unset), so the
+		// per-field validateAuthentication check never runs. Without the
+		// standalone check this block is silently discarded.
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              lookup_extensions_dir: /tmp/extensions
+            scope:
+              targets:
+                - host: 192.168.1.1
+                  authentication:
+                    protocol_version: SNMPv3
+                    security_level: noAuthNoPriv
+                    username: testuser
+              authentication:
+                context_name: mfpdirect
+       `)
+
+		_, err := manager.ParsePolicies(yamlData)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "policy-level: context_name is only valid for SNMPv3")
+	})
+
+	t.Run("Accepts context_name on SNMPv3 policy-level auth", func(t *testing.T) {
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              lookup_extensions_dir: /tmp/extensions
+            scope:
+              targets:
+                - host: 192.168.1.1
+              authentication:
+                protocol_version: SNMPv3
+                security_level: noAuthNoPriv
+                username: testuser
+                context_name: mfpdirect
+       `)
+
+		policies, err := manager.ParsePolicies(yamlData)
+		assert.NoError(t, err)
+		assert.Equal(t, "mfpdirect", policies["policy1"].Scope.Authentication.ContextName)
+	})
+}
+
 func TestManagerPolicyLifecycle(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
 	manager, err := policy.NewManager(context.Background(), logger, nil, nil)

--- a/orb-discovery/snmp-discovery/snmp/snmp.go
+++ b/orb-discovery/snmp-discovery/snmp/snmp.go
@@ -246,6 +246,7 @@ func NewClient(host string, port uint16, retries int, timeout time.Duration, aut
 				Retries:       retries,
 				MsgFlags:      msgFlags,
 				SecurityModel: gosnmp.UserSecurityModel,
+				ContextName:   authentication.ContextName,
 				Logger:        gosnmpLogger,
 				SecurityParameters: &gosnmp.UsmSecurityParameters{
 					UserName:                 authentication.Username,

--- a/orb-discovery/snmp-discovery/snmp/snmp_test.go
+++ b/orb-discovery/snmp-discovery/snmp/snmp_test.go
@@ -1,6 +1,7 @@
 package snmp_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
@@ -13,6 +14,7 @@ import (
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery/mapping"
@@ -249,10 +251,18 @@ func TestSNMPHost(t *testing.T) {
 
 func TestNewClient(t *testing.T) {
 	testCases := []struct {
-		name           string
-		auth           *config.Authentication
-		expectError    bool
-		expectedErrMsg string
+		name                string
+		auth                *config.Authentication
+		expectError         bool
+		expectedErrMsg      string
+		expectedContextName string
+		// checkContextWire additionally encodes a packet and asserts the
+		// context name is (or isn't) present on the wire. Only exercised for
+		// the context-name-specific rows below: it requires SecurityLevel to
+		// be unset (msgFlags == NoAuthNoPriv), since authPriv needs a
+		// discovered engine and fails with "invalid key size 0", and relying
+		// on bytes.Contains with an empty expected value would always match.
+		checkContextWire bool
 	}{
 		{
 			name: "Creates SNMPv1 client successfully",
@@ -261,6 +271,44 @@ func TestNewClient(t *testing.T) {
 				Community:       "public",
 			},
 			expectError: false,
+		},
+		{
+			name: "Creates SNMPv3 client with context name",
+			auth: &config.Authentication{
+				ProtocolVersion: snmp.ProtocolVersion3,
+				Username:        "testuser",
+				AuthProtocol:    "MD5",
+				AuthPassphrase:  "testpass",
+				PrivProtocol:    "AES",
+				PrivPassphrase:  "testpass",
+				ContextName:     "mfpdirect",
+			},
+			expectError:         false,
+			expectedContextName: "mfpdirect",
+			checkContextWire:    true,
+		},
+		{
+			name: "Creates SNMPv3 client without context name",
+			auth: &config.Authentication{
+				ProtocolVersion: snmp.ProtocolVersion3,
+				Username:        "testuser",
+				AuthProtocol:    "MD5",
+				AuthPassphrase:  "testpass",
+				PrivProtocol:    "AES",
+				PrivPassphrase:  "testpass",
+			},
+			expectError:         false,
+			expectedContextName: "",
+		},
+		{
+			name: "SNMPv2c ignores context name field",
+			auth: &config.Authentication{
+				ProtocolVersion: snmp.ProtocolVersion2c,
+				Community:       "public",
+				ContextName:     "mfpdirect",
+			},
+			expectError:         false,
+			expectedContextName: "",
 		},
 		{
 			name: "Creates SNMPv2c client successfully",
@@ -445,6 +493,23 @@ func TestNewClient(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, client)
+
+				typed, ok := client.(*snmp.Client)
+				assert.True(t, ok)
+				if ok {
+					assert.Equal(t, tc.expectedContextName, typed.ContextName)
+
+					if tc.checkContextWire {
+						// Assert at the wire, not just on the struct: SnmpEncodePacket runs
+						// the same mkSnmpPacket -> marshalMsg -> prepareV3ScopedPDU path as a
+						// live send, with no Connect() and no socket.
+						out, err := typed.SnmpEncodePacket(gosnmp.GetRequest,
+							[]gosnmp.SnmpPDU{{Name: "1.3.6.1.2.1.1.1.0", Type: gosnmp.Null}}, 0, 0)
+						require.NoError(t, err)
+						assert.Equal(t, tc.expectedContextName != "",
+							bytes.Contains(out, []byte(tc.expectedContextName)))
+					}
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

SNMPv3 devices that expose their MIB data in a named context (e.g. multi-function printers using `snmpwalk -v3 ... -n <context>`) returned zero entities, because the backend never set a context name on the v3 client — it always queried the default context. The walk succeeds and logs `entity_count=0` with no error, so the failure was silent.

This adds a `context_name` authentication field (SNMPv3 only) and wires it through to the client, so operators can configure `snmpwalk -n`-equivalent behavior instead of falling back to SNMPv1.

- Add `context_name` to `Authentication` (policy-level and per-target) and set it on the gosnmp v3 client's `ContextName` field.
- Support `${VAR}` environment variable substitution for `context_name`, consistent with the other auth fields.
- Reject `context_name` on SNMPv1/v2c with a clear validation error (context is a v3-only concept), including for a `scope.authentication` block that sets `context_name` without `protocol_version` — a case the existing validation gate otherwise skipped entirely.
- Document the new field in the backend README, the config sample, and the env-var substitution table, including a note that per-target authentication overrides the policy-level block wholesale (no field-level merge), so a policy-wide `context_name` is a no-op for any target with its own `authentication` block.



## Test plan

- [x] `go test -race ./...` passes in `orb-discovery/snmp-discovery`
- [x] New unit tests cover: client wiring (including a wire-level encoder check confirming the context name is actually present in the encoded SNMPv3 packet), YAML parsing at both policy and target level, env var resolution (success + missing var), and rejection on SNMPv1/v2c (including the no-`protocol_version` edge case)
- [x] Manual verification against a real or lab SNMPv3 agent configured with a named context (e.g. via `proxy -Cn` / AgentX), confirming `entity_count > 0` with `context_name` set vs. `0` without it
