### PR TITLE
fix(agent): keep a single pip in the docker image (INT-497)

### DIFF
--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -88,10 +88,6 @@ FROM netboxlabs/pktvisor:${PKTVISOR_TAG} AS pktvisor
 ########################################################################
 FROM python:3.14-alpine AS python-builder
 
-# Upgrade pip to latest version with fewer vulnerabilities
-RUN python -m pip install --upgrade --no-cache-dir pip==26.1.2 && \
-    rm -rf /usr/local/lib/python3.14/ensurepip/_bundled/pip-*.whl
-
 # Install the Python backends from in-repo source (was: published PyPI packages
 # netboxlabs-device-discovery / netboxlabs-orb-worker). Console scripts
 # device-discovery and orb-worker land in /usr/local/bin.
@@ -109,7 +105,13 @@ RUN BUILD_COMMIT="${BUILD_COMMIT}" BUILD_TRACK="${BUILD_TRACK}" \
       python /tmp/stamp_version.py "${DEVICE_DISCOVERY_VERSION}" /src/device-discovery/device_discovery/version.py && \
     BUILD_COMMIT="${BUILD_COMMIT}" BUILD_TRACK="${BUILD_TRACK}" \
       python /tmp/stamp_version.py "${WORKER_VERSION}" /src/worker/worker/version.py
-RUN pip3 install --no-cache-dir /src/device-discovery /src/worker
+# Uninstall pip once the packages are installed so the site-packages COPY into
+# the final stage carries application code only. Copying pip across stages
+# merges it file-by-file over the final stage's own pip — two versions with
+# different module layouts produce a broken chimera install (pip3 dies with
+# ImportError on every invocation).
+RUN pip3 install --no-cache-dir /src/device-discovery /src/worker && \
+    pip3 uninstall -y pip
 
 ########################################################################
 # Stage name is referenced by no-cache-filters in the build workflows so
@@ -141,7 +143,15 @@ ENV PATH=/opt/orb/files:$PATH
 ENV PIP_CACHE_DIR=/opt/orb/pip-cache
 ENV DEFAULT_CONFIG_PATH=/usr/local/share/orb-agent/default_config.yaml
 
-# Copy Python site-packages and binaries from builder (includes pip and package executables)
+# The runtime pip: used by the entrypoint's INSTALL_DRIVERS_PATH feature and
+# what image scans see. Pinned to a recent release with fewer vulnerabilities;
+# pip's self-upgrade cleanly removes the base image's copy first.
+RUN python -m pip install --upgrade --no-cache-dir pip==26.2.1 && \
+    rm -rf /usr/local/lib/python3.14/ensurepip/_bundled/pip-*.whl
+
+# Copy Python site-packages and binaries from builder (application packages and
+# their console scripts; the builder uninstalled pip so it cannot leak into —
+# and version-clash with — this stage's pip above)
 COPY --from=python-builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
 COPY --from=python-builder /usr/local/bin /usr/local/bin
 


### PR DESCRIPTION
Fixes INT-497.

## Motivation

The published `netboxlabs/orb-agent:develop` image ships a broken pip: every `pip3` invocation dies with `ImportError: cannot import name 'get_runnable_pip' from 'pip._internal.utils.misc'`. This has all controller-integrations e2e jobs red since Aug 6/7 (the entrypoint's `INSTALL_DRIVERS_PATH` install fails) and breaks orb-agent-pro image builds outright (they run `pip3 install` against this base at build time).

Root cause: the python-builder stage upgrades pip to a pinned 26.1.2, and the site-packages COPY into the final stage merges that pip file-by-file over the base image's own pip. The `python:3.14-alpine` base recently moved its bundled pip to 26.2.1, which restructured `pip/_internal/build_env` into a package. The shipped image ends up with both dist-infos and a mix of both versions' modules, and imports across them fail. Nothing in this repo changed; an upstream base refresh flipped it, and it will keep flipping whenever the base's pip and the builder pin drift apart.

## Change

Keep exactly one pip in the image, owned by the stage that ships it:

- python-builder installs the app packages with the base's own pip, then uninstalls pip so it cannot leak into the COPY.
- The final stage installs the single shipped pip via a pinned self-upgrade (`pip==26.2.1`), which cleanly removes the base's copy first, and takes over the ensurepip wheel removal.

The builder no longer pins pip at all: its pip is throwaway tooling that never ships, so there is no version pair to keep in sync.

## Testing

- Reproduced the failure on the published image: both `pip-26.1.2.dist-info` and `pip-26.2.1.dist-info` present, `pip3 --version` throws the ImportError above.
- Built this branch locally: single `pip-26.2.1.dist-info`, `pip3 --version` works, ensurepip wheel gone, `orb-worker` and `device-discovery` console scripts intact.
- Runtime driver-install path: `pip3 install` inside the built container succeeds (this is what the controller-integrations e2e entrypoint does).
- Built orb-agent-pro locally against this image (`AGENT_TAG=pip-fix-local`): build succeeds, all 11 nbl-* integration packages install from CodeArtifact, and the pro image inherits the single working pip.
