### PR TITLE
ci(repo): suppress pip-vendored CVE findings in orb-agent image scans

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,6 +87,9 @@ jobs:
           ignore-unfixed: true
           exit-code: "0"
           list-all-pkgs: "true"
+          # Trivy only auto-detects a plain .trivyignore in the working
+          # directory, so the YAML variant has to be named explicitly.
+          trivyignores: .trivyignore.yaml
 
       - name: Build scan summary
         id: scan-summary

--- a/.github/workflows/container-rescan.yaml
+++ b/.github/workflows/container-rescan.yaml
@@ -21,6 +21,14 @@ jobs:
       TRIVY_DISABLE_VEX_NOTICE: "true"
 
     steps:
+      # Only needed for .trivyignore.yaml: the scan target is the published
+      # image, not the working tree. The ignore file tracks the default branch,
+      # so an entry that expires takes effect on the next nightly run.
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
       - name: Pull image
         env:
           IMAGE_REF: ${{ env.IMAGE_REF }}
@@ -37,6 +45,9 @@ jobs:
           severity: CRITICAL,HIGH,MEDIUM,LOW
           ignore-unfixed: true
           exit-code: "0"
+          # Trivy only auto-detects a plain .trivyignore in the working
+          # directory, so the YAML variant has to be named explicitly.
+          trivyignores: .trivyignore.yaml
 
       - name: Build rescan summary
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,60 @@
+# Trivy ignore file for the orb-agent image scans (build.yaml, container-rescan.yaml).
+#
+# Every entry names a finding that is not reachable in the shipped image, and
+# every entry carries an expiry so it cannot outlive its justification. When an
+# entry expires the scan goes red again on purpose: re-verify the reasoning
+# against the pip version in the image and either extend the date or drop the
+# entry.
+#
+# All three entries below are pip's *vendored* copies under
+# site-packages/pip/_vendor/. Trivy reports them because pip ships its own
+# CycloneDX SBOM at pip/_vendor/bom.cdx.json and Trivy parses it, which is what
+# the "Third-party SBOM may lead to inaccurate vulnerability detection" warning
+# in the scan log refers to. Neither package is an orb-agent dependency; nothing
+# in orb-discovery/device-discovery or orb-discovery/worker resolves to them.
+#
+# There is no upgrade path: pip 26.2.1 is the latest release and vendors exactly
+# these versions, and the image needs pip at runtime for the entrypoint's
+# INSTALL_DRIVERS_PATH / INSTALL_WORKERS_PATH feature.
+#
+# Entries are pinned by PURL, so a pip bump that moves a vendored version makes
+# the entry stop matching and the scan fail again. The pin it is coupled to is
+# the pip version in agent/docker/Dockerfile. `paths` is not usable for scoping
+# here: findings sourced from pip's embedded SBOM carry no PkgPath.
+#
+# Do not "fix" this class of finding by deleting pip/_vendor/bom.cdx.json from
+# the image. pip also vendors urllib3, requests and certifi, which do handle
+# untrusted network data when the entrypoint installs drivers from an index;
+# dropping the BOM would blind the scanner to those permanently.
+
+vulnerabilities:
+  - id: GHSA-6v7p-g79w-8964
+    purls:
+      - "pkg:pypi/msgpack@1.1.2"
+    statement: >-
+      msgpack is vendored by pip (pip/_vendor/msgpack). The out-of-bounds read
+      requires reusing an Unpacker after a caught exception. pip's only msgpack
+      consumer is the vendored CacheControl, which unpacks HTTP-cache entries
+      that it serialized itself and uses a fresh unpack call per cache read, so
+      the vulnerable reuse pattern does not occur.
+    expired_at: 2026-11-08
+
+  - id: CVE-2025-47273
+    purls:
+      - "pkg:pypi/setuptools@70.3.0"
+    statement: >-
+      setuptools is listed in pip's vendor.txt but pip vendors only the
+      pkg_resources shim; pip/_vendor/pkg_resources/ holds __init__.py and
+      LICENSE, and there is no pip/_vendor/setuptools/ at all. The vulnerable
+      code is setuptools/package_index.py (PackageIndex path traversal), which
+      is not present anywhere in the image.
+    expired_at: 2026-11-08
+
+  - id: CVE-2026-59890
+    purls:
+      - "pkg:pypi/setuptools@70.3.0"
+    statement: >-
+      Same vendored-setuptools phantom as CVE-2025-47273. The MANIFEST.in
+      exclusion bypass lives in setuptools' sdist build machinery, which is
+      absent from pip's vendored subset, and nothing in the image builds sdists.
+    expired_at: 2026-11-08

--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -146,6 +146,10 @@ ENV DEFAULT_CONFIG_PATH=/usr/local/share/orb-agent/default_config.yaml
 # The runtime pip: used by the entrypoint's INSTALL_DRIVERS_PATH feature and
 # what image scans see. Pinned to a recent release with fewer vulnerabilities;
 # pip's self-upgrade cleanly removes the base image's copy first.
+# Scans also see pip's vendored packages under pip/_vendor, and three of those
+# findings are suppressed in /.trivyignore.yaml by exact PURL. Moving this pin
+# changes those vendored versions, so the entries stop matching and the scan
+# fails until they are re-verified. Update both together.
 RUN python -m pip install --upgrade --no-cache-dir pip==26.2.1 && \
     rm -rf /usr/local/lib/python3.14/ensurepip/_bundled/pip-*.whl
 


### PR DESCRIPTION
## Summary

- Added a root `.trivyignore.yaml` covering three findings that come from pip's *vendored* packages under `pip/_vendor/`, not from any orb-agent dependency: `GHSA-6v7p-g79w-8964` (msgpack 1.1.2, HIGH), `CVE-2025-47273` (setuptools 70.3.0, HIGH), `CVE-2026-59890` (setuptools 70.3.0, MEDIUM). These are what currently block Build & Scan on the release PR #521.
- Wired the ignore file into `build.yaml`, and into `container-rescan.yaml`, which also needed an `actions/checkout`: it only pulled the image, so a repo-root ignore file could never have applied there.
- Added a comment at the pip pin in `agent/docker/Dockerfile`: the ignore entries are pinned by exact PURL, so moving that pin makes them stop matching and the scan fail until they are re-verified.

The diff is additive only. No existing step or script is modified.

### Why suppress rather than fix

pip 26.2.1 is the latest release and vendors exactly these versions, so there is no upgrade path, and the image needs pip at runtime for the entrypoint's `INSTALL_DRIVERS_PATH` / `INSTALL_WORKERS_PATH` feature.

- setuptools (both CVEs): pip vendors only the `pkg_resources` shim. There is no `pip/_vendor/setuptools/` directory and no `package_index.py` anywhere under `_vendor/`. The vulnerable code is absent from the image.
- msgpack: the out-of-bounds read requires reusing an `Unpacker` after a caught exception. pip's only msgpack consumer is vendored CacheControl, which unpacks HTTP-cache entries it serialized itself, with a fresh unpack per read.

Each entry carries a `statement` and `expired_at: 2026-11-08`, so the suppression cannot silently become permanent. Entries are pinned by PURL rather than bare ID so they cannot quietly cover a future, genuinely-reachable copy of the same package.

### What triggered this

No code change here caused it. `python:3.14-alpine` refreshed its bundled pip to 26.2.x, and pip 26.2 is the first release to ship an embedded CycloneDX SBOM at `pip/_vendor/bom.cdx.json` (absent in 25.3/26.0/26.1/26.1.2, present in 26.2/26.2.1). Vendored packages carry no dist-info metadata, so Trivy had no way to see them before that file existed. The vendored versions themselves have not changed since at least pip 25.3, and all three advisories were published well before the alerts appeared on 2026-08-05.

## Test plan

- [x] Scanned the published `netboxlabs/orb-agent:develop` image with Trivy 0.70.0 (the version this action installs): 3 findings before, 0 after.
- [x] Ran the existing `build.yaml` summary script under node against that scan output: `has_blocking = false`.
- [x] Backdated `expired_at` and re-scanned: all three findings return, so the expiry is live rather than decorative.
- [x] Replayed `trivy-action`'s `entrypoint.sh` at the pinned SHA with a stub `trivy` on PATH: resolves to `TRIVY_IGNOREFILE=.trivyignore.yaml`.
- [x] `trivy convert` from the suppressed report yields 0 SARIF results and 0 SBOM vulnerabilities, so the three open code-scanning alerts should close on the first `develop` analysis after merge.
