### PR TITLE
fix(device-discovery): add '+' prefix to Slot number in the regular expression of 'dis stack'

### DIFF
--- a/orb-discovery/device-discovery/custom_napalm/huawei_vrp.py
+++ b/orb-discovery/device-discovery/custom_napalm/huawei_vrp.py
@@ -49,7 +49,7 @@ def _huawei_row_to_switchport_info(row: dict) -> SwitchportInfo:
     """
     Map an ntc-templates ``display port vlan`` row to a SwitchportInfo.
 
-    LINK_TYPE values from VRP: access, trunk, hybrid, desirable, auto.
+    LINK_TYPE values from : access, trunk, hybrid, desirable, auto.
     Hybrid collapses to trunk (native + tagged set). LNP-negotiated link
     types (``auto`` / ``desirable``) still carry VLAN state — mode is
     inferred from membership shape (any trunk VLAN list ⇒ trunk;
@@ -138,7 +138,7 @@ _YEAR_SECONDS = 365 * _DAY_SECONDS
 
 
 def _parse_uptime(uptime_str: str) -> int:
-    """Convert a Huawei VRP uptime string to total seconds."""
+    """Convert a Huawei  uptime string to total seconds."""
     seconds = 0
 
     for pattern, factor in (
@@ -175,7 +175,7 @@ def _separate_section(separator: str, content: str) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
-# Stack discovery — Huawei VRP iStack
+# Stack discovery — Huawei  iStack
 # ---------------------------------------------------------------------------
 #
 # `display stack` on a VRP iStack-mode chassis emits a settings-block followed
@@ -213,9 +213,9 @@ def _separate_section(separator: str, content: str) -> list[str]:
 _VRP_STACK_ROW_RE = re.compile(
     r"""
     ^\s*
-    (?P<id>\d+)\s+                                                   # Slot
+    \+?(?P<id>\d+)\s+                                                # Slot
     (?P<role>[A-Za-z]+)\s+                                           # Role
-    (?P<mac>[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4})\s+          # MAC
+    (?P<mac>[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4})\s+         # MAC
     (?P<priority>\d+)\s+                                             # Priority
     (?P<model>\S+(?:\s+\S+)*?)                                       # Device Type — non-greedy
                                                                      #   so the optional trailing

--- a/orb-discovery/device-discovery/custom_napalm/huawei_vrp.py
+++ b/orb-discovery/device-discovery/custom_napalm/huawei_vrp.py
@@ -49,7 +49,7 @@ def _huawei_row_to_switchport_info(row: dict) -> SwitchportInfo:
     """
     Map an ntc-templates ``display port vlan`` row to a SwitchportInfo.
 
-    LINK_TYPE values from : access, trunk, hybrid, desirable, auto.
+    LINK_TYPE values from: access, trunk, hybrid, desirable, auto.
     Hybrid collapses to trunk (native + tagged set). LNP-negotiated link
     types (``auto`` / ``desirable``) still carry VLAN state — mode is
     inferred from membership shape (any trunk VLAN list ⇒ trunk;
@@ -175,7 +175,7 @@ def _separate_section(separator: str, content: str) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
-# Stack discovery — Huawei  iStack
+# Stack discovery — Huawei iStack
 # ---------------------------------------------------------------------------
 #
 # `display stack` on a VRP iStack-mode chassis emits a settings-block followed

--- a/orb-discovery/device-discovery/custom_napalm/huawei_vrp.py
+++ b/orb-discovery/device-discovery/custom_napalm/huawei_vrp.py
@@ -138,7 +138,7 @@ _YEAR_SECONDS = 365 * _DAY_SECONDS
 
 
 def _parse_uptime(uptime_str: str) -> int:
-    """Convert a Huawei  uptime string to total seconds."""
+    """Convert a Huawei uptime string to total seconds."""
     seconds = 0
 
     for pattern, factor in (


### PR DESCRIPTION
https://github.com/netboxlabs/orb-agent/blob/44c69be1615242ca84f2d738982fddc54f1c429e/orb-discovery/device-discovery/custom_napalm/huawei_vrp.py#L216

In a vrp version, 'dis slot':
```
<Huawei>display stack
--------------------------------------------------------------------------------
MemberID Role     MAC              Priority   DeviceType         Description    
--------------------------------------------------------------------------------
+1       Master   80b5-7544-b370   200        CE6855-48S6Q-HI                   
 2       Standby  80b5-7544-9b30   150        CE6855-48S6Q-HI                   
--------------------------------------------------------------------------------
+ indicates the device where the activated management interface resides.
<Huawei>
```
So the regular expression should be ```\+?(?P<id>\d+)\s+```

Version infomation:
```
<cn.sha2.pe1>display version
Huawei Versatile Routing Platform Software
VRP (R) software, Version 8.150 (CE6855HI V200R002C50SPC800)
Copyright (C) 2012-2017 Huawei Technologies Co., Ltd.
HUAWEI CE6855-48S6Q-HI uptime is 2865 days, 19 hours, 26 minutes 
Patch Version: V200R002SPH026
```
https://github.com/netboxlabs/orb-agent/issues/533