### PR TITLE
fix(deps): bump golang-jwt/jwt/v4 to v4.5.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,9 @@ github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPE
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
-github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=


### PR DESCRIPTION
## Summary

Bumps the indirect dependency `github.com/golang-jwt/jwt/v4` from v4.5.0 to v4.5.2, clearing two advisories flagged by the container scan against `/usr/local/bin/orb-agent`.

| CVE | Severity | In | Fixed in |
|---|---|---|---|
| CVE-2025-30204 | 🟠 HIGH | v4.5.0 | 4.5.2 |
| CVE-2024-51744 | ⚪ LOW | v4.5.0 | 4.5.1 |

v4.5.2 covers both.

## Where it comes from

It is not a direct dependency. `go mod why` gives the chain:

```
github.com/netboxlabs/orb-agent/agent/secretsmgr
github.com/DelineaXPM/dsv-sdk-go/v2/vault
github.com/DelineaXPM/dsv-sdk-go/v2/auth
github.com/Azure/go-autorest/autorest
github.com/Azure/go-autorest/autorest/adal
github.com/golang-jwt/jwt/v4
```

So it arrived with the Delinea DSV backend in #532. Every requirer pins v4.5.0 — `dsv-sdk-go v2.2.0`, `go-autorest v0.11.29`, `azure/auth v0.5.13` — which is why the vulnerable version was selected.

## Why a floor bump is sufficient

Minimal version selection takes the maximum version required across the graph, so an explicit requirement in our own `go.mod` raises the selected version without waiting on any upstream release. v4.5.2 is a patch within the same minor as what every requirer asks for, so no API change is involved.

Diff is one line in `go.mod` and one net line in `go.sum`.

## Verification

- `go build ./...` clean
- `go test ./... -count=1` fully green on the bumped tree

## A flaky test worth knowing about, unrelated to this change

`agent/secretsmgr` failed once on the bumped tree and then passed on three consecutive re-runs. The same package also passes on an unmodified `develop`. It polls with real timers over roughly 30 to 40 seconds and logs a deliberate 404 path during the run, which is the likely source.

I checked this specifically because a single failure right after a dependency bump looks like causation, and it is not: the failure does not reproduce, and the clean tree is not immune. Deliberately not folding a test fix into a dependency bump, but it is worth its own issue if it recurs in CI.

## Note on the other scan findings

This does not touch the two Python advisories that currently fail `Build & Scan` — `msgpack` and `setuptools`. Both are pip's own vendored copies rather than project dependencies, so no dependency change in this repo reaches them; they need either dropping the runtime pip from the final image or a documented suppression. Separate piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)