### PR TITLE
docs(agent,gnmi-discovery): remove beta labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ orb:
 Supported secrets managers:
 - [HashiCorp Vault](./docs/secretsmgr/vault.md)
 - [Doppler](./docs/secretsmgr/doppler.md)
-- [CyberArk (CCP)](./docs/secretsmgr/cyberark.md) (beta)
-- [Delinea Secret Server](./docs/secretsmgr/delinea.md) (beta)
-- [Delinea DevOps Secrets Vault (DSV)](./docs/secretsmgr/dsv.md) (beta)
+- [CyberArk (CCP)](./docs/secretsmgr/cyberark.md)
+- [Delinea Secret Server](./docs/secretsmgr/delinea.md)
+- [Delinea DevOps Secrets Vault (DSV)](./docs/secretsmgr/dsv.md)
 
 The secrets manager to use, and its connection settings, can also be selected and configured entirely via environment variables — independently of the config manager and without editing the YAML file. See [Environment-Driven Configuration](./docs/advanced_config/env_config.md).
 
@@ -73,12 +73,12 @@ orb:
 ```
 
 #### Discovery Backends
-Only the `network_discovery`, `device_discovery`, `worker`, `snmp_discovery` and `gnmi_discovery` (beta) backends are currently supported. They do not require any special configuration.
+Only the `network_discovery`, `device_discovery`, `worker`, `snmp_discovery` and `gnmi_discovery` backends are currently supported. They do not require any special configuration.
 - [Device Discovery](./docs/backends/device_discovery/README.md) ([supported platforms](./docs/backends/device_discovery/supported_platforms.md))
 - [Network Discovery](./docs/backends/network_discovery.md)
 - [Worker](./docs/backends/worker.md)
 - [SNMP Discovery](./docs/backends/snmp_discovery/README.md) ([supported platforms](./docs/backends/snmp_discovery/supported_platforms.md))
-- [gNMI Discovery](./docs/backends/gnmi_discovery.md) (beta)
+- [gNMI Discovery](./docs/backends/gnmi_discovery.md)
 
 #### Observability Backends
 Observability backends focus on collecting and exporting rich telemetry from network traffic or probes so you can feed metrics into your monitoring stack.

--- a/docs/secretsmgr/cyberark.md
+++ b/docs/secretsmgr/cyberark.md
@@ -1,4 +1,4 @@
-# CyberArk Secrets Manager (beta)
+# CyberArk Secrets Manager
 
 The Orb Agent can integrate with [CyberArk Privileged Access Manager (PAM)](https://www.cyberark.com/products/privileged-access-manager/) via the Central Credential Provider (CCP) to retrieve secrets at runtime. This feature allows you to reference accounts stored in CyberArk directly in your policy configurations without hardcoding sensitive values.
 

--- a/docs/secretsmgr/delinea.md
+++ b/docs/secretsmgr/delinea.md
@@ -1,4 +1,4 @@
-# Delinea Secret Server Secrets Manager (beta)
+# Delinea Secret Server Secrets Manager
 
 The Orb Agent can integrate with [Delinea Secret Server](https://delinea.com/products/secret-server/) (both Secret Server Cloud and on-prem / Platform) to securely manage sensitive information such as passwords and API keys. This feature allows you to reference secrets stored in Delinea directly in your policy configurations without hardcoding sensitive values.
 

--- a/docs/secretsmgr/dsv.md
+++ b/docs/secretsmgr/dsv.md
@@ -1,4 +1,4 @@
-# Delinea DevOps Secrets Vault (DSV) Secrets Manager (beta)
+# Delinea DevOps Secrets Vault (DSV) Secrets Manager
 
 The Orb Agent can integrate with [Delinea DevOps Secrets Vault (DSV)](https://delinea.com/products/devops-secrets-management-vault) to resolve sensitive values — passwords, tokens, API keys — referenced from your policy and config values, without hardcoding them.
 


### PR DESCRIPTION
## Summary

Removes all eight `(beta)` markers from the docs, promoting the three secrets-manager integrations and the gNMI discovery backend to generally available.

| File | Removed from |
|---|---|
| `README.md` | CyberArk (CCP), Delinea Secret Server, Delinea DSV list entries |
| `README.md` | the supported-backends sentence, and the gNMI Discovery docs link |
| `docs/secretsmgr/cyberark.md` | page title |
| `docs/secretsmgr/delinea.md` | page title |
| `docs/secretsmgr/dsv.md` | page title |

Eight labels, four files, no other content touched.

## Scope check

Searched the whole repo case-insensitively rather than only for the parenthesised form. Every other hit is coincidental: manufacturer names in `snmp-discovery/data/manufacturers.yaml` (`BETAMONT sro`, `Beta Systems Software AG`, and others) and a test hostname in `test_portscan.py`. None is a maturity label.

Also confirmed there is **no code counterpart**. Nothing in the Go or Python sources gates, warns about, or feature-flags these integrations as beta, so this change is complete on its own rather than leaving docs and behaviour out of step.

## Worth a reviewer's attention

This is a product-maturity claim rather than a mechanical edit, and one entry is very new: Delinea DSV was added in #532, which is the current `develop` tip. Promoting it in the same window it shipped is a deliberate decision, made on the basis that the secrets-manager family is going GA together. Flagging it so it is an explicit call rather than something that slipped through with the batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)