### PR TITLE
chore(deps): bump github.com/netboxlabs/diode-sdk-go to v1.11.1

### DIFF
--- a/orb-discovery/gnmi-discovery/go.mod
+++ b/orb-discovery/gnmi-discovery/go.mod
@@ -5,7 +5,7 @@ go 1.26.4
 require (
 	github.com/gin-gonic/gin v1.12.0
 	github.com/google/uuid v1.6.0
-	github.com/netboxlabs/diode-sdk-go v1.11.0
+	github.com/netboxlabs/diode-sdk-go v1.11.1
 	github.com/openconfig/gnmi v0.14.1
 	github.com/openconfig/gnmic/pkg/api v0.1.11
 	github.com/stretchr/testify v1.11.1
@@ -13,7 +13,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0
 	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
-	google.golang.org/grpc v1.82.1
+	google.golang.org/grpc v1.83.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/orb-discovery/gnmi-discovery/go.sum
+++ b/orb-discovery/gnmi-discovery/go.sum
@@ -76,8 +76,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/netboxlabs/diode-sdk-go v1.11.0 h1:V7/GMhOIxAxX9s0NbvIwDhZ06OlrpBAmuSRcdkZm4KQ=
-github.com/netboxlabs/diode-sdk-go v1.11.0/go.mod h1:FFq4ANemG5T+QqoQthu9RjMo13cPxp1XYJay6ezGpB4=
+github.com/netboxlabs/diode-sdk-go v1.11.1 h1:wOZZNlKkSeTRuucetsFoPDMITd84N/IvscNoGEEg/Jw=
+github.com/netboxlabs/diode-sdk-go v1.11.1/go.mod h1:mcEpqnPP6EsjJ6nqNnyh4RoawBJCKrqcmBFbHAzcKi8=
 github.com/openconfig/gnmi v0.14.1 h1:qKMuFvhIRR2/xxCOsStPQ25aKpbMDdWr3kI+nP9bhMs=
 github.com/openconfig/gnmi v0.14.1/go.mod h1:whr6zVq9PCU8mV1D0K9v7Ajd3+swoN6Yam9n8OH3eT0=
 github.com/openconfig/gnmic/pkg/api v0.1.11 h1:Jrkz3ROyPQDGiXNm4oR52pYgKGApHxb5pDGlFJ1gDso=
@@ -154,8 +154,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260720211330-0afa2a65878a h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260720211330-0afa2a65878a/go.mod h1:1brfde68Npq6+WA75c1EHWPijZEG1kMus61ygPZfn4A=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260720211330-0afa2a65878a h1:qI/YMH1ep2qQtqcp00gMQyoU7mjvbhg88GJKCvfoLj0=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260720211330-0afa2a65878a/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
-google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+google.golang.org/grpc v1.83.0 h1:JeNZEKJFbQxArAMl+hiytHauacDNqJUllNfmIMmpqnQ=
+google.golang.org/grpc v1.83.0/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/orb-discovery/network-discovery/go.mod
+++ b/orb-discovery/network-discovery/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gin-gonic/gin v1.12.0
 	github.com/go-co-op/gocron/v2 v2.21.2
 	github.com/google/uuid v1.6.0
-	github.com/netboxlabs/diode-sdk-go v1.11.0
+	github.com/netboxlabs/diode-sdk-go v1.11.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0
@@ -63,6 +63,6 @@ require (
 	golang.org/x/text v0.40.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260720211330-0afa2a65878a // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260720211330-0afa2a65878a // indirect
-	google.golang.org/grpc v1.82.1 // indirect
+	google.golang.org/grpc v1.83.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/orb-discovery/network-discovery/go.sum
+++ b/orb-discovery/network-discovery/go.sum
@@ -72,8 +72,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/netboxlabs/diode-sdk-go v1.11.0 h1:V7/GMhOIxAxX9s0NbvIwDhZ06OlrpBAmuSRcdkZm4KQ=
-github.com/netboxlabs/diode-sdk-go v1.11.0/go.mod h1:FFq4ANemG5T+QqoQthu9RjMo13cPxp1XYJay6ezGpB4=
+github.com/netboxlabs/diode-sdk-go v1.11.1 h1:wOZZNlKkSeTRuucetsFoPDMITd84N/IvscNoGEEg/Jw=
+github.com/netboxlabs/diode-sdk-go v1.11.1/go.mod h1:mcEpqnPP6EsjJ6nqNnyh4RoawBJCKrqcmBFbHAzcKi8=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
 github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -146,8 +146,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260720211330-0afa2a65878a h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260720211330-0afa2a65878a/go.mod h1:1brfde68Npq6+WA75c1EHWPijZEG1kMus61ygPZfn4A=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260720211330-0afa2a65878a h1:qI/YMH1ep2qQtqcp00gMQyoU7mjvbhg88GJKCvfoLj0=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260720211330-0afa2a65878a/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
-google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+google.golang.org/grpc v1.83.0 h1:JeNZEKJFbQxArAMl+hiytHauacDNqJUllNfmIMmpqnQ=
+google.golang.org/grpc v1.83.0/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/orb-discovery/snmp-discovery/go.mod
+++ b/orb-discovery/snmp-discovery/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-co-op/gocron/v2 v2.21.2
 	github.com/google/uuid v1.6.0
 	github.com/gosnmp/gosnmp v1.43.2
-	github.com/netboxlabs/diode-sdk-go v1.11.0
+	github.com/netboxlabs/diode-sdk-go v1.11.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0
@@ -63,5 +63,5 @@ require (
 	golang.org/x/text v0.40.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260720211330-0afa2a65878a // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260720211330-0afa2a65878a // indirect
-	google.golang.org/grpc v1.82.1 // indirect
+	google.golang.org/grpc v1.83.0 // indirect
 )

--- a/orb-discovery/snmp-discovery/go.sum
+++ b/orb-discovery/snmp-discovery/go.sum
@@ -72,8 +72,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/netboxlabs/diode-sdk-go v1.11.0 h1:V7/GMhOIxAxX9s0NbvIwDhZ06OlrpBAmuSRcdkZm4KQ=
-github.com/netboxlabs/diode-sdk-go v1.11.0/go.mod h1:FFq4ANemG5T+QqoQthu9RjMo13cPxp1XYJay6ezGpB4=
+github.com/netboxlabs/diode-sdk-go v1.11.1 h1:wOZZNlKkSeTRuucetsFoPDMITd84N/IvscNoGEEg/Jw=
+github.com/netboxlabs/diode-sdk-go v1.11.1/go.mod h1:mcEpqnPP6EsjJ6nqNnyh4RoawBJCKrqcmBFbHAzcKi8=
 github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
 github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -144,8 +144,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260720211330-0afa2a65878a h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260720211330-0afa2a65878a/go.mod h1:1brfde68Npq6+WA75c1EHWPijZEG1kMus61ygPZfn4A=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260720211330-0afa2a65878a h1:qI/YMH1ep2qQtqcp00gMQyoU7mjvbhg88GJKCvfoLj0=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260720211330-0afa2a65878a/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
-google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+google.golang.org/grpc v1.83.0 h1:JeNZEKJFbQxArAMl+hiytHauacDNqJUllNfmIMmpqnQ=
+google.golang.org/grpc v1.83.0/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Picks up netboxlabs/diode-sdk-go#84, released as [v1.11.1](https://github.com/netboxlabs/diode-sdk-go/releases/tag/v1.11.1).

## Why

The SDK renewed its Diode access token only when a call came back `Unauthenticated`. That depends on the transport reporting the rejection precisely, which does not hold when an expired token is denied at the ingress with a plain HTTP 401 and no gRPC trailers — the client then receives `Internal: server closed the stream without sending trailers`, never refreshes, and **every** ingest fails until the process restarts.

This is ENGHLP-1563. One customer agent had 100% of its ingests rejected for three days, with the ingester never receiving a request. v1.11.1 renews proactively, so the agent no longer depends on how any intermediary renders an auth failure.

Validated end to end before release: against a fake edge reproducing the ingress byte shape, the pre-fix SDK failed permanently from the moment the token expired and issued exactly one token in the whole run; the fixed SDK completed every ingest across repeated expiries.

## Scope

Three modules consume the SDK and all move together:

| Module | diode-sdk-go | grpc-go |
|---|---|---|
| `orb-discovery/snmp-discovery` | v1.11.0 → v1.11.1 | v1.82.1 → v1.83.0 |
| `orb-discovery/network-discovery` | v1.11.0 → v1.11.1 | v1.82.1 → v1.83.0 |
| `orb-discovery/gnmi-discovery` | v1.11.0 → v1.11.1 | v1.82.1 → v1.83.0 |

grpc-go comes along transitively because the SDK now requires v1.83.0. Worth noting it is **not** the fix: the masking is a grpc-go regression from v1.82.0 ([#8929](https://github.com/grpc/grpc-go/pull/8929)) that is still present in v1.83.0, fixed on master by [#9217](https://github.com/grpc/grpc-go/pull/9217) but unreleased until 1.84. The SDK fix is deliberately version-independent.

The root module keeps grpc-go at v1.82.1; it does not depend on the SDK, and v1.82.1 already carries the HTTP/2 frame-flood mitigation. In workspace mode it resolves to v1.83.0 anyway. Left alone to keep this bump focused.

## Verification

- `go build ./...` clean in the root module and all three backends
- `go test ./...` clean in all four, workspace and `GOWORK=off`
- `make lint` clean in the root and each backend, 0 issues
- `go.work.sum` needed no changes
- Confirmed v1.11.1 actually carries the fix rather than trusting the tag, by checking the released module in the cache for its new symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)