### PR TITLE
fix(docs): scope byte unit to Bytes column in Top destinations table

### DIFF
--- a/docs/observability/dashboards/flow-overview.json
+++ b/docs/observability/dashboards/flow-overview.json
@@ -296,12 +296,7 @@
       "options": {
         "showHeader": true
       },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
+      "fieldConfig": { "defaults": {}, "overrides": [{ "matcher": { "id": "byName", "options": "Bytes" }, "properties": [{ "id": "unit", "value": "bytes" }] }, { "matcher": { "id": "byName", "options": "Dst Port" }, "properties": [{ "id": "unit", "value": "none" }] }] },
       "targets": [
         {
           "refId": "A",


### PR DESCRIPTION
…able

Panel fieldConfig.defaults.unit was set to "bytes" for the whole table, so any unrecognized destination port (pktvisor falls back to the raw numeric port when it can't resolve a service name) got coerced through the bytes formatter and displayed as a nonsensical size (e.g. "6.53 KiB" instead of a port number). Scoped the unit override to just the Bytes column so ports display as plain numbers.

Found by Dom while reviewing the dashboard ahead of the Grafana meeting.