### PR TITLE
docs(agent): bring Flow Overview dashboard to demo parity (gauge bars…

### DIFF
--- a/docs/observability/dashboards/flow-overview.json
+++ b/docs/observability/dashboards/flow-overview.json
@@ -1,474 +1,539 @@
 {
-  "annotations": {
-    "list": []
-  },
-  "editable": true,
-  "graphTooltip": 0,
-  "title": "Flow Overview",
-  "uid": "pktvisor-flow",
-  "tags": [
-    "pktvisor",
-    "netflow",
-    "flow"
-  ],
-  "timezone": "",
-  "schemaVersion": 39,
-  "version": 1,
-  "time": {
-    "from": "now-30m",
-    "to": "now"
-  },
-  "refresh": "30s",
-  "templating": {
-    "list": []
-  },
-  "panels": [
-    {
-      "id": 1,
-      "type": "timeseries",
-      "title": "Total traffic",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 16,
-        "x": 0,
-        "y": 0
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "bytes",
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 10
-          }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "legendFormat": "in",
-          "expr": "sum(flow_in_bytes)",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          }
-        },
-        {
-          "refId": "B",
-          "legendFormat": "out",
-          "expr": "sum(flow_out_bytes)",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          }
-        }
-      ]
+    "annotations": {
+          "list": []
     },
-    {
-      "id": 2,
-      "type": "stat",
-      "title": "Collecting devices",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 16,
-        "y": 0
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "color": {
-            "mode": "fixed",
-            "fixedColor": "green"
-          }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "count(count by(device) (flow_in_bytes))",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          }
-        }
-      ]
+    "editable": true,
+    "graphTooltip": 0,
+    "title": "Flow Overview",
+    "uid": "pktvisor-flow",
+    "tags": [
+          "pktvisor",
+          "netflow",
+          "flow"
+    ],
+    "timezone": "",
+    "schemaVersion": 39,
+    "version": 1,
+    "time": {
+          "from": "now-30m",
+          "to": "now"
     },
-    {
-      "id": 3,
-      "type": "stat",
-      "title": "Sources",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 20,
-        "y": 0
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "color": {
-            "mode": "fixed",
-            "fixedColor": "yellow"
-          }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "count(count by(ip) (flow_top_in_src_ips_bytes))",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          }
-        }
-      ]
+    "refresh": "30s",
+    "templating": {
+          "list": []
     },
-    {
-      "id": 4,
-      "type": "stat",
-      "title": "Destinations (ports)",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 16,
-        "y": 4
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "color": {
-            "mode": "fixed",
-            "fixedColor": "blue"
+    "panels": [
+          {
+                  "id": 1,
+                  "type": "timeseries",
+                  "title": "Total traffic",
+                  "datasource": {
+                            "type": "prometheus",
+                            "uid": "prometheus"
+                  },
+                  "gridPos": {
+                            "h": 8,
+                            "w": 16,
+                            "x": 0,
+                            "y": 0
+                  },
+                  "fieldConfig": {
+                            "defaults": {
+                                        "unit": "bytes",
+                                        "custom": {
+                                                      "drawStyle": "line",
+                                                      "fillOpacity": 10
+                                        }
+                            },
+                            "overrides": []
+                  },
+                  "targets": [
+                            {
+                                        "refId": "A",
+                                        "legendFormat": "in",
+                                        "expr": "sum(flow_in_bytes)",
+                                        "datasource": {
+                                                      "type": "prometheus",
+                                                      "uid": "prometheus"
+                                        }
+                            },
+                            {
+                                        "refId": "B",
+                                        "legendFormat": "out",
+                                        "expr": "sum(flow_out_bytes)",
+                                        "datasource": {
+                                                      "type": "prometheus",
+                                                      "uid": "prometheus"
+                                        }
+                            }
+                  ]
+          },
+          {
+                  "id": 2,
+                  "type": "stat",
+                  "title": "Collecting devices",
+                  "datasource": {
+                            "type": "prometheus",
+                            "uid": "prometheus"
+                  },
+                  "gridPos": {
+                            "h": 4,
+                            "w": 4,
+                            "x": 16,
+                            "y": 0
+                  },
+                  "fieldConfig": {
+                            "defaults": {
+                                        "unit": "short",
+                                        "color": {
+                                                      "mode": "fixed",
+                                                      "fixedColor": "green"
+                                        }
+                            },
+                            "overrides": []
+                  },
+                  "targets": [
+                            {
+                                        "refId": "A",
+                                        "expr": "count(count by(device) (flow_in_bytes))",
+                                        "datasource": {
+                                                      "type": "prometheus",
+                                                      "uid": "prometheus"
+                                        }
           }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "count(count by(port) (flow_top_in_dst_ports_bytes))",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
+                  ]
+          },
+          {
+                  "id": 3,
+                  "type": "stat",
+                  "title": "Sources",
+                  "datasource": {
+                            "type": "prometheus",
+                            "uid": "prometheus"
+                  },
+                  "gridPos": {
+                            "h": 4,
+                            "w": 4,
+                            "x": 20,
+                            "y": 0
+                  },
+                  "fieldConfig": {
+                            "defaults": {
+                                        "unit": "short",
+                                        "color": {
+                                                      "mode": "fixed",
+                                                      "fixedColor": "yellow"
+                                        }
+                            },
+                            "overrides": []
+                  },
+                  "targets": [
+                            {
+                                        "refId": "A",
+                                        "expr": "count(count by(ip) (flow_top_in_src_ips_bytes))",
+                                        "datasource": {
+                                                      "type": "prometheus",
+                                                      "uid": "prometheus"
+                                        }
+                            }
+                  ]
+          },
+          {
+                  "id": 4,
+                  "type": "stat",
+                  "title": "Destinations (ports)",
+                  "datasource": {
+                            "type": "prometheus",
+                            "uid": "prometheus"
+                  },
+                  "gridPos": {
+                            "h": 4,
+                            "w": 4,
+                            "x": 16,
+                            "y": 4
+                  },
+                  "fieldConfig": {
+                            "defaults": {
+                                        "unit": "short",
+                                        "color": {
+                                                      "mode": "fixed",
+                                                      "fixedColor": "blue"
+                                        }
+                            },
+                            "overrides": []
+                  },
+                  "targets": [
+                            {
+                                        "refId": "A",
+                                        "expr": "count(count by(port) (flow_top_in_dst_ports_bytes))",
+                                        "datasource": {
+                                                      "type": "prometheus",
+                                                      "uid": "prometheus"
+                                        }
+                            }
+                  ]
+          },
+          {
+                  "id": 5,
+                  "type": "stat",
+                  "title": "Total (observed) traffic",
+                  "datasource": {
+                            "type": "prometheus",
+                            "uid": "prometheus"
+                  },
+                  "gridPos": {
+                            "h": 4,
+                            "w": 4,
+                            "x": 20,
+                            "y": 4
+                  },
+                  "fieldConfig": {
+                            "defaults": {
+                                        "unit": "bytes",
+                                        "color": {
+                                                      "mode": "fixed",
+                                                      "fixedColor": "orange"
+                                        }
+                            },
+                            "overrides": []
+                  },
+                  "targets": [
+                            {
+                                        "refId": "A",
+                                        "expr": "sum(flow_in_bytes) + sum(flow_out_bytes)",
+                                        "datasource": {
+                                                      "type": "prometheus",
+                                                      "uid": "prometheus"
+                                        }
+                            }
+                  ]
+          },
+          {
+                  "id": 6,
+                  "type": "row",
+                  "title": "Top talkers",
+                  "gridPos": {
+                            "h": 1,
+                            "w": 24,
+                            "x": 0,
+                            "y": 8
+                  },
+                  "panels": []
+          },
+          {
+                  "id": 7,
+                  "type": "table",
+                  "title": "Top sources",
+                  "datasource": {
+                            "type": "prometheus",
+                            "uid": "prometheus"
+                  },
+                  "gridPos": {
+                            "h": 9,
+                            "w": 12,
+                            "x": 0,
+                            "y": 9
+                  },
+                  "options": {
+                            "showHeader": true
+                  },
+                  "fieldConfig": {
+                            "defaults": {
+                                        "unit": "bytes",
+                                        "fieldMinMax": true,
+                                        "color": {
+                                                      "mode": "continuous-BlPu"
+                                        }
+                            },
+                            "overrides": [
+                                        {
+                                                      "matcher": {
+                                                                      "id": "byName",
+                                                                      "options": "Bytes"
+                                                      },
+                                                      "properties": [
+                                                                      {
+                                                                                        "id": "custom.cellOptions",
+                                                                                        "value": {
+                                                                                                            "type": "gauge",
+                                                                                                            "mode": "basic"
+                                                                                          }
+                                                                      }
+                                                      ]
+                                        }
+                            ]
+                  },
+                  "targets": [
+                            {
+                                        "refId": "A",
+                                        "format": "table",
+                                        "instant": true,
+                                        "expr": "topk(10, flow_top_in_src_ips_bytes)",
+                                        "datasource": {
+                                                      "type": "prometheus",
+                                                      "uid": "prometheus"
+                                        }
+                            }
+                  ],
+                  "transformations": [
+                            {
+                                        "id": "organize",
+                                        "options": {
+                                                      "excludeByName": {
+                                                                      "Time": true,
+                                                                      "__name__": true,
+                                                                      "handler": true,
+                                                                      "policy": true,
+                                                                      "tap": true,
+                                                                      "job": true,
+                                                                      "instance": true
+                                                      },
+                                                      "renameByName": {
+                                                                      "device": "Device",
+                                                                      "device_interface": "Interface",
+                                                                      "ip": "Source IP",
+                                                                      "Value": "Bytes",
+                                                                      "Value #A": "Bytes"
+                                                      }
+                                        }
+                            }
+                  ]
+          },
+          {
+                  "id": 8,
+                  "type": "table",
+                  "title": "Top destinations (by port)",
+                  "datasource": {
+                            "type": "prometheus",
+                            "uid": "prometheus"
+                  },
+                  "gridPos": {
+                            "h": 9,
+                            "w": 12,
+                            "x": 12,
+                            "y": 9
+                  },
+                  "options": {
+                            "showHeader": true
+                  },
+                  "fieldConfig": { "defaults": { "fieldMinMax": true, "color": { "mode": "continuous-BlPu" } }, "overrides": [{ "matcher": { "id": "byName", "options": "Bytes" }, "properties": [{ "id": "unit", "value": "bytes" }, { "id": "custom.cellOptions", "value": { "type": "gauge", "mode": "basic" } }] }, { "matcher": { "id": "byName", "options": "Dst Port" }, "properties": [{ "id": "unit", "value": "none" }] }] },
+                  "targets": [
+                            {
+                                        "refId": "A",
+                                        "format": "table",
+                                        "instant": true,
+                                        "expr": "topk(10, flow_top_in_dst_ports_bytes)",
+                                        "datasource": {
+                                                      "type": "prometheus",
+                                                      "uid": "prometheus"
+                                        }
+                            }
+                  ],
+                  "transformations": [
+                            {
+                                        "id": "organize",
+                                        "options": {
+                                                      "excludeByName": {
+                                                                      "Time": true,
+                                                                      "__name__": true,
+                                                                      "handler": true,
+                                                                      "policy": true,
+                                                                      "tap": true,
+                                                                      "job": true,
+                                                                      "instance": true
+                                                      },
+                                                      "renameByName": {
+                                                                      "device": "Device",
+                                                                      "device_interface": "Interface",
+                                                                      "port": "Dst Port",
+                                                                      "Value": "Bytes",
+                                                                      "Value #A": "Bytes"
+                                                      }
+                                        }
+                            }
+                  ]
+          },
+          {
+                  "id": 9,
+                  "type": "row",
+                  "title": "Conversations",
+                  "gridPos": {
+                            "h": 1,
+                            "w": 24,
+                            "x": 0,
+                            "y": 18
+                  },
+                  "panels": []
+          },
+          {
+                  "id": 10,
+                  "type": "table",
+                  "title": "Conversation total bytes",
+                  "datasource": {
+                            "type": "prometheus",
+                            "uid": "prometheus"
+                  },
+                  "gridPos": {
+                            "h": 9,
+                            "w": 12,
+                            "x": 0,
+                            "y": 19
+                  },
+                  "options": {
+                            "showHeader": true
+                  },
+                  "fieldConfig": {
+                            "defaults": {
+                                        "unit": "bytes",
+                                        "fieldMinMax": true,
+                                        "color": {
+                                                      "mode": "continuous-BlPu"
+                                        }
+                            },
+                            "overrides": [
+                                        {
+                                                      "matcher": {
+                                                                      "id": "byName",
+                                                                      "options": "Bytes"
+                                                      },
+                                                      "properties": [
+                                                                      {
+                                                                                        "id": "custom.cellOptions",
+                                                                                        "value": {
+                                                                                                            "type": "gauge",
+                                                                                                            "mode": "basic"
+                                                                                          }
+                                                                      }
+                                                      ]
+                                        }
+                            ]
+                  },
+                  "targets": [
+                            {
+                                        "refId": "A",
+                                        "format": "table",
+                                        "instant": true,
+                                        "expr": "topk(10, flow_top_conversations_bytes)",
+                                        "datasource": {
+                                                      "type": "prometheus",
+                                                      "uid": "prometheus"
+                                        }
+                            }
+                  ],
+                  "transformations": [
+                            {
+                                        "id": "organize",
+                                        "options": {
+                                                      "excludeByName": {
+                                                                      "Time": true,
+                                                                      "__name__": true,
+                                                                      "handler": true,
+                                                                      "policy": true,
+                                                                      "tap": true,
+                                                                      "job": true,
+                                                                      "instance": true
+                                                      },
+                                                      "renameByName": {
+                                                                      "device": "Device",
+                                                                      "device_interface": "Interface",
+                                                                      "Value": "Bytes",
+                                                                      "Value #A": "Bytes"
+                                                      }
+                                        }
+                            },
+                            {
+                                        "id": "extractFields",
+                                        "options": {
+                                                      "source": "conversation",
+                                                      "format": "regexp",
+                                                      "regExp": "/^(?<Source>.+)\\/(?<Destination>[^\\/]+)$/",
+                                                      "replace": false
+                                        }
+                            },
+                            {
+                                        "id": "organize",
+                                        "options": {
+                                                      "excludeByName": {
+                                                                      "conversation": true
+                                                      },
+                                                      "renameByName": {},
+                                                      "indexByName": {
+                                                                      "Source": 0,
+                                                                      "Destination": 1,
+                                                                      "Device": 2,
+                                                                      "Interface": 3,
+                                                                      "Bytes": 4
+                                                      }
+                                        }
+                            }
+                  ]
+          },
+          {
+                  "id": 11,
+                  "type": "timeseries",
+                  "title": "Conversation traffic over time",
+                  "datasource": {
+                            "type": "prometheus",
+                            "uid": "prometheus"
+                  },
+                  "gridPos": {
+                            "h": 9,
+                            "w": 12,
+                            "x": 12,
+                            "y": 19
+                  },
+                  "fieldConfig": {
+                            "defaults": {
+                                        "unit": "bytes",
+                                        "custom": {
+                                                      "drawStyle": "line",
+                                                      "fillOpacity": 10
+                                        }
+                            },
+                            "overrides": []
+                  },
+                  "targets": [
+                            {
+                                        "refId": "A",
+                                        "expr": "sum(flow_top_conversations_bytes)",
+                                        "datasource": {
+                                                      "type": "prometheus",
+                                                      "uid": "prometheus"
+                                        }
+                            }
+                  ]
+          },
+          {
+                  "id": 12,
+                  "type": "piechart",
+                  "title": "Breakdown by source/destination pair",
+                  "datasource": {
+                            "type": "prometheus",
+                            "uid": "prometheus"
+                  },
+                  "gridPos": {
+                            "h": 9,
+                            "w": 12,
+                            "x": 0,
+                            "y": 28
+                  },
+                  "fieldConfig": {
+                            "defaults": {
+                                        "unit": "bytes"
+                            },
+                            "overrides": []
+                  },
+                  "targets": [
+                            {
+                                        "refId": "A",
+                                        "instant": true,
+                                        "expr": "topk(10, flow_top_conversations_bytes)",
+                                        "datasource": {
+                                                      "type": "prometheus",
+                                                      "uid": "prometheus"
+                                        }
+                            }
+                  ]
           }
-        }
-      ]
-    },
-    {
-      "id": 5,
-      "type": "stat",
-      "title": "Total (observed) traffic",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 20,
-        "y": 4
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "bytes",
-          "color": {
-            "mode": "fixed",
-            "fixedColor": "orange"
-          }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "sum(flow_in_bytes) + sum(flow_out_bytes)",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          }
-        }
-      ]
-    },
-    {
-      "id": 6,
-      "type": "row",
-      "title": "Top talkers",
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 8
-      },
-      "panels": []
-    },
-    {
-      "id": 7,
-      "type": "table",
-      "title": "Top sources",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 9
-      },
-      "options": {
-        "showHeader": true
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "format": "table",
-          "instant": true,
-          "expr": "topk(10, flow_top_in_src_ips_bytes)",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          }
-        }
-      ],
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "__name__": true,
-              "handler": true,
-              "policy": true,
-              "tap": true,
-              "job": true,
-              "instance": true
-            },
-            "renameByName": {
-              "device": "Device",
-              "device_interface": "Interface",
-              "ip": "Source IP",
-              "Value": "Bytes",
-              "Value #A": "Bytes"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": 8,
-      "type": "table",
-      "title": "Top destinations (by port)",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 9
-      },
-      "options": {
-        "showHeader": true
-      },
-      "fieldConfig": { "defaults": {}, "overrides": [{ "matcher": { "id": "byName", "options": "Bytes" }, "properties": [{ "id": "unit", "value": "bytes" }] }, { "matcher": { "id": "byName", "options": "Dst Port" }, "properties": [{ "id": "unit", "value": "none" }] }] },
-      "targets": [
-        {
-          "refId": "A",
-          "format": "table",
-          "instant": true,
-          "expr": "topk(10, flow_top_in_dst_ports_bytes)",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          }
-        }
-      ],
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "__name__": true,
-              "handler": true,
-              "policy": true,
-              "tap": true,
-              "job": true,
-              "instance": true
-            },
-            "renameByName": {
-              "device": "Device",
-              "device_interface": "Interface",
-              "port": "Dst Port",
-              "Value": "Bytes",
-              "Value #A": "Bytes"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": 9,
-      "type": "row",
-      "title": "Conversations",
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 18
-      },
-      "panels": []
-    },
-    {
-      "id": 10,
-      "type": "table",
-      "title": "Conversation total bytes",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 19
-      },
-      "options": {
-        "showHeader": true
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "format": "table",
-          "instant": true,
-          "expr": "topk(10, flow_top_conversations_bytes)",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          }
-        }
-      ],
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "__name__": true,
-              "handler": true,
-              "policy": true,
-              "tap": true,
-              "job": true,
-              "instance": true
-            },
-            "renameByName": {
-              "device": "Device",
-              "device_interface": "Interface",
-              "Value": "Bytes",
-              "Value #A": "Bytes"
-            }
-          }
-        }
-      ]
-    },
-    {
-      "id": 11,
-      "type": "timeseries",
-      "title": "Conversation traffic over time",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 19
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "bytes",
-          "custom": {
-            "drawStyle": "line",
-            "fillOpacity": 10
-          }
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "expr": "sum(flow_top_conversations_bytes)",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          }
-        }
-      ]
-    },
-    {
-      "id": 12,
-      "type": "piechart",
-      "title": "Breakdown by source/destination pair",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 28
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "topk(10, flow_top_conversations_bytes)",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          }
-        }
-      ]
-    }
-  ]
+    ]
 }


### PR DESCRIPTION


Updates flow-overview.json to match the latest verified demo dashboard:

- Adds ktranslate-style bar-gauge cell styling (Blue-Purple by-value color scheme, Field min/max, Gauge/Basic cell type) to the Bytes column in Top sources, Top destinations, and Conversation total bytes.
- Fixes the Conversation total bytes Source/Destination split: the extractFields regex now splits on the last "/" instead of requiring strict IP:port on both sides, so conversation labels carrying ASN/ISP enrichment metadata no longer produce blank Source/Destination cells.

Both changes were visually verified live against a running Grafana instance before this update.