### PR TITLE
fix(deps): build with go 1.26.6 and record pip's vendored-dependency findings

### DIFF
--- a/.github/workflows/_agent-release.yaml
+++ b/.github/workflows/_agent-release.yaml
@@ -111,7 +111,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Extract Go version from go.mod
-        run: echo "GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}' | cut -d. -f1,2)" >> "$GITHUB_ENV"
+        run: echo "GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}')" >> "$GITHUB_ENV"
       - name: Set build info
         run: |
           echo "$BUILD_COMMIT" > ./agent/version/BUILD_COMMIT.txt

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,6 +85,7 @@ jobs:
           scanners: vuln,secret
           severity: CRITICAL,HIGH,MEDIUM,LOW
           ignore-unfixed: true
+          trivyignores: .trivyignore.yaml
           exit-code: "0"
           list-all-pkgs: "true"
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Extract Go version from go.mod
-        run: echo "GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}' | cut -d. -f1,2)" >> $GITHUB_ENV
+        run: echo "GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}')" >> $GITHUB_ENV
 
       - name: Set build info
         run: |

--- a/.github/workflows/container-rescan.yaml
+++ b/.github/workflows/container-rescan.yaml
@@ -36,6 +36,7 @@ jobs:
           scanners: vuln,secret
           severity: CRITICAL,HIGH,MEDIUM,LOW
           ignore-unfixed: true
+          trivyignores: .trivyignore.yaml
           exit-code: "0"
 
       - name: Build rescan summary

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -48,7 +48,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract Go version from go.mod
-        run: echo "GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}' | cut -d. -f1,2)" >> $GITHUB_ENV
+        run: echo "GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}')" >> $GITHUB_ENV
 
       - name: Set build info
         run: |

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,50 @@
+# Accepted findings for the container scan in build.yaml and container-rescan.yaml.
+#
+# Every entry is time-boxed. When an entry expires the finding reappears and
+# blocks the build again, which is deliberate: an accepted risk should be
+# re-argued periodically, not inherited silently.
+#
+# How to re-check an entry before extending it:
+#   1. Is there a newer pip whose _vendor/vendor.txt raises the pinned version?
+#        curl -s https://pypi.org/pypi/pip/json | python3 -c \
+#          "import sys,json;print(json.load(sys.stdin)['info']['version'])"
+#      then read _vendor/vendor.txt from that release's wheel.
+#   2. Is the vulnerable code actually shipped, or is vendor.txt the only trace?
+#        docker run --rm --entrypoint sh netboxlabs/orb-agent:<tag> -c \
+#          "ls /usr/local/lib/python3.14/site-packages/pip/_vendor/"
+#   If either answer changed, fix it rather than extending the entry.
+
+vulnerabilities:
+  # pip vendors its own dependency set under pip/_vendor and records it in
+  # pip/_vendor/vendor.txt, which the image scanner reads as if each entry were
+  # an independently installed distribution. They are not: they have no
+  # dist-info of their own, and the SBOM records them in pip's own layer with no
+  # file path, unlike every genuinely installed package.
+  #
+  # pip is in the image only to serve the documented INSTALL_DRIVERS_PATH and
+  # INSTALL_WORKERS_PATH options (see docs/config_samples.md). It is invoked by
+  # the entrypoint solely when an operator sets one of those, and never during
+  # normal agent operation.
+
+  - id: CVE-2025-47273
+    statement: >-
+      setuptools reported at 70.3.0 from pip 26.2.1's vendor.txt. The vulnerable
+      code is not in the image: pip no longer ships _vendor/setuptools at all,
+      only _vendor/pkg_resources, so PackageIndex, the component this path
+      traversal affects, is absent. The finding is vendor.txt metadata rather
+      than reachable code. pip 26.2.1 is the current latest release and still
+      pins this version, so there is no upgrade that clears it.
+    expired_at: 2026-11-18
+
+  - id: GHSA-6v7p-g79w-8964
+    statement: >-
+      msgpack reported at 1.1.2 from pip 26.2.1's vendor.txt. Unlike the
+      setuptools entry, the code is present, under pip/_vendor/msgpack, where pip
+      uses it through CacheControl to serialise its own HTTP cache. Reaching the
+      out-of-bounds read requires pip to unpack attacker-influenced cache data
+      during a pip invocation, and pip only runs here when an operator opts into
+      installing extra drivers or workers from their own requirements file. pip
+      26.2.1 is the current latest release and still pins this version, so there
+      is no upgrade that clears it; removing runtime pip would, at the cost of
+      those two documented options.
+    expired_at: 2026-11-18

--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -1,6 +1,6 @@
 ARG PKTVISOR_TAG=develop-alpine
 ARG OTEL_TAG=develop
-ARG GO_VERSION=1.26
+ARG GO_VERSION=1.26.6
 
 ########################################################################
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-trixie AS builder

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/netboxlabs/orb-agent
 
-go 1.26.4
+go 1.26.6
 
 require (
 	github.com/DelineaXPM/dsv-sdk-go/v2 v2.2.0

--- a/orb-discovery/gnmi-discovery/go.mod
+++ b/orb-discovery/gnmi-discovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery
 
-go 1.26.4
+go 1.26.6
 
 require (
 	github.com/gin-gonic/gin v1.12.0

--- a/orb-discovery/network-discovery/go.mod
+++ b/orb-discovery/network-discovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/netboxlabs/orb-agent/orb-discovery/network-discovery
 
-go 1.26.4
+go 1.26.6
 
 require (
 	github.com/Ullaakut/nmap/v3 v3.0.4

--- a/orb-discovery/snmp-discovery/go.mod
+++ b/orb-discovery/snmp-discovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/netboxlabs/orb-agent/orb-discovery/snmp-discovery
 
-go 1.26.4
+go 1.26.6
 
 require (
 	github.com/gin-gonic/gin v1.12.0


### PR DESCRIPTION
Closes every open code-scanning alert on the repository and unblocks `Build & Scan`.

Two separate causes sat behind that red check: the Go toolchain the binaries were
compiled with, and three Python findings that come from pip's vendored
dependencies. The first is a fix, the second is a recorded acceptance.

## What is actually wrong

All **32** open code-scanning alerts are the same **8 Go standard-library CVEs**, reported by Trivy against each of the 4 shipped binaries (`orb-agent`, `snmp-discovery`, `network-discovery`, `gnmi-discovery`):

| CVE | package | installed | fixed in |
|---|---|---|---|
| CVE-2026-33818 | stdlib | v1.26.5 | 1.25.13, **1.26.6**, 1.27.0-rc.3 |
| CVE-2026-39821 | stdlib | v1.26.5 | 1.25.13, **1.26.6**, 1.27.0-rc.3 |
| CVE-2026-46600 | stdlib | v1.26.5 | **1.26.6**, 1.27.0-rc.3 |
| CVE-2026-56853 | stdlib | v1.26.5 | 1.25.13, **1.26.6**, 1.27.0-rc.3 |
| CVE-2026-56858 | stdlib | v1.26.5 | 1.25.13, **1.26.6**, 1.27.0-rc.3 |
| CVE-2026-56859 | stdlib | v1.26.5 | 1.25.13, **1.26.6**, 1.27.0-rc.3 |
| CVE-2026-56860 | stdlib | v1.26.5 | 1.25.13, **1.26.6**, 1.27.0-rc.3 |
| CVE-2026-56862 | stdlib | v1.26.5 | 1.25.13, **1.26.6**, 1.27.0-rc.3 |

Zero alerts come from any other tool, and none implicates our code or module graph. Every one is the toolchain the binaries were compiled with, so the entire set clears with one bump.

This is also the failure behind `Build & Scan` → *"Blocking vulnerabilities found (CRITICAL or HIGH)"*. That check fails on `develop` itself, so it currently blocks every open PR without any of them having caused it.

## Why the version was 1.26.5

The images build `FROM golang:${GO_VERSION}-trixie`, and the workflows derived `GO_VERSION` from `go.mod` while truncating it to major.minor:

```sh
GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}' | cut -d. -f1,2)   # 1.26.4 -> 1.26
```

`golang:1.26-trixie` is a moving tag that still resolves to 1.26.5, so the build picked up the vulnerable toolchain even though `1.26.6-trixie` has been published (last pushed 2026-08-16).

Rather than wait for the moving tag to advance, this keeps `go.mod` as the single source of truth and stops discarding the patch component. The build image and the declared toolchain can no longer disagree, and one bump moves both.

## Changes

- `go 1.26.4` → `go 1.26.6` in all four modules
- `ARG GO_VERSION=1.26` → `1.26.6` in `agent/docker/Dockerfile`
- dropped `| cut -d. -f1,2` from the `GO_VERSION` extraction in `build.yaml`, `develop.yaml` and `_agent-release.yaml`
- added `.trivyignore.yaml` and wired it into the scan step of `build.yaml` and `container-rescan.yaml`

`go.work` also pins the toolchain but is gitignored, so it is not in this diff. After pulling, a local `go work use` (or bumping its `go` line) is needed, otherwise workspace builds report *"go.work lists go 1.26.4"*.

## Verification

- `go build ./...` and `go vet ./...` clean in the root module and all three backends
- `go test ./...` green in all four; Go transparently fetched the 1.26.6 toolchain from the bumped directive
- `make lint` reports 0 issues in the root module and each backend
- confirmed `golang:1.26.6-trixie` exists on Docker Hub before pinning it
- simulated the new CI expression: it yields `1.26.6`, so the build uses `golang:1.26.6-trixie`

### One pre-existing flake, unrelated

`network-discovery` `TestRunStore_UpdateRun` failed once during a full-suite run, then passed 4/4 on re-run and 5/5 in isolation, and `develop` passes it too. It is racy by construction rather than affected by this change: `CreateRun` sets `CreatedAt` and `UpdatedAt` from the *same* `time.Now()`, `UpdateRun` re-reads the clock, and the test asserts `Greater` on a pair the code only guarantees to be `>=`. Whenever both reads land in one clock tick it fails. Out of scope here; worth its own fix.

## The remaining three findings are pip's vendored dependencies

The toolchain bump clears all 32 code-scanning alerts, but `Build & Scan` still
failed on three findings the alert list never showed:

| library | ID | severity | installed | fixed in |
|---|---|---|---|---|
| msgpack | GHSA-6v7p-g79w-8964 | HIGH | 1.1.2 | 1.2.1 |
| setuptools | CVE-2025-47273 | HIGH | 70.3.0 | 78.1.1 |
| setuptools | CVE-2026-59890 | MEDIUM | 70.3.0 | 83.0.0 |

Neither library is installed in the image. Both are pip's own vendored
dependencies, listed in `pip/_vendor/vendor.txt`, which Trivy's image scanner
reads as though each entry were an independently installed distribution.

The SBOM from the failing run states it plainly: the 19 python packages in that
layer are exactly pip's vendored set, they share pip's `LayerDiffID`, and every
one of them has no file path of its own. Only `pip` itself has one.

**There is no upgrade.** pip 26.2.1 is the current latest release, this image
already installs precisely that, and it still pins `msgpack==1.1.2` and
`setuptools==70.3.0`. Bumping pip is not an available fix, so the choice is to
accept the findings or to remove runtime pip.

Runtime pip is load-bearing: the entrypoint uses it for `INSTALL_DRIVERS_PATH`
and `INSTALL_WORKERS_PATH`, both documented in `docs/config_samples.md`.
Removing it would eliminate the msgpack code, and is a real option, but it drops
two documented features and belongs in its own change rather than smuggled into
a CVE fix.

So this records the acceptance in `.trivyignore.yaml`, wired into both scanning
workflows via the action's `trivyignores` input.

### The two entries are not equally strong, and say so

- **setuptools** is metadata only. pip no longer ships `_vendor/setuptools` at
  all, only `_vendor/pkg_resources`, so `PackageIndex`, the component the path
  traversal affects, is absent from the image. Verified by listing `_vendor/`.
- **msgpack** is genuinely present, under `pip/_vendor/msgpack`, where pip uses
  it through CacheControl for its own HTTP cache. Reaching the out-of-bounds
  read needs pip to unpack attacker-influenced cache data during a pip run, and
  pip only runs here when an operator opts into one of those two options.

Only the two blocking HIGHs are suppressed. The setuptools MEDIUM stays visible,
because nothing about it blocks the build and hiding it would buy nothing.

Both entries carry `expired_at: 2026-11-18`, so the acceptance has to be
re-argued rather than inherited, and the file carries the two commands to
re-check it: whether a newer pip raises the pins, and whether the vulnerable code
is shipped.

### Verified end to end, including the expiry

Suppression was not taken on trust. A minimal image reproducing the runtime pip
layer (`FROM python:3.14-alpine` plus this repo's `pip==26.2.1` upgrade)
reproduces all three findings exactly, which makes it a faithful stand-in:

| ignore file | findings reported | `has_blocking` |
|---|---|---|
| none | all 3 | `true` (build fails) |
| as committed | MEDIUM only | `false` (build passes) |
| dates forced into the past | all 3 again | `true` (build fails) |

The third row matters: it proves the entries expire rather than merely claiming
to. It also caught a real bug in the first attempt at this file. Trivy's YAML key
is `expired_at`, not the `expiredAt` I first wrote, and Trivy does not validate
the ignore-file schema, so the misspelled entries loaded silently and suppressed
findings with no expiry at all. Without the mutation run it would have shipped as
a permanent suppression wearing an expiry date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
