### PR TITLE
fix(ci): check out the ignore file before the scheduled rescan

### DIFF
--- a/.github/workflows/container-rescan.yaml
+++ b/.github/workflows/container-rescan.yaml
@@ -21,6 +21,15 @@ jobs:
       TRIVY_DISABLE_VEX_NOTICE: "true"
 
     steps:
+      # The scan needs .trivyignore.yaml from the repo. Nothing else here does,
+      # since the image is pulled rather than built.
+      - name: Check out the ignore file
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          sparse-checkout: .trivyignore.yaml
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
       - name: Pull image
         env:
           IMAGE_REF: ${{ env.IMAGE_REF }}


### PR DESCRIPTION
## What broke

The nightly `Scheduled Container Rescan` failed on its first run after
[#542](https://github.com/netboxlabs/orb-agent/pull/542) landed
([run 32222170461](https://github.com/netboxlabs/orb-agent/actions/runs/32222170461/job/95974556637)):

```
ERROR: cannot find ignorefile '.trivyignore.yaml'.
##[error]Process completed with exit code 1.
FATAL  Fatal error  file open error: open trivy-output.json: no such file or directory
##[error]Path does not exist: trivy-results.sarif
```

One missing file produced three failing steps: the scan aborted before writing
`trivy-output.json`, then `trivy convert` and the SARIF upload each failed on the
artifact that was never created.

It had passed every night up to 2026-08-18 and broke on the first run against
`21cd9ed`, so the cause is unambiguous.

## Why

`#542` wired `trivyignores: .trivyignore.yaml` into both scanning workflows, but
the two workflows are not alike:

| | `build.yaml` | `container-rescan.yaml` |
|---|---|---|
| checks out the repo | yes, it builds the image from source | **no**, it pulls a published image |
| so the ignore file is | on disk | absent |

Nothing in the rescan job read the working tree before, so it had no reason to
check anything out. Adding a file reference to the scan gave it one.

## The fix

A sparse checkout of that single file, rather than the whole tree. The scan
target is a pulled image and nothing else in the job reads the repo, so the
checkout exists only to place the ignore file.

Dropping the `trivyignores` input would be the wrong repair. This job uploads its
results to code scanning, so without the ignore file the two accepted
vendored-pip findings would come back as alerts, which is exactly what the file
exists to prevent.

## Verification

Not taken on trust a second time, since the first attempt at this wiring is what
broke. Details in the comment below.