### PR TITLE
feat(agent): add GitHub App auth to git config manager

### DIFF
--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -25,11 +25,11 @@ type LocalManager struct {
 // ConfigManager. Only github.com is supported (including GitHub Enterprise
 // Cloud, which is served from github.com / api.github.com).
 type GitHubAppAuth struct {
-	// AppID is the JWT issuer. Prefer the app's Client ID (Iv23li...), which is
+	// ClientID is the JWT issuer. Prefer the app's Client ID (Iv23li...), which is
 	// what the GitHub API documentation now specifies; the numeric App ID from
 	// the app's settings page is still accepted, but is the legacy form and may
 	// be dropped in a future API version.
-	AppID string `yaml:"app_id"`
+	ClientID string `yaml:"client_id"`
 	// InstallationID identifies the installation of the app on the account that
 	// owns the repository. It is the numeric id in the URL of the installation's
 	// settings page - not the App ID.

--- a/agent/config/types.go
+++ b/agent/config/types.go
@@ -21,16 +21,35 @@ type LocalManager struct {
 	Config string `yaml:"config"`
 }
 
+// GitHubAppAuth holds GitHub App installation credentials for the Git
+// ConfigManager. Only github.com is supported (including GitHub Enterprise
+// Cloud, which is served from github.com / api.github.com).
+type GitHubAppAuth struct {
+	// AppID is the JWT issuer. Prefer the app's Client ID (Iv23li...), which is
+	// what the GitHub API documentation now specifies; the numeric App ID from
+	// the app's settings page is still accepted, but is the legacy form and may
+	// be dropped in a future API version.
+	AppID string `yaml:"app_id"`
+	// InstallationID identifies the installation of the app on the account that
+	// owns the repository. It is the numeric id in the URL of the installation's
+	// settings page - not the App ID.
+	InstallationID string `yaml:"installation_id"`
+	// PrivateKey is the path to the app's .pem private key, or the PEM document
+	// itself when injected by ${VAR} or a secrets manager.
+	PrivateKey string `yaml:"private_key"`
+}
+
 // GitManager represents the Git ConfigManager configuration.
 type GitManager struct {
-	URL        string  `yaml:"url"`
-	Branch     string  `yaml:"branch"`
-	Auth       string  `yaml:"auth"`
-	Schedule   *string `yaml:"schedule,omitempty"`
-	Username   string  `yaml:"username"`
-	Password   string  `yaml:"password"`
-	PrivateKey string  `yaml:"private_key"`
-	SkipTLS    bool    `yaml:"skip_tls"`
+	URL        string        `yaml:"url"`
+	Branch     string        `yaml:"branch"`
+	Auth       string        `yaml:"auth"`
+	Schedule   *string       `yaml:"schedule,omitempty"`
+	Username   string        `yaml:"username"`
+	Password   string        `yaml:"password"`
+	PrivateKey string        `yaml:"private_key"`
+	SkipTLS    bool          `yaml:"skip_tls"`
+	GitHubApp  GitHubAppAuth `yaml:"github_app"`
 }
 
 // FleetManager represents the Fleet ConfigManager configuration.

--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -39,7 +39,21 @@ type gitConfigManager struct {
 	version          int32
 	matchPolicyPaths []string
 	namespace        uuid.UUID
-	tempDir          string // non-empty when using system git fallback (Azure DevOps)
+	tempDir          string         // non-empty when using system git fallback (Azure DevOps)
+	githubApp        *githubAppAuth // non-nil when auth is github_app; also stored in authMethod
+}
+
+// annotateAuthError attaches the last GitHub App token failure to a go-git
+// error. When SetAuth cannot mint, go-git only ever reports
+// transport.ErrAuthenticationRequired, which does not say why.
+func (gc *gitConfigManager) annotateAuthError(err error) error {
+	if err == nil || gc.githubApp == nil {
+		return err
+	}
+	if mintErr := gc.githubApp.lastError(); mintErr != nil {
+		return fmt.Errorf("%w (github_app token refresh also failed: %v)", err, mintErr)
+	}
+	return err
 }
 
 type (
@@ -231,7 +245,7 @@ func (gc *gitConfigManager) schedule(cfg config.Config, backends map[string]back
 			RefSpecs:        []gitconfig.RefSpec{"refs/heads/*:refs/heads/*"},
 		})
 		if err != nil && err != gitv5.NoErrAlreadyUpToDate {
-			gc.logger.Error("Failed to fetch latest changes", "error", err)
+			gc.logger.Error("Failed to fetch latest changes", "error", gc.annotateAuthError(err))
 			return
 		}
 	}
@@ -348,7 +362,7 @@ func (gc *gitConfigManager) schedule(cfg config.Config, backends map[string]back
 	}
 }
 
-func (gc *gitConfigManager) Start(_ context.Context, cfg config.Config, backends map[string]backend.Backend) error {
+func (gc *gitConfigManager) Start(ctx context.Context, cfg config.Config, backends map[string]backend.Backend) error {
 	var err error
 	var startOK bool
 	gc.version = 1
@@ -380,6 +394,20 @@ func (gc *gitConfigManager) Start(_ context.Context, cfg config.Config, backends
 		} else {
 			gc.authMethod, err = ssh.NewSSHAgentAuth("git")
 		}
+	case "github_app":
+		if err = requireGitHubHTTPSURL(gc.config.URL); err != nil {
+			return err
+		}
+		if gc.githubApp, err = newGitHubAppAuth(gc.logger, gc.config.GitHubApp, gc.config.SkipTLS); err != nil {
+			return err
+		}
+		// Mint once now so a bad key, app id or installation id fails startup with
+		// a specific error, the same way basic and ssh fail fast. SetAuth returns
+		// no error, so this is the only place those problems can be surfaced.
+		if _, err = gc.githubApp.token(ctx); err != nil {
+			return err
+		}
+		gc.authMethod = gc.githubApp
 	}
 
 	if err != nil {
@@ -435,7 +463,7 @@ func (gc *gitConfigManager) Start(_ context.Context, cfg config.Config, backends
 			Auth:            gc.authMethod,
 			InsecureSkipTLS: gc.config.SkipTLS,
 		}); err != nil && err != gitv5.NoErrAlreadyUpToDate {
-			return err
+			return gc.annotateAuthError(err)
 		}
 
 		// Get the remote reference list
@@ -446,7 +474,7 @@ func (gc *gitConfigManager) Start(_ context.Context, cfg config.Config, backends
 
 		refs, err := remote.List(&gitv5.ListOptions{Auth: gc.authMethod, InsecureSkipTLS: gc.config.SkipTLS})
 		if err != nil {
-			return err
+			return gc.annotateAuthError(err)
 		}
 
 		// Find the default branch
@@ -476,7 +504,7 @@ func (gc *gitConfigManager) Start(_ context.Context, cfg config.Config, backends
 			InsecureSkipTLS: gc.config.SkipTLS,
 		})
 		if err != nil {
-			return err
+			return gc.annotateAuthError(err)
 		}
 	}
 

--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -43,6 +43,15 @@ type gitConfigManager struct {
 	githubApp        *githubAppAuth // non-nil when auth is github_app; also stored in authMethod
 }
 
+type GitAuthMode string
+
+const (
+	GitAuthNone      GitAuthMode = ""
+	GitAuthBasic     GitAuthMode = "basic"
+	GitAuthSSH       GitAuthMode = "ssh"
+	GitAuthGitHubApp GitAuthMode = "github_app"
+)
+
 // annotateAuthError attaches the last GitHub App token failure to a go-git
 // error. When SetAuth cannot mint, go-git only ever reports
 // transport.ErrAuthenticationRequired, which does not say why.
@@ -376,8 +385,10 @@ func (gc *gitConfigManager) Start(ctx context.Context, cfg config.Config, backen
 		return err
 	}
 
-	switch gc.config.Auth {
-	case "basic":
+	// switch gc.config.Auth {
+	switch GitAuthMode(gc.config.Auth) {
+	case GitAuthNone:
+	case GitAuthBasic:
 		if gc.config.Password, err = config.ResolveEnv(gc.config.Password); err != nil {
 			return err
 		}
@@ -385,7 +396,7 @@ func (gc *gitConfigManager) Start(ctx context.Context, cfg config.Config, backen
 			Username: gc.config.Username,
 			Password: gc.config.Password,
 		}
-	case "ssh":
+	case GitAuthSSH:
 		if gc.config.PrivateKey != "" {
 			if gc.config.Password, err = config.ResolveEnv(gc.config.Password); err != nil {
 				return err
@@ -394,7 +405,7 @@ func (gc *gitConfigManager) Start(ctx context.Context, cfg config.Config, backen
 		} else {
 			gc.authMethod, err = ssh.NewSSHAgentAuth("git")
 		}
-	case "github_app":
+	case GitAuthGitHubApp:
 		if err = requireGitHubHTTPSURL(gc.config.URL); err != nil {
 			return err
 		}
@@ -408,6 +419,11 @@ func (gc *gitConfigManager) Start(ctx context.Context, cfg config.Config, backen
 			return err
 		}
 		gc.authMethod = gc.githubApp
+	default:
+		return fmt.Errorf(
+			"unsupported git auth mode %q; expected basic, ssh, github_app, or empty",
+			gc.config.Auth,
+		)
 	}
 
 	if err != nil {

--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -43,12 +43,20 @@ type gitConfigManager struct {
 	githubApp        *githubAppAuth // non-nil when auth is github_app; also stored in authMethod
 }
 
+// GitAuthMode is the authentication method the Git ConfigManager uses against
+// the policy repository, taken verbatim from config_manager.sources.git.auth.
 type GitAuthMode string
 
+// Supported values of GitAuthMode. Anything else is a typo and is rejected at
+// startup rather than silently falling back to unauthenticated access.
 const (
-	GitAuthNone      GitAuthMode = ""
-	GitAuthBasic     GitAuthMode = "basic"
-	GitAuthSSH       GitAuthMode = "ssh"
+	// GitAuthNone is the zero value: no auth, for public repositories.
+	GitAuthNone GitAuthMode = ""
+	// GitAuthBasic is HTTPS with a username and a password or token.
+	GitAuthBasic GitAuthMode = "basic"
+	// GitAuthSSH is an SSH private key, or the SSH agent when no key is set.
+	GitAuthSSH GitAuthMode = "ssh"
+	// GitAuthGitHubApp mints short-lived GitHub App installation tokens.
 	GitAuthGitHubApp GitAuthMode = "github_app"
 )
 
@@ -385,7 +393,6 @@ func (gc *gitConfigManager) Start(ctx context.Context, cfg config.Config, backen
 		return err
 	}
 
-	// switch gc.config.Auth {
 	switch GitAuthMode(gc.config.Auth) {
 	case GitAuthNone:
 	case GitAuthBasic:

--- a/agent/configmgr/git_github_app.go
+++ b/agent/configmgr/git_github_app.go
@@ -82,7 +82,7 @@ type githubAppAuth struct {
 	logger *slog.Logger
 
 	// Immutable after construction; read without the mutex.
-	appID          string
+	clientID       string
 	installationID string
 	privateKey     *rsa.PrivateKey
 	apiBase        string // overridden in tests
@@ -106,9 +106,9 @@ var _ githttp.AuthMethod = (*githubAppAuth)(nil)
 // newGitHubAppAuth validates the configuration and loads the private key. It
 // performs no network I/O; call token() to mint eagerly.
 func newGitHubAppAuth(logger *slog.Logger, cfg config.GitHubAppAuth, skipTLS bool) (*githubAppAuth, error) {
-	appID, err := config.ResolveEnv(cfg.AppID)
+	clientID, err := config.ResolveEnv(cfg.ClientID)
 	if err != nil {
-		return nil, fmt.Errorf("github_app: app_id: %w", err)
+		return nil, fmt.Errorf("github_app: client_id: %w", err)
 	}
 	installationID, err := config.ResolveEnv(cfg.InstallationID)
 	if err != nil {
@@ -120,8 +120,8 @@ func newGitHubAppAuth(logger *slog.Logger, cfg config.GitHubAppAuth, skipTLS boo
 	}
 
 	switch {
-	case appID == "":
-		return nil, errors.New("github_app: app_id is required when auth is github_app")
+	case clientID == "":
+		return nil, errors.New("github_app: client_id is required when auth is github_app")
 	case installationID == "":
 		return nil, errors.New("github_app: installation_id is required when auth is github_app")
 	case keyRef == "":
@@ -144,7 +144,7 @@ func newGitHubAppAuth(logger *slog.Logger, cfg config.GitHubAppAuth, skipTLS boo
 
 	return &githubAppAuth{
 		logger:         logger,
-		appID:          appID,
+		clientID:       clientID,
 		installationID: installationID,
 		privateKey:     key,
 		apiBase:        githubAPIBase,
@@ -252,7 +252,7 @@ func (a *githubAppAuth) Name() string { return "http-github-app-auth" }
 // immutable fields and therefore takes no lock - a locking String() would
 // deadlock if go-git logged the auth method from inside a locked section.
 func (a *githubAppAuth) String() string {
-	return fmt.Sprintf("%s - app_id: %s, installation_id: %s", a.Name(), a.appID, a.installationID)
+	return fmt.Sprintf("%s - client_id: %s, installation_id: %s", a.Name(), a.clientID, a.installationID)
 }
 
 // appJWT signs the short-lived RS256 assertion that authenticates the app itself
@@ -270,7 +270,7 @@ func (a *githubAppAuth) appJWT() (string, error) {
 
 	now := a.now()
 	assertion, err := jwt.Signed(signer).Claims(jwt.Claims{
-		Issuer:   a.appID,
+		Issuer:   a.clientID,
 		IssuedAt: jwt.NewNumericDate(now.Add(-githubAppJWTBackdate)),
 		Expiry:   jwt.NewNumericDate(now.Add(githubAppJWTTTL)),
 	}).Serialize()
@@ -375,7 +375,7 @@ func (a *githubAppAuth) tokenStatusError(resp *http.Response, body []byte) error
 		// GitHub's Date header next to ours.
 		return fmt.Errorf("github_app: GitHub rejected the app JWT (HTTP 401: %s); check that app_id %q "+
 			"matches the private key, and check the host clock (GitHub time: %q, agent time: %q)",
-			detail, a.appID, resp.Header.Get("Date"), a.now().UTC().Format(http.TimeFormat))
+			detail, a.clientID, resp.Header.Get("Date"), a.now().UTC().Format(http.TimeFormat))
 	case http.StatusForbidden:
 		return fmt.Errorf("github_app: GitHub refused the token request (HTTP 403: %s); the app may be "+
 			"suspended, blocked by an org policy, or rate limited", detail)
@@ -399,7 +399,7 @@ func loadGitHubAppKey(ref string) (*rsa.PrivateKey, error) {
 	}
 	data, err := os.ReadFile(ref)
 	if err != nil {
-		return nil, fmt.Errorf("github_app: failed to read private_key %q: %w", ref, err)
+		return nil, fmt.Errorf("github_app: failed to read private_key: %w", err)
 	}
 	return parseGitHubAppKey(data, ref)
 }

--- a/agent/configmgr/git_github_app.go
+++ b/agent/configmgr/git_github_app.go
@@ -470,12 +470,15 @@ func requireGitHubHTTPSURL(rawURL string) error {
 	if !strings.EqualFold(u.Scheme, "https") {
 		return fmt.Errorf("github_app: url uses scheme %q; github_app auth requires https", u.Scheme)
 	}
-	if host := strings.ToLower(u.Hostname()); host != "github.com" {
+	// The www check must precede the general host check below, which would
+	// otherwise swallow it with a less useful message.
+	host := strings.ToLower(u.Hostname())
+	if host == "www.github.com" {
+		return fmt.Errorf("github_app: url host must be github.com, not %q; credentials do not survive GitHub's www redirect", host)
+	}
+	if host != "github.com" {
 		return fmt.Errorf("github_app: url host %q is not github.com; github_app auth supports github.com "+
 			"only (for GitHub Enterprise Server use auth: basic with a personal access token)", host)
-	}
-	if host := strings.ToLower(u.Hostname()); host == "www.github.com" {
-		return fmt.Errorf("github_app: url host must be github.com, not %q; credentials do not survive GitHub's www redirect", host)
 	}
 	return nil
 }

--- a/agent/configmgr/git_github_app.go
+++ b/agent/configmgr/git_github_app.go
@@ -130,8 +130,8 @@ func newGitHubAppAuth(logger *slog.Logger, cfg config.GitHubAppAuth, skipTLS boo
 
 	// installation_id is interpolated into an API path, and confusing it with the
 	// app id is the most common misconfiguration. Requiring digits both prevents
-	// path injection and catches a client id pasted into the wrong key. app_id is
-	// deliberately not checked: the preferred value is a client id (Iv23li...).
+	// path injection and catches a client id pasted into the wrong key. client_id
+	// is deliberately not checked: the preferred value is a client id (Iv23li...).
 	if _, err := strconv.ParseUint(installationID, 10, 64); err != nil {
 		return nil, fmt.Errorf("github_app: installation_id %q is not numeric; it is the id in the URL of "+
 			"the app's installation settings page, not the app id or client id", installationID)
@@ -373,7 +373,7 @@ func (a *githubAppAuth) tokenStatusError(resp *http.Response, body []byte) error
 	case http.StatusUnauthorized:
 		// Clock skew is the most common cause and the hardest to guess, so echo
 		// GitHub's Date header next to ours.
-		return fmt.Errorf("github_app: GitHub rejected the app JWT (HTTP 401: %s); check that app_id %q "+
+		return fmt.Errorf("github_app: GitHub rejected the app JWT (HTTP 401: %s); check that client_id %q "+
 			"matches the private key, and check the host clock (GitHub time: %q, agent time: %q)",
 			detail, a.clientID, resp.Header.Get("Date"), a.now().UTC().Format(http.TimeFormat))
 	case http.StatusForbidden:

--- a/agent/configmgr/git_github_app.go
+++ b/agent/configmgr/git_github_app.go
@@ -1,0 +1,478 @@
+package configmgr
+
+import (
+	"context"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+
+	"github.com/netboxlabs/orb-agent/agent/config"
+)
+
+const (
+	// githubAPIBase is the REST API for github.com. GitHub App auth is
+	// deliberately github.com-only; GitHub Enterprise Server and GitHub
+	// Enterprise Cloud with data residency use different API hosts.
+	githubAPIBase = "https://api.github.com"
+
+	// githubAPIVersion pins the REST API version for the token exchange.
+	githubAPIVersion = "2026-03-10"
+
+	// githubAppTokenUser is the username GitHub expects for git-over-HTTPS basic
+	// auth when the password is an installation access token.
+	githubAppTokenUser = "x-access-token"
+
+	// githubAppJWTTTL and githubAppJWTBackdate bound the app JWT. GitHub rejects
+	// a JWT whose exp is more than 10 minutes ahead, and rejects an iat in the
+	// future - backdating absorbs modest host clock drift.
+	githubAppJWTTTL      = 9 * time.Minute
+	githubAppJWTBackdate = 60 * time.Second
+
+	// githubAppRefreshMargin is the validity that must remain on a cached
+	// installation token for it to be reused. A single git fetch is several HTTP
+	// requests, so a token that merely has not expired yet must not be handed to
+	// the first of them.
+	githubAppRefreshMargin = 5 * time.Minute
+
+	// githubAppTokenTimeout bounds one token-exchange request. go-git applies
+	// auth to a request before attaching the operation's context, so SetAuth has
+	// no context to inherit and this timeout is the only thing preventing a hung
+	// api.github.com connection from stalling a scheduler tick.
+	githubAppTokenTimeout = 30 * time.Second
+
+	// githubAppRetryCooldown throttles re-minting so a persistent failure does
+	// not turn every git request into an API call and an error log line.
+	githubAppRetryCooldown = 30 * time.Second
+
+	// githubAppMinMintInterval is a floor on mint frequency even after a success,
+	// guarding against a response whose expires_at is already inside the refresh
+	// margin.
+	githubAppMinMintInterval = 10 * time.Second
+
+	// githubAppFallbackTTL is assumed when expires_at is missing or unparsable.
+	// GitHub's documented lifetime is one hour.
+	githubAppFallbackTTL = 30 * time.Minute
+
+	// githubAppMaxResponseBytes caps how much of a token response is read.
+	githubAppMaxResponseBytes = 1 << 20
+)
+
+// githubAppAuth authenticates git-over-HTTPS to github.com as a GitHub App
+// installation. It implements go-git's http.AuthMethod; go-git calls SetAuth
+// once per HTTP request, so the cached installation token is re-checked - and
+// re-minted when close to expiry - per request rather than per fetch.
+type githubAppAuth struct {
+	logger *slog.Logger
+
+	// Immutable after construction; read without the mutex.
+	appID          string
+	installationID string
+	privateKey     *rsa.PrivateKey
+	apiBase        string // overridden in tests
+	skipTLS        bool
+	now            func() time.Time // overridden in tests
+
+	// mu guards the token cache. Minting happens while holding mu so concurrent
+	// callers collapse into a single API call: the loser blocks, re-checks the
+	// cache, and gets the fresh token for free.
+	mu          sync.Mutex
+	cachedToken string
+	expiresAt   time.Time
+	lastErr     error
+	nextAttempt time.Time
+}
+
+// Compile-time proof that go-git will accept this as an HTTP auth method.
+// Without SetAuth, go-git returns the opaque transport.ErrInvalidAuthMethod.
+var _ githttp.AuthMethod = (*githubAppAuth)(nil)
+
+// newGitHubAppAuth validates the configuration and loads the private key. It
+// performs no network I/O; call token() to mint eagerly.
+func newGitHubAppAuth(logger *slog.Logger, cfg config.GitHubAppAuth, skipTLS bool) (*githubAppAuth, error) {
+	appID, err := config.ResolveEnv(cfg.AppID)
+	if err != nil {
+		return nil, fmt.Errorf("github_app: app_id: %w", err)
+	}
+	installationID, err := config.ResolveEnv(cfg.InstallationID)
+	if err != nil {
+		return nil, fmt.Errorf("github_app: installation_id: %w", err)
+	}
+	keyRef, err := config.ResolveEnv(cfg.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("github_app: private_key: %w", err)
+	}
+
+	switch {
+	case appID == "":
+		return nil, errors.New("github_app: app_id is required when auth is github_app")
+	case installationID == "":
+		return nil, errors.New("github_app: installation_id is required when auth is github_app")
+	case keyRef == "":
+		return nil, errors.New("github_app: private_key is required when auth is github_app")
+	}
+
+	// installation_id is interpolated into an API path, and confusing it with the
+	// app id is the most common misconfiguration. Requiring digits both prevents
+	// path injection and catches a client id pasted into the wrong key. app_id is
+	// deliberately not checked: the preferred value is a client id (Iv23li...).
+	if _, err := strconv.ParseUint(installationID, 10, 64); err != nil {
+		return nil, fmt.Errorf("github_app: installation_id %q is not numeric; it is the id in the URL of "+
+			"the app's installation settings page, not the app id or client id", installationID)
+	}
+
+	key, err := loadGitHubAppKey(keyRef)
+	if err != nil {
+		return nil, err
+	}
+
+	return &githubAppAuth{
+		logger:         logger,
+		appID:          appID,
+		installationID: installationID,
+		privateKey:     key,
+		apiBase:        githubAPIBase,
+		skipTLS:        skipTLS,
+		now:            time.Now,
+	}, nil
+}
+
+// token returns a valid installation access token, minting one if the cache is
+// empty or within githubAppRefreshMargin of expiry.
+func (a *githubAppAuth) token(ctx context.Context) (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.tokenLocked(ctx)
+}
+
+// tokenLocked implements token(); the caller must hold a.mu.
+func (a *githubAppAuth) tokenLocked(ctx context.Context) (string, error) {
+	now := a.now()
+	if a.cachedToken != "" && now.Add(githubAppRefreshMargin).Before(a.expiresAt) {
+		return a.cachedToken, nil
+	}
+
+	tok, expiresAt, err := a.mintInstallationToken(ctx)
+	if err != nil {
+		a.lastErr = err
+		a.nextAttempt = now.Add(githubAppRetryCooldown)
+		return "", err
+	}
+
+	a.cachedToken, a.expiresAt, a.lastErr = tok, expiresAt, nil
+	// Floor the mint rate even on success, in case GitHub ever returns a token
+	// that is already inside the refresh margin.
+	a.nextAttempt = now.Add(githubAppMinMintInterval)
+
+	a.logger.Debug("github_app: minted installation access token",
+		"installation_id", a.installationID, "expires_at", expiresAt)
+	return tok, nil
+}
+
+// lastError returns the most recent mint failure, or nil. The git config manager
+// uses it to annotate go-git errors: a failed refresh surfaces from go-git as a
+// bare transport.ErrAuthenticationRequired, which says nothing about the cause.
+func (a *githubAppAuth) lastError() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.lastErr
+}
+
+// SetAuth implements go-git's http.AuthMethod.
+//
+// It cannot return an error, so a failed mint is handled three ways at once: it
+// is logged with the underlying cause; it is recorded on the struct so
+// lastError() can annotate the go-git error the caller ultimately sees; and,
+// when a previously minted token is still cached, that token is sent anyway.
+// Sending the stale token is the right fallback because the refresh margin is
+// conservative - a token due for refresh normally still has minutes of validity
+// - so a transient api.github.com blip does not become a failed poll.
+//
+// Note the context: go-git attaches the operation's context to the request only
+// after calling this, so r.Context() is context.Background() here and the mint
+// must supply its own timeout.
+func (a *githubAppAuth) SetAuth(r *http.Request) {
+	if a == nil || r == nil {
+		return
+	}
+
+	a.mu.Lock()
+	now := a.now()
+	needsMint := a.cachedToken == "" || !now.Add(githubAppRefreshMargin).Before(a.expiresAt)
+	if needsMint && !now.Before(a.nextAttempt) {
+		ctx, cancel := context.WithTimeout(context.Background(), githubAppTokenTimeout)
+		_, _ = a.tokenLocked(ctx) // failure is recorded in a.lastErr
+		cancel()
+	}
+	// Re-read the cache rather than using tokenLocked's return value: that is
+	// what makes the stale-token fallback work in both the failed-mint and the
+	// in-cooldown cases.
+	tok, lastErr := a.cachedToken, a.lastErr
+	a.mu.Unlock()
+
+	switch {
+	case tok == "":
+		a.logger.Error("github_app: no installation access token available; sending the git request "+
+			"unauthenticated, which will fail with HTTP 401",
+			"url", r.URL.Redacted(), "error", lastErr)
+		return
+	case lastErr != nil:
+		a.logger.Warn("github_app: token refresh failed; retrying the git request with the previously "+
+			"minted token, which may already have expired",
+			"url", r.URL.Redacted(), "error", lastErr)
+	}
+
+	// GitHub accepts installation tokens on the git HTTPS endpoints as basic auth
+	// with the fixed username x-access-token. It does not accept them as
+	// Authorization: Bearer there - that form is for the REST API only.
+	r.SetBasicAuth(githubAppTokenUser, tok)
+}
+
+// Name implements transport.AuthMethod.
+func (a *githubAppAuth) Name() string { return "http-github-app-auth" }
+
+// String implements transport.AuthMethod. go-git surfaces this in debug and
+// error output, so it must never contain the access token. It reads only
+// immutable fields and therefore takes no lock - a locking String() would
+// deadlock if go-git logged the auth method from inside a locked section.
+func (a *githubAppAuth) String() string {
+	return fmt.Sprintf("%s - app_id: %s, installation_id: %s", a.Name(), a.appID, a.installationID)
+}
+
+// appJWT signs the short-lived RS256 assertion that authenticates the app itself
+// to the GitHub API. iat is backdated so modest clock drift on the agent host
+// does not make GitHub reject the assertion as issued in the future, and exp
+// stays inside GitHub's 10-minute ceiling.
+func (a *githubAppAuth) appJWT() (string, error) {
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: a.privateKey},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
+	if err != nil {
+		return "", fmt.Errorf("github_app: failed to create JWT signer: %w", err)
+	}
+
+	now := a.now()
+	assertion, err := jwt.Signed(signer).Claims(jwt.Claims{
+		Issuer:   a.appID,
+		IssuedAt: jwt.NewNumericDate(now.Add(-githubAppJWTBackdate)),
+		Expiry:   jwt.NewNumericDate(now.Add(githubAppJWTTTL)),
+	}).Serialize()
+	if err != nil {
+		return "", fmt.Errorf("github_app: failed to sign app JWT: %w", err)
+	}
+	return assertion, nil
+}
+
+// githubInstallationToken is the access_tokens endpoint response.
+type githubInstallationToken struct {
+	Token     string `json:"token"`
+	ExpiresAt string `json:"expires_at"`
+}
+
+// githubAPIError is the error envelope the GitHub REST API returns.
+type githubAPIError struct {
+	Message string `json:"message"`
+}
+
+// mintInstallationToken exchanges a freshly signed app JWT for an installation
+// access token.
+func (a *githubAppAuth) mintInstallationToken(ctx context.Context) (string, time.Time, error) {
+	assertion, err := a.appJWT()
+	if err != nil {
+		return "", time.Time{}, err
+	}
+
+	endpoint := fmt.Sprintf("%s/app/installations/%s/access_tokens", a.apiBase, a.installationID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, nil)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("github_app: failed to create the token request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+assertion)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", githubAPIVersion)
+	req.Header.Set("User-Agent", "orb-agent")
+
+	client := &http.Client{
+		Timeout: githubAppTokenTimeout,
+		Transport: &http.Transport{
+			// Proxy must be set explicitly: a bare &http.Transport{} does not
+			// inherit ProxyFromEnvironment from DefaultTransport. go-git's own
+			// client uses DefaultTransport, so omitting this would send the git
+			// traffic through HTTP_PROXY but not the token exchange around it.
+			Proxy:           http.ProxyFromEnvironment,
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: a.skipTLS}, //nolint:gosec // opt-in via skip_tls
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("github_app: installation token request to %s failed: %w", endpoint, err)
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			a.logger.Warn("github_app: failed to close response body", "error", cerr)
+		}
+	}()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, githubAppMaxResponseBytes))
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("github_app: failed to read the installation token response: %w", err)
+	}
+
+	// The endpoint returns 201 Created, not 200.
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", time.Time{}, a.tokenStatusError(resp, body)
+	}
+
+	var payload githubInstallationToken
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return "", time.Time{}, fmt.Errorf("github_app: failed to parse the installation token response: %w", err)
+	}
+	if payload.Token == "" {
+		return "", time.Time{}, errors.New("github_app: GitHub returned an empty installation token")
+	}
+
+	expiresAt, err := time.Parse(time.RFC3339, payload.ExpiresAt)
+	if err != nil {
+		a.logger.Warn("github_app: could not parse expires_at; assuming a short lifetime",
+			"expires_at", payload.ExpiresAt, "assumed_ttl", githubAppFallbackTTL)
+		expiresAt = a.now().Add(githubAppFallbackTTL)
+	}
+	return payload.Token, expiresAt, nil
+}
+
+// tokenStatusError names the likely misconfiguration for each status GitHub
+// returns here. The alternative - letting the operator see a bare HTTP 401 from
+// git - tells them nothing about which of three settings is wrong.
+func (a *githubAppAuth) tokenStatusError(resp *http.Response, body []byte) error {
+	var apiErr githubAPIError
+	_ = json.Unmarshal(body, &apiErr)
+	detail := apiErr.Message
+	if detail == "" {
+		detail = strings.TrimSpace(string(body))
+	}
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		// Clock skew is the most common cause and the hardest to guess, so echo
+		// GitHub's Date header next to ours.
+		return fmt.Errorf("github_app: GitHub rejected the app JWT (HTTP 401: %s); check that app_id %q "+
+			"matches the private key, and check the host clock (GitHub time: %q, agent time: %q)",
+			detail, a.appID, resp.Header.Get("Date"), a.now().UTC().Format(http.TimeFormat))
+	case http.StatusForbidden:
+		return fmt.Errorf("github_app: GitHub refused the token request (HTTP 403: %s); the app may be "+
+			"suspended, blocked by an org policy, or rate limited", detail)
+	case http.StatusNotFound:
+		return fmt.Errorf("github_app: installation %s was not found (HTTP 404: %s); check installation_id - "+
+			"it is the id in the URL of the app's installation settings page, not the app id - and check "+
+			"that the app is still installed on the account that owns the repository", a.installationID, detail)
+	case http.StatusUnprocessableEntity:
+		return fmt.Errorf("github_app: GitHub rejected the token request (HTTP 422: %s)", detail)
+	default:
+		return fmt.Errorf("github_app: installation token request failed with status %d: %s", resp.StatusCode, detail)
+	}
+}
+
+// loadGitHubAppKey reads a GitHub App private key. ref is either a path to a PEM
+// file or - when ${VAR} or a secrets manager injected the key material directly
+// - the PEM document itself.
+func loadGitHubAppKey(ref string) (*rsa.PrivateKey, error) {
+	if strings.Contains(ref, "-----BEGIN") {
+		return parseGitHubAppKey([]byte(ref), "the inline private_key value")
+	}
+	data, err := os.ReadFile(ref)
+	if err != nil {
+		return nil, fmt.Errorf("github_app: failed to read private_key %q: %w", ref, err)
+	}
+	return parseGitHubAppKey(data, ref)
+}
+
+// parseGitHubAppKey accepts the PKCS#1 ("RSA PRIVATE KEY") PEM that GitHub
+// issues, and the PKCS#8 ("PRIVATE KEY") PEM produced by
+// `openssl pkcs8 -topk8 -nocrypt`. Every other input gets an error naming what
+// was actually found and what to do about it.
+func parseGitHubAppKey(data []byte, source string) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("github_app: no PEM block found in %s; expected the .pem file downloaded "+
+			"from the GitHub App settings page", source)
+	}
+
+	if _, encrypted := block.Headers["DEK-Info"]; encrypted {
+		return nil, fmt.Errorf("github_app: the key in %s is passphrase-protected, which is not supported; "+
+			"decrypt it first with `openssl rsa -in key.pem -out key-decrypted.pem`", source)
+	}
+
+	switch block.Type {
+	case "RSA PRIVATE KEY":
+		key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("github_app: failed to parse the PKCS#1 private key in %s: %w", source, err)
+		}
+		return key, nil
+
+	case "PRIVATE KEY":
+		parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("github_app: failed to parse the PKCS#8 private key in %s: %w", source, err)
+		}
+		key, ok := parsed.(*rsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("github_app: the private key in %s is %T; GitHub App keys are always RSA",
+				source, parsed)
+		}
+		return key, nil
+
+	case "ENCRYPTED PRIVATE KEY":
+		return nil, fmt.Errorf("github_app: the key in %s is an encrypted PKCS#8 key, which is not supported; "+
+			"provide an unencrypted key", source)
+
+	case "OPENSSH PRIVATE KEY":
+		return nil, fmt.Errorf("github_app: %s holds an OpenSSH key, not a GitHub App key; download the app "+
+			"private key from Settings > Developer settings > GitHub Apps > Private keys", source)
+
+	default:
+		return nil, fmt.Errorf("github_app: %s holds a %q PEM block; expected \"RSA PRIVATE KEY\" (PKCS#1, "+
+			"what GitHub issues) or \"PRIVATE KEY\" (PKCS#8)", source, block.Type)
+	}
+}
+
+// requireGitHubHTTPSURL rejects configurations that cannot work with github_app
+// auth, before any credential or network work happens. An installation token is
+// an HTTPS-only credential scoped to github.com: go-git's SSH transport rejects
+// a non-ssh.AuthMethod with the opaque transport.ErrInvalidAuthMethod, and any
+// other host answers with an unexplained 401.
+func requireGitHubHTTPSURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Scheme == "" {
+		// scp-style remotes such as git@github.com:org/repo.git land here:
+		// url.Parse rejects them with "first path segment cannot contain colon".
+		return fmt.Errorf("github_app: url %q must be an https://github.com/... URL "+
+			"(scp-style and ssh URLs cannot use installation tokens)", rawURL)
+	}
+	if !strings.EqualFold(u.Scheme, "https") {
+		return fmt.Errorf("github_app: url uses scheme %q; github_app auth requires https", u.Scheme)
+	}
+	if host := strings.ToLower(u.Hostname()); host != "github.com" && host != "www.github.com" {
+		return fmt.Errorf("github_app: url host %q is not github.com; github_app auth supports github.com "+
+			"only (for GitHub Enterprise Server use auth: basic with a personal access token)", host)
+	}
+	return nil
+}

--- a/agent/configmgr/git_github_app.go
+++ b/agent/configmgr/git_github_app.go
@@ -470,9 +470,12 @@ func requireGitHubHTTPSURL(rawURL string) error {
 	if !strings.EqualFold(u.Scheme, "https") {
 		return fmt.Errorf("github_app: url uses scheme %q; github_app auth requires https", u.Scheme)
 	}
-	if host := strings.ToLower(u.Hostname()); host != "github.com" && host != "www.github.com" {
+	if host := strings.ToLower(u.Hostname()); host != "github.com" {
 		return fmt.Errorf("github_app: url host %q is not github.com; github_app auth supports github.com "+
 			"only (for GitHub Enterprise Server use auth: basic with a personal access token)", host)
+	}
+	if host := strings.ToLower(u.Hostname()); host == "www.github.com" {
+		return fmt.Errorf("github_app: url host must be github.com, not %q; credentials do not survive GitHub's www redirect", host)
 	}
 	return nil
 }

--- a/agent/configmgr/git_github_app_test.go
+++ b/agent/configmgr/git_github_app_test.go
@@ -556,8 +556,9 @@ func TestRequireGitHubHTTPSURL(t *testing.T) {
 	}{
 		{url: "https://github.com/org/repo"},
 		{url: "https://github.com/org/repo.git"},
-		{url: "https://www.github.com/org/repo"},
 		{url: "HTTPS://GitHub.com/org/repo"},
+		{url: "https://www.github.com/org/repo", wantErr: `must be github.com, not "www.github.com"`},
+		{url: "https://WWW.GitHub.com/org/repo", wantErr: `must be github.com, not "www.github.com"`},
 		{url: "git@github.com:org/repo.git", wantErr: "scp-style and ssh URLs"},
 		{url: "ssh://git@github.com/org/repo.git", wantErr: `scheme "ssh"`},
 		{url: "http://github.com/org/repo", wantErr: `scheme "http"`},
@@ -655,7 +656,7 @@ func TestGitStartGitHubAppValidation(t *testing.T) {
 					ClientID: "Iv23li", InstallationID: "78901234", PrivateKey: validKey,
 				},
 			},
-			wantErr: "must be github.com, not www.github.com",
+			wantErr: `must be github.com, not "www.github.com"`,
 		},
 	}
 

--- a/agent/configmgr/git_github_app_test.go
+++ b/agent/configmgr/git_github_app_test.go
@@ -1,0 +1,692 @@
+package configmgr
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/config"
+)
+
+// testAppKey is shared across the package: RSA key generation costs ~100ms and
+// the key is read-only, so sharing it keeps `go test -race` fast and stays
+// race-free.
+var testAppKey = sync.OnceValue(func() *rsa.PrivateKey {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+	return key
+})
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func pkcs1PEM(t *testing.T, key *rsa.PrivateKey) []byte {
+	t.Helper()
+	return pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+}
+
+func pkcs8PEM(t *testing.T, key any) []byte {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+}
+
+// fakeClock drives githubAppAuth.now so the refresh-margin behaviour can be
+// tested deterministically without sleeping.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{now: time.Date(2026, 3, 10, 12, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+// newTestGitHubApp builds a githubAppAuth pointed at a test server, with the
+// clock and API base swapped out.
+func newTestGitHubApp(t *testing.T, apiBase string, clock *fakeClock) *githubAppAuth {
+	t.Helper()
+	auth, err := newGitHubAppAuth(testLogger(), config.GitHubAppAuth{
+		AppID:          "Iv23liTestClientID",
+		InstallationID: "78901234",
+		PrivateKey:     string(pkcs1PEM(t, testAppKey())),
+	}, false)
+	require.NoError(t, err)
+	auth.apiBase = apiBase
+	auth.now = clock.Now
+	return auth
+}
+
+// tokenServer is an httptest server standing in for api.github.com. It counts
+// hits and computes expires_at from the *same* fake clock the auth method uses -
+// using time.Now() here would make the caching tests nondeterministic.
+type tokenServer struct {
+	*httptest.Server
+	hits   atomic.Int32
+	status atomic.Int32 // when non-zero, respond with this status instead of 201
+	ttl    time.Duration
+}
+
+func newTokenServer(t *testing.T, clock *fakeClock) *tokenServer {
+	t.Helper()
+	ts := &tokenServer{ttl: time.Hour}
+	ts.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := ts.hits.Add(1)
+		if s := ts.status.Load(); s != 0 {
+			w.WriteHeader(int(s))
+			_, _ = w.Write([]byte(`{"message":"forced failure"}`))
+			return
+		}
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/app/installations/78901234/access_tokens", r.URL.Path)
+		assert.Equal(t, "application/vnd.github+json", r.Header.Get("Accept"))
+		assert.Equal(t, githubAPIVersion, r.Header.Get("X-GitHub-Api-Version"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated) // the endpoint returns 201, not 200
+		_ = json.NewEncoder(w).Encode(githubInstallationToken{
+			Token:     fmt.Sprintf("ghs_token_%d", n),
+			ExpiresAt: clock.Now().Add(ts.ttl).Format(time.RFC3339),
+		})
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestParseGitHubAppKey(t *testing.T) {
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	encryptedPKCS1 := pem.EncodeToMemory(&pem.Block{
+		Type:    "RSA PRIVATE KEY",
+		Headers: map[string]string{"Proc-Type": "4,ENCRYPTED", "DEK-Info": "AES-128-CBC,0123"},
+		Bytes:   []byte("not-really-encrypted"),
+	})
+
+	tests := []struct {
+		name    string
+		data    []byte
+		wantErr string
+	}{
+		{name: "pkcs1", data: pkcs1PEM(t, testAppKey())},
+		{name: "pkcs8", data: pkcs8PEM(t, testAppKey())},
+		{name: "pkcs8 ecdsa", data: pkcs8PEM(t, ecKey), wantErr: "always RSA"},
+		{name: "garbage", data: []byte("not a pem file"), wantErr: "no PEM block found"},
+		{name: "passphrase protected", data: encryptedPKCS1, wantErr: "passphrase-protected"},
+		{
+			name:    "openssh",
+			data:    pem.EncodeToMemory(&pem.Block{Type: "OPENSSH PRIVATE KEY", Bytes: []byte("x")}),
+			wantErr: "OpenSSH key, not a GitHub App key",
+		},
+		{
+			name:    "encrypted pkcs8",
+			data:    pem.EncodeToMemory(&pem.Block{Type: "ENCRYPTED PRIVATE KEY", Bytes: []byte("x")}),
+			wantErr: "encrypted PKCS#8 key",
+		},
+		{
+			name:    "certificate",
+			data:    pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("x")}),
+			wantErr: `holds a "CERTIFICATE" PEM block`,
+		},
+		{
+			name:    "corrupt pkcs1",
+			data:    pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: []byte("corrupt")}),
+			wantErr: "failed to parse the PKCS#1 private key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, err := parseGitHubAppKey(tt.data, "the test key")
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Contains(t, err.Error(), "github_app: ")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, testAppKey().N, key.N)
+		})
+	}
+}
+
+func TestLoadGitHubAppKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.pem")
+	require.NoError(t, os.WriteFile(path, pkcs1PEM(t, testAppKey()), 0o600))
+
+	t.Run("from file path", func(t *testing.T) {
+		key, err := loadGitHubAppKey(path)
+		require.NoError(t, err)
+		assert.Equal(t, testAppKey().N, key.N)
+	})
+
+	t.Run("from inline PEM", func(t *testing.T) {
+		key, err := loadGitHubAppKey(string(pkcs1PEM(t, testAppKey())))
+		require.NoError(t, err)
+		assert.Equal(t, testAppKey().N, key.N)
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		_, err := loadGitHubAppKey(filepath.Join(t.TempDir(), "absent.pem"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read private_key")
+	})
+}
+
+func TestGitHubAppJWT(t *testing.T) {
+	clock := newFakeClock()
+	auth := newTestGitHubApp(t, "https://api.github.com", clock)
+
+	assertion, err := auth.appJWT()
+	require.NoError(t, err)
+
+	parsed, err := jwt.ParseSigned(assertion, []jose.SignatureAlgorithm{jose.RS256})
+	require.NoError(t, err)
+	require.Len(t, parsed.Headers, 1)
+	assert.Equal(t, "JWT", parsed.Headers[0].ExtraHeaders[jose.HeaderType])
+
+	var claims jwt.Claims
+	require.NoError(t, parsed.Claims(&testAppKey().PublicKey, &claims))
+
+	assert.Equal(t, "Iv23liTestClientID", claims.Issuer)
+	require.NotNil(t, claims.IssuedAt)
+	require.NotNil(t, claims.Expiry)
+
+	iat, exp := claims.IssuedAt.Time(), claims.Expiry.Time()
+	// iat is backdated to absorb clock drift; GitHub rejects a future iat.
+	assert.GreaterOrEqual(t, clock.Now().Sub(iat), 59*time.Second)
+	// GitHub rejects an exp more than 10 minutes ahead of its own clock.
+	assert.LessOrEqual(t, exp.Sub(iat), 600*time.Second)
+}
+
+func TestMintInstallationToken_Success(t *testing.T) {
+	clock := newFakeClock()
+	var gotAuthHeader string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuthHeader = r.Header.Get("Authorization")
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/app/installations/78901234/access_tokens", r.URL.Path)
+		assert.Equal(t, "application/vnd.github+json", r.Header.Get("Accept"))
+		assert.Equal(t, githubAPIVersion, r.Header.Get("X-GitHub-Api-Version"))
+		assert.Equal(t, "orb-agent", r.Header.Get("User-Agent"))
+
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"token":"ghs_abc123","expires_at":"2026-03-10T13:00:00Z"}`))
+	}))
+	defer srv.Close()
+
+	auth := newTestGitHubApp(t, srv.URL, clock)
+	tok, expiresAt, err := auth.mintInstallationToken(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "ghs_abc123", tok)
+	assert.Equal(t, time.Date(2026, 3, 10, 13, 0, 0, 0, time.UTC), expiresAt.UTC())
+
+	// The Authorization header must carry a JWT that verifies against the app key.
+	require.True(t, len(gotAuthHeader) > 7 && gotAuthHeader[:7] == "Bearer ")
+	parsed, err := jwt.ParseSigned(gotAuthHeader[7:], []jose.SignatureAlgorithm{jose.RS256})
+	require.NoError(t, err)
+	var claims jwt.Claims
+	require.NoError(t, parsed.Claims(&testAppKey().PublicKey, &claims))
+	assert.Equal(t, "Iv23liTestClientID", claims.Issuer)
+}
+
+func TestMintInstallationToken_Errors(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		body     string
+		wantErrs []string
+	}{
+		{
+			name: "401 names clock skew", status: http.StatusUnauthorized,
+			body:     `{"message":"'Expiration time' claim ('exp') is invalid"}`,
+			wantErrs: []string{"host clock", "GitHub time", "agent time", "Iv23liTestClientID"},
+		},
+		{
+			name: "403 names suspension", status: http.StatusForbidden,
+			body:     `{"message":"Resource not accessible by integration"}`,
+			wantErrs: []string{"suspended", "rate limited"},
+		},
+		{
+			name: "404 names installation_id", status: http.StatusNotFound,
+			body:     `{"message":"Not Found"}`,
+			wantErrs: []string{"installation settings page", "not the app id", "78901234"},
+		},
+		{
+			name: "422", status: http.StatusUnprocessableEntity,
+			body:     `{"message":"Invalid request"}`,
+			wantErrs: []string{"HTTP 422", "Invalid request"},
+		},
+		{
+			name: "500 falls through to the default", status: http.StatusInternalServerError,
+			body:     `upstream exploded`,
+			wantErrs: []string{"status 500", "upstream exploded"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			auth := newTestGitHubApp(t, srv.URL, newFakeClock())
+			_, _, err := auth.mintInstallationToken(context.Background())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "github_app: ")
+			for _, want := range tt.wantErrs {
+				assert.Contains(t, err.Error(), want)
+			}
+		})
+	}
+}
+
+func TestMintInstallationToken_EmptyToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"token":"","expires_at":"2026-03-10T13:00:00Z"}`))
+	}))
+	defer srv.Close()
+
+	auth := newTestGitHubApp(t, srv.URL, newFakeClock())
+	_, _, err := auth.mintInstallationToken(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty installation token")
+}
+
+func TestMintInstallationToken_UnparsableExpiry(t *testing.T) {
+	clock := newFakeClock()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"token":"ghs_abc","expires_at":"whenever"}`))
+	}))
+	defer srv.Close()
+
+	auth := newTestGitHubApp(t, srv.URL, clock)
+	tok, expiresAt, err := auth.mintInstallationToken(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "ghs_abc", tok)
+	assert.Equal(t, clock.Now().Add(githubAppFallbackTTL), expiresAt)
+}
+
+// TestTokenCachingAndRefreshMargin is the core test for the caching behaviour: a
+// token must be re-minted once it is within githubAppRefreshMargin of expiry,
+// because a single git fetch spans several HTTP requests.
+func TestTokenCachingAndRefreshMargin(t *testing.T) {
+	clock := newFakeClock()
+	srv := newTokenServer(t, clock)
+	auth := newTestGitHubApp(t, srv.URL, clock)
+	ctx := context.Background()
+
+	tok, err := auth.token(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "ghs_token_1", tok)
+	assert.EqualValues(t, 1, srv.hits.Load())
+
+	// Immediately again: served from cache.
+	tok, err = auth.token(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "ghs_token_1", tok)
+	assert.EqualValues(t, 1, srv.hits.Load())
+
+	// 6 minutes of validity left - outside the 5 minute margin, still cached.
+	clock.Advance(time.Hour - 6*time.Minute)
+	tok, err = auth.token(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "ghs_token_1", tok)
+	assert.EqualValues(t, 1, srv.hits.Load())
+
+	// 4 minutes left - inside the margin, must re-mint.
+	clock.Advance(2 * time.Minute)
+	tok, err = auth.token(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "ghs_token_2", tok)
+	assert.EqualValues(t, 2, srv.hits.Load())
+
+	// Past expiry of the second token - re-mint again.
+	clock.Advance(time.Hour)
+	tok, err = auth.token(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "ghs_token_3", tok)
+	assert.EqualValues(t, 3, srv.hits.Load())
+}
+
+func TestSetAuthAppliesBasicAuth(t *testing.T) {
+	clock := newFakeClock()
+	srv := newTokenServer(t, clock)
+	auth := newTestGitHubApp(t, srv.URL, clock)
+
+	// Lazy mint: SetAuth is the first call, no eager token() beforehand.
+	r := httptest.NewRequest(http.MethodGet, "https://github.com/org/repo.git/info/refs", nil)
+	auth.SetAuth(r)
+
+	user, pass, ok := r.BasicAuth()
+	require.True(t, ok)
+	assert.Equal(t, githubAppTokenUser, user)
+	assert.Equal(t, "ghs_token_1", pass)
+	assert.EqualValues(t, 1, srv.hits.Load())
+
+	// A second request within the token's life reuses the cached value.
+	r2 := httptest.NewRequest(http.MethodPost, "https://github.com/org/repo.git/git-upload-pack", nil)
+	auth.SetAuth(r2)
+	_, pass2, ok := r2.BasicAuth()
+	require.True(t, ok)
+	assert.Equal(t, "ghs_token_1", pass2)
+	assert.EqualValues(t, 1, srv.hits.Load())
+}
+
+func TestSetAuthFallsBackToStaleToken(t *testing.T) {
+	clock := newFakeClock()
+	srv := newTokenServer(t, clock)
+	auth := newTestGitHubApp(t, srv.URL, clock)
+
+	require.NoError(t, func() error { _, err := auth.token(context.Background()); return err }())
+	assert.EqualValues(t, 1, srv.hits.Load())
+
+	// Refresh starts failing, and the clock moves into the refresh margin.
+	srv.status.Store(http.StatusInternalServerError)
+	clock.Advance(time.Hour - 4*time.Minute)
+
+	r := httptest.NewRequest(http.MethodGet, "https://github.com/org/repo.git/info/refs", nil)
+	auth.SetAuth(r)
+	_, pass, ok := r.BasicAuth()
+	require.True(t, ok)
+	assert.Equal(t, "ghs_token_1", pass, "the previously minted token should still be sent")
+	require.Error(t, auth.lastError())
+	assert.EqualValues(t, 2, srv.hits.Load())
+
+	// A second attempt inside the retry cooldown must not hit the API again.
+	r2 := httptest.NewRequest(http.MethodPost, "https://github.com/org/repo.git/git-upload-pack", nil)
+	auth.SetAuth(r2)
+	_, pass2, ok := r2.BasicAuth()
+	require.True(t, ok)
+	assert.Equal(t, "ghs_token_1", pass2)
+	assert.EqualValues(t, 2, srv.hits.Load(), "the retry cooldown should suppress a second mint")
+}
+
+func TestSetAuthWithNoTokenSendsNothing(t *testing.T) {
+	clock := newFakeClock()
+	srv := newTokenServer(t, clock)
+	srv.status.Store(http.StatusUnauthorized)
+	auth := newTestGitHubApp(t, srv.URL, clock)
+
+	r := httptest.NewRequest(http.MethodGet, "https://github.com/org/repo.git/info/refs", nil)
+	auth.SetAuth(r)
+
+	assert.Empty(t, r.Header.Get("Authorization"))
+	require.Error(t, auth.lastError())
+}
+
+func TestGitHubAppNameAndStringDoNotLeak(t *testing.T) {
+	clock := newFakeClock()
+	srv := newTokenServer(t, clock)
+	auth := newTestGitHubApp(t, srv.URL, clock)
+
+	tok, err := auth.token(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, "http-github-app-auth", auth.Name())
+	assert.Contains(t, auth.String(), "Iv23liTestClientID")
+	assert.Contains(t, auth.String(), "78901234")
+	assert.NotContains(t, auth.String(), tok)
+}
+
+// TestConcurrentSetAuth proves the mutex collapses concurrent callers into a
+// single token exchange. Run under -race.
+func TestConcurrentSetAuth(t *testing.T) {
+	clock := newFakeClock()
+	srv := newTokenServer(t, clock)
+	auth := newTestGitHubApp(t, srv.URL, clock)
+
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Go(func() {
+			r := httptest.NewRequest(http.MethodGet, "https://github.com/org/repo.git/info/refs", nil)
+			auth.SetAuth(r)
+			_ = auth.String()
+		})
+	}
+	wg.Wait()
+
+	assert.EqualValues(t, 1, srv.hits.Load())
+}
+
+func TestNewGitHubAppAuthValidation(t *testing.T) {
+	validKey := string(pkcs1PEM(t, testAppKey()))
+
+	tests := []struct {
+		name    string
+		cfg     config.GitHubAppAuth
+		wantErr string
+	}{
+		{
+			name:    "missing app_id",
+			cfg:     config.GitHubAppAuth{InstallationID: "78901234", PrivateKey: validKey},
+			wantErr: "app_id is required",
+		},
+		{
+			name:    "missing installation_id",
+			cfg:     config.GitHubAppAuth{AppID: "Iv23li", PrivateKey: validKey},
+			wantErr: "installation_id is required",
+		},
+		{
+			name:    "missing private_key",
+			cfg:     config.GitHubAppAuth{AppID: "Iv23li", InstallationID: "78901234"},
+			wantErr: "private_key is required",
+		},
+		{
+			name:    "non-numeric installation_id",
+			cfg:     config.GitHubAppAuth{AppID: "Iv23li", InstallationID: "Iv23li", PrivateKey: validKey},
+			wantErr: "is not numeric",
+		},
+		{
+			name:    "unresolvable env var",
+			cfg:     config.GitHubAppAuth{AppID: "${ORB_TEST_UNSET_APP_ID}", InstallationID: "1", PrivateKey: validKey},
+			wantErr: "github_app: app_id",
+		},
+		{
+			name:    "bad key",
+			cfg:     config.GitHubAppAuth{AppID: "Iv23li", InstallationID: "78901234", PrivateKey: "/nonexistent.pem"},
+			wantErr: "failed to read private_key",
+		},
+		{
+			// A numeric App ID is still accepted; the client id is only preferred.
+			name: "numeric app_id is accepted",
+			cfg:  config.GitHubAppAuth{AppID: "123456", InstallationID: "78901234", PrivateKey: validKey},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			auth, err := newGitHubAppAuth(testLogger(), tt.cfg, false)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, githubAPIBase, auth.apiBase)
+		})
+	}
+}
+
+func TestRequireGitHubHTTPSURL(t *testing.T) {
+	tests := []struct {
+		url     string
+		wantErr string
+	}{
+		{url: "https://github.com/org/repo"},
+		{url: "https://github.com/org/repo.git"},
+		{url: "https://www.github.com/org/repo"},
+		{url: "HTTPS://GitHub.com/org/repo"},
+		{url: "git@github.com:org/repo.git", wantErr: "scp-style and ssh URLs"},
+		{url: "ssh://git@github.com/org/repo.git", wantErr: `scheme "ssh"`},
+		{url: "http://github.com/org/repo", wantErr: `scheme "http"`},
+		{url: "https://github.example.com/org/repo", wantErr: "is not github.com"},
+		{url: "https://gitlab.com/org/repo", wantErr: "is not github.com"},
+		{url: "https://dev.azure.com/org/proj/_git/repo", wantErr: "is not github.com"},
+		{url: "file:///tmp/repo", wantErr: `scheme "file"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			err := requireGitHubHTTPSURL(tt.url)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.Contains(t, err.Error(), "github_app: ")
+		})
+	}
+}
+
+// TestGitStartGitHubAppValidation checks that every github_app misconfiguration
+// fails during Start, before any git I/O - so none of these cases touch the
+// network.
+func TestGitStartGitHubAppValidation(t *testing.T) {
+	validKey := filepath.Join(t.TempDir(), "app.pem")
+	require.NoError(t, os.WriteFile(validKey, pkcs1PEM(t, testAppKey()), 0o600))
+
+	tests := []struct {
+		name    string
+		git     config.GitManager
+		wantErr string
+	}{
+		{
+			name: "non-github url",
+			git: config.GitManager{
+				URL:  "file:///tmp/repo",
+				Auth: "github_app",
+				GitHubApp: config.GitHubAppAuth{
+					AppID: "Iv23li", InstallationID: "78901234", PrivateKey: validKey,
+				},
+			},
+			wantErr: `scheme "file"`,
+		},
+		{
+			name: "ssh url",
+			git: config.GitManager{
+				URL:  "git@github.com:org/repo.git",
+				Auth: "github_app",
+				GitHubApp: config.GitHubAppAuth{
+					AppID: "Iv23li", InstallationID: "78901234", PrivateKey: validKey,
+				},
+			},
+			wantErr: "scp-style and ssh URLs",
+		},
+		{
+			name: "missing app_id",
+			git: config.GitManager{
+				URL:       "https://github.com/org/repo",
+				Auth:      "github_app",
+				GitHubApp: config.GitHubAppAuth{InstallationID: "78901234", PrivateKey: validKey},
+			},
+			wantErr: "app_id is required",
+		},
+		{
+			name: "app id in installation_id",
+			git: config.GitManager{
+				URL:  "https://github.com/org/repo",
+				Auth: "github_app",
+				GitHubApp: config.GitHubAppAuth{
+					AppID: "Iv23li", InstallationID: "Iv23li", PrivateKey: validKey,
+				},
+			},
+			wantErr: "is not numeric",
+		},
+		{
+			name: "unreadable key",
+			git: config.GitManager{
+				URL:  "https://github.com/org/repo",
+				Auth: "github_app",
+				GitHubApp: config.GitHubAppAuth{
+					AppID: "Iv23li", InstallationID: "78901234", PrivateKey: "/nonexistent.pem",
+				},
+			},
+			wantErr: "failed to read private_key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gc := &gitConfigManager{logger: testLogger()}
+			cfg := config.Config{}
+			cfg.OrbAgent.ConfigManager.Sources.Git = tt.git
+
+			err := gc.Start(context.Background(), cfg, nil)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestAnnotateAuthError(t *testing.T) {
+	baseErr := fmt.Errorf("authentication required")
+
+	t.Run("nil error passes through", func(t *testing.T) {
+		gc := &gitConfigManager{logger: testLogger()}
+		assert.NoError(t, gc.annotateAuthError(nil))
+	})
+
+	t.Run("no github app configured", func(t *testing.T) {
+		gc := &gitConfigManager{logger: testLogger()}
+		assert.Equal(t, baseErr, gc.annotateAuthError(baseErr))
+	})
+
+	t.Run("annotates with the mint failure", func(t *testing.T) {
+		clock := newFakeClock()
+		srv := newTokenServer(t, clock)
+		srv.status.Store(http.StatusNotFound)
+		auth := newTestGitHubApp(t, srv.URL, clock)
+		_, err := auth.token(context.Background())
+		require.Error(t, err)
+
+		gc := &gitConfigManager{logger: testLogger(), githubApp: auth}
+		got := gc.annotateAuthError(baseErr)
+		require.Error(t, got)
+		assert.Contains(t, got.Error(), "authentication required")
+		assert.Contains(t, got.Error(), "github_app token refresh also failed")
+		assert.ErrorIs(t, got, baseErr)
+	})
+}

--- a/agent/configmgr/git_github_app_test.go
+++ b/agent/configmgr/git_github_app_test.go
@@ -646,6 +646,17 @@ func TestGitStartGitHubAppValidation(t *testing.T) {
 			},
 			wantErr: "failed to read private_key",
 		},
+		{
+			name: "invalid www url",
+			git: config.GitManager{
+				URL:  "https://www.github.com/org/repo",
+				Auth: "github_app",
+				GitHubApp: config.GitHubAppAuth{
+					ClientID: "Iv23li", InstallationID: "78901234", PrivateKey: validKey,
+				},
+			},
+			wantErr: "must be github.com, not www.github.com",
+		},
 	}
 
 	for _, tt := range tests {

--- a/agent/configmgr/git_github_app_test.go
+++ b/agent/configmgr/git_github_app_test.go
@@ -83,7 +83,7 @@ func (c *fakeClock) Advance(d time.Duration) {
 func newTestGitHubApp(t *testing.T, apiBase string, clock *fakeClock) *githubAppAuth {
 	t.Helper()
 	auth, err := newGitHubAppAuth(testLogger(), config.GitHubAppAuth{
-		AppID:          "Iv23liTestClientID",
+		ClientID:       "Iv23liTestClientID",
 		InstallationID: "78901234",
 		PrivateKey:     string(pkcs1PEM(t, testAppKey())),
 	}, false)
@@ -499,39 +499,39 @@ func TestNewGitHubAppAuthValidation(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "missing app_id",
+			name:    "missing client_id",
 			cfg:     config.GitHubAppAuth{InstallationID: "78901234", PrivateKey: validKey},
-			wantErr: "app_id is required",
+			wantErr: "client_id is required",
 		},
 		{
 			name:    "missing installation_id",
-			cfg:     config.GitHubAppAuth{AppID: "Iv23li", PrivateKey: validKey},
+			cfg:     config.GitHubAppAuth{ClientID: "Iv23li", PrivateKey: validKey},
 			wantErr: "installation_id is required",
 		},
 		{
 			name:    "missing private_key",
-			cfg:     config.GitHubAppAuth{AppID: "Iv23li", InstallationID: "78901234"},
+			cfg:     config.GitHubAppAuth{ClientID: "Iv23li", InstallationID: "78901234"},
 			wantErr: "private_key is required",
 		},
 		{
 			name:    "non-numeric installation_id",
-			cfg:     config.GitHubAppAuth{AppID: "Iv23li", InstallationID: "Iv23li", PrivateKey: validKey},
+			cfg:     config.GitHubAppAuth{ClientID: "Iv23li", InstallationID: "Iv23li", PrivateKey: validKey},
 			wantErr: "is not numeric",
 		},
 		{
 			name:    "unresolvable env var",
-			cfg:     config.GitHubAppAuth{AppID: "${ORB_TEST_UNSET_APP_ID}", InstallationID: "1", PrivateKey: validKey},
-			wantErr: "github_app: app_id",
+			cfg:     config.GitHubAppAuth{ClientID: "${ORB_TEST_UNSET_CLIENT_ID}", InstallationID: "1", PrivateKey: validKey},
+			wantErr: "github_app: client_id",
 		},
 		{
 			name:    "bad key",
-			cfg:     config.GitHubAppAuth{AppID: "Iv23li", InstallationID: "78901234", PrivateKey: "/nonexistent.pem"},
+			cfg:     config.GitHubAppAuth{ClientID: "Iv23li", InstallationID: "78901234", PrivateKey: "/nonexistent.pem"},
 			wantErr: "failed to read private_key",
 		},
 		{
-			// A numeric App ID is still accepted; the client id is only preferred.
-			name: "numeric app_id is accepted",
-			cfg:  config.GitHubAppAuth{AppID: "123456", InstallationID: "78901234", PrivateKey: validKey},
+			// A numeric Client ID is still accepted; the client id is only preferred.
+			name: "numeric client_id is accepted",
+			cfg:  config.GitHubAppAuth{ClientID: "123456", InstallationID: "78901234", PrivateKey: validKey},
 		},
 	}
 
@@ -599,7 +599,7 @@ func TestGitStartGitHubAppValidation(t *testing.T) {
 				URL:  "file:///tmp/repo",
 				Auth: "github_app",
 				GitHubApp: config.GitHubAppAuth{
-					AppID: "Iv23li", InstallationID: "78901234", PrivateKey: validKey,
+					ClientID: "Iv23li", InstallationID: "78901234", PrivateKey: validKey,
 				},
 			},
 			wantErr: `scheme "file"`,
@@ -610,27 +610,27 @@ func TestGitStartGitHubAppValidation(t *testing.T) {
 				URL:  "git@github.com:org/repo.git",
 				Auth: "github_app",
 				GitHubApp: config.GitHubAppAuth{
-					AppID: "Iv23li", InstallationID: "78901234", PrivateKey: validKey,
+					ClientID: "Iv23li", InstallationID: "78901234", PrivateKey: validKey,
 				},
 			},
 			wantErr: "scp-style and ssh URLs",
 		},
 		{
-			name: "missing app_id",
+			name: "missing client_id",
 			git: config.GitManager{
 				URL:       "https://github.com/org/repo",
 				Auth:      "github_app",
 				GitHubApp: config.GitHubAppAuth{InstallationID: "78901234", PrivateKey: validKey},
 			},
-			wantErr: "app_id is required",
+			wantErr: "client_id is required",
 		},
 		{
-			name: "app id in installation_id",
+			name: "client id in installation_id",
 			git: config.GitManager{
 				URL:  "https://github.com/org/repo",
 				Auth: "github_app",
 				GitHubApp: config.GitHubAppAuth{
-					AppID: "Iv23li", InstallationID: "Iv23li", PrivateKey: validKey,
+					ClientID: "Iv23li", InstallationID: "Iv23li", PrivateKey: validKey,
 				},
 			},
 			wantErr: "is not numeric",
@@ -641,7 +641,7 @@ func TestGitStartGitHubAppValidation(t *testing.T) {
 				URL:  "https://github.com/org/repo",
 				Auth: "github_app",
 				GitHubApp: config.GitHubAppAuth{
-					AppID: "Iv23li", InstallationID: "78901234", PrivateKey: "/nonexistent.pem",
+					ClientID: "Iv23li", InstallationID: "78901234", PrivateKey: "/nonexistent.pem",
 				},
 			},
 			wantErr: "failed to read private_key",

--- a/agent/configmgr/git_test.go
+++ b/agent/configmgr/git_test.go
@@ -114,7 +114,7 @@ backend1:
 					Git: config.GitManager{
 						URL:      repoURL,
 						Branch:   "",        // let it detect default branch
-						Auth:     "none",    // no auth for file:// protocol
+						Auth:     "",        // no auth for file:// protocol
 						Schedule: &schedule, // every minute
 					},
 				},
@@ -198,7 +198,7 @@ backend1:
 				Sources: config.Sources{
 					Git: config.GitManager{
 						URL:  repoURL,
-						Auth: "none",
+						Auth: "", // no auth for file:// protocol
 					},
 				},
 			},
@@ -216,6 +216,38 @@ backend1:
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no policies match the selector")
 	pMgr.AssertNotCalled(t, "ManagePolicy", mock.Anything)
+}
+
+// TestGitStartUnsupportedAuthMode verifies that a misspelled auth mode fails
+// startup instead of silently falling back to unauthenticated access. Auth is
+// resolved before any network I/O, so no repository is needed.
+func TestGitStartUnsupportedAuthMode(t *testing.T) {
+	for _, auth := range []string{"none", "bacsic", "github-app"} {
+		t.Run(auth, func(t *testing.T) {
+			pMgr := new(mockPolicyManager)
+			cfg := config.Config{
+				OrbAgent: config.OrbAgent{
+					ConfigManager: config.ManagerConfig{
+						Active: "git",
+						Sources: config.Sources{
+							Git: config.GitManager{
+								URL:  "https://example.com/org/policyrepo.git",
+								Auth: auth,
+							},
+						},
+					},
+				},
+			}
+
+			logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+			gc := configmgr.New(logger, pMgr, cfg.OrbAgent.ConfigManager.Active, &mockBackendState{}, nil)
+
+			err := gc.Start(context.Background(), cfg, map[string]backend.Backend{})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "unsupported git auth mode")
+			pMgr.AssertNotCalled(t, "ManagePolicy", mock.Anything)
+		})
+	}
 }
 
 // TestGitStartAzureDevOpsURLFallback verifies that an Azure DevOps URL triggers
@@ -300,7 +332,7 @@ backend1:
 					Git: config.GitManager{
 						URL:    adoURL,
 						Branch: "", // auto-detect
-						Auth:   "none",
+						Auth:   "", // no auth for file:// protocol
 					},
 				},
 			},

--- a/agent/redact/redact_test.go
+++ b/agent/redact/redact_test.go
@@ -155,10 +155,10 @@ func TestSensitiveData_GitHubApp(t *testing.T) {
 		t.Errorf("Expected github_app.private_key to be masked, got %v", githubApp["private_key"])
 	}
 
-	// app_id and installation_id are not secrets; keeping them readable is what
-	// makes a misconfiguration diagnosable from the logs.
-	if githubApp["app_id"] != "Iv23liAbCdEfGhIjKlMn" {
-		t.Errorf("Expected github_app.app_id to be preserved, got %v", githubApp["app_id"])
+	// client_id and installation_id are not secrets; keeping them readable is
+	// what makes a misconfiguration diagnosable from the logs.
+	if githubApp["client_id"] != "Iv23liAbCdEfGhIjKlMn" {
+		t.Errorf("Expected github_app.client_id to be preserved, got %v", githubApp["client_id"])
 	}
 	if githubApp["installation_id"] != "78901234" {
 		t.Errorf("Expected github_app.installation_id to be preserved, got %v", githubApp["installation_id"])

--- a/agent/redact/redact_test.go
+++ b/agent/redact/redact_test.go
@@ -130,6 +130,41 @@ func TestSensitiveData_GitManager(t *testing.T) {
 	}
 }
 
+// TestSensitiveData_GitHubApp tests that the nested github_app block has its
+// private key masked while the non-sensitive identifiers stay readable.
+func TestSensitiveData_GitHubApp(t *testing.T) {
+	original := config.GitManager{
+		URL:  "https://github.com/myorg/policyrepo",
+		Auth: "github_app",
+		GitHubApp: config.GitHubAppAuth{
+			AppID:          "Iv23liAbCdEfGhIjKlMn",
+			InstallationID: "78901234",
+			PrivateKey:     "-----BEGIN RSA PRIVATE KEY-----",
+		},
+	}
+
+	redacted := SensitiveData(original)
+
+	redactedMap := redacted.(map[string]any)
+	githubApp, ok := redactedMap["github_app"].(map[string]any)
+	if !ok {
+		t.Fatalf("Expected github_app to be a nested map, got %T", redactedMap["github_app"])
+	}
+
+	if githubApp["private_key"] != MaskedSecret {
+		t.Errorf("Expected github_app.private_key to be masked, got %v", githubApp["private_key"])
+	}
+
+	// app_id and installation_id are not secrets; keeping them readable is what
+	// makes a misconfiguration diagnosable from the logs.
+	if githubApp["app_id"] != "Iv23liAbCdEfGhIjKlMn" {
+		t.Errorf("Expected github_app.app_id to be preserved, got %v", githubApp["app_id"])
+	}
+	if githubApp["installation_id"] != "78901234" {
+		t.Errorf("Expected github_app.installation_id to be preserved, got %v", githubApp["installation_id"])
+	}
+}
+
 // TestSensitiveData_BackendCommons tests BackendCommons with Diode config
 func TestSensitiveData_BackendCommons(t *testing.T) {
 	original := config.BackendCommons{}

--- a/agent/redact/redact_test.go
+++ b/agent/redact/redact_test.go
@@ -137,7 +137,7 @@ func TestSensitiveData_GitHubApp(t *testing.T) {
 		URL:  "https://github.com/myorg/policyrepo",
 		Auth: "github_app",
 		GitHubApp: config.GitHubAppAuth{
-			AppID:          "Iv23liAbCdEfGhIjKlMn",
+			ClientID:       "Iv23liAbCdEfGhIjKlMn",
 			InstallationID: "78901234",
 			PrivateKey:     "-----BEGIN RSA PRIVATE KEY-----",
 		},

--- a/docs/config_samples.md
+++ b/docs/config_samples.md
@@ -108,6 +108,48 @@ docker run \
   netboxlabs/orb-agent:latest run -c /opt/orb/agent.yaml
 ```
 
+### GitHub App authentication (github.com)
+
+Create a GitHub App with `Contents: Read` on the policy repository, install it on the account that
+owns the repo, and download its private key. See [GitHub App Authentication](configs/git.md#github-app-authentication)
+for the full walkthrough.
+
+```yaml
+orb:
+  labels:
+    region: EU
+    pop: ams02
+  config_manager:
+    active: git
+    sources:
+      git:
+        url: "https://github.com/myorg/policyrepo"
+        auth: github_app
+        github_app:
+          app_id: "Iv23liAbCdEfGhIjKlMn"
+          installation_id: "78901234"
+          private_key: "/opt/orb/github-app.pem"
+        schedule: "* * * * *"
+  backends:
+    network_discovery:
+    common:
+      diode:
+        target: grpc://192.168.0.100:8080/diode
+        client_id: ${DIODE_CLIENT_ID}
+        client_secret: ${DIODE_CLIENT_SECRET}
+        agent_name: agent01
+```
+
+Run command — note the private key is mounted read-only:
+```bash
+docker run \
+  -v /local/orb:/opt/orb \
+  -v /local/orb/github-app.pem:/opt/orb/github-app.pem:ro \
+  -e DIODE_CLIENT_ID=${DIODE_CLIENT_ID} \
+  -e DIODE_CLIENT_SECRET=${DIODE_CLIENT_SECRET} \
+  netboxlabs/orb-agent:latest run -c /opt/orb/agent.yaml
+```
+
 ## Device-discovery backend
 This sample configuration file demonstrates the device discovery backend connecting to a Cisco router at 192.168.0.5. It retrieves device, interface, and IP information, then sends the data to a [diode](https://github.com/netboxlabs/diode) server running at 192.168.0.100.
 

--- a/docs/config_samples.md
+++ b/docs/config_samples.md
@@ -126,7 +126,7 @@ orb:
         url: "https://github.com/myorg/policyrepo"
         auth: github_app
         github_app:
-          app_id: "Iv23liAbCdEfGhIjKlMn"
+          client_id: "Iv23liAbCdEfGhIjKlMn"
           installation_id: "78901234"
           private_key: "/opt/orb/github-app.pem"
         schedule: "* * * * *"

--- a/docs/configs/agent_yaml.md
+++ b/docs/configs/agent_yaml.md
@@ -98,7 +98,7 @@ orb:
 | `password` | string | No | Password or token for basic auth; passphrase for SSH keys |
 | `private_key` | string | No | Path to SSH private key file |
 | `skip_tls` | bool | No | Skip TLS certificate verification (default: `false`) |
-| `github_app.app_id` | string | With `github_app` | GitHub App Client ID (preferred) or numeric App ID |
+| `github_app.client_id` | string | With `github_app` | GitHub App Client ID (preferred) or numeric App ID |
 | `github_app.installation_id` | string | With `github_app` | Numeric id of the app's installation on the repo owner |
 | `github_app.private_key` | string | With `github_app` | Path to the app's `.pem` key, or the PEM content itself |
 

--- a/docs/configs/agent_yaml.md
+++ b/docs/configs/agent_yaml.md
@@ -93,11 +93,14 @@ orb:
 | `url` | string | Yes | Git repository URL |
 | `branch` | string | No | Branch to use (default: repository default branch) |
 | `schedule` | cron | No | How often to poll for changes. If omitted, policies are fetched once at startup |
-| `auth` | string | No | `basic` (password or token) or `ssh`. Omit for public repositories |
+| `auth` | string | No | `basic` (password or token), `ssh`, or `github_app`. Omit for public repositories |
 | `username` | string | No | Username for basic auth |
 | `password` | string | No | Password or token for basic auth; passphrase for SSH keys |
 | `private_key` | string | No | Path to SSH private key file |
 | `skip_tls` | bool | No | Skip TLS certificate verification (default: `false`) |
+| `github_app.app_id` | string | With `github_app` | GitHub App Client ID (preferred) or numeric App ID |
+| `github_app.installation_id` | string | With `github_app` | Numeric id of the app's installation on the repo owner |
+| `github_app.private_key` | string | With `github_app` | Path to the app's `.pem` key, or the PEM content itself |
 
 ---
 

--- a/docs/configs/git.md
+++ b/docs/configs/git.md
@@ -69,7 +69,7 @@ orb:
         branch: develop
         auth: github_app
         github_app:
-          app_id: "Iv23liAbCdEfGhIjKlMn"
+          client_id: "Iv23liAbCdEfGhIjKlMn"
           installation_id: "78901234"
           private_key: /opt/orb/github-app.pem
 ```
@@ -85,7 +85,7 @@ See [GitHub App Authentication](#github-app-authentication) below for how to cre
 | password | string | no | the password used for authentication. If the auth method is 'basic' it should contain the password or auth token. If the method is 'ssh' it should contain the passphrase for the private key file (leave empty for unprotected keys) |
 | private_key | string | no | the path to the SSH private key file |
 | skip_tls | bool | no | skip TLS certificate verification when connecting to the repository (default: false). Useful for self-signed or private CA certificates |
-| github_app.app_id | string | yes, when auth is 'github_app' | the GitHub App's Client ID (preferred) or its numeric App ID |
+| github_app.client_id | string | yes, when auth is 'github_app' | the GitHub App's Client ID (preferred) or its numeric App ID |
 | github_app.installation_id | string | yes, when auth is 'github_app' | the numeric id of the app's installation on the account that owns the repository |
 | github_app.private_key | string | yes, when auth is 'github_app' | the path to the app's `.pem` private key, or the PEM content itself |
 
@@ -157,7 +157,7 @@ residency (`*.ghe.com`) — use `auth: basic` with a personal access token for t
 
 ### Finding the IDs
 
-- **`app_id`** — use the app's **Client ID** (`Iv23li…`), shown on the app's settings page. This is
+- **`client_id`** — use the app's **Client ID** (`Iv23li…`), shown on the app's settings page. This is
   the form the GitHub API documentation specifies, and the numeric App ID looks likely to be dropped
   in a future API version. The numeric App ID still works today.
 - **`installation_id`** — the number at the end of the URL of the *installation's* settings page,
@@ -181,7 +181,7 @@ environment variable or a secrets manager without ever being written to disk:
 
 ```yaml
         github_app:
-          app_id: "Iv23liAbCdEfGhIjKlMn"
+          client_id: "Iv23liAbCdEfGhIjKlMn"
           installation_id: "78901234"
           private_key: ${GITHUB_APP_KEY}          # PEM content in an env var
           # private_key: ${vault://secret/github-app#pem}
@@ -203,7 +203,7 @@ automatically once fewer than five minutes of validity remain. There is nothing 
 
 | Symptom | Likely cause |
 |---------|--------------|
-| `GitHub rejected the app JWT (HTTP 401…)` | Host clock skew, or `app_id` does not match the private key. The error prints GitHub's time next to the agent's — compare them. |
+| `GitHub rejected the app JWT (HTTP 401…)` | Host clock skew, or `client_id` does not match the private key. The error prints GitHub's time next to the agent's — compare them. |
 | `installation … was not found (HTTP 404…)` | `installation_id` holds the App ID, or the app was uninstalled. |
 | `GitHub refused the token request (HTTP 403…)` | The app is suspended, blocked by an org policy, or rate limited. |
 | Clone fails with 404 after a successful token mint | The app is installed on the account but the policy repo was not selected during installation. |

--- a/docs/configs/git.md
+++ b/docs/configs/git.md
@@ -5,7 +5,7 @@ The Git configuration manager outlines a policy management system where an agent
 
 ### Config
 
-The `config_manager.sources.git` section supports three authentication modes. Pick the snippet that matches your repository and omit the fields you do not use — mixing basic and SSH fields in the same config is not needed.
+The `config_manager.sources.git` section supports four authentication modes. Pick the snippet that matches your repository and omit the fields you do not use — mixing basic, SSH and GitHub App fields in the same config is not needed.
 
 **Public repository (no auth):**
 ```yaml
@@ -57,16 +57,37 @@ orb:
 ```
 See [SSH Authentication](#ssh-authentication) below for the required `known_hosts` setup.
 
+**GitHub App authentication** (short-lived installation tokens, github.com only):
+```yaml
+orb:
+  config_manager:
+    active: git
+    sources:
+      git:
+        url: "https://github.com/myorg/policyrepo"
+        schedule: "* * * * *"
+        branch: develop
+        auth: github_app
+        github_app:
+          app_id: "Iv23liAbCdEfGhIjKlMn"
+          installation_id: "78901234"
+          private_key: /opt/orb/github-app.pem
+```
+See [GitHub App Authentication](#github-app-authentication) below for how to create and install the app.
+
 | Parameter | Type | Required | Description |
 |:---------:|:----:|:--------:|:-----------:|
 | url | string | yes  |  the url of the repository  that contain agent policies  |
 | schedule | cron format | no  |  If defined, it will execute fetch remote changes on cron schedule time. If not defined, it will execute the match and apply policies only once  |
 | branch | string | no  |  the git branch that should be used by the agent. If not specified, the default branch will be used   |
-| auth | string | no | it can be either 'basic' or 'ssh'. The basic authentication supports both password or token. If not specified, no auth will be used (public repository) |
+| auth | string | no | it can be 'basic', 'ssh' or 'github_app'. The basic authentication supports both password or token. If not specified, no auth will be used (public repository) |
 | username | string | no | username used for authentication |
 | password | string | no | the password used for authentication. If the auth method is 'basic' it should contain the password or auth token. If the method is 'ssh' it should contain the passphrase for the private key file (leave empty for unprotected keys) |
 | private_key | string | no | the path to the SSH private key file |
 | skip_tls | bool | no | skip TLS certificate verification when connecting to the repository (default: false). Useful for self-signed or private CA certificates |
+| github_app.app_id | string | yes, when auth is 'github_app' | the GitHub App's Client ID (preferred) or its numeric App ID |
+| github_app.installation_id | string | yes, when auth is 'github_app' | the numeric id of the app's installation on the account that owns the repository |
+| github_app.private_key | string | yes, when auth is 'github_app' | the path to the app's `.pem` private key, or the PEM content itself |
 
 ## SSH Authentication
 
@@ -109,6 +130,87 @@ ssh-keygen -t ed25519 -f /local/orb/id_ed25519 -N ""
 ```
 
 > **Note:** Azure DevOps requires RSA keys. Use `ssh-keygen -t rsa -b 4096` instead.
+
+## GitHub App Authentication
+
+When using `auth: github_app`, the agent authenticates as a GitHub App installation rather than as a
+user. Compared to a personal access token this gives you a credential that is not tied to a person,
+is scoped to exactly the repositories the app is installed on, and is short-lived — the agent mints a
+one-hour installation access token and refreshes it automatically.
+
+This mode supports **github.com only**, which includes GitHub Enterprise Cloud (served from
+`github.com`). It does **not** support GitHub Enterprise Server or GitHub Enterprise Cloud with data
+residency (`*.ghe.com`) — use `auth: basic` with a personal access token for those.
+
+### Creating the App
+
+1. Go to **Settings > Developer settings > GitHub Apps > New GitHub App** (under your organization if
+   the policy repo is org-owned).
+2. Under **Repository permissions**, grant **`Contents: Read`**. Nothing else is required — the agent
+   only reads `selector.yaml` and the policy files, and never writes to the repository.
+3. Uncheck **Webhook > Active**; the agent polls on the configured `schedule` and does not receive
+   webhooks.
+4. Create the app, then under **Private keys** click **Generate a private key**. This downloads a
+   PKCS#1 `.pem` file.
+5. Click **Install App** and install it on the account that owns the policy repo, choosing **Only
+   select repositories** and selecting just that repo.
+
+### Finding the IDs
+
+- **`app_id`** — use the app's **Client ID** (`Iv23li…`), shown on the app's settings page. This is
+  the form the GitHub API documentation specifies, and the numeric App ID looks likely to be dropped
+  in a future API version. The numeric App ID still works today.
+- **`installation_id`** — the number at the end of the URL of the *installation's* settings page,
+  e.g. `https://github.com/organizations/myorg/settings/installations/78901234` → `78901234`.
+  Putting the App ID or Client ID here is the most common misconfiguration; the agent rejects a
+  non-numeric value at startup with a message saying so.
+
+### Supplying the private key
+
+Mount the `.pem` **read-only** and keep it out of the image:
+
+```bash
+docker run \
+  -v /local/orb:/opt/orb \
+  -v /local/orb/github-app.pem:/opt/orb/github-app.pem:ro \
+  netboxlabs/orb-agent:latest run -c /opt/orb/agent.yaml
+```
+
+`private_key` accepts either a path or the PEM content itself, so the key can also come from an
+environment variable or a secrets manager without ever being written to disk:
+
+```yaml
+        github_app:
+          app_id: "Iv23liAbCdEfGhIjKlMn"
+          installation_id: "78901234"
+          private_key: ${GITHUB_APP_KEY}          # PEM content in an env var
+          # private_key: ${vault://secret/github-app#pem}
+```
+
+Both PKCS#1 (`-----BEGIN RSA PRIVATE KEY-----`, what GitHub issues) and PKCS#8
+(`-----BEGIN PRIVATE KEY-----`) are accepted. Passphrase-protected keys are not; decrypt first with
+`openssl rsa -in key.pem -out key-decrypted.pem`.
+
+The agent never logs the private key or the minted token — both are redacted from any config dump.
+
+### Token lifetime
+
+Installation access tokens last one hour. The agent mints one at startup — so a wrong App ID, a wrong
+installation ID or an unreadable key fails startup immediately with a specific error — and re-mints
+automatically once fewer than five minutes of validity remain. There is nothing to schedule or rotate.
+
+### Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| `GitHub rejected the app JWT (HTTP 401…)` | Host clock skew, or `app_id` does not match the private key. The error prints GitHub's time next to the agent's — compare them. |
+| `installation … was not found (HTTP 404…)` | `installation_id` holds the App ID, or the app was uninstalled. |
+| `GitHub refused the token request (HTTP 403…)` | The app is suspended, blocked by an org policy, or rate limited. |
+| Clone fails with 404 after a successful token mint | The app is installed on the account but the policy repo was not selected during installation. |
+| `holds an OpenSSH key, not a GitHub App key` | `private_key` points at an SSH key instead of the app's `.pem`. |
+
+> **Note:** `skip_tls: true` also disables TLS verification for the api.github.com token exchange, not
+> just for the git connection.
 
 ## What Goes in Git vs. the Local Agent Config
 


### PR DESCRIPTION
## Summary

Adds `auth: github_app` as a new authentication mode for `config_manager.sources.git`, alongside the existing `basic` and `ssh` modes. Instead of using a personal identity with a static PAT or SSH key sitting on disk indefinitely, the agent authenticates to GitHub as a GitHub App Installation and mints a short-lived (~1 hour), narrowly-scoped installation token on every policy-fetch cycle.

This is primarily a security hardening change for anyone running the Git config manager against GitHub Enterprise Cloud as it removes the need to distribute and rotate a long-lived credential to every agent.

## Motivation

The Git config manager currently supports two credentialed auth modes, and both rely on a static secret that lives for as long as nobody rotates it:

`auth: basic` — a username + password/PAT, passed straight through as HTTP Basic auth
`auth: ssh` — a private key file (+ optional passphrase) mounted on the agent host

Both work, but they share the same underlying problem: the credential doesn't expire on its own, it's usually broader in scope than "read this one policy repo," and if it leaks due to a compromised host, misconfigured volume mount, log capture, etc., it stays valid until a human notices and manually revokes it. PATs are also typically tied to a person's account rather than the agent itself, which muddies audit trails and complicates offboarding.

GitHub Apps address this directly:
- Replaces a long-lived Git credential with short-lived installation access tokens. The GitHub App private key remains a long-lived credential and must be protected and rotated, but it provides centralized revocation and separates Git activity from individual user accounts.
- Least privilege: The App can be created/installed with only `contents:read` access to the specific policy repo(s) it needs and nothing else
- Clean audit trail: Git operations show up as the App/Installation rather than an individual's PAT
- Centralized revocation: Disabling/Uninstalling the app or rotating its key once is all that's necessary rather than hunting down copies of a PAT across every agent host
- Policy-aligned: A growing number of organizations restrict or block classic PATs outright and put extra scrutiny towards fine-grained PATs. `github_app` provides a way for those organizations to continue using the Git config manager instead of `basic` auth breaking.