### PR TITLE
fix(device-discovery): warn on unrecognized config and options keys

### DIFF
--- a/orb-discovery/device-discovery/device_discovery/policy/models.py
+++ b/orb-discovery/device-discovery/device_discovery/policy/models.py
@@ -12,6 +12,7 @@ from typing import Any, Literal
 from croniter import CroniterBadCronError, croniter
 from pydantic import BaseModel, Field, field_validator
 
+from device_discovery.policy.unknown_keys import WarnUnknownKeys
 from device_discovery.stack_naming import (
     DEFAULT_STACK_MEMBER_TEMPLATE,
     stack_template_problem,
@@ -237,7 +238,7 @@ class Defaults(BaseModel):
         return v
 
 
-class Options(BaseModel):
+class Options(WarnUnknownKeys):
     """Model for discovery options."""
 
     platform_omit_version: bool | None = Field(
@@ -409,7 +410,7 @@ class Options(BaseModel):
     )
 
 
-class Config(BaseModel):
+class Config(WarnUnknownKeys):
     """Model for discovery configuration."""
 
     schedule: str | None = Field(default=None, description="cron interval, optional")

--- a/orb-discovery/device-discovery/device_discovery/policy/unknown_keys.py
+++ b/orb-discovery/device-discovery/device_discovery/policy/unknown_keys.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""
+Report policy keys a model does not define, instead of dropping them.
+
+Pydantic ignores unrecognized input keys by default, so a key written at the
+wrong nesting level parses without complaint and the setting never takes
+effect. Nothing downstream can tell that apart from the option being absent.
+The mixin here keeps that permissive behaviour and adds a warning that names
+the key, and where it would have been recognized when that is nearby.
+"""
+
+import logging
+import typing
+from collections import deque
+from typing import Any
+
+from pydantic import BaseModel, model_validator
+
+logger = logging.getLogger(__name__)
+
+# A misplaced key is almost always one or two levels from where it belongs
+# (``discover_modules`` written on config rather than config.options). Past
+# that the guess stops being useful and starts pointing at coincidences.
+_MAX_SUGGESTION_DEPTH = 2
+
+
+def _accepted_names(model: type[BaseModel]) -> set[str]:
+    """Return every key name ``model`` accepts from input, aliases included."""
+    names: set[str] = set()
+    for name, field in model.model_fields.items():
+        names.add(name)
+        for alias in (field.alias, field.validation_alias):
+            if isinstance(alias, str):
+                names.add(alias)
+    return names
+
+
+def _annotation_models(annotation: Any) -> list[type[BaseModel]]:
+    """Pull every model out of an annotation, unwrapping unions and containers."""
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return [annotation]
+    found: list[type[BaseModel]] = []
+    for arg in typing.get_args(annotation):
+        found.extend(_annotation_models(arg))
+    return found
+
+
+def _nested_models(model: type[BaseModel]) -> list[tuple[str, type[BaseModel]]]:
+    """Return (field name, nested model) for each field that holds a model."""
+    return [(name, nested) for name, field in model.model_fields.items() for nested in _annotation_models(field.annotation)]
+
+
+def suggest_path(model: type[BaseModel], key: str) -> str | None:
+    """
+    Return the dotted path where ``key`` would be recognized, or None.
+
+    Breadth-first so the shallowest match wins: a key valid on both
+    ``options`` and ``defaults.device`` reports the shorter path.
+    """
+    queue: deque[tuple[type[BaseModel], tuple[str, ...]]] = deque([(model, ())])
+    seen: set[type[BaseModel]] = {model}
+    while queue:
+        current, path = queue.popleft()
+        if len(path) >= _MAX_SUGGESTION_DEPTH:
+            continue
+        for name, nested in _nested_models(current):
+            if key in _accepted_names(nested):
+                return ".".join((*path, name, key))
+            if nested not in seen:
+                seen.add(nested)
+                queue.append((nested, (*path, name)))
+    return None
+
+
+class WarnUnknownKeys(BaseModel):
+    """
+    Mixin that warns about input keys the model does not define.
+
+    Applied to the two blocks whose contents are a fixed, documented set of
+    keys — ``config`` and its ``options`` — so the class name is also the
+    YAML key an operator writes. Blocks that legitimately carry
+    operator-chosen keys, such as the policy map and the ``scope`` entries,
+    are deliberately left out: there is no closed key set to check against.
+    """
+
+    @model_validator(mode="before")
+    @classmethod
+    def _warn_unknown_keys(cls, data: Any) -> Any:
+        """Log one warning per unrecognized key, then hand the input on unchanged."""
+        if not isinstance(data, dict):
+            return data
+        label = cls.__name__.lower()
+        accepted = _accepted_names(cls)
+        for key in data:
+            if not isinstance(key, str) or key in accepted:
+                continue
+            suggestion = suggest_path(cls, key)
+            if suggestion:
+                logger.warning(
+                    "ignoring unrecognized %s key %r; did you mean %r?",
+                    label,
+                    key,
+                    suggestion,
+                )
+            else:
+                logger.warning("ignoring unrecognized %s key %r", label, key)
+        return data

--- a/orb-discovery/device-discovery/tests/policy/test_unknown_keys.py
+++ b/orb-discovery/device-discovery/tests/policy/test_unknown_keys.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""NetBox Labs - Unrecognized Policy Key Warning Unit Tests."""
+
+import logging
+
+import yaml
+
+from device_discovery.policy.models import Config, Options, PolicyRequest
+
+MISPLACED_OPTION = """
+policies:
+  my-policy:
+    config:
+      discover_modules: full
+      defaults:
+        site: test-site
+    scope:
+      - hostname: 10.0.0.1
+        username: u
+        password: p
+        driver: ios
+"""
+
+
+def test_misplaced_option_is_reported_with_the_nesting_it_belongs_under(caplog):
+    """
+    An option written at config level names the path it should have used.
+
+    This is the exact shape that made a real report unreproducible: the key
+    is silently dropped, module discovery stays off, and the entity count is
+    identical with and without it.
+    """
+    with caplog.at_level(logging.WARNING):
+        PolicyRequest(policies=yaml.safe_load(MISPLACED_OPTION)["policies"])
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("discover_modules" in m for m in messages), messages
+    assert any("options.discover_modules" in m for m in messages), f"expected the correct path in the warning, got {messages}"
+
+
+def test_unknown_key_is_reported_even_with_no_suggestion(caplog):
+    """A key that matches nothing anywhere is still reported rather than dropped."""
+    with caplog.at_level(logging.WARNING):
+        Config(**{"totally_made_up_key": 42})
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("totally_made_up_key" in m for m in messages), messages
+
+
+def test_recognized_keys_are_silent(caplog):
+    """A correct policy logs nothing, so the warning stays meaningful."""
+    good = """
+    policies:
+      my-policy:
+        config:
+          options:
+            discover_modules: full
+          defaults:
+            site: test-site
+        scope:
+          - hostname: 10.0.0.1
+            username: u
+            password: p
+            driver: ios
+    """
+    with caplog.at_level(logging.WARNING):
+        req = PolicyRequest(policies=yaml.safe_load(good)["policies"])
+    assert req.policies["my-policy"].config.options.discover_modules == "full"
+    assert [r.getMessage() for r in caplog.records] == []
+
+
+def test_unknown_keys_do_not_change_parsed_values(caplog):
+    """The key is still ignored: warning only, no behaviour change."""
+    with caplog.at_level(logging.WARNING):
+        opts = Options(discover_modules="full", bogus="x")
+    assert opts.discover_modules == "full"
+    assert not hasattr(opts, "bogus")
+
+
+def test_options_block_reports_its_own_unknown_keys(caplog):
+    """The options block is checked too, not just the config block above it."""
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        Options(nope_option=1)
+    joined = " ".join(r.getMessage() for r in caplog.records)
+    assert "nope_option" in joined, joined
+    assert "options" in joined, joined
+
+
+def test_blocks_with_operator_chosen_keys_stay_silent(caplog):
+    """
+    Only config and options are checked, by design.
+
+    The policy map is keyed by names an operator picks, scope entries vary by
+    driver, and the surrounding YAML may carry anchors. Warning on those would
+    fire on correct files, which would train operators to ignore the warning.
+    """
+    from device_discovery.policy.models import Defaults, Napalm, Policy
+
+    with caplog.at_level(logging.WARNING):
+        Defaults(site="s", anchor_leftover=1)
+        Napalm(hostname="h", username="u", password="p", extra_scope_key=1)
+        Policy(scope=[{"hostname": "h", "username": "u", "password": "p"}], stray=1)
+    assert [r.getMessage() for r in caplog.records] == []


### PR DESCRIPTION
## Why

A policy key written at the wrong nesting level parses without complaint and is then
dropped, so the setting never takes effect and nothing says so.

This is how #514 stayed open for two weeks. The reporter had:

```yaml
config:
  discover_modules: full   # belongs under config.options
  defaults:
    site: <site>
```

`config.options` came out `None`, the runner gate never opened, `get_modules()` was never
called. Every symptom pointed at the hardware instead: entity count identical with and
without the option, no warnings anywhere, nothing in the reconciler logs, and the same
result on standalone, stack and StackWise Virtual. A fix shipped for that report was never
once exercised on the reporter's device.

A completely invented key was accepted just as silently.

## What

Keeps the permissive parse and adds a warning naming the key, plus the path where it would
have been recognized when that is within two levels:

```
WARNING device_discovery.policy.unknown_keys: ignoring unrecognized config key
'discover_modules'; did you mean 'options.discover_modules'?
```

Scoped deliberately to `config` and `options`, whose keys are a closed documented set. The
policy map, `scope` entries and the surrounding YAML carry operator-chosen keys and
anchors with no set to check against, so warning there would fire on correct files and
train operators to ignore the warning.

Not `extra="forbid"`: that would turn any existing config with a stray key into a hard
failure on upgrade.

## Verification

- 2320 passed, 161 skipped. The only warnings this fires across the whole suite are the
  four from its own tests, so it does not fire on any existing valid config.
- Confirmed end to end through the real `PolicyManager` with the reporter's exact policy.
- `ruff check` and `ruff format --check` clean.

## Notes

The other three backends have the same silent-ignore behaviour (`snmp-discovery`,
`gnmi-discovery`, `network-discovery` all use plain `yaml.Unmarshal`). Verified by test:
both a misplaced `discover_modules` and a `totally_bogus_key` parse without error. Those
follow in their own PRs, one per scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)