### PR TITLE
fix(gnmi-discovery): warn on unrecognized config and options keys

### DIFF
--- a/orb-discovery/gnmi-discovery/config/unknown_keys.go
+++ b/orb-discovery/gnmi-discovery/config/unknown_keys.go
@@ -18,8 +18,11 @@ import (
 // reports those keys instead.
 
 // unknownFieldRe pulls the key and the type out of a yaml.TypeError entry,
+// The key capture allows whitespace: `discover modules: full` is a valid YAML
+// mapping key, and skipping it would hide the very mistake this warning exists
+// to surface.
 // which reads: `line 5: field discover_modules not found in type config.Options`.
-var unknownFieldRe = regexp.MustCompile(`field (\S+) not found in type (\S+)$`)
+var unknownFieldRe = regexp.MustCompile(`field (.+) not found in type (\S+)$`)
 
 // narrowedTypes are the blocks whose keys are a closed, documented set. The
 // policy map, scope entries and surrounding YAML carry operator-chosen keys

--- a/orb-discovery/gnmi-discovery/config/unknown_keys.go
+++ b/orb-discovery/gnmi-discovery/config/unknown_keys.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// yaml.v3 ignores unrecognized keys, so a key written at the wrong nesting
+// level decodes without complaint and is then dropped: the setting silently
+// never takes effect, and nothing downstream can tell that apart from the
+// option being absent. WarnUnknownPolicyKeys keeps the permissive decode and
+// reports those keys instead.
+
+// unknownFieldRe pulls the key and the type out of a yaml.TypeError entry,
+// which reads: `line 5: field discover_modules not found in type config.Options`.
+var unknownFieldRe = regexp.MustCompile(`field (\S+) not found in type (\S+)$`)
+
+// narrowedTypes are the blocks whose keys are a closed, documented set. The
+// policy map, scope entries and surrounding YAML carry operator-chosen keys
+// and anchors with no set to check against, so reporting those would fire on
+// correct files and train operators to ignore the warning.
+var narrowedTypes = map[string]bool{
+	"config.PolicyConfig": true,
+	"config.Options":      true,
+}
+
+// WarnUnknownPolicyKeys logs one warning per unrecognized key in a policy's
+// config or options block, naming the path the key belongs at when it is a
+// field of the options block one level down.
+//
+// Decoding happens a second time purely to collect the report; the error is
+// never returned, so an unrecognized key stays non-fatal.
+func WarnUnknownPolicyKeys(data []byte, logger *slog.Logger) {
+	if logger == nil {
+		return
+	}
+	var throwaway Policies
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	var typeErr *yaml.TypeError
+	if err := dec.Decode(&throwaway); err == nil || !errors.As(err, &typeErr) {
+		// No unknown fields, or a syntax error the permissive decode reports.
+		return
+	}
+	optionKeys := yamlFieldNames(reflect.TypeFor[Options]())
+	for _, entry := range typeErr.Errors {
+		match := unknownFieldRe.FindStringSubmatch(entry)
+		if match == nil || !narrowedTypes[match[2]] {
+			continue
+		}
+		key := match[1]
+		if match[2] == "config.PolicyConfig" && optionKeys[key] {
+			logger.Warn("ignoring unrecognized config key",
+				"key", key, "did_you_mean", "options."+key, "detail", entry)
+			continue
+		}
+		logger.Warn("ignoring unrecognized policy key", "key", key, "detail", entry)
+	}
+}
+
+// yamlFieldNames returns the yaml key each field of a struct accepts.
+func yamlFieldNames(t reflect.Type) map[string]bool {
+	names := make(map[string]bool)
+	for field := range t.Fields() {
+		name, _, _ := strings.Cut(field.Tag.Get("yaml"), ",")
+		if name != "" && name != "-" {
+			names[name] = true
+		}
+	}
+	return names
+}

--- a/orb-discovery/gnmi-discovery/config/unknown_keys_test.go
+++ b/orb-discovery/gnmi-discovery/config/unknown_keys_test.go
@@ -3,8 +3,10 @@ package config
 import (
 	"bytes"
 	"log/slog"
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func captureWarnings(t *testing.T, yamlText string) string {
@@ -17,8 +19,8 @@ func captureWarnings(t *testing.T, yamlText string) string {
 
 // A key written at config level instead of config.options is reported with the
 // path it belongs at. This is the shape that made a real report unreproducible:
-// the key is dropped, module discovery stays off, and the emitted entity count
-// is identical with and without it.
+// the key is dropped, the option stays off, and the emitted entity count is
+// identical with and without it.
 func TestMisplacedOptionNamesTheCorrectPath(t *testing.T) {
 	out := captureWarnings(t, `
 policies:
@@ -31,12 +33,8 @@ policies:
       targets:
         - host: 10.0.0.1
 `)
-	if !strings.Contains(out, "capture_config") {
-		t.Fatalf("key not reported: %s", out)
-	}
-	if !strings.Contains(out, "options.capture_config") {
-		t.Fatalf("expected the correct path in the warning, got: %s", out)
-	}
+	require.Contains(t, out, "capture_config")
+	require.Contains(t, out, "options.capture_config", "the warning must name the path the key belongs at")
 }
 
 func TestUnknownKeyReportedWithoutSuggestion(t *testing.T) {
@@ -49,12 +47,8 @@ policies:
       targets:
         - host: 10.0.0.1
 `)
-	if !strings.Contains(out, "totally_made_up_key") {
-		t.Fatalf("key not reported: %s", out)
-	}
-	if strings.Contains(out, "did_you_mean") {
-		t.Fatalf("should not invent a suggestion: %s", out)
-	}
+	require.Contains(t, out, "totally_made_up_key")
+	assert.NotContains(t, out, "did_you_mean", "a key matching nothing must not get an invented suggestion")
 }
 
 func TestUnknownKeyInsideOptionsIsReported(t *testing.T) {
@@ -69,9 +63,23 @@ policies:
       targets:
         - host: 10.0.0.1
 `)
-	if !strings.Contains(out, "nope_option") {
-		t.Fatalf("key not reported: %s", out)
-	}
+	require.Contains(t, out, "nope_option")
+}
+
+// `capture config: true` is a valid YAML mapping key, and yaml.v3 reports it
+// with the space intact. Requiring a single non-whitespace token skipped the
+// entry, hiding the very mistake this warning exists to surface.
+func TestKeyContainingWhitespaceIsReported(t *testing.T) {
+	out := captureWarnings(t, `
+policies:
+  p1:
+    config:
+      bogus key: 1
+    scope:
+      targets:
+        - host: 10.0.0.1
+`)
+	require.Contains(t, out, "bogus key")
 }
 
 // Only the config and options blocks are checked. Warning on blocks that carry
@@ -88,9 +96,7 @@ policies:
         - host: 10.0.0.1
           stray_target: 1
 `)
-	if out != "" {
-		t.Fatalf("expected silence outside config/options, got: %s", out)
-	}
+	assert.Empty(t, out, "expected silence outside config and options")
 }
 
 func TestValidPolicyIsSilent(t *testing.T) {
@@ -107,36 +113,16 @@ policies:
       targets:
         - host: 10.0.0.1
 `)
-	if out != "" {
-		t.Fatalf("valid policy must not warn, got: %s", out)
-	}
+	assert.Empty(t, out, "a valid policy must not warn")
 }
 
 func TestMalformedYamlIsLeftToThePermissiveDecode(t *testing.T) {
 	out := captureWarnings(t, "policies: [this is not a map")
-	if out != "" {
-		t.Fatalf("syntax errors are reported by the real decode, got: %s", out)
-	}
+	assert.Empty(t, out, "syntax errors are reported by the real decode")
 }
 
-func TestNilLoggerIsSafe(_ *testing.T) {
-	WarnUnknownPolicyKeys([]byte("policies:\n  p1:\n    config:\n      bogus: 1\n"), nil)
-}
-
-// `bogus key: 1` is a valid YAML mapping key, and yaml.v3 reports it with the
-// space intact. Requiring a single non-whitespace token skipped the entry,
-// hiding the very mistake this warning exists to surface.
-func TestKeyContainingWhitespaceIsReported(t *testing.T) {
-	out := captureWarnings(t, `
-policies:
-  p1:
-    config:
-      bogus key: 1
-    scope:
-      targets:
-        - host: 10.0.0.1
-`)
-	if !strings.Contains(out, "bogus key") {
-		t.Fatalf("whitespace key not reported: %s", out)
-	}
+func TestNilLoggerIsSafe(t *testing.T) {
+	assert.NotPanics(t, func() {
+		WarnUnknownPolicyKeys([]byte("policies:\n  p1:\n    config:\n      bogus: 1\n"), nil)
+	})
 }

--- a/orb-discovery/gnmi-discovery/config/unknown_keys_test.go
+++ b/orb-discovery/gnmi-discovery/config/unknown_keys_test.go
@@ -1,0 +1,124 @@
+package config
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func captureWarnings(t *testing.T, yamlText string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	WarnUnknownPolicyKeys([]byte(yamlText), logger)
+	return buf.String()
+}
+
+// A key written at config level instead of config.options is reported with the
+// path it belongs at. This is the shape that made a real report unreproducible:
+// the key is dropped, module discovery stays off, and the emitted entity count
+// is identical with and without it.
+func TestMisplacedOptionNamesTheCorrectPath(t *testing.T) {
+	out := captureWarnings(t, `
+policies:
+  p1:
+    config:
+      capture_config: true
+      defaults:
+        site: s
+    scope:
+      targets:
+        - host: 10.0.0.1
+`)
+	if !strings.Contains(out, "capture_config") {
+		t.Fatalf("key not reported: %s", out)
+	}
+	if !strings.Contains(out, "options.capture_config") {
+		t.Fatalf("expected the correct path in the warning, got: %s", out)
+	}
+}
+
+func TestUnknownKeyReportedWithoutSuggestion(t *testing.T) {
+	out := captureWarnings(t, `
+policies:
+  p1:
+    config:
+      totally_made_up_key: 42
+    scope:
+      targets:
+        - host: 10.0.0.1
+`)
+	if !strings.Contains(out, "totally_made_up_key") {
+		t.Fatalf("key not reported: %s", out)
+	}
+	if strings.Contains(out, "did_you_mean") {
+		t.Fatalf("should not invent a suggestion: %s", out)
+	}
+}
+
+func TestUnknownKeyInsideOptionsIsReported(t *testing.T) {
+	out := captureWarnings(t, `
+policies:
+  p1:
+    config:
+      options:
+        capture_config: true
+        nope_option: 1
+    scope:
+      targets:
+        - host: 10.0.0.1
+`)
+	if !strings.Contains(out, "nope_option") {
+		t.Fatalf("key not reported: %s", out)
+	}
+}
+
+// Only the config and options blocks are checked. Warning on blocks that carry
+// operator-chosen keys would fire on correct files.
+func TestBlocksWithOperatorChosenKeysStaySilent(t *testing.T) {
+	out := captureWarnings(t, `
+policies:
+  p1:
+    config:
+      defaults:
+        stray_default: 1
+    scope:
+      targets:
+        - host: 10.0.0.1
+          stray_target: 1
+`)
+	if out != "" {
+		t.Fatalf("expected silence outside config/options, got: %s", out)
+	}
+}
+
+func TestValidPolicyIsSilent(t *testing.T) {
+	out := captureWarnings(t, `
+policies:
+  p1:
+    config:
+      mode: subscribe
+      options:
+        capture_config: true
+      defaults:
+        site: s
+    scope:
+      targets:
+        - host: 10.0.0.1
+`)
+	if out != "" {
+		t.Fatalf("valid policy must not warn, got: %s", out)
+	}
+}
+
+func TestMalformedYamlIsLeftToThePermissiveDecode(t *testing.T) {
+	out := captureWarnings(t, "policies: [this is not a map")
+	if out != "" {
+		t.Fatalf("syntax errors are reported by the real decode, got: %s", out)
+	}
+}
+
+func TestNilLoggerIsSafe(_ *testing.T) {
+	WarnUnknownPolicyKeys([]byte("policies:\n  p1:\n    config:\n      bogus: 1\n"), nil)
+}

--- a/orb-discovery/gnmi-discovery/config/unknown_keys_test.go
+++ b/orb-discovery/gnmi-discovery/config/unknown_keys_test.go
@@ -122,3 +122,21 @@ func TestMalformedYamlIsLeftToThePermissiveDecode(t *testing.T) {
 func TestNilLoggerIsSafe(_ *testing.T) {
 	WarnUnknownPolicyKeys([]byte("policies:\n  p1:\n    config:\n      bogus: 1\n"), nil)
 }
+
+// `bogus key: 1` is a valid YAML mapping key, and yaml.v3 reports it with the
+// space intact. Requiring a single non-whitespace token skipped the entry,
+// hiding the very mistake this warning exists to surface.
+func TestKeyContainingWhitespaceIsReported(t *testing.T) {
+	out := captureWarnings(t, `
+policies:
+  p1:
+    config:
+      bogus key: 1
+    scope:
+      targets:
+        - host: 10.0.0.1
+`)
+	if !strings.Contains(out, "bogus key") {
+		t.Fatalf("whitespace key not reported: %s", out)
+	}
+}

--- a/orb-discovery/gnmi-discovery/policy/manager.go
+++ b/orb-discovery/gnmi-discovery/policy/manager.go
@@ -62,6 +62,7 @@ func (m *Manager) ParsePolicies(data []byte) (map[string]config.Policy, error) {
 	if err := yaml.Unmarshal(data, &payload); err != nil {
 		return nil, err
 	}
+	config.WarnUnknownPolicyKeys(data, m.logger)
 	if len(payload.Policies) == 0 {
 		return nil, errors.New("no policies found in the request")
 	}


### PR DESCRIPTION
## Why

Same class of bug as #548 and #549, in the gNMI backend. `yaml.Unmarshal` ignores
unrecognized keys, so a policy key written at the wrong nesting level decodes without
complaint and is then dropped. The setting never takes effect and nothing says so.

## What

A second decode with `KnownFields(true)` purely to harvest the report, logged as warnings.
The error is never returned, so an unrecognized key stays non-fatal:

```
level=WARN msg="ignoring unrecognized config key" key=capture_config did_you_mean=options.capture_config
```

`KnownFields` covers the whole document, so the report is filtered to `config.PolicyConfig`
and `config.Options` — the blocks whose keys are a closed documented set. Scope entries, the
policy map and surrounding YAML anchors are deliberately excluded: warning there would fire
on correct files and train operators to ignore the warning.

Same helper as #549, with the suggestion derived by reflection over this backend's own
`Options` tags, so it cannot drift from the real field set.

## Verification

- 7 packages pass, 0 failures. 7 tests cover the misplacement, an invented key, an unknown
  key inside `options`, silence outside the two blocks, silence on a valid policy, a syntax
  error left to the real decode, and a nil logger.
- No existing policy fixture triggers the warning.
- `make lint-all` clean for all Go modules.

Part of a set of four, one per backend: #548 device-discovery, #549 snmp-discovery, this one,
and network-discovery to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)