### PR TITLE
fix(agent): name the file in git config parse errors

### DIFF
--- a/agent/configmgr/git.go
+++ b/agent/configmgr/git.go
@@ -94,7 +94,7 @@ func (gc *gitConfigManager) readPolicies(tree *object.Tree, matchingPolicies []s
 
 		reader, err := file.Reader()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to read %s: %w", path, err)
 		}
 		defer func() {
 			if err := reader.Close(); err != nil {
@@ -104,12 +104,12 @@ func (gc *gitConfigManager) readPolicies(tree *object.Tree, matchingPolicies []s
 
 		data, err := io.ReadAll(reader)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to read %s: %w", path, err)
 		}
 
 		var policies map[string]map[string]any
 		if err = yaml.Unmarshal(data, &policies); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to parse %s: %w", path, err)
 		}
 
 		for beName, policy := range policies {
@@ -184,7 +184,7 @@ func (gc *gitConfigManager) applyPolicies(policies policyData, backends map[stri
 func (gc *gitConfigManager) processSelector(file *object.File, cfg config.Config) ([]string, error) {
 	reader, err := file.Reader()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read %s: %w", file.Name, err)
 	}
 	defer func() {
 		if err := reader.Close(); err != nil {
@@ -194,7 +194,7 @@ func (gc *gitConfigManager) processSelector(file *object.File, cfg config.Config
 
 	data, err := io.ReadAll(reader)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read %s: %w", file.Name, err)
 	}
 
 	var selectors map[string]struct {
@@ -205,7 +205,7 @@ func (gc *gitConfigManager) processSelector(file *object.File, cfg config.Config
 		} `yaml:"policies"`
 	}
 	if err = yaml.Unmarshal(data, &selectors); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse %s: %w", file.Name, err)
 	}
 
 	// Use a set (map) to store unique policy paths

--- a/agent/configmgr/git_test.go
+++ b/agent/configmgr/git_test.go
@@ -354,3 +354,91 @@ backend1:
 	require.NoError(t, err, "Start() via system git fallback should succeed")
 	pMgr.AssertCalled(t, "ManagePolicy", mock.Anything)
 }
+
+// writeGitRepo creates a one-commit repository containing files and returns its file:// URL.
+func writeGitRepo(t *testing.T, files map[string]string) string {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "cfgmgr-parse-error")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(dir))
+	})
+
+	repo, err := gitv5.PlainInit(dir, false)
+	require.NoError(t, err)
+	worktree, err := repo.Worktree()
+	require.NoError(t, err)
+
+	for path, content := range files {
+		full := filepath.Join(dir, path)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0o644))
+		_, err = worktree.Add(path)
+		require.NoError(t, err)
+	}
+
+	_, err = worktree.Commit("initial commit", &gitv5.CommitOptions{
+		Author: &object.Signature{Name: "tester", Email: "tester@example.com", When: time.Now()},
+	})
+	require.NoError(t, err)
+
+	return "file://" + dir
+}
+
+// startWithRepo runs the git config manager against repoURL and returns the startup error.
+func startWithRepo(t *testing.T, repoURL string) error {
+	t.Helper()
+
+	cfg := config.Config{
+		OrbAgent: config.OrbAgent{
+			Labels: map[string]string{"env": "test"},
+			ConfigManager: config.ManagerConfig{
+				Active:  "git",
+				Sources: config.Sources{Git: config.GitManager{URL: repoURL}},
+			},
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	gc := configmgr.New(logger, new(mockPolicyManager), cfg.OrbAgent.ConfigManager.Active,
+		&mockBackendState{}, nil)
+
+	return gc.Start(context.Background(), cfg, map[string]backend.Backend{
+		"backend1": &mockBackend{name: "backend1"},
+	})
+}
+
+// TestGitStartNamesTheSelectorFileOnParseError pins that a malformed selector.yaml reports its own
+// name. Without it the bare parser error reads as a failure of the clone that precedes it.
+func TestGitStartNamesTheSelectorFileOnParseError(t *testing.T) {
+	repoURL := writeGitRepo(t, map[string]string{
+		"selector.yaml": "test_selector:\n  selector:\n    env: test\n   broken: value\n",
+	})
+
+	err := startWithRepo(t, repoURL)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "selector.yaml",
+		"a parse error must name the file it came from, or an operator cannot tell what to fix")
+}
+
+// TestGitStartNamesThePolicyFileOnParseError pins the same for a selected policy file, which is the
+// harder case: a selector may point at many policies and the error named none of them.
+func TestGitStartNamesThePolicyFileOnParseError(t *testing.T) {
+	repoURL := writeGitRepo(t, map[string]string{
+		"selector.yaml": "test_selector:\n" +
+			"  selector:\n" +
+			"    env: test\n" +
+			"  policies:\n" +
+			"    test_policy:\n" +
+			"      enabled: true\n" +
+			"      path: \"policies/broken.yaml\"\n",
+		"policies/broken.yaml": "backend1:\n  test_policy:\n    key: value\n   broken: value\n",
+	})
+
+	err := startWithRepo(t, repoURL)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "policies/broken.yaml",
+		"a parse error must name the policy file it came from")
+}


### PR DESCRIPTION
## Problem

Reported in #554. A config repository with a malformed YAML file failed startup with the bare parser error:

```
{"level":"INFO","msg":"detected default branch","branch":"main"}
{"level":"INFO","msg":"cloning repository","url":"ssh://git@umitgit:222/diode/orb_launch","branch":"main"}
{"level":"ERROR","msg":"agent startup error","error":"yaml: line 89: did not find expected key"}
```

The message names neither the file nor the step. Sitting directly under `cloning repository`, it reads as a clone failure, and the reporter filed it as SSH key authentication breaking. Authentication had in fact succeeded three times by that point: the fetch, the ref listing that produced `detected default branch`, and the clone itself.

A selector can point at many policy files, so on a real repository the error gives an operator nothing to act on.

## Change

`processSelector` and `readPolicies` now attribute their read and parse failures to the file:

```
failed to parse policies/broken.yaml: yaml: line 89: did not find expected key
```

This is the pattern `decodeFile` already uses for the local config file, so the two paths now report the same way.

## Tests

Two tests build a repository containing a malformed file and assert the startup error names it, one for `selector.yaml` and one for a selected policy file. Both fail on `develop` with `"yaml: line 1: did not find expected key" does not contain "selector.yaml"`.

`go test -race ./agent/configmgr/` and the full `./agent/...` suite pass; `make lint` reports 0 issues.