### PR TITLE
feat(gnmi-discovery): accept a subnet or range as a target, and sweep it before subscribing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ test-coverage:
 	@mkdir -p .coverage
 	@go test -race -cover -json -coverprofile=.coverage/cover.out.tmp ./... | grep -Ev "cmd|mocks" | tparse -format=markdown > .coverage/test-report.md
 	@cat .coverage/cover.out.tmp | grep -Ev "cmd|mocks" > .coverage/cover.out
-	@go tool cover -func=.coverage/cover.out | grep total | awk '{print substr($$3, 1, length($$3)-1)}' > .coverage/coverage.txt
+	@go tool cover -func=.coverage/cover.out | grep -E '^total:' | awk '{print substr($$3, 1, length($$3)-1)}' > .coverage/coverage.txt
 
 .PHONY: lint
 lint:

--- a/agent/backend/backend.go
+++ b/agent/backend/backend.go
@@ -13,15 +13,22 @@ import (
 
 // PolicyStatusRun represents a run in the backend status response
 type PolicyStatusRun struct {
-	ID          string            `json:"id"`
-	Status      string            `json:"status"`
-	Reason      string            `json:"reason"`
-	EntityCount int64             `json:"entity_count,omitzero"`
-	CreatedAt   int64             `json:"created_at"` // nanoseconds since epoch
-	UpdatedAt   int64             `json:"updated_at"` // nanoseconds since epoch
-	Targets     []string          `json:"targets,omitempty"`
-	Driver      string            `json:"driver,omitempty"`
-	Metadata    map[string]string `json:"metadata,omitempty"`
+	ID          string   `json:"id"`
+	Status      string   `json:"status"`
+	Reason      string   `json:"reason"`
+	EntityCount int64    `json:"entity_count,omitzero"`
+	CreatedAt   int64    `json:"created_at"` // nanoseconds since epoch
+	UpdatedAt   int64    `json:"updated_at"` // nanoseconds since epoch
+	Targets     []string `json:"targets,omitempty"`
+	Driver      string   `json:"driver,omitempty"`
+	// Kind distinguishes runs that describe different work, where a backend
+	// emits more than one shape. gnmi-discovery emits "sweep" for a policy-wide
+	// target sweep and "flush" for a per-device ingest; they can carry the same
+	// target list and both report completed, and a sweep completes well before
+	// the first flush, so without this a consumer cannot tell whether a completed
+	// run means anything was ingested.
+	Kind     string            `json:"kind,omitempty"`
+	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
 // PolicyStatus represents policy status from backend status endpoint

--- a/agent/backend/backend_state.go
+++ b/agent/backend/backend_state.go
@@ -188,6 +188,7 @@ func convertToRunData(statusRuns []PolicyStatusRun) []policies.RunData {
 			UpdatedAt:   nsToTime(sr.UpdatedAt),
 			Targets:     targets,
 			Driver:      sr.Driver,
+			Kind:        sr.Kind,
 		}
 	}
 	return runs

--- a/agent/backend/gnmidiscovery/gnmi_discovery.go
+++ b/agent/backend/gnmidiscovery/gnmi_discovery.go
@@ -384,6 +384,7 @@ type gnmiStatusResponse struct {
 			ID          string   `json:"id"`
 			Target      string   `json:"target"`
 			Targets     []string `json:"targets"`
+			Kind        string   `json:"kind"`
 			Status      string   `json:"status"`
 			Reason      string   `json:"reason"`
 			EntityCount int64    `json:"entity_count"`
@@ -426,6 +427,13 @@ func (d *gnmiDiscoveryBackend) GetPolicyStatus() ([]backend.PolicyStatus, error)
 		runs := make([]backend.PolicyStatusRun, 0, len(p.Runs))
 		for _, r := range p.Runs {
 			targets := runTargets(r.Targets, r.Target)
+			// A sweep run and a flush run describe different things and complete
+			// at different times, and they can carry the same target list, so
+			// nothing else in this payload tells them apart.
+			var metadata map[string]string
+			if r.Kind != "" {
+				metadata = map[string]string{"kind": r.Kind}
+			}
 			runs = append(runs, backend.PolicyStatusRun{
 				ID:          r.ID,
 				Status:      r.Status,
@@ -434,6 +442,7 @@ func (d *gnmiDiscoveryBackend) GetPolicyStatus() ([]backend.PolicyStatus, error)
 				CreatedAt:   r.CreatedAt,
 				UpdatedAt:   r.UpdatedAt,
 				Targets:     targets,
+				Metadata:    metadata,
 			})
 		}
 		policies = append(policies, backend.PolicyStatus{

--- a/agent/backend/gnmidiscovery/gnmi_discovery.go
+++ b/agent/backend/gnmidiscovery/gnmi_discovery.go
@@ -322,7 +322,11 @@ func (d *gnmiDiscoveryBackend) ApplyPolicy(data policies.PolicyData, updatePolic
 		}
 	}
 
-	d.logger.Debug("gnmi-discovery policy apply", "policy_id", data.ID, "data", data.Data)
+	// The body is deliberately not logged. A gnmi policy may carry a literal
+	// password, and a scope-level credential now covers a whole subnet rather
+	// than one device, so a debug-level agent would put the campus password in
+	// the log stream. The id and name identify the policy for troubleshooting.
+	d.logger.Debug("gnmi-discovery policy apply", "policy_id", data.ID, "policy_name", data.Name)
 
 	fullPolicy := map[string]any{
 		"policies": map[string]any{

--- a/agent/backend/gnmidiscovery/gnmi_discovery.go
+++ b/agent/backend/gnmidiscovery/gnmi_discovery.go
@@ -427,13 +427,6 @@ func (d *gnmiDiscoveryBackend) GetPolicyStatus() ([]backend.PolicyStatus, error)
 		runs := make([]backend.PolicyStatusRun, 0, len(p.Runs))
 		for _, r := range p.Runs {
 			targets := runTargets(r.Targets, r.Target)
-			// A sweep run and a flush run describe different things and complete
-			// at different times, and they can carry the same target list, so
-			// nothing else in this payload tells them apart.
-			var metadata map[string]string
-			if r.Kind != "" {
-				metadata = map[string]string{"kind": r.Kind}
-			}
 			runs = append(runs, backend.PolicyStatusRun{
 				ID:          r.ID,
 				Status:      r.Status,
@@ -442,7 +435,10 @@ func (d *gnmiDiscoveryBackend) GetPolicyStatus() ([]backend.PolicyStatus, error)
 				CreatedAt:   r.CreatedAt,
 				UpdatedAt:   r.UpdatedAt,
 				Targets:     targets,
-				Metadata:    metadata,
+				// A sweep run and a flush run describe different things and
+				// complete at different times, and can carry the same target
+				// list, so nothing else in the payload tells them apart.
+				Kind: r.Kind,
 			})
 		}
 		policies = append(policies, backend.PolicyStatus{

--- a/agent/backend/gnmidiscovery/gnmi_discovery.go
+++ b/agent/backend/gnmidiscovery/gnmi_discovery.go
@@ -371,25 +371,43 @@ func (d *gnmiDiscoveryBackend) RemovePolicy(data policies.PolicyData) error {
 	return nil
 }
 
-// gnmiStatusResponse mirrors gnmi-discovery's /api/v1/status. Each run carries a
-// single `target` (string), unlike the shared backend.PolicyStatusRun which
-// expects a `targets` array — so decoding straight into backend.StatusResponse
-// would drop the per-run target. We decode into this shape and normalize
-// `target` into Targets below.
+// gnmiStatusResponse mirrors gnmi-discovery's /api/v1/status. A run carries both
+// a `targets` array and a single `target`, while the shared
+// backend.PolicyStatusRun has only the array — so decoding straight into
+// backend.StatusResponse would drop a run's target entirely. We decode into this
+// shape and normalize below.
 type gnmiStatusResponse struct {
 	Policies []struct {
 		Name   string `json:"name"`
 		Status string `json:"status"`
 		Runs   []struct {
-			ID          string `json:"id"`
-			Target      string `json:"target"`
-			Status      string `json:"status"`
-			Reason      string `json:"reason"`
-			EntityCount int64  `json:"entity_count"`
-			CreatedAt   int64  `json:"created_at"`
-			UpdatedAt   int64  `json:"updated_at"`
+			ID          string   `json:"id"`
+			Target      string   `json:"target"`
+			Targets     []string `json:"targets"`
+			Status      string   `json:"status"`
+			Reason      string   `json:"reason"`
+			EntityCount int64    `json:"entity_count"`
+			CreatedAt   int64    `json:"created_at"`
+			UpdatedAt   int64    `json:"updated_at"`
 		} `json:"runs"`
 	} `json:"policies"`
+}
+
+// runTargets picks the target list to report for one run.
+//
+// The array wins. A sweep run covering several scope entries carries each
+// original host string in `targets` and a comma-joined compatibility value in
+// `target`, so reading the singular field would deliver
+// "10.0.0.0/24,10.1.0.0/24" to the fleet as one target instead of two. The
+// singular field remains the fallback for a payload that predates the array.
+func runTargets(targets []string, target string) []string {
+	if len(targets) > 0 {
+		return targets
+	}
+	if target == "" {
+		return nil
+	}
+	return []string{target}
 }
 
 // GetPolicyStatus returns per-policy run status from the REST status endpoint,
@@ -407,10 +425,7 @@ func (d *gnmiDiscoveryBackend) GetPolicyStatus() ([]backend.PolicyStatus, error)
 	for _, p := range resp.Policies {
 		runs := make([]backend.PolicyStatusRun, 0, len(p.Runs))
 		for _, r := range p.Runs {
-			var targets []string
-			if r.Target != "" {
-				targets = []string{r.Target}
-			}
+			targets := runTargets(r.Targets, r.Target)
 			runs = append(runs, backend.PolicyStatusRun{
 				ID:          r.ID,
 				Status:      r.Status,

--- a/agent/backend/gnmidiscovery/status_targets_test.go
+++ b/agent/backend/gnmidiscovery/status_targets_test.go
@@ -1,0 +1,55 @@
+package gnmidiscovery
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The backend emits both a `targets` array and a comma-joined `target`. A sweep
+// run covering several scope entries has to reach the fleet as several targets,
+// not as the single string "10.0.0.0/24,10.1.0.0/24".
+func TestSweepRunTargetsAreDecodedAsAnArray(t *testing.T) {
+	var resp gnmiStatusResponse
+	require.NoError(t, json.Unmarshal([]byte(`{
+	  "policies": [{
+	    "name": "campus",
+	    "status": "completed",
+	    "runs": [{
+	      "id": "r1",
+	      "target": "10.0.0.0/24,10.1.0.0/24",
+	      "targets": ["10.0.0.0/24", "10.1.0.0/24"],
+	      "status": "completed",
+	      "entity_count": 4
+	    }]
+	  }]
+	}`), &resp))
+
+	run := resp.Policies[0].Runs[0]
+	require.Equal(t, []string{"10.0.0.0/24", "10.1.0.0/24"}, run.Targets)
+}
+
+// A payload from a backend that predates the array still yields its target: the
+// singular field is the fallback, not the primary.
+func TestASingularTargetIsStillHonouredAsAFallback(t *testing.T) {
+	var resp gnmiStatusResponse
+	require.NoError(t, json.Unmarshal([]byte(`{
+	  "policies": [{
+	    "name": "campus",
+	    "runs": [{"id": "r1", "target": "10.0.0.11:6030"}]
+	  }]
+	}`), &resp))
+
+	run := resp.Policies[0].Runs[0]
+	require.Empty(t, run.Targets)
+	require.Equal(t, "10.0.0.11:6030", run.Target)
+}
+
+func TestRunTargetsPrefersTheArray(t *testing.T) {
+	require.Equal(t, []string{"a", "b"},
+		runTargets([]string{"a", "b"}, "a,b"))
+	require.Equal(t, []string{"10.0.0.11:6030"},
+		runTargets(nil, "10.0.0.11:6030"), "the singular field is the fallback")
+	require.Nil(t, runTargets(nil, ""), "a run with no target reports none")
+}

--- a/agent/backend/gnmidiscovery/status_targets_test.go
+++ b/agent/backend/gnmidiscovery/status_targets_test.go
@@ -53,3 +53,24 @@ func TestRunTargetsPrefersTheArray(t *testing.T) {
 		runTargets(nil, "10.0.0.11:6030"), "the singular field is the fallback")
 	require.Nil(t, runTargets(nil, ""), "a run with no target reports none")
 }
+
+// A sweep run and a flush run describe different things and complete at
+// different times — a sweep of a named host finishes at once, while its first
+// flush waits for debounce, subscribe and the initial sync. They can also carry
+// the same target list, so without this nothing in the payload tells them apart
+// and "any completed run" reads as "the policy ingested something".
+func TestRunKindReachesTheFleetAsMetadata(t *testing.T) {
+	var resp gnmiStatusResponse
+	require.NoError(t, json.Unmarshal([]byte(`{
+	  "policies": [{
+	    "name": "campus",
+	    "runs": [
+	      {"id": "s1", "kind": "sweep", "status": "completed", "targets": ["10.0.0.0/24"]},
+	      {"id": "f1", "kind": "flush", "status": "completed", "targets": ["10.0.0.1:9339"]}
+	    ]
+	  }]
+	}`), &resp))
+
+	require.Equal(t, "sweep", resp.Policies[0].Runs[0].Kind)
+	require.Equal(t, "flush", resp.Policies[0].Runs[1].Kind)
+}

--- a/agent/backend/run_kind_test.go
+++ b/agent/backend/run_kind_test.go
@@ -1,0 +1,31 @@
+package backend
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The hop that was broken: Kind was set on PolicyStatusRun and convertToRunData
+// mapped eight fields, not including it.
+func TestConvertToRunDataCarriesKind(t *testing.T) {
+	runs := convertToRunData([]PolicyStatusRun{
+		{ID: "s1", Status: "completed", Kind: "sweep", Targets: []string{"10.0.0.0/24"}},
+		{ID: "f1", Status: "completed", Kind: "flush", Targets: []string{"10.0.0.1:9339"}},
+		{ID: "x1", Status: "completed"},
+	})
+
+	require.Len(t, runs, 3)
+	require.Equal(t, "sweep", runs[0].Kind)
+	require.Equal(t, "flush", runs[1].Kind)
+	require.Empty(t, runs[2].Kind)
+}
+
+// The legacy metadata path still works: network-discovery v1.x encodes targets as
+// a JSON array string in metadata, and adding Kind must not disturb that.
+func TestMetadataTargetsFallbackStillWorks(t *testing.T) {
+	runs := convertToRunData([]PolicyStatusRun{
+		{ID: "n1", Status: "completed", Metadata: map[string]string{"targets": `["10.0.0.1"]`}},
+	})
+	require.Equal(t, []string{"10.0.0.1"}, runs[0].Targets)
+}

--- a/agent/backend/utils.go
+++ b/agent/backend/utils.go
@@ -57,19 +57,29 @@ func CommonRequest(backendName string, proc Commander, logger *slog.Logger, url 
 	if status != Running {
 		logger.Warn("skipping REST API request because process is not running or is unresponsive",
 			"backend", backendName, "url", url, "method", method, "error", err)
+		if err == nil {
+			// GetRunningStatus reports a stopped or unresponsive backend with a
+			// nil error. Returning it verbatim told the caller the request had
+			// succeeded, so a policy that was never delivered was recorded as
+			// applied.
+			err = fmt.Errorf("%s backend is %s", backendName, status)
+		}
 		return err
 	}
 
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
-		return fmt.Errorf("received error from payload %v", slog.Any("error", err))
+		return fmt.Errorf("%s: building %s %s: %w", backendName, method, url, err)
 	}
 
 	req.Header.Add("Content-Type", contentType)
 	res, getErr := client.Do(req)
 
 	if getErr != nil {
-		return fmt.Errorf("received error from payload %v", slog.Any("error", err))
+		// Reported err, not getErr. err is nil here by construction — the request
+		// built fine — so every connection failure, timeout and refused dial
+		// arrived as "received error from payload error=<nil>".
+		return fmt.Errorf("%s: %s %s: %w", backendName, method, url, getErr)
 	}
 
 	defer func() {

--- a/agent/configmgr/fleet/heartbeats.go
+++ b/agent/configmgr/fleet/heartbeats.go
@@ -196,6 +196,7 @@ func convertRunsToStateInfo(runs []policies.RunData) []messages.RunStateInfo {
 			UpdatedAt:   run.UpdatedAt,
 			Targets:     run.Targets,
 			Driver:      run.Driver,
+			Kind:        run.Kind,
 		}
 	}
 	return runInfos

--- a/agent/configmgr/fleet/messages/fleet_messages.go
+++ b/agent/configmgr/fleet/messages/fleet_messages.go
@@ -41,6 +41,9 @@ type RunStateInfo struct {
 	UpdatedAt   time.Time `json:"updated_at"`
 	Targets     []string  `json:"targets,omitempty"`
 	Driver      string    `json:"driver,omitempty"`
+	// Kind distinguishes runs describing different work. See
+	// backend.PolicyStatusRun.Kind.
+	Kind string `json:"kind,omitempty"`
 }
 
 // PolicyStateInfo contains state information for a policy

--- a/agent/configmgr/fleet/run_kind_chain_test.go
+++ b/agent/configmgr/fleet/run_kind_chain_test.go
@@ -1,0 +1,28 @@
+package fleet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/policies"
+)
+
+// A run's kind has to survive every hop to be worth anything, and it did not:
+// the gnmi backend emitted it, PolicyStatusRun carried it, and convertToRunData
+// then dropped it, so the heartbeat Fleet receives still had otherwise-identical
+// sweep and flush runs with nothing to tell them apart. Testing the field at each
+// struct in isolation is what let that gap sit unnoticed, so this covers the hop
+// that was actually broken.
+func TestRunKindReachesTheHeartbeat(t *testing.T) {
+	infos := convertRunsToStateInfo([]policies.RunData{
+		{ID: "s1", Status: "completed", Kind: "sweep", Targets: []string{"10.0.0.0/24"}},
+		{ID: "f1", Status: "completed", Kind: "flush", Targets: []string{"10.0.0.1:9339"}},
+		{ID: "x1", Status: "completed"}, // a backend that emits no kind
+	})
+
+	require.Len(t, infos, 3)
+	require.Equal(t, "sweep", infos[0].Kind)
+	require.Equal(t, "flush", infos[1].Kind)
+	require.Empty(t, infos[2].Kind, "a backend that emits no kind is unaffected")
+}

--- a/agent/policies/types.go
+++ b/agent/policies/types.go
@@ -16,6 +16,9 @@ type RunData struct {
 	UpdatedAt   time.Time `json:"updated_at"`
 	Targets     []string  `json:"targets,omitempty"`
 	Driver      string    `json:"driver,omitempty"`
+	// Kind distinguishes runs describing different work, for a backend that
+	// emits more than one shape. See backend.PolicyStatusRun.Kind.
+	Kind string `json:"kind,omitempty"`
 }
 
 // PolicyData represents a policy

--- a/docs/backends/gnmi_discovery.md
+++ b/docs/backends/gnmi_discovery.md
@@ -112,10 +112,11 @@ subscription. This matters because a gNMI subscription is a persistent stream
 rather than a poll — without the probe, a `/24` would leave ~250 goroutines
 redialling empty addresses for the life of the policy.
 
-A CIDR excludes its network and broadcast addresses, so `10.0.0.0/24` is 254
-addresses. A range does not, because the operator enumerated it explicitly:
-`10.0.0.0-255` is 256. A policy may expand to at most 1024 addresses in total,
-counted across all its targets and checked before any expansion happens.
+A CIDR excludes its network and broadcast addresses, so `10.0.0.0/24` is 254 and
+`10.0.0.0/22` is 1022. A `/31` and a `/32` have no such pair to exclude and stay
+2 and 1. A range excludes nothing, because the operator enumerated it explicitly:
+`10.0.0.0-255` is 256, not 254. A policy may expand to at most 1024 addresses in
+total, counted across all its targets and checked before any expansion happens.
 
 A probe answers the question "is anything listening on the gNMI port", and
 nothing more. Any response admits the address, including a rejected RPC or a

--- a/docs/backends/gnmi_discovery.md
+++ b/docs/backends/gnmi_discovery.md
@@ -54,6 +54,8 @@ gNMI discovery policies are broken into two subsections: `config` and `scope`.
 | debounce_ms | int | no | Flush delay in ms after the last notification before a snapshot is ingested (default `2000`). |
 | sample_interval_ms | int | no | `SAMPLE` subscription interval in ms (default `300000` = 5m). |
 | get_interval_ms | int | no | `GET` poll interval in ms (default `900000` = 15m). |
+| probe_timeout_ms | int | no | How long a sweep waits for one address to answer (default `3000`). Too low and a whole subnet reports as absent with no failure signal. |
+| rescan_interval_ms | int | no | Re-probe addresses this policy is not subscribed to, picking up devices that were down when the policy was applied. Unset or `0` disables it; a non-zero value below `60000` is rejected. |
 | options | map | no | Per-policy toggles. `capture_config` (bool) captures the CONFIG datastore into `Device.config.running` (default off). |
 | defaults | map | no | NetBox defaults applied to discovered entities (see below). |
 
@@ -76,20 +78,59 @@ gNMI discovery policies are broken into two subsections: `config` and `scope`.
 
 | Parameter | Type | Required | Description |
 |:---------:|:----:|:--------:|:-----------:|
-| targets | list | yes | The gNMI endpoints to subscribe to (see target fields below). |
+| targets | list | yes | The gNMI endpoints to discover (see target fields below). |
+| username | str | no | Default gNMI username for every target that does not set its own. `${ENV_VAR}` syntax is supported. |
+| password | str | no | Default gNMI password for every target that does not set its own. `${ENV_VAR}` syntax is supported. |
+| port | int | no | Default port for every target whose `host` carries no port and that sets no `port` of its own (default `9339`). |
+| origin | str | no | Default gNMI path origin. A target that sets `origin: ""` keeps origin-less paths rather than inheriting. |
+| tls | map | no | Default TLS settings. A target's own `tls` block **replaces** this one entirely rather than merging field by field, because a bool cannot distinguish "unset" from "false". |
+
+Scope-level settings are defaults, not overrides: a target that sets a field keeps
+its own value. `mode`, `profile` and `override_defaults` are deliberately not
+scope fields — `mode` and `override_defaults` duplicate the policy-level `config`
+knobs, and a scope-level `profile` would pin one vendor profile onto every device
+in a range whose contents are by definition unknown.
 
 #### Target
 | Key | Type | Required | Description |
 |:---:|:----:|:--------:|:-----------:|
-| host | str | yes | `host:port` of the gNMI endpoint (e.g. `10.0.0.11:6030`). When the port is omitted, the IANA gNMI port `9339` is used. |
+| host | str | yes | A single endpoint (`10.0.0.11`, `10.0.0.11:6030`, `switch-a.example.com`), a CIDR (`10.0.0.0/24`), or a range (`10.1.0.0-50`, `10.2.0.0-10.2.0.9`). A CIDR or range cannot carry an inline `:port` — use the `port` field. |
+| port | int | no | Port for this target, used when `host` carries no inline port (default `9339`). An inline `host:port` wins over this field, which wins over the scope's. |
 | username | str | no | gNMI username. `${ENV_VAR}` syntax is supported. |
 | password | str | no | gNMI password. `${ENV_VAR}` syntax is supported. |
 | tls | map | no | TLS settings: `skip_verify` (keep TLS, don't verify the cert), `insecure` (opt-in PLAINTEXT, off by default), `ca`/`cert`/`key` (optional mTLS). TLS with system root CAs is the default. |
 | mode | str | no | Per-target delivery mode override (`auto`/`on_change`/`sample`/`get`). |
 | profile | str | no | Pin a gNMI profile (auto-detected when omitted). |
 | origin | str | no | gNMI path origin (default `openconfig`); set `""` for origin-less paths. |
-| netbox_id | int | no | Pin discovery to an existing NetBox device ID. |
+| netbox_id | int | no | Pin discovery to an existing NetBox device ID. Silently ignored when `host` is a CIDR or range: one NetBox device ID cannot describe a range. |
 | override_defaults | map | no | Per-target overrides of the policy `defaults`. |
+
+#### Ranges and subnets
+A `host` that names more than one address is expanded and each address is probed
+once before anything is subscribed to; only the addresses that answer get a
+subscription. This matters because a gNMI subscription is a persistent stream
+rather than a poll — without the probe, a `/24` would leave ~250 goroutines
+redialling empty addresses for the life of the policy.
+
+A CIDR excludes its network and broadcast addresses, so `10.0.0.0/24` is 254
+addresses. A range does not, because the operator enumerated it explicitly:
+`10.0.0.0-255` is 256. A policy may expand to at most 1024 addresses in total,
+counted across all its targets and checked before any expansion happens.
+
+A probe answers the question "is anything listening on the gNMI port", and
+nothing more. Any response admits the address, including a rejected RPC or a
+failed TLS handshake — an mTLS device probed without a client cert, or a campus
+of self-signed certificates, is present, not absent. Only silence means absence.
+Probes carry no credentials, so a sweep never sprays the scope password across a
+range.
+
+A single named host is never probed: naming it is the operator asserting it
+exists, and a device that happens to be rebooting should not be dropped for the
+life of the policy.
+
+The sweep reports itself as a run on `/status`, named after the host strings you
+wrote, with the number of addresses that answered and the reason the rest did
+not. A range where nothing answered is reported as a failed run.
 
 #### Interface type discovery
 Each interface's NetBox type is resolved per interface, in precedence order:
@@ -117,15 +158,20 @@ orb:
                 type: 10gbase-x-sfpp
             interface_exclude_patterns:
               - "^Management"
+          rescan_interval_ms: 3600000    # re-probe hourly for devices that were down
         scope:
+          username: ${GNMI_USER}         # inherited by every target below
+          password: ${GNMI_PASS}
+          port: 6030                     # Arista EOS default gNMI port
+          tls:
+            ca: /run/secrets/ca.pem      # prefer a CA over skip_verify
           targets:
-            - host: 10.0.0.11:6030       # Arista EOS default gNMI port
-              username: ${GNMI_USER}
-              password: ${GNMI_PASS}
-              tls:
-                skip_verify: true
+            - host: 10.0.0.0/24          # swept: only addresses that answer subscribe
+            - host: 10.1.0.0-50
+            - host: 10.0.0.11            # a named host is subscribed without probing
               profile: arista_eos
-            - host: 10.0.0.21:57400      # Nokia SR-OS default gNMI port
+            - host: 10.0.0.21            # Nokia SR-OS
+              port: 57400
               username: admin
-              password: ${GNMI_PASS}
+              netbox_id: 42              # honoured: a bare address, not a range
 ```

--- a/docs/backends/gnmi_discovery.md
+++ b/docs/backends/gnmi_discovery.md
@@ -86,7 +86,9 @@ gNMI discovery policies are broken into two subsections: `config` and `scope`.
 | tls | map | no | Default TLS settings. A target's own `tls` block **replaces** this one entirely rather than merging field by field, because a bool cannot distinguish "unset" from "false". |
 
 Scope-level settings are defaults, not overrides: a target that sets a field keeps
-its own value. `mode`, `profile` and `override_defaults` are deliberately not
+its own value. What counts is that the field is *present*, not that it is
+non-empty, so a target inside a credentialed scope can connect anonymously by
+writing `username: ""` and `password: ""`. `mode`, `profile` and `override_defaults` are deliberately not
 scope fields — `mode` and `override_defaults` duplicate the policy-level `config`
 knobs, and a scope-level `profile` would pin one vendor profile onto every device
 in a range whose contents are by definition unknown.
@@ -96,8 +98,8 @@ in a range whose contents are by definition unknown.
 |:---:|:----:|:--------:|:-----------:|
 | host | str | yes | A single endpoint (`10.0.0.11`, `10.0.0.11:6030`, `switch-a.example.com`), a CIDR (`10.0.0.0/24`), or a range (`10.1.0.0-50`, `10.2.0.0-10.2.0.9`). A CIDR or range cannot carry an inline `:port` — use the `port` field. |
 | port | int | no | Port for this target, used when `host` carries no inline port (default `9339`). An inline `host:port` wins over this field, which wins over the scope's. |
-| username | str | no | gNMI username. `${ENV_VAR}` syntax is supported. |
-| password | str | no | gNMI password. `${ENV_VAR}` syntax is supported. |
+| username | str | no | gNMI username. `${ENV_VAR}` syntax is supported. Set it to `""` to connect anonymously from inside a scope that sets one — an omitted field inherits, an explicitly empty one does not. |
+| password | str | no | gNMI password. `${ENV_VAR}` syntax is supported. Set it to `""` to block the scope's, as with `username`. |
 | tls | map | no | TLS settings: `skip_verify` (keep TLS, don't verify the cert), `insecure` (opt-in PLAINTEXT, off by default), `ca`/`cert`/`key` (optional mTLS). TLS with system root CAs is the default. |
 | mode | str | no | Per-target delivery mode override (`auto`/`on_change`/`sample`/`get`). |
 | profile | str | no | Pin a gNMI profile (auto-detected when omitted). |

--- a/docs/backends/gnmi_discovery.md
+++ b/docs/backends/gnmi_discovery.md
@@ -56,6 +56,7 @@ gNMI discovery policies are broken into two subsections: `config` and `scope`.
 | get_interval_ms | int | no | `GET` poll interval in ms (default `900000` = 15m). |
 | probe_timeout_ms | int | no | How long a sweep waits for one address to answer (default `3000`). Too low and a whole subnet reports as absent with no failure signal. |
 | rescan_interval_ms | int | no | Re-probe addresses this policy is not subscribed to, picking up devices that were down when the policy was applied. Unset or `0` disables it; a non-zero value below `60000` is rejected. |
+| send_credentials_to_unverified_targets | bool | no | Permit a CIDR or range target to carry a password when TLS does not authenticate the server. Off by default, and the refusal is deliberate — see [Credentials and ranges](#credentials-and-ranges). |
 | options | map | no | Per-policy toggles. `capture_config` (bool) captures the CONFIG datastore into `Device.config.running` (default off). |
 | defaults | map | no | NetBox defaults applied to discovered entities (see below). |
 
@@ -134,6 +135,40 @@ life of the policy.
 The sweep reports itself as a run on `/status`, named after the host strings you
 wrote, with the number of addresses that answered and the reason the rest did
 not. A range where nothing answered is reported as a failed run.
+
+#### Credentials and ranges
+A probe carries no credentials, but the subscription that follows a successful
+probe does. Since a probe admits anything that answers, a range plus a password
+plus `skip_verify` or `insecure` means the password is offered to any service
+listening on the gNMI port inside that range — including one that is not a network
+device at all. That is reachable by accident: a range overlapping a server VLAN is
+a typo, not an attack.
+
+So that combination is **refused**:
+
+| Target | Password | TLS verification | Result |
+|:------:|:--------:|:----------------:|:------:|
+| explicit host | yes | any | allowed |
+| CIDR / range | no | any | allowed |
+| CIDR / range | yes | verified (`ca`, or system roots) | allowed |
+| CIDR / range | yes | `skip_verify` | refused |
+| CIDR / range | yes | `insecure` | refused |
+
+Naming a host explicitly is unaffected — the operator said where the credential
+may go, and an attacker would have to intercept that connection rather than merely
+listen on a free address.
+
+The gate is on the password, not on every credential. A client certificate is not
+a bearer secret: TLS binds possession to the session, so an endpoint that receives
+one cannot replay it. mTLS over a range without a password is allowed, as is a
+username without a password.
+
+To do credentialed range discovery, give the scope a `ca` so the server is
+authenticated. If the devices have per-device self-signed certificates and no
+shared CA, that is not possible, and the options are to name the hosts explicitly
+or to set `config.send_credentials_to_unverified_targets: true` and accept the
+exposure. Setting it logs a warning on every policy apply and is reported on every
+sweep run, so the decision stays visible rather than being forgotten.
 
 #### Interface type discovery
 Each interface's NetBox type is resolved per interface, in precedence order:

--- a/orb-discovery/gnmi-discovery/Makefile
+++ b/orb-discovery/gnmi-discovery/Makefile
@@ -37,7 +37,7 @@ test-coverage:
 	@mkdir -p .coverage
 	@go test -race -cover -json -coverprofile=.coverage/cover.out.tmp ./... | grep -Ev "cmd" | tparse -format=markdown > .coverage/test-report.md
 	@cat .coverage/cover.out.tmp | grep -Ev "cmd" > .coverage/cover.out
-	@go tool cover -func=.coverage/cover.out | grep total | awk '{print substr($$3, 1, length($$3)-1)}' > .coverage/coverage.txt
+	@go tool cover -func=.coverage/cover.out | grep -E '^total:' | awk '{print substr($$3, 1, length($$3)-1)}' > .coverage/coverage.txt
 	@gcov2lcov -infile=.coverage/cover.out -outfile=.coverage/lcov.info
 
 .PHONY: test

--- a/orb-discovery/gnmi-discovery/README.md
+++ b/orb-discovery/gnmi-discovery/README.md
@@ -103,27 +103,40 @@ policies:
         # Name-regex; matching interfaces are skipped entirely:
         interface_exclude_patterns:
           - "^Management"
+        probe_timeout_ms: 3000       # how long one sweep probe waits (default 3000)
+        rescan_interval_ms: 3600000  # re-probe unsubscribed addresses; 0 disables, floor 60000
     scope:
+      # Scope settings are defaults: a target that sets the field keeps its own.
+      username: ${GNMI_USER}         # ${ENV_VAR} syntax supported
+      password: ${GNMI_PASS}
+      port: 6030                     # default port for targets with no inline :port
+      origin: openconfig             # gNMI path origin (default); set "" for origin-less
+      tls:                           # TLS is the default (system root CAs)
+        ca: /run/secrets/ca.pem      # prefer a CA over skip_verify
       targets:
-        - host: 10.0.0.11:6030       # Arista EOS default gNMI port
-          username: ${GNMI_USER}     # ${ENV_VAR} syntax supported
-          password: ${GNMI_PASS}
-          tls:                       # TLS is the default (system root CAs)
-            skip_verify: true        # keep TLS but don't verify the target cert
-            insecure: false          # opt-in PLAINTEXT (no TLS) — off by default
-            ca: /run/secrets/ca.pem  # optional mTLS
-            cert: /run/secrets/cert.pem
-            key: /run/secrets/key.pem
+        # A CIDR or range is expanded and probed; only addresses that answer are
+        # subscribed to. A CIDR drops network and broadcast (/24 = 254); a range
+        # keeps everything written (10.1.0.0-255 = 256). 1024 addresses per policy.
+        - host: 10.0.0.0/24
+        - host: 10.1.0.0-50
+        - host: 10.2.0.0-10.2.0.9
+
+        # A named host is subscribed without probing: naming it asserts it exists.
+        - host: 10.0.0.11            # inherits every scope setting above
           profile: arista_eos        # pin a profile (auto-detect if omitted)
           mode: on_change            # per-target mode override
-          origin: openconfig         # gNMI path origin (default); set "" for origin-less
-          netbox_id: 42              # pin to an existing NetBox device ID
+          netbox_id: 42              # honoured: a bare address, not a range
           override_defaults:         # per-target defaults override
             site: Chicago IL
 
-        - host: 10.0.0.21:57400     # Nokia SR-OS default gNMI port
-          username: admin
-          password: pw
+        - host: 10.0.0.21            # Nokia SR-OS
+          port: 57400                # beats the scope port; an inline :port beats both
+          username: admin            # beats the scope username
+          tls:                       # replaces the scope block wholesale, never merges
+            skip_verify: true        # keep TLS but don't verify the target cert
+            insecure: false          # opt-in PLAINTEXT (no TLS) — off by default
+            cert: /run/secrets/cert.pem
+            key: /run/secrets/key.pem
 ```
 
 ### Interface type discovery

--- a/orb-discovery/gnmi-discovery/README.md
+++ b/orb-discovery/gnmi-discovery/README.md
@@ -130,6 +130,13 @@ policies:
           override_defaults:         # per-target defaults override
             site: Chicago IL
 
+        # An explicitly empty credential blocks the scope's; an omitted one
+        # inherits it. This is how a device that takes no auth lives in a
+        # credentialed scope.
+        - host: 10.0.0.31
+          username: ""
+          password: ""
+
         - host: 10.0.0.21            # Nokia SR-OS
           port: 57400                # beats the scope port; an inline :port beats both
           username: admin            # beats the scope username

--- a/orb-discovery/gnmi-discovery/README.md
+++ b/orb-discovery/gnmi-discovery/README.md
@@ -115,8 +115,9 @@ policies:
         ca: /run/secrets/ca.pem      # prefer a CA over skip_verify
       targets:
         # A CIDR or range is expanded and probed; only addresses that answer are
-        # subscribed to. A CIDR drops network and broadcast (/24 = 254); a range
-        # keeps everything written (10.1.0.0-255 = 256). 1024 addresses per policy.
+        # subscribed to. A CIDR drops network and broadcast (/24 = 254, /31 and
+        # /32 have none to drop); a range keeps everything written (10.1.0.0-255
+        # = 256). At most 1024 addresses per policy, summed across targets.
         - host: 10.0.0.0/24
         - host: 10.1.0.0-50
         - host: 10.2.0.0-10.2.0.9

--- a/orb-discovery/gnmi-discovery/README.md
+++ b/orb-discovery/gnmi-discovery/README.md
@@ -67,6 +67,9 @@ policies:
       debounce_ms: 2000    # flush delay after last notification (default 2000)
       probe_timeout_ms: 3000       # how long one sweep probe waits for an address (default 3000)
       rescan_interval_ms: 3600000  # re-probe unsubscribed addresses; 0 disables, floor 60000
+      # A credentialed CIDR/range needs verified TLS: the sweep admits anything that
+      # answers and then sends the password to it. Set this only to accept that.
+      # send_credentials_to_unverified_targets: false
       sample_interval_ms: 300000   # SAMPLE subscription interval (default 300000 = 5m)
       get_interval_ms: 900000      # GET poll interval (default 900000 = 15m)
       options:                     # per-policy behavior toggles (peer to defaults)

--- a/orb-discovery/gnmi-discovery/README.md
+++ b/orb-discovery/gnmi-discovery/README.md
@@ -65,6 +65,8 @@ policies:
     config:
       mode: auto           # auto (default) | on_change | sample | get
       debounce_ms: 2000    # flush delay after last notification (default 2000)
+      probe_timeout_ms: 3000       # how long one sweep probe waits for an address (default 3000)
+      rescan_interval_ms: 3600000  # re-probe unsubscribed addresses; 0 disables, floor 60000
       sample_interval_ms: 300000   # SAMPLE subscription interval (default 300000 = 5m)
       get_interval_ms: 900000      # GET poll interval (default 900000 = 15m)
       options:                     # per-policy behavior toggles (peer to defaults)
@@ -103,8 +105,6 @@ policies:
         # Name-regex; matching interfaces are skipped entirely:
         interface_exclude_patterns:
           - "^Management"
-        probe_timeout_ms: 3000       # how long one sweep probe waits (default 3000)
-        rescan_interval_ms: 3600000  # re-probe unsubscribed addresses; 0 disables, floor 60000
     scope:
       # Scope settings are defaults: a target that sets the field keeps its own.
       username: ${GNMI_USER}         # ${ENV_VAR} syntax supported

--- a/orb-discovery/gnmi-discovery/config/config.go
+++ b/orb-discovery/gnmi-discovery/config/config.go
@@ -19,6 +19,14 @@ const (
 	DefaultDebounceMs     = 2000
 	DefaultSampleInterval = 300000 // 5m
 	DefaultGetInterval    = 900000 // 15m
+
+	// DefaultProbeTimeoutMs bounds one sweep probe. snmp-discovery's equivalent
+	// is 1s, but a gNMI probe is a TLS handshake plus a gRPC call rather than a
+	// UDP walk, so it needs longer.
+	DefaultProbeTimeoutMs = 3000
+
+	// MinRescanIntervalMs is the floor for a non-zero rescan_interval_ms.
+	MinRescanIntervalMs = 60000
 )
 
 // Status represents the runtime status of the gnmi-discovery service.
@@ -218,12 +226,46 @@ func (o *Options) ConfigCaptureEnabled() bool {
 
 // PolicyConfig holds policy-wide config (spec §7).
 type PolicyConfig struct {
-	Mode             string   `yaml:"mode,omitempty"`
-	DebounceMs       int      `yaml:"debounce_ms,omitempty"`
-	SampleIntervalMs int      `yaml:"sample_interval_ms,omitempty"`
-	GetIntervalMs    int      `yaml:"get_interval_ms,omitempty"`
-	Defaults         Defaults `yaml:"defaults"`
-	Options          Options  `yaml:"options,omitempty"`
+	Mode             string `yaml:"mode,omitempty"`
+	DebounceMs       int    `yaml:"debounce_ms,omitempty"`
+	SampleIntervalMs int    `yaml:"sample_interval_ms,omitempty"`
+	GetIntervalMs    int    `yaml:"get_interval_ms,omitempty"`
+
+	// ProbeTimeoutMs bounds one sweep probe. 0 or unset means
+	// DefaultProbeTimeoutMs, not "no timeout": a probe without a deadline against
+	// a silently-dropping address never returns, and the sweep would never finish.
+	ProbeTimeoutMs int `yaml:"probe_timeout_ms,omitempty"`
+
+	// RescanIntervalMs re-probes addresses this policy is not currently
+	// subscribed to, picking up devices that were down when the policy was
+	// applied. 0 or unset disables it. It exists because nothing else re-applies
+	// a policy periodically: the config manager returns early on an unchanged git
+	// ref, and on a new commit whose diff touches no matching policy file.
+	//
+	// Values below MinRescanIntervalMs are rejected rather than clamped. A sparse
+	// /24 re-probes ~250 addresses per tick, which is fine hourly and is a
+	// continuous scan per minute.
+	RescanIntervalMs int `yaml:"rescan_interval_ms,omitempty"`
+
+	Defaults Defaults `yaml:"defaults"`
+	Options  Options  `yaml:"options,omitempty"`
+}
+
+// ResolvedProbeTimeout returns the effective sweep probe timeout.
+func (c PolicyConfig) ResolvedProbeTimeout() time.Duration {
+	if c.ProbeTimeoutMs <= 0 {
+		return DefaultProbeTimeoutMs * time.Millisecond
+	}
+	return time.Duration(c.ProbeTimeoutMs) * time.Millisecond
+}
+
+// ResolvedRescanInterval returns the effective rescan period, or 0 when rescan
+// is disabled.
+func (c PolicyConfig) ResolvedRescanInterval() time.Duration {
+	if c.RescanIntervalMs <= 0 {
+		return 0
+	}
+	return time.Duration(c.RescanIntervalMs) * time.Millisecond
 }
 
 // Policy is a gnmi-discovery policy.

--- a/orb-discovery/gnmi-discovery/config/config.go
+++ b/orb-discovery/gnmi-discovery/config/config.go
@@ -13,8 +13,10 @@ const (
 // Default config values.
 const (
 	// DefaultGNMIPort is the IANA-registered gNMI port. Vendors differ in
-	// practice (Arista 6030, Nokia 57400), so operators should set an explicit
-	// host:port; this default only applies when a target omits the port.
+	// practice (Arista 6030, Nokia 57400), so operators should set the port
+	// explicitly — inline as host:port for a single endpoint, or via the port
+	// field, which is the only option for a CIDR or range. This default applies
+	// only when neither is given.
 	DefaultGNMIPort       = 9339
 	DefaultDebounceMs     = 2000
 	DefaultSampleInterval = 300000 // 5m

--- a/orb-discovery/gnmi-discovery/config/config.go
+++ b/orb-discovery/gnmi-discovery/config/config.go
@@ -259,6 +259,21 @@ type PolicyConfig struct {
 	// a silently-dropping address never returns, and the sweep would never finish.
 	ProbeTimeoutMs int `yaml:"probe_timeout_ms,omitempty"`
 
+	// SendCredentialsToUnverifiedTargets permits a CIDR or range target to carry
+	// a password when TLS does not authenticate the server.
+	//
+	// Off by default, and the refusal is the point. A sweep admits anything that
+	// answers on the gNMI port — deliberately, because only silence is absence —
+	// and the subscription that follows sends this policy's password to whatever
+	// was admitted. With skip_verify or insecure there is nothing authenticating
+	// the far end, so an unrelated service listening on that port inside the
+	// scanned range collects the credential. That is reachable by accident: a
+	// range that overlaps a server VLAN is a typo, not an attack.
+	//
+	// Naming a host explicitly is unaffected. The operator said where the
+	// credential may go.
+	SendCredentialsToUnverifiedTargets bool `yaml:"send_credentials_to_unverified_targets,omitempty"`
+
 	// RescanIntervalMs re-probes addresses this policy is not currently
 	// subscribed to, picking up devices that were down when the policy was
 	// applied. 0 or unset disables it. It exists because nothing else re-applies

--- a/orb-discovery/gnmi-discovery/config/config.go
+++ b/orb-discovery/gnmi-discovery/config/config.go
@@ -53,9 +53,14 @@ type TLSConfig struct {
 
 // Target is one gNMI endpoint.
 type Target struct {
-	Host     string `yaml:"host"`
-	Username string `yaml:"username,omitempty"`
-	Password string `yaml:"password,omitempty"`
+	Host string `yaml:"host"`
+	// Username and Password are pointers so that presence, not emptiness,
+	// controls inheritance. An anonymous device inside a credentialed scope is
+	// expressed as `username: ""` — present, so nothing is inherited — which a
+	// plain string cannot distinguish from an omitted field. snmp-discovery
+	// expresses the same thing through the presence of its authentication block.
+	Username *string `yaml:"username,omitempty"`
+	Password *string `yaml:"password,omitempty"`
 	// Port is the gNMI port. An inline "host:port" suffix wins over this field,
 	// which in turn wins over the scope's; unset everywhere means
 	// DefaultGNMIPort. A CIDR or range cannot carry an inline port, which is
@@ -91,6 +96,22 @@ func (t Target) ResolvedTLS() TLSConfig {
 		return TLSConfig{}
 	}
 	return *t.TLS
+}
+
+// ResolvedUsername returns this target's gNMI username, or "" when none is set.
+func (t Target) ResolvedUsername() string {
+	if t.Username == nil {
+		return ""
+	}
+	return *t.Username
+}
+
+// ResolvedPassword returns this target's gNMI password, or "" when none is set.
+func (t Target) ResolvedPassword() string {
+	if t.Password == nil {
+		return ""
+	}
+	return *t.Password
 }
 
 // ResolvedOrigin returns the gNMI request-path origin for this target: the

--- a/orb-discovery/gnmi-discovery/config/config.go
+++ b/orb-discovery/gnmi-discovery/config/config.go
@@ -43,20 +43,44 @@ type TLSConfig struct {
 
 // Target is one gNMI endpoint.
 type Target struct {
-	Host             string    `yaml:"host"`
-	Username         string    `yaml:"username,omitempty"`
-	Password         string    `yaml:"password,omitempty"`
-	TLS              TLSConfig `yaml:"tls,omitempty"`
-	Mode             string    `yaml:"mode,omitempty"`    // overrides PolicyConfig.Mode
-	Profile          string    `yaml:"profile,omitempty"` // pins a profile; else auto-detect
-	OverrideDefaults *Defaults `yaml:"override_defaults,omitempty"`
-	NetboxID         *int      `yaml:"netbox_id,omitempty"`
+	Host     string `yaml:"host"`
+	Username string `yaml:"username,omitempty"`
+	Password string `yaml:"password,omitempty"`
+	// Port is the gNMI port. An inline "host:port" suffix wins over this field,
+	// which in turn wins over the scope's; unset everywhere means
+	// DefaultGNMIPort. A CIDR or range cannot carry an inline port, which is
+	// why this field exists.
+	Port uint16 `yaml:"port,omitempty"`
+	// TLS is a pointer so that "absent" is distinguishable from "present and
+	// zero": nil inherits the scope's block, a present block replaces it
+	// wholesale. Read it through ResolvedTLS, never directly — a nil
+	// dereference here compiles cleanly and panics at runtime.
+	TLS              *TLSConfig `yaml:"tls,omitempty"`
+	Mode             string     `yaml:"mode,omitempty"`    // overrides PolicyConfig.Mode
+	Profile          string     `yaml:"profile,omitempty"` // pins a profile; else auto-detect
+	OverrideDefaults *Defaults  `yaml:"override_defaults,omitempty"`
+	NetboxID         *int       `yaml:"netbox_id,omitempty"`
 	// Origin is the gNMI path origin sent on Subscribe/Get requests. Unset (nil)
 	// defaults to "openconfig" — the canonical OpenConfig origin, required by
 	// strict targets like Nokia SR Linux (which otherwise resolves an origin-less
 	// path against its native schema and rejects it). Set it explicitly to ""
 	// for a target that needs origin-less paths, or to a vendor-specific origin.
 	Origin *string `yaml:"origin,omitempty"`
+}
+
+// ResolvedTLS returns this target's TLS settings, or the zero value when no
+// block is set.
+//
+// Every read of Target.TLS goes through here. Go auto-dereferences a pointer
+// field selector, so `t.TLS.SkipVerify` on a nil TLS compiles without complaint
+// and panics at runtime — and nil is the common case, since most policies set no
+// tls block at all. The zero value is the secure default (TLS with the system
+// root CAs), which is what the field meant before it became a pointer.
+func (t Target) ResolvedTLS() TLSConfig {
+	if t.TLS == nil {
+		return TLSConfig{}
+	}
+	return *t.TLS
 }
 
 // ResolvedOrigin returns the gNMI request-path origin for this target: the
@@ -68,9 +92,24 @@ func (t Target) ResolvedOrigin() string {
 	return "openconfig"
 }
 
-// Scope holds the targets for a policy.
+// Scope holds a policy's targets and the settings they inherit.
+//
+// The scope block carries five of Target's fields. It deliberately does not
+// carry mode, override_defaults or profile: the first two duplicate
+// policy-level knobs (PolicyConfig.Mode and PolicyConfig.Defaults), and a
+// scope-level profile would pin one vendor profile across a whole range,
+// bypassing capability auto-detection — which defeats the point of scanning a
+// subnet whose contents are unknown.
+//
+// host and netbox_id are per-target by nature: host is the thing being
+// enumerated, and one NetBox device id cannot describe a range.
 type Scope struct {
-	Targets []Target `yaml:"targets"`
+	Username string     `yaml:"username,omitempty"`
+	Password string     `yaml:"password,omitempty"`
+	Port     uint16     `yaml:"port,omitempty"`
+	Origin   *string    `yaml:"origin,omitempty"`
+	TLS      *TLSConfig `yaml:"tls,omitempty"`
+	Targets  []Target   `yaml:"targets"`
 }
 
 // DeviceDefaults mirrors snmp-discovery's device defaults subset.

--- a/orb-discovery/gnmi-discovery/config/unknown_keys.go
+++ b/orb-discovery/gnmi-discovery/config/unknown_keys.go
@@ -98,15 +98,16 @@ func yamlFieldNames(t reflect.Type) map[string]bool {
 	return names
 }
 
-// WarnNullTLSBlocks reports a `tls:` key written with nothing under it.
+// WarnAmbiguousNullKeys reports an inheritable key written with nothing under it.
 //
-// Target.TLS is a pointer so that nil can mean "inherit the scope's block", and
-// a null node unmarshals to exactly that nil. So an operator who writes a bare
-// `tls:` on a target to mean "no TLS settings here" gets the opposite: the
-// scope's block, complete with whatever skip_verify or CA path it carries. The
-// distinction is invisible after unmarshalling, so it has to be caught on the
+// Target.TLS, Username and Password are pointers so that nil can mean "inherit
+// the scope's value", and a null node unmarshals to exactly that nil. So an
+// operator who writes a bare `tls:` or `username:` to mean "nothing here" gets
+// the opposite — the scope's value, complete with whatever credential or
+// skip_verify it carries. yaml.v3 gives `key:` and `key: null` the same nil, so
+// the distinction is invisible after unmarshalling and has to be caught on the
 // raw document.
-func WarnNullTLSBlocks(data []byte, logger *slog.Logger) {
+func WarnAmbiguousNullKeys(data []byte, logger *slog.Logger) {
 	if logger == nil {
 		return
 	}
@@ -126,7 +127,8 @@ func WarnNullTLSBlocks(data []byte, logger *slog.Logger) {
 		if scope == nil {
 			continue
 		}
-		warnIfNullTLS(logger, scope, name, "scope")
+		warnIfNull(logger, scope, name, "scope", "tls",
+			"empty tls block inherits the scope's TLS settings; remove the key to inherit, or give it fields to override")
 		targets := mapValue(scope, "targets")
 		if targets == nil {
 			continue
@@ -136,18 +138,25 @@ func WarnNullTLSBlocks(data []byte, logger *slog.Logger) {
 			if h := mapValue(target, "host"); h != nil {
 				host = h.Value
 			}
-			warnIfNullTLS(logger, target, name, host)
+			warnIfNull(logger, target, name, host, "tls",
+				"empty tls block inherits the scope's TLS settings; remove the key to inherit, or give it fields to override")
+			// A bare `username:` reads as "no username" and does the opposite:
+			// yaml.v3 decodes it to the same nil an omitted key produces, so the
+			// scope's credential is inherited. Only an empty string is present.
+			for _, key := range []string{"username", "password"} {
+				warnIfNull(logger, target, name, host, key,
+					"empty "+key+` key inherits the scope's value; write `+key+`: "" to connect without one`)
+			}
 		}
 	}
 }
 
-func warnIfNullTLS(logger *slog.Logger, node *yaml.Node, policy, where string) {
-	tls := mapValue(node, "tls")
-	if tls == nil || tls.Tag != "!!null" {
+func warnIfNull(logger *slog.Logger, node *yaml.Node, policy, where, key, msg string) {
+	value := mapValue(node, key)
+	if value == nil || value.Tag != "!!null" {
 		return
 	}
-	logger.Warn("empty tls block inherits the scope's TLS settings; remove the key to inherit, or give it fields to override",
-		"policy", policy, "target", where)
+	logger.Warn(msg, "policy", policy, "target", where)
 }
 
 // mapValue returns the value node for key in a mapping node, or nil.

--- a/orb-discovery/gnmi-discovery/config/unknown_keys.go
+++ b/orb-discovery/gnmi-discovery/config/unknown_keys.go
@@ -160,14 +160,66 @@ func warnIfNull(logger *slog.Logger, node *yaml.Node, policy, where, key, msg st
 }
 
 // mapValue returns the value node for key in a mapping node, or nil.
+//
+// It follows aliases and honours `<<` merge keys, because the decoder does. A
+// walker that only matched literal keys went blind on any policy written with
+// anchors: a target inheriting `username: null` through a merge decodes to the
+// same nil as a target that wrote it directly, so it would silently take the
+// scope's credential while the direct one was warned about.
 func mapValue(node *yaml.Node, key string) *yaml.Node {
+	node = resolveAlias(node)
 	if node == nil || node.Kind != yaml.MappingNode {
 		return nil
 	}
+
+	var merged []*yaml.Node
 	for i := 0; i+1 < len(node.Content); i += 2 {
-		if node.Content[i].Value == key {
-			return node.Content[i+1]
+		k, v := node.Content[i], node.Content[i+1]
+		if k.Value == key {
+			// An explicit key wins over anything merged, which is YAML's own
+			// rule, so this returns before the merge sources are consulted.
+			return resolveAlias(v)
 		}
+		if k.Tag == mergeTag || k.Value == "<<" {
+			merged = append(merged, v)
+		}
+	}
+
+	// A merge value is a mapping or a sequence of them, earlier entries taking
+	// precedence — again YAML's rule, and why this returns on the first hit.
+	for _, m := range merged {
+		m = resolveAlias(m)
+		if m == nil {
+			continue
+		}
+		if m.Kind == yaml.SequenceNode {
+			for _, item := range m.Content {
+				if found := mapValue(item, key); found != nil {
+					return found
+				}
+			}
+			continue
+		}
+		if found := mapValue(m, key); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// mergeTag is the tag yaml.v3 gives a `<<` key.
+const mergeTag = "!!merge"
+
+// resolveAlias follows an alias to the node it names.
+func resolveAlias(n *yaml.Node) *yaml.Node {
+	// Bounded rather than a bare loop: yaml.v3 rejects a recursive anchor, but
+	// this walker runs on operator-supplied input and must not be the thing that
+	// spins on a malformed document.
+	for range 100 {
+		if n == nil || n.Kind != yaml.AliasNode {
+			return n
+		}
+		n = n.Alias
 	}
 	return nil
 }

--- a/orb-discovery/gnmi-discovery/config/unknown_keys.go
+++ b/orb-discovery/gnmi-discovery/config/unknown_keys.go
@@ -25,12 +25,20 @@ import (
 var unknownFieldRe = regexp.MustCompile(`field (.+) not found in type (\S+)$`)
 
 // narrowedTypes are the blocks whose keys are a closed, documented set. The
-// policy map, scope entries and surrounding YAML carry operator-chosen keys
-// and anchors with no set to check against, so reporting those would fire on
-// correct files and train operators to ignore the warning.
+// policy map and the surrounding YAML carry operator-chosen names and anchors
+// with no set to check against, so reporting those would fire on correct files
+// and train operators to ignore the warning.
+//
+// The scope and target blocks matter most here. A misspelled scope-level
+// `usernme` is silently dropped by the permissive decode, and every target in
+// the range then authenticates with no username at all — a whole subnet failing
+// for a reason nothing reports.
 var narrowedTypes = map[string]bool{
 	"config.PolicyConfig": true,
 	"config.Options":      true,
+	"config.Scope":        true,
+	"config.Target":       true,
+	"config.TLSConfig":    true,
 }
 
 // WarnUnknownPolicyKeys logs one warning per unrecognized key in a policy's
@@ -77,4 +85,69 @@ func yamlFieldNames(t reflect.Type) map[string]bool {
 		}
 	}
 	return names
+}
+
+// WarnNullTLSBlocks reports a `tls:` key written with nothing under it.
+//
+// Target.TLS is a pointer so that nil can mean "inherit the scope's block", and
+// a null node unmarshals to exactly that nil. So an operator who writes a bare
+// `tls:` on a target to mean "no TLS settings here" gets the opposite: the
+// scope's block, complete with whatever skip_verify or CA path it carries. The
+// distinction is invisible after unmarshalling, so it has to be caught on the
+// raw document.
+func WarnNullTLSBlocks(data []byte, logger *slog.Logger) {
+	if logger == nil {
+		return
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil || len(doc.Content) == 0 {
+		return
+	}
+	policies := mapValue(doc.Content[0], "policies")
+	if policies == nil {
+		return
+	}
+	// A mapping node interleaves keys and values, so names and bodies are read
+	// two at a time.
+	for i := 0; i+1 < len(policies.Content); i += 2 {
+		name, body := policies.Content[i].Value, policies.Content[i+1]
+		scope := mapValue(body, "scope")
+		if scope == nil {
+			continue
+		}
+		warnIfNullTLS(logger, scope, name, "scope")
+		targets := mapValue(scope, "targets")
+		if targets == nil {
+			continue
+		}
+		for _, target := range targets.Content {
+			host := "?"
+			if h := mapValue(target, "host"); h != nil {
+				host = h.Value
+			}
+			warnIfNullTLS(logger, target, name, host)
+		}
+	}
+}
+
+func warnIfNullTLS(logger *slog.Logger, node *yaml.Node, policy, where string) {
+	tls := mapValue(node, "tls")
+	if tls == nil || tls.Tag != "!!null" {
+		return
+	}
+	logger.Warn("empty tls block inherits the scope's TLS settings; remove the key to inherit, or give it fields to override",
+		"policy", policy, "target", where)
+}
+
+// mapValue returns the value node for key in a mapping node, or nil.
+func mapValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
 }

--- a/orb-discovery/gnmi-discovery/config/unknown_keys.go
+++ b/orb-discovery/gnmi-discovery/config/unknown_keys.go
@@ -100,13 +100,18 @@ func yamlFieldNames(t reflect.Type) map[string]bool {
 
 // WarnAmbiguousNullKeys reports an inheritable key written with nothing under it.
 //
-// Target.TLS, Username and Password are pointers so that nil can mean "inherit
-// the scope's value", and a null node unmarshals to exactly that nil. So an
-// operator who writes a bare `tls:` or `username:` to mean "nothing here" gets
-// the opposite — the scope's value, complete with whatever credential or
-// skip_verify it carries. yaml.v3 gives `key:` and `key: null` the same nil, so
-// the distinction is invisible after unmarshalling and has to be caught on the
-// raw document.
+// Every inheritable field a target can override — tls, username, password and
+// origin — is a pointer so that nil can mean "inherit the scope's value", and a
+// null node unmarshals to exactly that nil. So an operator who writes a bare
+// `tls:` or `origin:` to mean "nothing here" gets the opposite: the scope's
+// value, complete with whatever credential, skip_verify or vendor origin it
+// carries. yaml.v3 gives `key:` and `key: null` the same nil, so the distinction
+// is invisible after unmarshalling and has to be caught on the raw document.
+//
+// All four are checked. Leaving origin out was its own bug: a target meant to
+// use origin-less paths silently took the scope's vendor origin, and the failure
+// then surfaced as its Subscribe or Get paths being rejected by the device, with
+// nothing connecting that back to the policy.
 func WarnAmbiguousNullKeys(data []byte, logger *slog.Logger) {
 	if logger == nil {
 		return
@@ -143,10 +148,15 @@ func WarnAmbiguousNullKeys(data []byte, logger *slog.Logger) {
 				"empty tls block inherits the scope's TLS settings; remove the key to inherit, or give it fields to override")
 			// A bare `username:` reads as "no username" and does the opposite:
 			// yaml.v3 decodes it to the same nil an omitted key produces, so the
-			// scope's credential is inherited. Only an empty string is present.
-			for _, key := range []string{"username", "password"} {
-				warnIfNull(logger, target, name, host, key,
-					"empty "+key+` key inherits the scope's value; write `+key+`: "" to connect without one`)
+			// scope's value is inherited. Only an empty string is present, and the
+			// guidance differs per field because what "" means differs.
+			for _, f := range []struct{ key, fix string }{
+				{"username", `write username: "" to connect without one`},
+				{"password", `write password: "" to connect without one`},
+				{"origin", `write origin: "" for origin-less paths`},
+			} {
+				warnIfNull(logger, target, name, host, f.key,
+					"empty "+f.key+" key inherits the scope's value; "+f.fix)
 			}
 		}
 	}

--- a/orb-discovery/gnmi-discovery/config/unknown_keys.go
+++ b/orb-discovery/gnmi-discovery/config/unknown_keys.go
@@ -119,10 +119,11 @@ func WarnAmbiguousNullKeys(data []byte, logger *slog.Logger) {
 	if policies == nil {
 		return
 	}
-	// A mapping node interleaves keys and values, so names and bodies are read
-	// two at a time.
-	for i := 0; i+1 < len(policies.Content); i += 2 {
-		name, body := policies.Content[i].Value, policies.Content[i+1]
+	// Through mapEntries, not policies.Content: a policies map may itself import
+	// entries with `<<`, and reading the raw content visits the merge key instead
+	// of the policies it brought in.
+	for _, entry := range mapEntries(policies, maxMergeDepth) {
+		name, body := entry[0].Value, entry[1]
 		scope := mapValue(body, "scope")
 		if scope == nil {
 			continue
@@ -159,49 +160,74 @@ func warnIfNull(logger *slog.Logger, node *yaml.Node, policy, where, key, msg st
 	logger.Warn(msg, "policy", policy, "target", where)
 }
 
-// mapValue returns the value node for key in a mapping node, or nil.
+// mapEntries returns a mapping's effective key/value pairs, following aliases
+// and `<<` merge keys the way the decoder does.
 //
-// It follows aliases and honours `<<` merge keys, because the decoder does. A
-// walker that only matched literal keys went blind on any policy written with
-// anchors: a target inheriting `username: null` through a merge decodes to the
-// same nil as a target that wrote it directly, so it would silently take the
-// scope's credential while the direct one was warned about.
-func mapValue(node *yaml.Node, key string) *yaml.Node {
+// This is the primitive; both the lookup below and the policy enumeration are
+// expressed through it. They were separate once, and the split was the bug: the
+// lookup learned to resolve merges while the enumeration still read
+// node.Content directly, so policies imported into the map through `<<` were
+// decoded normally and never walked at all.
+//
+// Precedence is YAML's own: an explicit key beats anything merged, and among
+// merge sources the earlier entry wins. Both fall out of taking the first
+// occurrence of a name and ignoring the rest.
+func mapEntries(node *yaml.Node, depth int) [][2]*yaml.Node {
 	node = resolveAlias(node)
-	if node == nil || node.Kind != yaml.MappingNode {
+	if node == nil || node.Kind != yaml.MappingNode || depth <= 0 {
 		return nil
 	}
 
+	var out [][2]*yaml.Node
+	seen := make(map[string]bool, len(node.Content)/2)
 	var merged []*yaml.Node
+
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		k, v := node.Content[i], node.Content[i+1]
-		if k.Value == key {
-			// An explicit key wins over anything merged, which is YAML's own
-			// rule, so this returns before the merge sources are consulted.
-			return resolveAlias(v)
-		}
 		if k.Tag == mergeTag || k.Value == "<<" {
 			merged = append(merged, v)
+			continue
 		}
+		if seen[k.Value] {
+			continue
+		}
+		seen[k.Value] = true
+		out = append(out, [2]*yaml.Node{k, resolveAlias(v)})
 	}
 
-	// A merge value is a mapping or a sequence of them, earlier entries taking
-	// precedence — again YAML's rule, and why this returns on the first hit.
 	for _, m := range merged {
 		m = resolveAlias(m)
 		if m == nil {
 			continue
 		}
+		sources := []*yaml.Node{m}
 		if m.Kind == yaml.SequenceNode {
-			for _, item := range m.Content {
-				if found := mapValue(item, key); found != nil {
-					return found
-				}
-			}
-			continue
+			sources = m.Content
 		}
-		if found := mapValue(m, key); found != nil {
-			return found
+		for _, src := range sources {
+			for _, e := range mapEntries(src, depth-1) {
+				if seen[e[0].Value] {
+					continue
+				}
+				seen[e[0].Value] = true
+				out = append(out, e)
+			}
+		}
+	}
+	return out
+}
+
+// maxMergeDepth bounds how far merge keys are followed. A merge chain is finite
+// in any document yaml.v3 accepts, but this walker runs on operator-supplied
+// input and must not be the thing that overflows the stack on a self-referential
+// one.
+const maxMergeDepth = 32
+
+// mapValue returns the value node for key in a mapping node, or nil.
+func mapValue(node *yaml.Node, key string) *yaml.Node {
+	for _, e := range mapEntries(node, maxMergeDepth) {
+		if e[0].Value == key {
+			return e[1]
 		}
 	}
 	return nil

--- a/orb-discovery/gnmi-discovery/config/unknown_keys.go
+++ b/orb-discovery/gnmi-discovery/config/unknown_keys.go
@@ -39,6 +39,17 @@ var narrowedTypes = map[string]bool{
 	"config.Scope":        true,
 	"config.Target":       true,
 	"config.TLSConfig":    true,
+
+	// The defaults blocks, where a typo silently drops a NetBox default and the
+	// entities land with the built-in value instead of the operator's.
+	"config.Defaults":          true,
+	"config.DeviceDefaults":    true,
+	"config.InterfaceDefaults": true,
+	"config.PrefixDefaults":    true,
+	"config.VlanDefaults":      true,
+	"config.IPAddressDefaults": true,
+	"config.VRFDefaults":       true,
+	"config.InterfacePattern":  true,
 }
 
 // WarnUnknownPolicyKeys logs one warning per unrecognized key in a policy's

--- a/orb-discovery/gnmi-discovery/config/unknown_keys_test.go
+++ b/orb-discovery/gnmi-discovery/config/unknown_keys_test.go
@@ -82,8 +82,8 @@ policies:
 	require.Contains(t, out, "bogus key")
 }
 
-// Only the config and options blocks are checked. Warning on blocks that carry
-// operator-chosen keys would fire on correct files.
+// Blocks that are not a closed, documented set stay silent. Warning on those
+// would fire on correct files and train operators to ignore the warning.
 func TestBlocksWithOperatorChosenKeysStaySilent(t *testing.T) {
 	out := captureWarnings(t, `
 policies:
@@ -94,9 +94,28 @@ policies:
     scope:
       targets:
         - host: 10.0.0.1
-          stray_target: 1
 `)
-	assert.Empty(t, out, "expected silence outside config and options")
+	assert.Empty(t, out, "expected silence outside the narrowed blocks")
+}
+
+// A misspelled scope credential is the expensive one: the permissive decode
+// drops it, and every target in the range then authenticates with no username at
+// all — a whole subnet failing for a reason nothing else reports.
+func TestMisspelledScopeAndTargetKeysAreReported(t *testing.T) {
+	out := captureWarnings(t, `
+policies:
+  p1:
+    scope:
+      usernme: admin
+      targets:
+        - host: 10.0.0.1
+          passwrd: hunter2
+          tls:
+            skip_verfy: true
+`)
+	assert.Contains(t, out, "usernme")
+	assert.Contains(t, out, "passwrd")
+	assert.Contains(t, out, "skip_verfy")
 }
 
 func TestValidPolicyIsSilent(t *testing.T) {
@@ -125,4 +144,43 @@ func TestNilLoggerIsSafe(t *testing.T) {
 	assert.NotPanics(t, func() {
 		WarnUnknownPolicyKeys([]byte("policies:\n  p1:\n    config:\n      bogus: 1\n"), nil)
 	})
+}
+
+// A bare `tls:` reads as "no TLS settings here" and means the opposite: a null
+// node unmarshals to the nil that signals inheritance, so the target silently
+// picks up the scope's block — skip_verify, CA path and all.
+func TestBareTLSKeyIsReported(t *testing.T) {
+	out := captureNullTLSWarnings(t, `
+policies:
+  p1:
+    scope:
+      tls:
+        skip_verify: true
+      targets:
+        - host: 10.0.0.1
+          tls:
+        - host: 10.0.0.2
+`)
+	assert.Contains(t, out, "10.0.0.1")
+	assert.NotContains(t, out, "10.0.0.2", "an absent tls key is the normal way to inherit")
+}
+
+func TestFilledTLSBlocksAreSilent(t *testing.T) {
+	out := captureNullTLSWarnings(t, `
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.1
+          tls:
+            insecure: true
+`)
+	assert.Empty(t, out)
+}
+
+func captureNullTLSWarnings(t *testing.T, doc string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	WarnNullTLSBlocks([]byte(doc), slog.New(slog.NewTextHandler(&buf, nil)))
+	return buf.String()
 }

--- a/orb-discovery/gnmi-discovery/config/unknown_keys_test.go
+++ b/orb-discovery/gnmi-discovery/config/unknown_keys_test.go
@@ -188,7 +188,7 @@ func TestNilLoggerIsSafe(t *testing.T) {
 // node unmarshals to the nil that signals inheritance, so the target silently
 // picks up the scope's block — skip_verify, CA path and all.
 func TestBareTLSKeyIsReported(t *testing.T) {
-	out := captureNullTLSWarnings(t, `
+	out := captureNullKeyWarnings(t, `
 policies:
   p1:
     scope:
@@ -204,7 +204,7 @@ policies:
 }
 
 func TestFilledTLSBlocksAreSilent(t *testing.T) {
-	out := captureNullTLSWarnings(t, `
+	out := captureNullKeyWarnings(t, `
 policies:
   p1:
     scope:
@@ -216,9 +216,36 @@ policies:
 	assert.Empty(t, out)
 }
 
-func captureNullTLSWarnings(t *testing.T, doc string) string {
+func captureNullKeyWarnings(t *testing.T, doc string) string {
 	t.Helper()
 	var buf bytes.Buffer
-	WarnNullTLSBlocks([]byte(doc), slog.New(slog.NewTextHandler(&buf, nil)))
+	WarnAmbiguousNullKeys([]byte(doc), slog.New(slog.NewTextHandler(&buf, nil)))
 	return buf.String()
+}
+
+// yaml.v3 gives `username:` and `username: null` the same nil pointer an omitted
+// key produces, so a bare credential key reads as "no username" and silently
+// does the opposite: it inherits the scope's. Only an empty string is present.
+func TestBareCredentialKeysAreReported(t *testing.T) {
+	out := captureNullKeyWarnings(t, `
+policies:
+  p1:
+    scope:
+      username: admin
+      password: campus-secret
+      targets:
+        - host: 10.0.0.1
+          username:
+        - host: 10.0.0.2
+          password: null
+        - host: 10.0.0.3
+          username: ""
+        - host: 10.0.0.4
+`)
+	assert.Contains(t, out, "10.0.0.1")
+	assert.Contains(t, out, "empty username key")
+	assert.Contains(t, out, "10.0.0.2")
+	assert.Contains(t, out, "empty password key")
+	assert.NotContains(t, out, "10.0.0.3", `username: "" is present, and does what it says`)
+	assert.NotContains(t, out, "10.0.0.4", "an absent key is the normal way to inherit")
 }

--- a/orb-discovery/gnmi-discovery/config/unknown_keys_test.go
+++ b/orb-discovery/gnmi-discovery/config/unknown_keys_test.go
@@ -249,3 +249,64 @@ policies:
 	assert.NotContains(t, out, "10.0.0.3", `username: "" is present, and does what it says`)
 	assert.NotContains(t, out, "10.0.0.4", "an absent key is the normal way to inherit")
 }
+
+// Anchors and merge keys are ordinary YAML, and the decoder honours them. A
+// walker that matched only literal keys went blind on any policy using them: a
+// target inheriting `username: null` through a merge decodes to the same nil as
+// one that wrote it directly, so it silently took the scope's credential while
+// the direct one was warned about.
+func TestNullCredentialsInheritedThroughAMergeAreReported(t *testing.T) {
+	out := captureNullKeyWarnings(t, `
+policies:
+  p1:
+    scope:
+      username: admin
+      password: campus-secret
+      targets:
+        - &anon
+          host: 10.0.0.1
+          username: null
+        - <<: *anon
+          host: 10.0.0.2
+        - host: 10.0.0.3
+`)
+	assert.Contains(t, out, "10.0.0.1", "the direct null")
+	assert.Contains(t, out, "10.0.0.2", "the same null reached through a merge")
+	assert.NotContains(t, out, "10.0.0.3", "a target that inherits normally is silent")
+}
+
+// An explicit key beats a merged one, which is YAML's own precedence rule.
+func TestAnExplicitKeyOverridesAMergedNull(t *testing.T) {
+	out := captureNullKeyWarnings(t, `
+policies:
+  p1:
+    scope:
+      username: admin
+      targets:
+        - &base
+          host: 10.0.0.1
+          username: null
+        - <<: *base
+          host: 10.0.0.2
+          username: legacy
+`)
+	assert.Contains(t, out, "10.0.0.1")
+	assert.NotContains(t, out, "10.0.0.2", "the explicit username wins over the merged null")
+}
+
+// A whole target supplied as an alias is still walked.
+func TestATargetSuppliedAsAnAliasIsWalked(t *testing.T) {
+	out := captureNullKeyWarnings(t, `
+policies:
+  p1:
+    scope:
+      username: admin
+      targets:
+        - &whole
+          host: 10.0.0.1
+          tls:
+        - *whole
+`)
+	assert.Contains(t, out, "10.0.0.1")
+	assert.Contains(t, out, "tls block")
+}

--- a/orb-discovery/gnmi-discovery/config/unknown_keys_test.go
+++ b/orb-discovery/gnmi-discovery/config/unknown_keys_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -309,4 +310,75 @@ policies:
 `)
 	assert.Contains(t, out, "10.0.0.1")
 	assert.Contains(t, out, "tls block")
+}
+
+// A policies map may itself import entries with `<<`. The decoder brings them in
+// normally, so a merged policy's targets are live — and reading policies.Content
+// directly visited the merge key instead of the policies it imported, so those
+// targets were never walked at all.
+func TestPoliciesImportedThroughAMergeAreWalked(t *testing.T) {
+	out := captureNullKeyWarnings(t, `
+shared: &shared
+  p1:
+    scope:
+      username: admin
+      password: campus-secret
+      targets:
+        - host: 10.0.0.1
+          username: null
+policies:
+  <<: *shared
+  p2:
+    scope:
+      username: admin
+      targets:
+        - host: 10.0.0.2
+          username: null
+`)
+	assert.Contains(t, out, "10.0.0.1", "the merged policy's target")
+	assert.Contains(t, out, "10.0.0.2", "the literal policy's target")
+}
+
+// An explicit policy name beats a merged one of the same name, which is YAML's
+// own rule and therefore what the decoder will use.
+func TestAnExplicitPolicyOverridesAMergedOneOfTheSameName(t *testing.T) {
+	out := captureNullKeyWarnings(t, `
+shared: &shared
+  p1:
+    scope:
+      username: admin
+      targets:
+        - host: 10.0.0.1
+          username: null
+policies:
+  <<: *shared
+  p1:
+    scope:
+      targets:
+        - host: 10.9.9.9
+`)
+	assert.NotContains(t, out, "10.0.0.1", "the merged p1 is shadowed and never applied")
+	assert.NotContains(t, out, "10.9.9.9", "the winning p1 has nothing to warn about")
+}
+
+// A self-referential merge must not take the walker down with it. yaml.v3
+// rejects most of these before this code runs, but the walker reads
+// operator-supplied input and should not be what overflows the stack.
+func TestASelfReferentialMergeTerminates(t *testing.T) {
+	done := make(chan string, 1)
+	go func() {
+		done <- captureNullKeyWarnings(t, `
+policies: &loop
+  <<: *loop
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.1
+`)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("WarnAmbiguousNullKeys did not terminate on a self-referential merge")
+	}
 }

--- a/orb-discovery/gnmi-discovery/config/unknown_keys_test.go
+++ b/orb-discovery/gnmi-discovery/config/unknown_keys_test.go
@@ -382,3 +382,50 @@ policies: &loop
 		t.Fatal("WarnAmbiguousNullKeys did not terminate on a self-referential merge")
 	}
 }
+
+// origin is the fourth inheritable pointer field and was the one left out of this
+// check. A target meant to use origin-less paths writes `origin: ""`; a bare
+// `origin:` decodes to the same nil an omitted key produces, so it takes the
+// scope's vendor origin instead and the device then rejects its Subscribe or Get
+// paths, with nothing connecting that back to the policy.
+func TestABareOriginKeyIsReported(t *testing.T) {
+	out := captureNullKeyWarnings(t, `
+policies:
+  p1:
+    scope:
+      origin: srl_nokia
+      targets:
+        - host: 10.0.0.1
+          origin:
+        - host: 10.0.0.2
+          origin: null
+        - host: 10.0.0.3
+          origin: ""
+        - host: 10.0.0.4
+`)
+	assert.Contains(t, out, "10.0.0.1")
+	assert.Contains(t, out, "10.0.0.2")
+	assert.Contains(t, out, "empty origin key")
+	// slog escapes the quotes in its own output, so match the stable half.
+	assert.Contains(t, out, "for origin-less paths")
+	assert.NotContains(t, out, "10.0.0.3", `origin: "" is present and means what it says`)
+	assert.NotContains(t, out, "10.0.0.4", "an absent key is the normal way to inherit")
+}
+
+// Each field's guidance says what "" means for that field, since it is not the
+// same thing for a credential and for a path origin.
+func TestNullKeyGuidanceIsPerField(t *testing.T) {
+	out := captureNullKeyWarnings(t, `
+policies:
+  p1:
+    scope:
+      username: admin
+      origin: srl_nokia
+      targets:
+        - host: 10.0.0.1
+          username:
+          origin:
+`)
+	assert.Contains(t, out, "to connect without one")
+	assert.Contains(t, out, "for origin-less paths")
+}

--- a/orb-discovery/gnmi-discovery/config/unknown_keys_test.go
+++ b/orb-discovery/gnmi-discovery/config/unknown_keys_test.go
@@ -82,20 +82,58 @@ policies:
 	require.Contains(t, out, "bogus key")
 }
 
-// Blocks that are not a closed, documented set stay silent. Warning on those
-// would fire on correct files and train operators to ignore the warning.
+// Blocks that are not a closed, documented set stay silent. Policy names and the
+// surrounding agent config are operator-chosen, so warning on them would fire on
+// correct files and train operators to ignore the warning.
 func TestBlocksWithOperatorChosenKeysStaySilent(t *testing.T) {
 	out := captureWarnings(t, `
 policies:
-  p1:
-    config:
-      defaults:
-        stray_default: 1
+  a_policy_name_nobody_can_predict:
     scope:
       targets:
         - host: 10.0.0.1
 `)
 	assert.Empty(t, out, "expected silence outside the narrowed blocks")
+}
+
+// A key written at the wrong indent level lands in a neighbouring block, where
+// the permissive decode drops it and the feature it configures never turns on.
+// This is the mistake a copied sample propagates.
+func TestAKeyInTheWrongBlockIsReported(t *testing.T) {
+	out := captureWarnings(t, `
+policies:
+  p1:
+    config:
+      defaults:
+        site: New York NY
+        rescan_interval_ms: 3600000
+    scope:
+      targets:
+        - host: 10.0.0.1
+`)
+	assert.Contains(t, out, "rescan_interval_ms")
+}
+
+// A typo inside a defaults block silently ships the built-in value instead of
+// the operator's.
+func TestMisspelledDefaultsKeysAreReported(t *testing.T) {
+	out := captureWarnings(t, `
+policies:
+  p1:
+    config:
+      defaults:
+        rol: Router
+        device:
+          manufacurer: Acme
+        interface:
+          if_typ: other
+    scope:
+      targets:
+        - host: 10.0.0.1
+`)
+	assert.Contains(t, out, "rol")
+	assert.Contains(t, out, "manufacurer")
+	assert.Contains(t, out, "if_typ")
 }
 
 // A misspelled scope credential is the expensive one: the permissive decode

--- a/orb-discovery/gnmi-discovery/policy/coverage_boost_test.go
+++ b/orb-discovery/gnmi-discovery/policy/coverage_boost_test.go
@@ -314,12 +314,12 @@ policies:
 
 func TestEnsurePortEmpty(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, "", ensurePort(""))
+	require.Equal(t, "", ensurePort("", config.DefaultGNMIPort))
 }
 
 func TestEnsurePort(t *testing.T) {
 	t.Parallel()
-	dp := config.DefaultGNMIPort
+	var dp uint16 = config.DefaultGNMIPort
 	cases := map[string]string{
 		"10.0.0.1":                 fmt.Sprintf("10.0.0.1:%d", dp),            // IPv4, no port
 		"10.0.0.1:830":             "10.0.0.1:830",                            // IPv4 with port (unchanged)
@@ -332,7 +332,7 @@ func TestEnsurePort(t *testing.T) {
 		"fe80::1%eth0":             fmt.Sprintf("[fe80::1%%eth0]:%d", dp),     // zone-qualified IPv6 -> bracketed
 	}
 	for in, want := range cases {
-		require.Equal(t, want, ensurePort(in), "ensurePort(%q)", in)
+		require.Equal(t, want, ensurePort(in, dp), "ensurePort(%q)", in)
 	}
 }
 

--- a/orb-discovery/gnmi-discovery/policy/coverage_boost_test.go
+++ b/orb-discovery/gnmi-discovery/policy/coverage_boost_test.go
@@ -36,7 +36,8 @@ func TestNewManagerBadProfilesDir(t *testing.T) {
 	t.Parallel()
 	// A non-existent override dir is treated as "no overrides" (warn + continue)
 	// by LoadProfilesWithLogger, so NewManager must succeed.
-	m, err := NewManager(context.Background(), slog.Default(), nil,
+	m, err := NewManager(
+		context.Background(), slog.Default(), nil,
 		&gnmi.FakeDialer{Session: &gnmi.FakeSession{}},
 		"/nonexistent/profiles/dir/that/cannot/exist",
 	)

--- a/orb-discovery/gnmi-discovery/policy/credential_boundary_test.go
+++ b/orb-discovery/gnmi-discovery/policy/credential_boundary_test.go
@@ -1,0 +1,240 @@
+package policy
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/gnmi"
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/mapping"
+)
+
+// The anonymous probe only postpones the credential by one RPC: admission is
+// deliberately broad, and the subscription that follows sends this policy's
+// password to whatever was admitted. Without TLS authenticating the far end,
+// that means any service listening on the gNMI port inside the range.
+//
+// Refused by default because it is reachable by accident — a range that overlaps
+// a server VLAN is a typo, not an attack.
+func TestACredentialedRangeWithoutServerAuthIsRefused(t *testing.T) {
+	for name, tlsBlock := range map[string]string{
+		"skip_verify": "        skip_verify: true\n",
+		// Worse than skip_verify: plaintext, so the password is also sniffable.
+		"insecure": "        insecure: true\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			m := newTestManager(t)
+			_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      username: admin
+      password: campus-secret
+      tls:
+` + tlsBlock + `      targets:
+        - host: 10.0.0.0/24
+`))
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "10.0.0.0/24")
+			require.Contains(t, err.Error(), "send_credentials_to_unverified_targets",
+				"the error has to name the way out")
+		})
+	}
+}
+
+// Ranges are what changes the exposure: an attacker needs only to listen on a
+// free address, rather than intercept a connection to a host the operator named.
+// So naming the host explicitly is unaffected — the operator said where the
+// credential may go.
+func TestACredentialedExplicitHostIsUnaffected(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      username: admin
+      password: campus-secret
+      tls:
+        skip_verify: true
+      targets:
+        - host: 10.0.0.11:6030
+        - host: switch-a.example.com
+        - host: fe80::1%br-lan
+`))
+	require.NoError(t, err, "an explicitly named host is the operator's own decision")
+}
+
+// Verified TLS authenticates the far end, so the credential only reaches
+// endpoints the operator's CA vouches for. That is the supported way to do
+// credentialed range discovery.
+func TestACredentialedRangeWithVerifiedTLSIsAllowed(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      username: admin
+      password: campus-secret
+      tls:
+        ca: /run/secrets/ca.pem
+      targets:
+        - host: 10.0.0.0/24
+`))
+	require.NoError(t, err)
+
+	// The default is verified TLS with the system roots, which is also fine.
+	_, err = m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      username: admin
+      password: campus-secret
+      targets:
+        - host: 10.0.0.0/24
+`))
+	require.NoError(t, err, "no tls block means verified TLS with the system roots")
+}
+
+// The gate is on the password, not on any credential. A client certificate is
+// not a bearer secret — TLS binds possession to the session, so an endpoint that
+// receives one cannot replay it or relay it to a real device. Gating it would
+// break mTLS range discovery, which is the strongest configuration available.
+func TestMTLSWithoutAPasswordIsAllowedOverARange(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      tls:
+        skip_verify: true
+        cert: /run/secrets/client.pem
+        key: /run/secrets/client.key
+      targets:
+        - host: 10.0.0.0/24
+`))
+	require.NoError(t, err, "no password means no bearer secret to disclose")
+}
+
+// A username is not a secret — it is usually "admin" — and gating on it would
+// refuse mTLS plus a username over a range, which discloses nothing reusable.
+func TestAUsernameWithoutAPasswordIsAllowedOverARange(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      username: admin
+      tls:
+        skip_verify: true
+      targets:
+        - host: 10.0.0.0/24
+`))
+	require.NoError(t, err)
+}
+
+// An explicitly emptied password blocks inheritance, so it must also clear the
+// gate: that target sends no secret.
+func TestAnEmptiedPasswordClearsTheGate(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      username: admin
+      password: campus-secret
+      tls:
+        skip_verify: true
+      targets:
+        - host: 10.0.0.0/24
+          password: ""
+`))
+	require.NoError(t, err, "the range inherits no password, so nothing is disclosed")
+}
+
+// The opt-in permits it, and says so out loud every time the policy is applied.
+func TestTheOptInPermitsItAndWarns(t *testing.T) {
+	var logs bytes.Buffer
+	m := newManagerWithLogger(t, slog.New(slog.NewTextHandler(&logs, nil)))
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    config:
+      send_credentials_to_unverified_targets: true
+    scope:
+      username: admin
+      password: campus-secret
+      tls:
+        skip_verify: true
+      targets:
+        - host: 10.0.0.0/24
+`))
+	require.NoError(t, err)
+	require.Contains(t, logs.String(), "not authenticated",
+		"opting in does not make it quiet")
+	require.Contains(t, logs.String(), "range_targets=1")
+}
+
+// And it stays visible after the day it was set: the sweep run carries it, so it
+// shows in Fleet rather than only in a container log nobody re-reads.
+func TestTheSweepRunReportsTheUnverifiedCredentialOptIn(t *testing.T) {
+	m := newTestManager(t)
+	policies, err := m.ParsePolicies([]byte(`
+policies:
+  campus:
+    config:
+      send_credentials_to_unverified_targets: true
+    scope:
+      username: admin
+      password: campus-secret
+      tls:
+        skip_verify: true
+      targets:
+        - host: 10.0.0.0/30
+`))
+	require.NoError(t, err)
+
+	dialer := newPerHostDialer(nil)
+	dialer.defaultCapsErr = dialingErr()
+	store, err := mapping.LoadProfiles("")
+	require.NoError(t, err)
+	r, err := NewRunner(t.Context(), slog.New(slog.DiscardHandler), "campus",
+		policies["campus"], &recordingClient{}, dialer, store)
+	require.NoError(t, err)
+	r.backoffBase = time.Millisecond
+	r.Start()
+	t.Cleanup(func() { _ = r.Stop() })
+
+	run := sweepRunFor(t, r)
+	require.Contains(t, run.Reason, "not authenticated")
+	require.Contains(t, run.Reason, "1 range target(s)")
+}
+
+// A policy on the supported path says nothing about it.
+func TestASweepRunIsSilentWhenTheServerIsVerified(t *testing.T) {
+	policy := config.Policy{
+		Config: config.PolicyConfig{Mode: config.ModeAuto, DebounceMs: 10},
+		Scope: config.Scope{
+			Targets: []config.Target{{Host: "10.0.0.0/30"}},
+		},
+	}
+	dialer := newPerHostDialer(nil)
+	dialer.defaultCapsErr = dialingErr()
+	r := newRunnerFor(t, policy, dialer)
+	r.Start()
+	t.Cleanup(func() { _ = r.Stop() })
+
+	run := sweepRunFor(t, r)
+	require.NotContains(t, run.Reason, "not authenticated")
+}
+
+func newManagerWithLogger(t *testing.T, logger *slog.Logger) *Manager {
+	t.Helper()
+	m, err := NewManager(t.Context(), logger, nil,
+		&gnmi.FakeDialer{Session: &gnmi.FakeSession{}}, "")
+	require.NoError(t, err)
+	return m
+}

--- a/orb-discovery/gnmi-discovery/policy/docs_sample_test.go
+++ b/orb-discovery/gnmi-discovery/policy/docs_sample_test.go
@@ -1,0 +1,112 @@
+package policy
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/gnmi"
+)
+
+// The documented sample must be a policy this backend actually accepts.
+//
+// Prose drifts from the parser silently, and a sample is the thing operators
+// copy: a key documented one indent level off lands in the wrong block, is
+// dropped by the permissive decode, and takes its whole feature with it.
+func TestTheDocumentedSamplePolicyIsValid(t *testing.T) {
+	t.Setenv("GNMI_USER", "admin")
+	t.Setenv("GNMI_PASS", "s3cret")
+
+	for _, tc := range []struct {
+		file string
+		path []string // keys to descend to reach the {name: policy} map
+	}{
+		{file: "../README.md", path: []string{"policies"}},
+		{file: "../../../docs/backends/gnmi_discovery.md", path: []string{"orb", "policies", "gnmi_discovery"}},
+	} {
+		t.Run(tc.file, func(t *testing.T) {
+			doc := policyBlockFromMarkdown(t, tc.file, tc.path)
+
+			var warnings bytes.Buffer
+			m, err := NewManager(context.Background(),
+				slog.New(slog.NewTextHandler(&warnings, nil)), nil,
+				&gnmi.FakeDialer{Session: &gnmi.FakeSession{}}, "")
+			require.NoError(t, err)
+
+			policies, err := m.ParsePolicies(doc)
+			require.NoError(t, err, "the documented sample must parse and validate")
+			require.NotEmpty(t, policies)
+			require.NotContains(t, warnings.String(), "unrecognized",
+				"every key in the sample must be one the parser knows")
+		})
+	}
+}
+
+// policyBlockFromMarkdown returns the first fenced yaml block in file, descended
+// through path, re-emitted as a {policies: ...} document.
+func policyBlockFromMarkdown(t *testing.T, file string, path []string) []byte {
+	t.Helper()
+	raw, err := os.ReadFile(file)
+	require.NoError(t, err)
+
+	// A page has several yaml blocks; take the one that holds a policy map, so
+	// adding an unrelated snippet above it does not silently retarget the test.
+	rest := string(raw)
+	for {
+		var ok bool
+		_, rest, ok = strings.Cut(rest, "```yaml")
+		require.True(t, ok, "%s: no yaml block contains a policy map at %v", file, path)
+		var block string
+		block, rest, ok = strings.Cut(rest, "```")
+		require.True(t, ok, "%s has an unterminated yaml block", file)
+
+		var node map[string]any
+		if err := yaml.Unmarshal([]byte(stripElisions(block)), &node); err != nil {
+			continue
+		}
+		if policies, found := descend(node, path); found {
+			out, err := yaml.Marshal(map[string]any{"policies": policies})
+			require.NoError(t, err)
+			return out
+		}
+	}
+}
+
+// descend walks path to the {name: policy} map.
+func descend(node map[string]any, path []string) (any, bool) {
+	cur := any(node)
+	for _, key := range path {
+		asMap, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		if cur, ok = asMap[key]; !ok {
+			return nil, false
+		}
+	}
+	if _, ok := cur.(map[string]any); !ok {
+		return nil, false
+	}
+	return cur, true
+}
+
+// stripElisions drops the "..." lines the docs use to mean "surrounding config
+// omitted". YAML reads a bare ... as the document-end marker, so a sample
+// carrying one does not parse as written.
+func stripElisions(block string) string {
+	lines := strings.Split(block, "\n")
+	kept := lines[:0]
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "..." {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "\n")
+}

--- a/orb-discovery/gnmi-discovery/policy/fleet_path_test.go
+++ b/orb-discovery/gnmi-discovery/policy/fleet_path_test.go
@@ -1,0 +1,106 @@
+package policy
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// asAgentWouldSend reproduces the transformation a fleet-delivered policy goes
+// through: it arrives as JSON, so every number is a float64, and the agent then
+// yaml.Marshals it into the {policies: {name: ...}} envelope it POSTs here.
+//
+// See agent/backend/gnmidiscovery, ApplyPolicy.
+func asAgentWouldSend(t *testing.T, name, policyJSON string) []byte {
+	t.Helper()
+	var data any
+	require.NoError(t, json.Unmarshal([]byte(policyJSON), &data))
+	out, err := yaml.Marshal(map[string]any{"policies": map[string]any{name: data}})
+	require.NoError(t, err)
+	return out
+}
+
+// The knobs added for subnet scope are bare integer milliseconds rather than
+// duration strings, and the stated reason was this path: a JSON number becomes a
+// float64 and re-marshals in scientific notation. That rationale was never
+// actually exercised — the other tests here all write YAML directly, which is the
+// local path, not the fleet one.
+//
+// It holds: yaml.v3 decodes an integral float into an int field, so 3.6e+06
+// arrives as 3600000. This test exists to keep it holding, because the failure
+// would only appear for fleet-delivered policies and would look like the backend
+// ignoring a value the operator set.
+func TestFleetDeliveredIntervalsSurviveTheFloatRoundTrip(t *testing.T) {
+	for _, ms := range []int{60000, 60001, 100000, 1234567, 3600000, 86400000, 999999999} {
+		t.Run(fmt.Sprint(ms), func(t *testing.T) {
+			body := asAgentWouldSend(t, "campus", fmt.Sprintf(`{
+			  "config": {"rescan_interval_ms": %d, "probe_timeout_ms": 3000, "debounce_ms": 2000},
+			  "scope": {"port": 6030, "targets": [{"host": "10.0.0.1"}]}
+			}`, ms))
+
+			m := newTestManager(t)
+			policies, err := m.ParsePolicies(body)
+			require.NoError(t, err)
+
+			c := policies["campus"].Config
+			require.Equal(t, ms, c.RescanIntervalMs, "the interval must survive as written")
+			require.Equal(t, 3000, c.ProbeTimeoutMs)
+			require.Equal(t, 2000, c.DebounceMs)
+			require.Equal(t, uint16(6030), policies["campus"].Scope.Port)
+		})
+	}
+}
+
+// The boolean opt-in travels the same path, and a safety switch that silently
+// failed to arrive would be the worst thing on it to lose.
+func TestTheCredentialOptInSurvivesTheFleetPath(t *testing.T) {
+	body := asAgentWouldSend(t, "campus", `{
+	  "config": {"send_credentials_to_unverified_targets": true},
+	  "scope": {
+	    "username": "admin", "password": "campus-secret",
+	    "tls": {"skip_verify": true},
+	    "targets": [{"host": "10.0.0.0/24"}]
+	  }
+	}`)
+
+	m := newTestManager(t)
+	policies, err := m.ParsePolicies(body)
+	require.NoError(t, err, "the opt-in has to arrive, or this policy is refused")
+	require.True(t, policies["campus"].Config.SendCredentialsToUnverifiedTargets)
+}
+
+// And without it, the same fleet-delivered policy is refused — the gate is not
+// bypassed by the delivery path.
+func TestTheCredentialGateAppliesToFleetDeliveredPolicies(t *testing.T) {
+	body := asAgentWouldSend(t, "campus", `{
+	  "config": {},
+	  "scope": {
+	    "username": "admin", "password": "campus-secret",
+	    "tls": {"skip_verify": true},
+	    "targets": [{"host": "10.0.0.0/24"}]
+	  }
+	}`)
+
+	m := newTestManager(t)
+	_, err := m.ParsePolicies(body)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "send_credentials_to_unverified_targets")
+}
+
+// Validation applies on this path too: a sub-floor rescan is still rejected, and
+// is small enough not to be re-marshalled in scientific notation, so it exercises
+// the plain-integer case as well.
+func TestFleetDeliveredValidationStillApplies(t *testing.T) {
+	body := asAgentWouldSend(t, "campus", `{
+	  "config": {"rescan_interval_ms": 5000},
+	  "scope": {"targets": [{"host": "10.0.0.1"}]}
+	}`)
+
+	m := newTestManager(t)
+	_, err := m.ParsePolicies(body)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "rescan_interval_ms")
+}

--- a/orb-discovery/gnmi-discovery/policy/manager.go
+++ b/orb-discovery/gnmi-discovery/policy/manager.go
@@ -217,10 +217,16 @@ func (m *Manager) resolveEnv(policy *config.Policy) error {
 		t := &policy.Scope.Targets[i]
 		// Resolve every string field a user is likely to source from env: host,
 		// credentials, and TLS material paths.
-		for _, f := range []*string{
-			&t.Host, &t.Username, &t.Password,
-			&t.TLS.CAFile, &t.TLS.CertFile, &t.TLS.KeyFile,
-		} {
+		fields := []*string{&t.Host, &t.Username, &t.Password}
+		// TLS is a pointer, and taking the address of a field through a nil one
+		// panics rather than failing to compile. No tls block is the common
+		// case, so this guard is on the hot path, not an edge case. ResolvedTLS
+		// cannot serve here: it returns a copy, so writing through it would not
+		// propagate.
+		if t.TLS != nil {
+			fields = append(fields, &t.TLS.CAFile, &t.TLS.CertFile, &t.TLS.KeyFile)
+		}
+		for _, f := range fields {
 			resolved, err := env.ResolveEnv(*f)
 			if err != nil {
 				return err

--- a/orb-discovery/gnmi-discovery/policy/manager.go
+++ b/orb-discovery/gnmi-discovery/policy/manager.go
@@ -320,7 +320,7 @@ func validateTargetHosts(policy *config.Policy, logger *slog.Logger) error {
 			namedHosts++
 		}
 
-		key := fmt.Sprintf("%s:%d", strings.ToLower(bare), port)
+		key := fmt.Sprintf("%s:%d", canonicalHost(bare), port)
 		if first, dup := seen[key]; dup {
 			return fmt.Errorf(
 				"targets %d and %d both name %q; one device cannot have two entries", first, i, t.Host)
@@ -363,6 +363,27 @@ func splitEffectivePort(host string, field uint16) (string, uint16) {
 		}
 	}
 	return host, resolvedPort(field)
+}
+
+// canonicalHost normalizes a bare host for comparison: an IP literal to the one
+// spelling Go prints for it, a name to lower case.
+//
+// Validation and expansion must agree on what "the same endpoint" means, and
+// they did not. Validation lowercased the raw text while expansion canonicalized
+// through net.ParseIP, so `2001:db8::1` and `2001:0db8::1` passed validation as
+// two targets with two sets of credentials and were then collapsed into one by
+// the expansion dedupe — leaving the effective configuration to depend on which
+// entry came first, with only a warning. Both layers now call this.
+//
+// Lower-casing a name rather than resolving it is deliberate: Expand never
+// resolves DNS, so a name and an address cannot be known to be the same device,
+// but DNS names are case-insensitive.
+func canonicalHost(h string) string {
+	h = strings.Trim(h, "[]")
+	if ip := net.ParseIP(h); ip != nil {
+		return ip.String()
+	}
+	return strings.ToLower(h)
 }
 
 // checkNoControlChars rejects a policy-supplied string carrying control

--- a/orb-discovery/gnmi-discovery/policy/manager.go
+++ b/orb-discovery/gnmi-discovery/policy/manager.go
@@ -288,6 +288,7 @@ func validateTargetHosts(policy *config.Policy, logger *slog.Logger) error {
 	// endpoints, so merging across ports would undercount.
 	spans := map[uint16][][2]uint32{}
 	var namedHosts, scanWork uint64
+	var unverified int
 
 	for i, t := range policy.Scope.Targets {
 		if err := checkNoControlChars(t.Host, "target host"); err != nil {
@@ -328,6 +329,25 @@ func validateTargetHosts(policy *config.Policy, logger *slog.Logger) error {
 
 		scanWork += count
 
+		// A ranged target sends this policy's password to whatever the sweep
+		// admits, and admission is deliberately broad. Without TLS authenticating
+		// the far end, that means any service listening on the gNMI port inside
+		// the range — reachable by accident when a range overlaps a server VLAN.
+		if !targets.IsSingleEndpoint(bare) && t.ResolvedPassword() != "" {
+			tls := t.ResolvedTLS()
+			if tls.Insecure || tls.SkipVerify {
+				if !policy.Config.SendCredentialsToUnverifiedTargets {
+					return fmt.Errorf(
+						"target %q carries a password but does not verify the server, and a range"+
+							" sends that password to every address the sweep admits: set a ca so the"+
+							" server is authenticated, drop the password, name the hosts explicitly,"+
+							" or set config.send_credentials_to_unverified_targets to accept it",
+						t.Host)
+				}
+				unverified++
+			}
+		}
+
 		start, end, enumerable, err := targets.Span(bare)
 		if err != nil {
 			return fmt.Errorf("target %q: %w", t.Host, err)
@@ -358,6 +378,14 @@ func validateTargetHosts(policy *config.Policy, logger *slog.Logger) error {
 		return fmt.Errorf(
 			"this policy expands to %d distinct addresses, more than the %d supported",
 			total, targets.MaxExpand)
+	}
+
+	if unverified > 0 {
+		// One line per policy, not per target. Logged even though the operator
+		// opted in: the whole point of the opt-in is that the risk stays visible.
+		logger.Warn("this policy sends credentials to targets whose server is not authenticated;"+
+			" a range sweep will offer the password to any endpoint answering on the gNMI port",
+			"range_targets", unverified)
 	}
 
 	// Bounding the union alone bounds the subscriptions, which is what the cap

--- a/orb-discovery/gnmi-discovery/policy/manager.go
+++ b/orb-discovery/gnmi-discovery/policy/manager.go
@@ -70,6 +70,11 @@ func (m *Manager) ParsePolicies(data []byte) (map[string]config.Policy, error) {
 		return nil, errors.New("no policies found in the request")
 	}
 	for name, policy := range payload.Policies {
+		// The policy name reaches a log line on nearly every path through this
+		// backend, so it is checked before anything else logs it.
+		if err := checkNoControlChars(name, "policy name"); err != nil {
+			return nil, err
+		}
 		// Inherit BEFORE resolving env. resolveEnv walks only the target list,
 		// so inheriting afterwards would copy a scope-level ${GNMI_PASS} into
 		// every target as that literal string with resolution already past —
@@ -274,7 +279,7 @@ func validateTargetHosts(policy *config.Policy, logger *slog.Logger) error {
 	var namedHosts uint64
 
 	for i, t := range policy.Scope.Targets {
-		if err := checkHostText(t.Host); err != nil {
+		if err := checkNoControlChars(t.Host, "target host"); err != nil {
 			return err
 		}
 
@@ -360,18 +365,18 @@ func splitEffectivePort(host string, field uint16) (string, uint16) {
 	return host, resolvedPort(field)
 }
 
-// checkHostText rejects a host carrying control characters.
+// checkNoControlChars rejects a policy-supplied string carrying control
+// characters.
 //
-// No hostname, IP, CIDR or range contains one, so this costs nothing legitimate.
-// It also removes the only route by which policy text reaches a log line as
-// something other than one field value: a host holding a newline could otherwise
-// forge whole log records, which is what CodeQL flags every log of a
-// policy-derived host for.
-func checkHostText(host string) error {
-	for _, r := range host {
-		if r == 0x7f || (r < 0x20 && r != 0) {
-			return fmt.Errorf("target host contains a control character at byte offset %d",
-				strings.IndexRune(host, r))
+// No policy name, hostname, IP, CIDR or range contains one, so this refuses
+// nothing legitimate. It closes at the source the route by which policy text
+// reaches a log line as something other than one field value: a value holding a
+// newline could otherwise forge whole log records, which is what CodeQL flags
+// every log of a policy-derived host or policy name for.
+func checkNoControlChars(value, what string) error {
+	for i, r := range value {
+		if r == 0x7f || r < 0x20 {
+			return fmt.Errorf("%s contains a control character at byte offset %d", what, i)
 		}
 	}
 	return nil

--- a/orb-discovery/gnmi-discovery/policy/manager.go
+++ b/orb-discovery/gnmi-discovery/policy/manager.go
@@ -211,8 +211,10 @@ func (m *Manager) applyDefaults(policy *config.Policy) {
 		t := &policy.Scope.Targets[i]
 		// A CIDR or range is not an endpoint yet. The runner appends the port to
 		// each address once it expands, so stamping one here would produce
-		// "10.0.0.0/24:9339" and break the parse it is about to do.
-		if targets.LooksLikeMultiAddress(t.Host) {
+		// "10.0.0.0/24:9339" and break the parse it is about to do. Asked of
+		// Expand's own branch decision, so a hostname that happens to begin with
+		// an address still gets its port.
+		if !targets.IsSingleEndpoint(t.Host) {
 			continue
 		}
 		t.Host = ensurePort(t.Host, resolvedPort(t.Port))
@@ -283,14 +285,16 @@ func validateTargetHosts(policy *config.Policy, logger *slog.Logger) error {
 			return err
 		}
 
-		bare, port := splitEffectivePort(t.Host, t.Port)
+		bare, port, inline := splitEffectivePort(t.Host, t.Port)
 
-		if targets.LooksLikeMultiAddress(t.Host) {
-			if _, _, err := net.SplitHostPort(t.Host); err == nil {
-				return fmt.Errorf(
-					"target %q: a CIDR or range cannot carry an inline port; use the port field", t.Host)
-			}
-		} else if _, _, err := net.SplitHostPort(t.Host); err == nil && t.Port != 0 {
+		// Asked of the host with its port removed, so a hostname that merely
+		// starts with an address — "10.0.0.1-switch.example.com:6030" — is not
+		// mistaken for a range carrying an inline port.
+		if inline && !targets.IsSingleEndpoint(bare) {
+			return fmt.Errorf(
+				"target %q: a CIDR or range cannot carry an inline port; use the port field", t.Host)
+		}
+		if inline && t.Port != 0 {
 			// An inline port wins, so the field is dead weight here. Warn rather
 			// than reject: an inline port on a single host is the documented form
 			// and must keep working.
@@ -353,16 +357,13 @@ func validateTargetHosts(policy *config.Policy, logger *slog.Logger) error {
 // "10.0.0.5:6030" and "10.0.0.5:57400" collide on one key — two real endpoints
 // rejected as a duplicate — and let an inline ":6030" and a "port: 6030" on the
 // same host produce two keys for one endpoint.
-func splitEffectivePort(host string, field uint16) (string, uint16) {
-	if targets.LooksLikeMultiAddress(host) {
-		return host, resolvedPort(field)
-	}
+func splitEffectivePort(host string, field uint16) (bare string, port uint16, inline bool) {
 	if h, p, err := net.SplitHostPort(host); err == nil {
 		if n, cerr := strconv.ParseUint(p, 10, 16); cerr == nil {
-			return strings.Trim(h, "[]"), uint16(n)
+			return strings.Trim(h, "[]"), uint16(n), true
 		}
 	}
-	return host, resolvedPort(field)
+	return host, resolvedPort(field), false
 }
 
 // canonicalHost normalizes a bare host for comparison: an IP literal to the one

--- a/orb-discovery/gnmi-discovery/policy/manager.go
+++ b/orb-discovery/gnmi-discovery/policy/manager.go
@@ -19,6 +19,7 @@ import (
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/env"
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/gnmi"
 	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/mapping"
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/targets"
 )
 
 // maxIntervalMs is the largest interval (in ms) that can be multiplied by
@@ -67,14 +68,29 @@ func (m *Manager) ParsePolicies(data []byte) (map[string]config.Policy, error) {
 		return nil, errors.New("no policies found in the request")
 	}
 	for name, policy := range payload.Policies {
+		// Inherit BEFORE resolving env. resolveEnv walks only the target list,
+		// so inheriting afterwards would copy a scope-level ${GNMI_PASS} into
+		// every target as that literal string with resolution already past —
+		// every device in a subnet authenticating with the eleven characters
+		// "${GNMI_PASS}". Inheriting first also lets validatePolicy see each
+		// target's effective values rather than consulting two places.
+		inheritScopeDefaults(&policy)
+
 		if err := m.validatePolicy(policy); err != nil {
 			return nil, fmt.Errorf("%s : invalid policy : %w", name, err)
 		}
 		// Resolve env BEFORE applying defaults: ResolveEnv only matches a
-		// whole-string ${VAR}, so the host must be resolved before the default
-		// port is appended (otherwise "${HOST}:9339" would never resolve).
+		// whole-string ${VAR}, so the host must be resolved before the port is
+		// appended (otherwise "${HOST}:9339" would never resolve).
 		if err := m.resolveEnv(&policy); err != nil {
 			return nil, fmt.Errorf("%s : failed to resolve environment variables : %w", name, err)
+		}
+		// Host checks run here, after resolution, because a host written as
+		// ${SUBNET} is an opaque string until now: checked earlier it parses as
+		// a hostname and passes every bound, then resolves to a /8 that the
+		// runner enumerates into hundreds of megabytes.
+		if err := validateTargetHosts(&policy, m.logger); err != nil {
+			return nil, fmt.Errorf("%s : invalid policy : %w", name, err)
 		}
 		m.applyDefaults(&policy)
 		payload.Policies[name] = policy
@@ -174,7 +190,14 @@ func (m *Manager) applyDefaults(policy *config.Policy) {
 		policy.Config.Defaults.Interface.Type = "other"
 	}
 	for i := range policy.Scope.Targets {
-		policy.Scope.Targets[i].Host = ensurePort(policy.Scope.Targets[i].Host)
+		t := &policy.Scope.Targets[i]
+		// A CIDR or range is not an endpoint yet. The runner appends the port to
+		// each address once it expands, so stamping one here would produce
+		// "10.0.0.0/24:9339" and break the parse it is about to do.
+		if targets.LooksLikeMultiAddress(t.Host) {
+			continue
+		}
+		t.Host = ensurePort(t.Host, resolvedPort(t.Port))
 	}
 }
 
@@ -182,7 +205,19 @@ func (m *Manager) applyDefaults(policy *config.Policy) {
 // IPv6-safe: a bare IPv6 literal (e.g. 2001:db8::1) has colons but no port, so
 // net.SplitHostPort is used to detect a real port, and IPv6 literals are
 // bracketed before the port is appended.
-func ensurePort(h string) string {
+// resolvedPort returns the port to use for a target. Inheritance has already
+// folded the scope's value into the target, so the precedence chain
+// inline > target > scope > default reduces to this plus ensurePort's refusal
+// to overwrite an inline suffix.
+func resolvedPort(port uint16) uint16 {
+	if port == 0 {
+		return config.DefaultGNMIPort
+	}
+	return port
+}
+
+// ensurePort appends port to h unless h already carries one.
+func ensurePort(h string, port uint16) string {
 	if h == "" {
 		return h
 	}
@@ -202,13 +237,105 @@ func ensurePort(h string) string {
 	}
 	switch {
 	case strings.HasPrefix(h, "[") && strings.HasSuffix(h, "]"):
-		return fmt.Sprintf("%s:%d", h, config.DefaultGNMIPort) // bracketed IPv6, no port
+		return fmt.Sprintf("%s:%d", h, port) // bracketed IPv6, no port
 	case net.ParseIP(ipPart) != nil && strings.Contains(h, ":"):
-		return fmt.Sprintf("[%s]:%d", h, config.DefaultGNMIPort) // bare IPv6 literal (incl. zone) -> bracket
+		return fmt.Sprintf("[%s]:%d", h, port) // bare IPv6 literal (incl. zone) -> bracket
 	case strings.Contains(h, ":"):
 		return h // malformed host:port -> leave untouched
 	default:
-		return fmt.Sprintf("%s:%d", h, config.DefaultGNMIPort) // hostname / IPv4, no port
+		return fmt.Sprintf("%s:%d", h, port) // hostname / IPv4, no port
+	}
+}
+
+// validateTargetHosts checks what only becomes checkable once ${VAR}s are
+// resolved: how far each host expands, whether the forms are usable, and
+// whether two entries name the same endpoint.
+//
+// Expansion itself is deferred to the runner — a sweep of a /22 cannot happen
+// inside a policy POST — so this counts without enumerating.
+func validateTargetHosts(policy *config.Policy, logger *slog.Logger) error {
+	seen := make(map[string]int, len(policy.Scope.Targets))
+	var total uint64
+
+	for i, t := range policy.Scope.Targets {
+		port := resolvedPort(t.Port)
+
+		if targets.LooksLikeMultiAddress(t.Host) {
+			if _, _, err := net.SplitHostPort(t.Host); err == nil {
+				return fmt.Errorf(
+					"target %q: a CIDR or range cannot carry an inline port; use the port field", t.Host)
+			}
+		} else if _, _, err := net.SplitHostPort(t.Host); err == nil && t.Port != 0 {
+			// An inline port wins, so the field is dead weight here. Warn rather
+			// than reject: an inline port on a single host is the documented form
+			// and must keep working.
+			logger.Warn("target sets both an inline port and the port field; the inline port wins",
+				"host", t.Host, "ignored_port", t.Port)
+		}
+
+		count, err := targets.Count(t.Host)
+		if err != nil {
+			return fmt.Errorf("target %q: %w", t.Host, err)
+		}
+		total += count
+		if total > targets.MaxExpand {
+			return fmt.Errorf(
+				"target %q brings this policy to %d addresses, more than the %d supported",
+				t.Host, total, targets.MaxExpand)
+		}
+
+		key := fmt.Sprintf("%s:%d", strings.ToLower(hostWithoutPort(t.Host)), port)
+		if first, dup := seen[key]; dup {
+			return fmt.Errorf(
+				"targets %d and %d both name %q; one device cannot have two entries", first, i, t.Host)
+		}
+		seen[key] = i
+	}
+	return nil
+}
+
+// hostWithoutPort strips an inline port so two spellings of one endpoint
+// collide. A hostname keeps its own text, since Expand never resolves DNS and
+// so cannot know a name and an address are the same device.
+func hostWithoutPort(host string) string {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		return h
+	}
+	return host
+}
+
+// inheritScopeDefaults folds the scope's settings into each target that has not
+// set them. Scalars inherit individually; tls inherits as a whole block, because
+// a bool cannot distinguish "unset" from "false" and a partial merge would
+// silently zero the fields a target did not mention.
+//
+// Blocks are copied rather than aliased. A shared pointer would give every
+// target in a 254-address expansion the same TLSConfig, which resolveEnv then
+// writes through once per target — the aliasing MergeDefaults documents avoiding
+// for the same reason.
+func inheritScopeDefaults(policy *config.Policy) {
+	scope := &policy.Scope
+	for i := range scope.Targets {
+		t := &scope.Targets[i]
+		if t.Username == "" {
+			t.Username = scope.Username
+		}
+		if t.Password == "" {
+			t.Password = scope.Password
+		}
+		if t.Port == 0 {
+			t.Port = scope.Port
+		}
+		// Origin distinguishes unset from an explicit "", so test for nil: a
+		// target asking for origin-less paths must not inherit "openconfig".
+		if t.Origin == nil && scope.Origin != nil {
+			origin := *scope.Origin
+			t.Origin = &origin
+		}
+		if t.TLS == nil && scope.TLS != nil {
+			tls := *scope.TLS
+			t.TLS = &tls
+		}
 	}
 }
 

--- a/orb-discovery/gnmi-discovery/policy/manager.go
+++ b/orb-discovery/gnmi-discovery/policy/manager.go
@@ -305,7 +305,8 @@ func validateTargetHosts(policy *config.Policy, logger *slog.Logger) error {
 		// mistaken for a range carrying an inline port.
 		if inline && !targets.IsSingleEndpoint(bare) {
 			return fmt.Errorf(
-				"target %q: a CIDR or range cannot carry an inline port; use the port field", t.Host)
+				"target %q: a CIDR or range cannot carry an inline port; use the port field", t.Host,
+			)
 		}
 		if inline && t.Port != 0 {
 			// An inline port wins, so the field is dead weight here. Warn rather
@@ -324,7 +325,8 @@ func validateTargetHosts(policy *config.Policy, logger *slog.Logger) error {
 		if count > targets.MaxExpand {
 			return fmt.Errorf(
 				"target %q expands to %d addresses, more than the %d supported",
-				t.Host, count, targets.MaxExpand)
+				t.Host, count, targets.MaxExpand,
+			)
 		}
 
 		scanWork += count
@@ -342,7 +344,8 @@ func validateTargetHosts(policy *config.Policy, logger *slog.Logger) error {
 							" sends that password to every address the sweep admits: set a ca so the"+
 							" server is authenticated, drop the password, name the hosts explicitly,"+
 							" or set config.send_credentials_to_unverified_targets to accept it",
-						t.Host)
+						t.Host,
+					)
 				}
 				unverified++
 			}
@@ -361,7 +364,8 @@ func validateTargetHosts(policy *config.Policy, logger *slog.Logger) error {
 		key := fmt.Sprintf("%s:%d", canonicalHost(bare), port)
 		if first, dup := seen[key]; dup {
 			return fmt.Errorf(
-				"targets %d and %d both name %q; one device cannot have two entries", first, i, t.Host)
+				"targets %d and %d both name %q; one device cannot have two entries", first, i, t.Host,
+			)
 		}
 		seen[key] = i
 	}
@@ -377,7 +381,8 @@ func validateTargetHosts(policy *config.Policy, logger *slog.Logger) error {
 	if total > targets.MaxExpand {
 		return fmt.Errorf(
 			"this policy expands to %d distinct addresses, more than the %d supported",
-			total, targets.MaxExpand)
+			total, targets.MaxExpand,
+		)
 	}
 
 	if unverified > 0 {
@@ -397,7 +402,8 @@ func validateTargetHosts(policy *config.Policy, logger *slog.Logger) error {
 		return fmt.Errorf(
 			"this policy's targets enumerate %d addresses in total, more than the %d supported;"+
 				" overlapping ranges are expanded separately before being deduplicated",
-			scanWork, maxScanWork)
+			scanWork, maxScanWork,
+		)
 	}
 	return nil
 }
@@ -449,7 +455,8 @@ func checkInlinePort(host string) error {
 	}
 	if _, cerr := strconv.ParseUint(port, 10, 16); cerr != nil {
 		return fmt.Errorf(
-			"target %q: inline port %q must be a number between 0 and 65535", host, port)
+			"target %q: inline port %q must be a number between 0 and 65535", host, port,
+		)
 	}
 	return nil
 }

--- a/orb-discovery/gnmi-discovery/policy/manager.go
+++ b/orb-discovery/gnmi-discovery/policy/manager.go
@@ -65,7 +65,7 @@ func (m *Manager) ParsePolicies(data []byte) (map[string]config.Policy, error) {
 		return nil, err
 	}
 	config.WarnUnknownPolicyKeys(data, m.logger)
-	config.WarnNullTLSBlocks(data, m.logger)
+	config.WarnAmbiguousNullKeys(data, m.logger)
 	if len(payload.Policies) == 0 {
 		return nil, errors.New("no policies found in the request")
 	}

--- a/orb-discovery/gnmi-discovery/policy/manager.go
+++ b/orb-discovery/gnmi-discovery/policy/manager.go
@@ -395,11 +395,16 @@ func inheritScopeDefaults(policy *config.Policy) {
 	scope := &policy.Scope
 	for i := range scope.Targets {
 		t := &scope.Targets[i]
-		if t.Username == "" {
-			t.Username = scope.Username
+		// Presence, not emptiness. A target that writes `username: ""` has said
+		// it connects anonymously, and inheriting over that would send the scope
+		// credentials to a device the operator marked as taking none.
+		if t.Username == nil && scope.Username != "" {
+			v := scope.Username
+			t.Username = &v
 		}
-		if t.Password == "" {
-			t.Password = scope.Password
+		if t.Password == nil && scope.Password != "" {
+			v := scope.Password
+			t.Password = &v
 		}
 		if t.Port == 0 {
 			t.Port = scope.Port
@@ -422,7 +427,13 @@ func (m *Manager) resolveEnv(policy *config.Policy) error {
 		t := &policy.Scope.Targets[i]
 		// Resolve every string field a user is likely to source from env: host,
 		// credentials, and TLS material paths.
-		fields := []*string{&t.Host, &t.Username, &t.Password}
+		fields := []*string{&t.Host}
+		if t.Username != nil {
+			fields = append(fields, t.Username)
+		}
+		if t.Password != nil {
+			fields = append(fields, t.Password)
+		}
 		// TLS is a pointer, and taking the address of a field through a nil one
 		// panics rather than failing to compile. No tls block is the common
 		// case, so this guard is on the hot path, not an edge case. ResolvedTLS

--- a/orb-discovery/gnmi-discovery/policy/manager.go
+++ b/orb-discovery/gnmi-discovery/policy/manager.go
@@ -381,6 +381,21 @@ func splitEffectivePort(host string, field uint16) (bare string, port uint16, in
 // but DNS names are case-insensitive.
 func canonicalHost(h string) string {
 	h = strings.Trim(h, "[]")
+
+	// A zone identifier is an interface name, and net.ParseIP refuses any address
+	// carrying one — so the whole value fell to the lower-casing path meant for
+	// hostnames, and got both halves wrong. Linux interface names are
+	// case-sensitive, so fe80::1%Eth0 and fe80::1%eth0 are two different links
+	// and were being rejected as one duplicate; meanwhile the address half was
+	// never canonicalized, so fe80::0001%eth0 and fe80::1%eth0 were treated as
+	// two endpoints when they are one.
+	if addr, zone, ok := strings.Cut(h, "%"); ok {
+		if ip := net.ParseIP(addr); ip != nil {
+			return ip.String() + "%" + zone
+		}
+		return strings.ToLower(addr) + "%" + zone
+	}
+
 	if ip := net.ParseIP(h); ip != nil {
 		return ip.String()
 	}

--- a/orb-discovery/gnmi-discovery/policy/manager.go
+++ b/orb-discovery/gnmi-discovery/policy/manager.go
@@ -64,6 +64,7 @@ func (m *Manager) ParsePolicies(data []byte) (map[string]config.Policy, error) {
 		return nil, err
 	}
 	config.WarnUnknownPolicyKeys(data, m.logger)
+	config.WarnNullTLSBlocks(data, m.logger)
 	if len(payload.Policies) == 0 {
 		return nil, errors.New("no policies found in the request")
 	}

--- a/orb-discovery/gnmi-discovery/policy/manager.go
+++ b/orb-discovery/gnmi-discovery/policy/manager.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -267,10 +268,17 @@ func ensurePort(h string, port uint16) string {
 // inside a policy POST — so this counts without enumerating.
 func validateTargetHosts(policy *config.Policy, logger *slog.Logger) error {
 	seen := make(map[string]int, len(policy.Scope.Targets))
-	var total uint64
+	// Spans are grouped by port: the same address reached on two ports is two
+	// endpoints, so merging across ports would undercount.
+	spans := map[uint16][][2]uint32{}
+	var namedHosts uint64
 
 	for i, t := range policy.Scope.Targets {
-		port := resolvedPort(t.Port)
+		if err := checkHostText(t.Host); err != nil {
+			return err
+		}
+
+		bare, port := splitEffectivePort(t.Host, t.Port)
 
 		if targets.LooksLikeMultiAddress(t.Host) {
 			if _, _, err := net.SplitHostPort(t.Host); err == nil {
@@ -285,35 +293,88 @@ func validateTargetHosts(policy *config.Policy, logger *slog.Logger) error {
 				"host", t.Host, "ignored_port", t.Port)
 		}
 
-		count, err := targets.Count(t.Host)
+		// Per target first, so one oversized entry is named as the offender
+		// rather than blamed on whatever happened to come last.
+		count, err := targets.Count(bare)
 		if err != nil {
 			return fmt.Errorf("target %q: %w", t.Host, err)
 		}
-		total += count
-		if total > targets.MaxExpand {
+		if count > targets.MaxExpand {
 			return fmt.Errorf(
-				"target %q brings this policy to %d addresses, more than the %d supported",
-				t.Host, total, targets.MaxExpand)
+				"target %q expands to %d addresses, more than the %d supported",
+				t.Host, count, targets.MaxExpand)
 		}
 
-		key := fmt.Sprintf("%s:%d", strings.ToLower(hostWithoutPort(t.Host)), port)
+		start, end, enumerable, err := targets.Span(bare)
+		if err != nil {
+			return fmt.Errorf("target %q: %w", t.Host, err)
+		}
+		if enumerable {
+			spans[port] = append(spans[port], [2]uint32{start, end})
+		} else {
+			namedHosts++
+		}
+
+		key := fmt.Sprintf("%s:%d", strings.ToLower(bare), port)
 		if first, dup := seen[key]; dup {
 			return fmt.Errorf(
 				"targets %d and %d both name %q; one device cannot have two entries", first, i, t.Host)
 		}
 		seen[key] = i
 	}
+
+	// The union, not the sum. Naming a subnet and then pinning hosts inside it to
+	// give them their own credentials describes the subnet's endpoints and no
+	// more, and summing the two rejected a policy that expands to fewer targets
+	// than the cap allows.
+	total := namedHosts
+	for _, group := range spans {
+		total += targets.UnionSize(group)
+	}
+	if total > targets.MaxExpand {
+		return fmt.Errorf(
+			"this policy expands to %d distinct addresses, more than the %d supported",
+			total, targets.MaxExpand)
+	}
 	return nil
 }
 
-// hostWithoutPort strips an inline port so two spellings of one endpoint
-// collide. A hostname keeps its own text, since Expand never resolves DNS and
-// so cannot know a name and an address are the same device.
-func hostWithoutPort(host string) string {
-	if h, _, err := net.SplitHostPort(host); err == nil {
-		return h
+// splitEffectivePort returns a target's host without its port, and the port it
+// will actually be reached on: an inline suffix wins over the port field, which
+// wins over the scope's value and the default.
+//
+// Both halves have to come from the same decision. Taking the host from
+// hostWithoutPort while taking the port from the field alone made
+// "10.0.0.5:6030" and "10.0.0.5:57400" collide on one key — two real endpoints
+// rejected as a duplicate — and let an inline ":6030" and a "port: 6030" on the
+// same host produce two keys for one endpoint.
+func splitEffectivePort(host string, field uint16) (string, uint16) {
+	if targets.LooksLikeMultiAddress(host) {
+		return host, resolvedPort(field)
 	}
-	return host
+	if h, p, err := net.SplitHostPort(host); err == nil {
+		if n, cerr := strconv.ParseUint(p, 10, 16); cerr == nil {
+			return strings.Trim(h, "[]"), uint16(n)
+		}
+	}
+	return host, resolvedPort(field)
+}
+
+// checkHostText rejects a host carrying control characters.
+//
+// No hostname, IP, CIDR or range contains one, so this costs nothing legitimate.
+// It also removes the only route by which policy text reaches a log line as
+// something other than one field value: a host holding a newline could otherwise
+// forge whole log records, which is what CodeQL flags every log of a
+// policy-derived host for.
+func checkHostText(host string) error {
+	for _, r := range host {
+		if r == 0x7f || (r < 0x20 && r != 0) {
+			return fmt.Errorf("target host contains a control character at byte offset %d",
+				strings.IndexRune(host, r))
+		}
+	}
+	return nil
 }
 
 // inheritScopeDefaults folds the scope's settings into each target that has not

--- a/orb-discovery/gnmi-discovery/policy/manager.go
+++ b/orb-discovery/gnmi-discovery/policy/manager.go
@@ -386,7 +386,12 @@ func splitEffectivePort(host string, field uint16) (bare string, port uint16, in
 			return strings.Trim(h, "[]"), uint16(n), true
 		}
 	}
-	return host, resolvedPort(field), false
+	// Brackets come off here too, not only on the branch above. bare is what
+	// Count, Span, IsSingleEndpoint and canonicalHost are all asked about, and it
+	// was normalized on one path and not the other: canonicalHost trims its own
+	// input, so "[10.0.0.1]" collapsed with the plain address for identity while
+	// Span refused to parse it and counted it as a separate endpoint.
+	return strings.Trim(host, "[]"), resolvedPort(field), false
 }
 
 // canonicalHost normalizes a bare host for comparison: an IP literal to the one

--- a/orb-discovery/gnmi-discovery/policy/manager.go
+++ b/orb-discovery/gnmi-discovery/policy/manager.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"math"
 	"net"
+	"net/netip"
 	"regexp"
 	"strconv"
 	"strings"
@@ -26,6 +27,14 @@ import (
 // maxIntervalMs is the largest interval (in ms) that can be multiplied by
 // time.Millisecond without overflowing time.Duration (int64 ns).
 const maxIntervalMs = int64(math.MaxInt64) / int64(time.Millisecond)
+
+// maxScanWork bounds how many addresses a policy's targets enumerate in total,
+// as opposed to how many distinct endpoints they describe. The two differ when
+// ranges overlap, because each entry is expanded before the results are
+// deduplicated. Four times the endpoint cap leaves ample room for a subnet plus
+// pinned hosts, or nested prefixes carrying different credentials, while refusing
+// the degenerate case.
+const maxScanWork = 4 * uint64(targets.MaxExpand)
 
 // Manager owns the set of running policies.
 type Manager struct {
@@ -278,7 +287,7 @@ func validateTargetHosts(policy *config.Policy, logger *slog.Logger) error {
 	// Spans are grouped by port: the same address reached on two ports is two
 	// endpoints, so merging across ports would undercount.
 	spans := map[uint16][][2]uint32{}
-	var namedHosts uint64
+	var namedHosts, scanWork uint64
 
 	for i, t := range policy.Scope.Targets {
 		if err := checkNoControlChars(t.Host, "target host"); err != nil {
@@ -314,6 +323,8 @@ func validateTargetHosts(policy *config.Policy, logger *slog.Logger) error {
 				t.Host, count, targets.MaxExpand)
 		}
 
+		scanWork += count
+
 		start, end, enumerable, err := targets.Span(bare)
 		if err != nil {
 			return fmt.Errorf("target %q: %w", t.Host, err)
@@ -344,6 +355,18 @@ func validateTargetHosts(policy *config.Policy, logger *slog.Logger) error {
 		return fmt.Errorf(
 			"this policy expands to %d distinct addresses, more than the %d supported",
 			total, targets.MaxExpand)
+	}
+
+	// Bounding the union alone bounds the subscriptions, which is what the cap
+	// was for, but not the work: the runner expands every entry independently
+	// before deduping, so heavily overlapping ranges cost the sum even though
+	// they yield the union. Forty equivalent /22s passed the union check and
+	// enumerated ~41k addresses per sweep, repeated on every rescan tick.
+	if scanWork > maxScanWork {
+		return fmt.Errorf(
+			"this policy's targets enumerate %d addresses in total, more than the %d supported;"+
+				" overlapping ranges are expanded separately before being deduplicated",
+			scanWork, maxScanWork)
 	}
 	return nil
 }
@@ -399,6 +422,14 @@ func canonicalHost(h string) string {
 	if ip := net.ParseIP(h); ip != nil {
 		return ip.String()
 	}
+
+	// A prefix names a subnet, and 10.0.0.1/22 names the same subnet as
+	// 10.0.0.0/22. Without masking, the two are separate entries that expand to
+	// the same 1022 addresses, and the second expansion is discarded wholesale.
+	if prefix, err := netip.ParsePrefix(h); err == nil {
+		return prefix.Masked().String()
+	}
+
 	return strings.ToLower(h)
 }
 

--- a/orb-discovery/gnmi-discovery/policy/manager.go
+++ b/orb-discovery/gnmi-discovery/policy/manager.go
@@ -293,6 +293,9 @@ func validateTargetHosts(policy *config.Policy, logger *slog.Logger) error {
 		if err := checkNoControlChars(t.Host, "target host"); err != nil {
 			return err
 		}
+		if err := checkInlinePort(t.Host); err != nil {
+			return err
+		}
 
 		bare, port, inline := splitEffectivePort(t.Host, t.Port)
 
@@ -392,6 +395,35 @@ func splitEffectivePort(host string, field uint16) (bare string, port uint16, in
 	// input, so "[10.0.0.1]" collapsed with the plain address for identity while
 	// Span refused to parse it and counted it as a separate endpoint.
 	return strings.Trim(host, "[]"), resolvedPort(field), false
+}
+
+// checkInlinePort rejects an inline port that is not a number in range.
+//
+// net.SplitHostPort accepts a service name, and Go's dialer resolves one through
+// /etc/services — net.LookupPort("tcp", "http") is 80 — so "10.0.0.1:http"
+// reaches a device on port 80 while every check here read it as an unported host
+// named "10.0.0.1:http". A pinned target written that way never matched the
+// numeric candidate a range produced, so the device got two subscriptions with
+// two sets of credentials. The same silence swallowed an out-of-range number and
+// a trailing colon: "10.0.0.1:99999" and "10.0.0.1:" both became hostnames, to be
+// resolved by DNS and fail as lookups.
+//
+// Rejected rather than resolved. Resolving would make a policy's meaning depend
+// on the /etc/services of whichever host parsed it, so the same policy could
+// validate differently in the agent container than where it was written. Every
+// documented form is numeric and the port field is a uint16, so nothing
+// legitimate is refused.
+func checkInlinePort(host string) error {
+	_, port, err := net.SplitHostPort(host)
+	if err != nil {
+		// No inline port, or an IPv6 literal written without brackets.
+		return nil
+	}
+	if _, cerr := strconv.ParseUint(port, 10, 16); cerr != nil {
+		return fmt.Errorf(
+			"target %q: inline port %q must be a number between 0 and 65535", host, port)
+	}
+	return nil
 }
 
 // canonicalHost normalizes a bare host for comparison: an IP literal to the one

--- a/orb-discovery/gnmi-discovery/policy/manager.go
+++ b/orb-discovery/gnmi-discovery/policy/manager.go
@@ -119,6 +119,17 @@ func (m *Manager) validatePolicy(policy config.Policy) error {
 	if policy.Config.DebounceMs < 0 || int64(policy.Config.DebounceMs) > maxIntervalMs {
 		return fmt.Errorf("debounce_ms must be >= 0 and <= %d, got %d", maxIntervalMs, policy.Config.DebounceMs)
 	}
+	if policy.Config.ProbeTimeoutMs < 0 || int64(policy.Config.ProbeTimeoutMs) > maxIntervalMs {
+		return fmt.Errorf("probe_timeout_ms must be >= 0 and <= %d, got %d", maxIntervalMs, policy.Config.ProbeTimeoutMs)
+	}
+	// Rejected rather than clamped: an operator who wrote 5000 meant seconds and
+	// wants to know the field is milliseconds, not to be silently given an hour.
+	if ms := policy.Config.RescanIntervalMs; ms != 0 {
+		if ms < config.MinRescanIntervalMs || int64(ms) > maxIntervalMs {
+			return fmt.Errorf("rescan_interval_ms must be 0 (disabled) or between %d and %d, got %d",
+				config.MinRescanIntervalMs, maxIntervalMs, ms)
+		}
+	}
 	// Compile the interface name patterns/excludes at parse time so a bad regex
 	// fails the POST /policies with a 400 instead of silently breaking at flush.
 	if err := validateInterfaceRegexes(&policy.Config.Defaults); err != nil {

--- a/orb-discovery/gnmi-discovery/policy/manager_test.go
+++ b/orb-discovery/gnmi-discovery/policy/manager_test.go
@@ -316,7 +316,7 @@ policies:
 `)
 	policies, err := m.ParsePolicies(data)
 	require.NoError(t, err)
-	require.Equal(t, "s3cret", policies["p1"].Scope.Targets[0].Password)
+	require.Equal(t, "s3cret", policies["p1"].Scope.Targets[0].ResolvedPassword())
 }
 
 func TestResolvesEnvInHostAndTLS(t *testing.T) {

--- a/orb-discovery/gnmi-discovery/policy/rescan_test.go
+++ b/orb-discovery/gnmi-discovery/policy/rescan_test.go
@@ -1,0 +1,165 @@
+package policy
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/gnmi"
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/mapping"
+)
+
+// A rescan exists to pick up a device that was down when the policy was applied.
+// Nothing else re-applies a policy: the config manager returns early on an
+// unchanged git ref, and on a new commit whose diff touches no policy file.
+func TestRescanPicksUpADeviceThatWasDownAtApplyTime(t *testing.T) {
+	dialer := newPerHostDialer(map[string]error{"10.0.0.2:9339": dialingErr()})
+	r := newRescanRunner(t, "10.0.0.0/30", dialer, 60*time.Millisecond)
+	r.Start()
+	t.Cleanup(func() { _ = r.Stop() })
+
+	require.Eventually(t, func() bool {
+		return len(r.TargetStatuses()) == 1
+	}, 3*time.Second, 10*time.Millisecond, "only .1 answers the first sweep")
+
+	// The device finishes booting.
+	dialer.mu.Lock()
+	delete(dialer.capsErr, "10.0.0.2:9339")
+	dialer.mu.Unlock()
+
+	require.Eventually(t, func() bool {
+		return len(r.TargetStatuses()) == 2
+	}, 3*time.Second, 10*time.Millisecond, "the rescan admits the newcomer")
+}
+
+// The one thing a rescan must not do is disturb a working subscription. A device
+// admitted by an earlier sweep must never be probed again: filtering after the
+// probe rather than before would re-probe every live device, every tick, forever.
+func TestRescanNeverReprobesASubscribedTarget(t *testing.T) {
+	dialer := newPerHostDialer(map[string]error{"10.0.0.2:9339": dialingErr()})
+	r := newRescanRunner(t, "10.0.0.0/30", dialer, 40*time.Millisecond)
+	r.Start()
+	t.Cleanup(func() { _ = r.Stop() })
+
+	require.Eventually(t, func() bool {
+		return len(r.TargetStatuses()) == 1
+	}, 3*time.Second, 10*time.Millisecond)
+
+	// Let several ticks pass, then count how often the rejected address was
+	// re-probed versus the admitted one.
+	require.Eventually(t, func() bool {
+		return countHost(dialer.dialedHosts(), "10.0.0.2:9339") >= 3
+	}, 3*time.Second, 10*time.Millisecond, "the rejected address is re-probed each tick")
+
+	// The admitted host is dialed exactly twice for the life of the policy: once
+	// by the sweep that admitted it, once by the loop that subscribed. A third
+	// dial would mean a rescan tick probed a live subscription.
+	require.Equal(t, 2, countHost(dialer.dialedHosts(), "10.0.0.1:9339"),
+		"a subscribed target is never re-probed")
+	require.Equal(t, 1, dialer.closeCount("10.0.0.1:9339"),
+		"only the admitting probe closed a session; the subscription stays open")
+}
+
+// Rescan is off by default, and the sweep goroutine must then actually exit
+// rather than sit on a ticker for the life of the policy.
+func TestRescanIsDisabledByDefault(t *testing.T) {
+	dialer := newPerHostDialer(map[string]error{"10.0.0.2:9339": dialingErr()})
+	r := newRescanRunner(t, "10.0.0.0/30", dialer, 0)
+	r.Start()
+	t.Cleanup(func() { _ = r.Stop() })
+
+	require.Eventually(t, func() bool {
+		return countHost(dialer.dialedHosts(), "10.0.0.2:9339") == 1
+	}, 3*time.Second, 10*time.Millisecond)
+
+	time.Sleep(150 * time.Millisecond)
+	require.Equal(t, 1, countHost(dialer.dialedHosts(), "10.0.0.2:9339"),
+		"with rescan off the address is probed exactly once")
+}
+
+// A rescan tick must not outlive Stop. The sweep goroutine holds one WaitGroup
+// count for its whole life, ticker included.
+func TestStopEndsTheRescanLoop(t *testing.T) {
+	dialer := newPerHostDialer(map[string]error{"10.0.0.2:9339": dialingErr()})
+	r := newRescanRunner(t, "10.0.0.0/30", dialer, 30*time.Millisecond)
+	r.Start()
+
+	require.Eventually(t, func() bool {
+		return countHost(dialer.dialedHosts(), "10.0.0.2:9339") >= 2
+	}, 3*time.Second, 5*time.Millisecond)
+
+	done := make(chan struct{})
+	go func() { _ = r.Stop(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop did not return: the rescan ticker outlived the runner")
+	}
+
+	before := len(dialer.dialedHosts())
+	time.Sleep(120 * time.Millisecond)
+	require.Equal(t, before, len(dialer.dialedHosts()), "no probe after Stop returned")
+}
+
+func countHost(hosts []string, want string) int {
+	n := 0
+	for _, h := range hosts {
+		if h == want {
+			n++
+		}
+	}
+	return n
+}
+
+func newRescanRunner(t *testing.T, host string, dialer gnmi.Dialer, rescan time.Duration) *Runner {
+	t.Helper()
+	policy := config.Policy{
+		Config: config.PolicyConfig{
+			Mode:             config.ModeAuto,
+			DebounceMs:       10,
+			RescanIntervalMs: int(rescan / time.Millisecond),
+		},
+		Scope: config.Scope{Targets: []config.Target{{Host: host}}},
+	}
+	store, err := mapping.LoadProfiles("")
+	require.NoError(t, err)
+	r, err := NewRunner(context.Background(), slog.New(slog.DiscardHandler),
+		"p1", policy, &recordingClient{}, dialer, store)
+	require.NoError(t, err)
+	r.backoffBase = time.Millisecond
+	return r
+}
+
+// A too-frequent rescan is a continuous port scan of the operator's own campus,
+// so a value under the floor is rejected rather than clamped: someone who wrote
+// 5000 meant seconds and needs to learn the field is milliseconds, not to be
+// silently handed a minute.
+func TestRescanIntervalBelowTheFloorIsRejected(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    config:
+      rescan_interval_ms: 5000
+    scope:
+      targets:
+        - host: 10.0.0.1
+`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "rescan_interval_ms")
+
+	_, err = m.ParsePolicies([]byte(`
+policies:
+  p1:
+    config:
+      rescan_interval_ms: 0
+    scope:
+      targets:
+        - host: 10.0.0.1
+`))
+	require.NoError(t, err, "0 means disabled, not too small")
+}

--- a/orb-discovery/gnmi-discovery/policy/run.go
+++ b/orb-discovery/gnmi-discovery/policy/run.go
@@ -21,6 +21,19 @@ const (
 	RunStatusFailed RunStatus = "failed"
 )
 
+// Run kinds. A sweep run and a per-device flush run describe different things
+// and complete at different times — a sweep of a named host finishes at once,
+// while its first flush waits for debounce, subscribe and the initial sync — so a
+// consumer asking "has this policy ingested anything?" needs to tell them apart.
+// Before the sweep run existed every run was a flush, and "any completed run" was
+// a sound proxy for that; it no longer is, and nothing in the payload said so.
+const (
+	// RunKindFlush is one reconciled-snapshot ingest for one device.
+	RunKindFlush = "flush"
+	// RunKindSweep is one target sweep for the whole policy.
+	RunKindSweep = "sweep"
+)
+
 const maxRunsPerTarget = 3
 
 // maxRunsPerPolicy caps what /status reports for one policy. A /22 policy can
@@ -36,7 +49,9 @@ type Run struct {
 	// Targets is what the agent actually reads: PolicyStatusRun decodes
 	// `json:"targets"` and has no `target` field, so a run that carries only the
 	// singular form reaches the fleet with no target at all.
-	Targets     []string  `json:"targets,omitempty"`
+	Targets []string `json:"targets,omitempty"`
+	// Kind distinguishes a policy-wide sweep run from a per-device flush run.
+	Kind        string    `json:"kind"`
 	Status      RunStatus `json:"status"`
 	Reason      string    `json:"reason,omitempty"`
 	EntityCount int       `json:"entity_count"`
@@ -64,8 +79,8 @@ func (rs *RunStore) CreateRun(policy, host string) *Run {
 	now := time.Now().UTC().UnixNano()
 	run := &Run{
 		ID: uuid.New().String(), PolicyID: policy, Target: host,
-		Targets: []string{host},
-		Status:  RunStatusRunning, CreatedAt: now, UpdatedAt: now,
+		Targets: []string{host}, Kind: RunKindFlush,
+		Status: RunStatusRunning, CreatedAt: now, UpdatedAt: now,
 	}
 	if rs.runs[policy] == nil {
 		rs.runs[policy] = make(map[string][]*Run)
@@ -98,6 +113,7 @@ func (rs *RunStore) CreateSweepRun(policy string, originalTargets []string) *Run
 			// wrote rather than a synthesized pseudo-host.
 			r.Targets = append([]string(nil), originalTargets...)
 			r.Target = strings.Join(originalTargets, ",")
+			r.Kind = RunKindSweep
 			return copyRun(r)
 		}
 	}

--- a/orb-discovery/gnmi-discovery/policy/run.go
+++ b/orb-discovery/gnmi-discovery/policy/run.go
@@ -23,6 +23,11 @@ const (
 
 const maxRunsPerTarget = 3
 
+// maxRunsPerPolicy caps what /status reports for one policy. A /22 policy can
+// hold three runs for each of a thousand targets, and the whole list is
+// marshalled on every health check.
+const maxRunsPerPolicy = 100
+
 // Run is a single flush execution (one reconciled-snapshot ingest).
 type Run struct {
 	ID       string `json:"id"`
@@ -138,20 +143,46 @@ func (rs *RunStore) UpdateRun(policy, host, runID string, status RunStatus, err 
 	}
 }
 
-// GetRunsForPolicy returns all runs for a policy (flattened, newest first).
+// GetRunsForPolicy returns a policy's most recently active runs.
+//
+// The result is capped. A policy sweeping a /22 holds up to maxRunsPerTarget
+// runs for each of a thousand targets, and the agent polls /status every 10s
+// with a 2s budget and restarts the backend when that times out — so an
+// uncapped list turns a large policy into a restart loop.
+//
+// Sweep runs are exempt from the cap. They are the one record that describes the
+// policy as a whole, and they are also the easiest to lose: a busy range
+// produces device runs continuously, which would push the sweep off the end.
 func (rs *RunStore) GetRunsForPolicy(policy string) []*Run {
 	rs.mu.RLock()
 	defer rs.mu.RUnlock()
 	out := make([]*Run, 0)
-	for _, targetRuns := range rs.runs[policy] {
+	var sweeps []*Run
+	for host, targetRuns := range rs.runs[policy] {
 		for _, r := range targetRuns {
+			if host == sweepRunKey {
+				sweeps = append(sweeps, copyRun(r))
+				continue
+			}
 			out = append(out, copyRun(r))
 		}
 	}
-	// Most-recent-activity order, not creation order. A sweep run is created
-	// before every run it starts, so sorting on CreatedAt would bury it under the
-	// per-device runs it produced — and activity order is the more useful one
-	// generally. Per-device runs consequently order by activity too.
-	sort.Slice(out, func(i, j int) bool { return out[i].UpdatedAt > out[j].UpdatedAt })
+	sortByActivity(out)
+	if room := maxRunsPerPolicy - len(sweeps); len(out) > room {
+		out = out[:max(room, 0)]
+	}
+	out = append(out, sweeps...)
+	sortByActivity(out)
 	return out
+}
+
+// sortByActivity orders runs most-recently-active first.
+//
+// Not creation order: a sweep run is created before every run it starts, so
+// sorting on CreatedAt would permanently bury it under the per-device runs it
+// produced. Activity order is also the more useful one generally. The
+// consequence for existing policies is that per-device runs order by activity
+// rather than by creation.
+func sortByActivity(runs []*Run) {
+	sort.Slice(runs, func(i, j int) bool { return runs[i].UpdatedAt > runs[j].UpdatedAt })
 }

--- a/orb-discovery/gnmi-discovery/policy/run.go
+++ b/orb-discovery/gnmi-discovery/policy/run.go
@@ -143,37 +143,69 @@ func (rs *RunStore) UpdateRun(policy, host, runID string, status RunStatus, err 
 	}
 }
 
-// GetRunsForPolicy returns a policy's most recently active runs.
+// GetRunsForPolicy returns a policy's runs, capped.
 //
-// The result is capped. A policy sweeping a /22 holds up to maxRunsPerTarget
+// The cap exists because a policy sweeping a /22 holds up to maxRunsPerTarget
 // runs for each of a thousand targets, and the agent polls /status every 10s
-// with a 2s budget and restarts the backend when that times out — so an
-// uncapped list turns a large policy into a restart loop.
+// with a 2s budget and restarts the backend when that times out — so an uncapped
+// list turns a large policy into a restart loop.
 //
-// Sweep runs are exempt from the cap. They are the one record that describes the
-// policy as a whole, and they are also the easiest to lose: a busy range
-// produces device runs continuously, which would push the sweep off the end.
+// What survives the cap is ordered by how much it explains, not by recency:
+//
+// Sweep runs first. They are the one record describing the policy as a whole,
+// and the easiest to lose, since a busy range produces device runs continuously.
+//
+// Then runs still in flight, stalest first. These must never be dropped, and
+// activity order drops them first: a run's UpdatedAt is stamped when it is
+// created and not touched again until it finishes, so the longer one hangs the
+// further it sinks. deriveStatus looks for RunStatusRunning in this result alone,
+// so truncating an in-flight run makes a policy with a hung ingest report
+// completed and hides the run that would explain it. Stalest first because if
+// even these have to be trimmed, the most stuck ones are the ones worth seeing.
+//
+// Finished runs fill whatever budget is left, most recently active first.
 func (rs *RunStore) GetRunsForPolicy(policy string) []*Run {
 	rs.mu.RLock()
 	defer rs.mu.RUnlock()
-	out := make([]*Run, 0)
-	var sweeps []*Run
+
+	var sweeps, running, finished []*Run
 	for host, targetRuns := range rs.runs[policy] {
 		for _, r := range targetRuns {
-			if host == sweepRunKey {
-				sweeps = append(sweeps, copyRun(r))
-				continue
+			c := copyRun(r)
+			switch {
+			case host == sweepRunKey:
+				sweeps = append(sweeps, c)
+			case c.Status == RunStatusRunning:
+				running = append(running, c)
+			default:
+				finished = append(finished, c)
 			}
-			out = append(out, copyRun(r))
 		}
 	}
-	sortByActivity(out)
-	if room := maxRunsPerPolicy - len(sweeps); len(out) > room {
-		out = out[:max(room, 0)]
+
+	sortByStalest(running)
+	sortByActivity(finished)
+
+	budget := max(maxRunsPerPolicy-len(sweeps), 0)
+	if len(running) > budget {
+		running = running[:budget]
 	}
+	budget -= len(running)
+	if len(finished) > budget {
+		finished = finished[:max(budget, 0)]
+	}
+
+	out := make([]*Run, 0, len(sweeps)+len(running)+len(finished))
 	out = append(out, sweeps...)
+	out = append(out, running...)
+	out = append(out, finished...)
 	sortByActivity(out)
 	return out
+}
+
+// sortByStalest orders runs least-recently-active first.
+func sortByStalest(runs []*Run) {
+	sort.Slice(runs, func(i, j int) bool { return runs[i].UpdatedAt < runs[j].UpdatedAt })
 }
 
 // sortByActivity orders runs most-recently-active first.

--- a/orb-discovery/gnmi-discovery/policy/run.go
+++ b/orb-discovery/gnmi-discovery/policy/run.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -24,9 +25,13 @@ const maxRunsPerTarget = 3
 
 // Run is a single flush execution (one reconciled-snapshot ingest).
 type Run struct {
-	ID          string    `json:"id"`
-	PolicyID    string    `json:"policy_id"`
-	Target      string    `json:"target"`
+	ID       string `json:"id"`
+	PolicyID string `json:"policy_id"`
+	Target   string `json:"target"`
+	// Targets is what the agent actually reads: PolicyStatusRun decodes
+	// `json:"targets"` and has no `target` field, so a run that carries only the
+	// singular form reaches the fleet with no target at all.
+	Targets     []string  `json:"targets,omitempty"`
 	Status      RunStatus `json:"status"`
 	Reason      string    `json:"reason,omitempty"`
 	EntityCount int       `json:"entity_count"`
@@ -54,7 +59,8 @@ func (rs *RunStore) CreateRun(policy, host string) *Run {
 	now := time.Now().UTC().UnixNano()
 	run := &Run{
 		ID: uuid.New().String(), PolicyID: policy, Target: host,
-		Status: RunStatusRunning, CreatedAt: now, UpdatedAt: now,
+		Targets: []string{host},
+		Status:  RunStatusRunning, CreatedAt: now, UpdatedAt: now,
 	}
 	if rs.runs[policy] == nil {
 		rs.runs[policy] = make(map[string][]*Run)
@@ -65,6 +71,49 @@ func (rs *RunStore) CreateRun(policy, host string) *Run {
 	}
 	rs.runs[policy][host] = runs
 	return copyRun(run)
+}
+
+// sweepRunKey is the store key for a policy's sweep runs. A real host is never
+// empty, so this cannot collide with a per-device run — including the case where
+// the policy's only target is a single host that has runs of its own.
+// device-discovery distinguishes the same two shapes the same way, with an empty
+// parent_target.
+const sweepRunKey = ""
+
+// CreateSweepRun records the start of a target sweep. It is created at the
+// start, not on completion, so a sweep that hangs or takes minutes against a
+// large range is visible while it runs rather than only afterwards.
+func (rs *RunStore) CreateSweepRun(policy string, originalTargets []string) *Run {
+	run := rs.CreateRun(policy, sweepRunKey)
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	for _, r := range rs.runs[policy][sweepRunKey] {
+		if r.ID == run.ID {
+			// The operator's own host strings, so the run names the CIDR they
+			// wrote rather than a synthesized pseudo-host.
+			r.Targets = append([]string(nil), originalTargets...)
+			r.Target = strings.Join(originalTargets, ",")
+			return copyRun(r)
+		}
+	}
+	return run
+}
+
+// FinishSweepRun closes a sweep run with a human-readable reason. UpdateRun
+// fills Reason only from a non-nil error, and a successful sweep has no error
+// to report while still having something worth saying.
+func (rs *RunStore) FinishSweepRun(policy, runID string, status RunStatus, reason string, admitted int) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	for _, run := range rs.runs[policy][sweepRunKey] {
+		if run.ID == runID {
+			run.Status = status
+			run.Reason = reason
+			run.EntityCount = admitted
+			run.UpdatedAt = time.Now().UTC().UnixNano()
+			return
+		}
+	}
 }
 
 // UpdateRun updates the status and metadata of a run.
@@ -99,6 +148,10 @@ func (rs *RunStore) GetRunsForPolicy(policy string) []*Run {
 			out = append(out, copyRun(r))
 		}
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].CreatedAt > out[j].CreatedAt })
+	// Most-recent-activity order, not creation order. A sweep run is created
+	// before every run it starts, so sorting on CreatedAt would bury it under the
+	// per-device runs it produced — and activity order is the more useful one
+	// generally. Per-device runs consequently order by activity too.
+	sort.Slice(out, func(i, j int) bool { return out[i].UpdatedAt > out[j].UpdatedAt })
 	return out
 }

--- a/orb-discovery/gnmi-discovery/policy/runner.go
+++ b/orb-discovery/gnmi-discovery/policy/runner.go
@@ -64,6 +64,13 @@ type Runner struct {
 
 	mu     sync.Mutex
 	states map[string]*targetState // by host
+
+	// subscribed records every host that has a target loop, so a rescan probes
+	// only newcomers. It is deliberately not r.states: a later change that
+	// recorded rejected addresses in states for visibility would make every
+	// address a member and silently stop rescan from ever finding anything.
+	// Entries are never removed — a loop retries for the life of the policy.
+	subscribed map[string]struct{}
 }
 
 type targetState struct {
@@ -86,6 +93,7 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 		runStore:    NewRunStore(),
 		backoffBase: time.Second,
 		states:      map[string]*targetState{},
+		subscribed:  map[string]struct{}{},
 	}, nil
 }
 
@@ -125,8 +133,15 @@ func (r *Runner) setState(host string, fn func(*targetState)) {
 // survive reconnects (spec §9): a flap reconnects, the fresh initial sync
 // re-marks the live paths, and generation pruning removes only what genuinely
 // disappeared — no full re-ingest churn, no leaked debouncer goroutines.
-func (r *Runner) targetLoop(t config.Target) {
+func (r *Runner) targetLoop(t config.Target, startDelay time.Duration) {
 	defer r.wg.Done()
+	if startDelay > 0 {
+		select {
+		case <-time.After(startDelay):
+		case <-r.ctx.Done():
+			return
+		}
+	}
 	model := mapping.NewDeviceModel()
 	deb := NewDebouncer(time.Duration(r.policy.Config.DebounceMs) * time.Millisecond)
 	defer deb.Stop()

--- a/orb-discovery/gnmi-discovery/policy/runner.go
+++ b/orb-discovery/gnmi-discovery/policy/runner.go
@@ -200,7 +200,7 @@ func (r *Runner) targetLoop(t config.Target, startDelay time.Duration) {
 func (r *Runner) runOnce(t config.Target, model *mapping.DeviceModel, deb *Debouncer, retry *time.Timer) error {
 	tls := t.ResolvedTLS()
 	sess, err := r.dialer.Dial(r.ctx, gnmi.TargetSpec{
-		Host: t.Host, Username: t.Username, Password: t.Password,
+		Host: t.Host, Username: t.ResolvedUsername(), Password: t.ResolvedPassword(),
 		SkipVerify: tls.SkipVerify, Insecure: tls.Insecure, Origin: t.ResolvedOrigin(),
 		CAFile: tls.CAFile, CertFile: tls.CertFile, KeyFile: tls.KeyFile,
 	})

--- a/orb-discovery/gnmi-discovery/policy/runner.go
+++ b/orb-discovery/gnmi-discovery/policy/runner.go
@@ -181,10 +181,11 @@ func (r *Runner) targetLoop(t config.Target) {
 // permanently demotes the target. Explicit on_change/sample modes never
 // auto-downgrade; they return the error to reconnect at the same mode.
 func (r *Runner) runOnce(t config.Target, model *mapping.DeviceModel, deb *Debouncer, retry *time.Timer) error {
+	tls := t.ResolvedTLS()
 	sess, err := r.dialer.Dial(r.ctx, gnmi.TargetSpec{
 		Host: t.Host, Username: t.Username, Password: t.Password,
-		SkipVerify: t.TLS.SkipVerify, Insecure: t.TLS.Insecure, Origin: t.ResolvedOrigin(),
-		CAFile: t.TLS.CAFile, CertFile: t.TLS.CertFile, KeyFile: t.TLS.KeyFile,
+		SkipVerify: tls.SkipVerify, Insecure: tls.Insecure, Origin: t.ResolvedOrigin(),
+		CAFile: tls.CAFile, CertFile: tls.CertFile, KeyFile: tls.KeyFile,
 	})
 	if err != nil {
 		return err

--- a/orb-discovery/gnmi-discovery/policy/runner.go
+++ b/orb-discovery/gnmi-discovery/policy/runner.go
@@ -92,15 +92,17 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 // Runs returns the recent flush runs for this policy (newest first), for /status.
 func (r *Runner) Runs() []*Run { return r.runStore.GetRunsForPolicy(r.name) }
 
-// Start launches one goroutine per target.
+// Start launches the target sweep, which expands and probes before starting one
+// goroutine per admitted target.
+//
+// The wg.Add here is load-bearing and must stay on this side of the return:
+// StartPolicy calls Start under the manager lock precisely so that wg.Add
+// happens-before any StopPolicy's wg.Wait. An uncounted sweep goroutine would
+// let Stop return while the sweep is still probing, leaving it to outlive its
+// own runner, and would race wg.Add against an unblocking wg.Wait.
 func (r *Runner) Start() {
-	for _, t := range r.policy.Scope.Targets {
-		r.mu.Lock()
-		r.states[t.Host] = &targetState{}
-		r.mu.Unlock()
-		r.wg.Add(1)
-		go r.targetLoop(t)
-	}
+	r.wg.Add(1)
+	go r.sweep()
 }
 
 // Stop cancels all goroutines and waits.

--- a/orb-discovery/gnmi-discovery/policy/scope_defaults_test.go
+++ b/orb-discovery/gnmi-discovery/policy/scope_defaults_test.go
@@ -58,3 +58,273 @@ policies:
 	require.Equal(t, "/run/secrets/ca.pem", targets[0].TLS.CAFile)
 	require.Nil(t, targets[1].TLS)
 }
+
+// Inheritance must run BEFORE resolveEnv, not after. resolveEnv walks only the
+// target list, so inheriting afterwards would copy a scope-level ${GNMI_PASS}
+// into every target as that literal string, with resolution already past —
+// every device in a subnet authenticating with the eleven characters
+// "${GNMI_PASS}".
+func TestScopeCredentialsAreInheritedAndThenResolved(t *testing.T) {
+	t.Setenv("GNMI_PASS", "s3cret")
+	m := newTestManager(t)
+	data := []byte(`
+policies:
+  p1:
+    scope:
+      username: admin
+      password: ${GNMI_PASS}
+      port: 6030
+      targets:
+        - host: 10.0.0.1
+        - host: 10.0.0.2
+          username: legacy
+`)
+	policies, err := m.ParsePolicies(data)
+	require.NoError(t, err)
+	targets := policies["p1"].Scope.Targets
+
+	require.Equal(t, "admin", targets[0].Username)
+	require.Equal(t, "s3cret", targets[0].Password, "scope secret must be resolved, not literal")
+	require.Equal(t, "10.0.0.1:6030", targets[0].Host, "scope port applied")
+
+	require.Equal(t, "legacy", targets[1].Username, "target overrides scope")
+	require.Equal(t, "s3cret", targets[1].Password, "unset fields still inherit")
+}
+
+// A tls block replaces the scope's wholesale rather than merging field by field.
+// Merging is not expressible: a bool cannot distinguish "unset" from "false", so
+// a target setting insecure would silently zero the scope's skip_verify and ca.
+func TestTargetTLSBlockReplacesTheScopeBlockWholesale(t *testing.T) {
+	m := newTestManager(t)
+	data := []byte(`
+policies:
+  p1:
+    scope:
+      tls:
+        skip_verify: true
+        ca: /run/secrets/ca.pem
+      targets:
+        - host: 10.0.0.1
+        - host: 10.0.0.2
+          tls:
+            insecure: true
+`)
+	policies, err := m.ParsePolicies(data)
+	require.NoError(t, err)
+	targets := policies["p1"].Scope.Targets
+
+	inherited := targets[0].ResolvedTLS()
+	require.True(t, inherited.SkipVerify)
+	require.Equal(t, "/run/secrets/ca.pem", inherited.CAFile)
+
+	replaced := targets[1].ResolvedTLS()
+	require.True(t, replaced.Insecure)
+	require.False(t, replaced.SkipVerify, "target block replaces, so nothing is inherited")
+	require.Empty(t, replaced.CAFile, "target block replaces, so nothing is inherited")
+}
+
+// Inheriting a pointer would alias one struct across every expanded target, and
+// resolveEnv then writes through it once per target. MergeDefaults documents the
+// same rule for the same reason: an inherited block is owned, not shared.
+func TestInheritedTLSBlockIsCopiedNotAliased(t *testing.T) {
+	m := newTestManager(t)
+	data := []byte(`
+policies:
+  p1:
+    scope:
+      tls:
+        ca: /run/secrets/ca.pem
+      targets:
+        - host: 10.0.0.1
+        - host: 10.0.0.2
+`)
+	policies, err := m.ParsePolicies(data)
+	require.NoError(t, err)
+	targets := policies["p1"].Scope.Targets
+	require.NotSame(t, targets[0].TLS, targets[1].TLS, "each target owns its block")
+}
+
+// Origin distinguishes unset from an explicit "", so inheritance must test for
+// nil. A target asking for origin-less paths must not inherit "openconfig".
+func TestExplicitEmptyOriginIsNotOverwrittenByTheScope(t *testing.T) {
+	m := newTestManager(t)
+	data := []byte(`
+policies:
+  p1:
+    scope:
+      origin: srl_nokia
+      targets:
+        - host: 10.0.0.1
+        - host: 10.0.0.2
+          origin: ""
+`)
+	policies, err := m.ParsePolicies(data)
+	require.NoError(t, err)
+	targets := policies["p1"].Scope.Targets
+	// Deliberately not "openconfig": that is the built-in default, so asserting
+	// it would pass whether the scope was inherited or ignored.
+	require.Equal(t, "srl_nokia", targets[0].ResolvedOrigin())
+	require.Equal(t, "", targets[1].ResolvedOrigin(), "explicit empty origin survives inheritance")
+}
+
+// An inline host:port wins over the port field, which wins over the scope's.
+func TestPortPrecedenceIsInlineThenTargetThenScope(t *testing.T) {
+	m := newTestManager(t)
+	data := []byte(`
+policies:
+  p1:
+    scope:
+      port: 6030
+      targets:
+        - host: 10.0.0.1
+        - host: 10.0.0.2
+          port: 57400
+        - host: 10.0.0.3:1234
+          port: 57400
+        - host: 10.0.0.4
+`)
+	policies, err := m.ParsePolicies(data)
+	require.NoError(t, err)
+	hosts := []string{}
+	for _, tgt := range policies["p1"].Scope.Targets {
+		hosts = append(hosts, tgt.Host)
+	}
+	require.Equal(t, []string{
+		"10.0.0.1:6030",  // scope
+		"10.0.0.2:57400", // target beats scope
+		"10.0.0.3:1234",  // inline beats both
+		"10.0.0.4:6030",  // scope
+	}, hosts)
+}
+
+func TestPortFallsBackToTheGNMIDefault(t *testing.T) {
+	m := newTestManager(t)
+	data := []byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.1
+`)
+	policies, err := m.ParsePolicies(data)
+	require.NoError(t, err)
+	require.Equal(t, "10.0.0.1:9339", policies["p1"].Scope.Targets[0].Host)
+}
+
+// The cap must be checked AFTER env resolution. At validatePolicy time the host
+// is still the literal "${SUBNET}", which parses as a hostname and sails past
+// every bounds check — and then the runner enumerates 10.0.0.0/8 into hundreds
+// of megabytes inside a container that does not have them.
+func TestOverCapSubnetFromAnEnvVarIsRejected(t *testing.T) {
+	t.Setenv("SUBNET", "10.0.0.0/8")
+	m := newTestManager(t)
+	data := []byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: ${SUBNET}
+`)
+	_, err := m.ParsePolicies(data)
+	require.Error(t, err, "an over-cap CIDR must not reach the runner")
+	require.Contains(t, err.Error(), "10.0.0.0/8", "the error names the offending target")
+}
+
+func TestSubnetFromAnEnvVarIsAcceptedWhenItFits(t *testing.T) {
+	t.Setenv("SUBNET", "10.0.0.0/24")
+	m := newTestManager(t)
+	data := []byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: ${SUBNET}
+`)
+	policies, err := m.ParsePolicies(data)
+	require.NoError(t, err)
+	require.Equal(t, "10.0.0.0/24", policies["p1"].Scope.Targets[0].Host,
+		"a prefix is not expanded at parse time, only counted")
+}
+
+// The cap is per policy, so several entries that each fit can still exceed it.
+func TestTheCapIsSummedAcrossTargets(t *testing.T) {
+	m := newTestManager(t)
+	data := []byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.0/23
+        - host: 10.1.0.0/23
+        - host: 10.2.0.0/23
+`)
+	_, err := m.ParsePolicies(data)
+	require.Error(t, err, "3 x 510 exceeds the per-policy cap")
+}
+
+func TestIPv6PrefixIsRejectedWithAReason(t *testing.T) {
+	m := newTestManager(t)
+	data := []byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 2001:db8::/64
+`)
+	_, err := m.ParsePolicies(data)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "enumerat")
+}
+
+// Keeping inline host:port while adding range syntax creates this trap: an
+// operator carrying the documented "10.0.0.11:6030" habit forward to a range
+// writes something Expand treats as a DNS name, which then retries a
+// nonexistent host forever with only a generic dial error.
+func TestARangeCarryingAnInlinePortIsRejected(t *testing.T) {
+	m := newTestManager(t)
+	for _, host := range []string{"10.0.0.1-10:6030", "10.0.0.0/24:6030"} {
+		data := []byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: ` + host + `
+`)
+		_, err := m.ParsePolicies(data)
+		require.Error(t, err, "host %q must be rejected", host)
+		require.Contains(t, err.Error(), "port", "the error points at the port field")
+	}
+}
+
+// An operator naming one device twice, with two credential sets, has a bug.
+// Two entries for the same host at DIFFERENT ports are two real endpoints
+// though — that is the Arista-and-Nokia pairing the docs teach.
+func TestDuplicateTargetsAreRejectedUnlessThePortsDiffer(t *testing.T) {
+	m := newTestManager(t)
+	dup := []byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.5
+          username: a
+        - host: 10.0.0.5
+          username: b
+`)
+	_, err := m.ParsePolicies(dup)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "10.0.0.5")
+
+	distinct := []byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.5
+          port: 6030
+        - host: 10.0.0.5
+          port: 57400
+`)
+	_, err = m.ParsePolicies(distinct)
+	require.NoError(t, err, "same host, different ports: two endpoints, not a duplicate")
+}

--- a/orb-discovery/gnmi-discovery/policy/scope_defaults_test.go
+++ b/orb-discovery/gnmi-discovery/policy/scope_defaults_test.go
@@ -83,12 +83,12 @@ policies:
 	require.NoError(t, err)
 	targets := policies["p1"].Scope.Targets
 
-	require.Equal(t, "admin", targets[0].Username)
-	require.Equal(t, "s3cret", targets[0].Password, "scope secret must be resolved, not literal")
+	require.Equal(t, "admin", targets[0].ResolvedUsername())
+	require.Equal(t, "s3cret", targets[0].ResolvedPassword(), "scope secret must be resolved, not literal")
 	require.Equal(t, "10.0.0.1:6030", targets[0].Host, "scope port applied")
 
-	require.Equal(t, "legacy", targets[1].Username, "target overrides scope")
-	require.Equal(t, "s3cret", targets[1].Password, "unset fields still inherit")
+	require.Equal(t, "legacy", targets[1].ResolvedUsername(), "target overrides scope")
+	require.Equal(t, "s3cret", targets[1].ResolvedPassword(), "unset fields still inherit")
 }
 
 // A tls block replaces the scope's wholesale rather than merging field by field.
@@ -327,4 +327,74 @@ policies:
 `)
 	_, err = m.ParsePolicies(distinct)
 	require.NoError(t, err, "same host, different ports: two endpoints, not a duplicate")
+}
+
+// An anonymous device inside a credentialed scope. Presence, not emptiness,
+// controls inheritance: a target that writes `username: ""` has said it connects
+// without credentials, and inheriting over that would send the campus password
+// to a device the operator marked as taking none.
+//
+// This is why the fields are pointers. A plain string cannot tell an omitted
+// field from an explicitly empty one, since YAML decodes both to "".
+func TestAnExplicitlyEmptyCredentialBlocksInheritance(t *testing.T) {
+	m := newTestManager(t)
+	data := []byte(`
+policies:
+  p1:
+    scope:
+      username: admin
+      password: campus-secret
+      targets:
+        - host: 10.0.0.1
+        - host: 10.0.0.2
+          username: ""
+          password: ""
+`)
+	policies, err := m.ParsePolicies(data)
+	require.NoError(t, err)
+	targets := policies["p1"].Scope.Targets
+
+	require.Equal(t, "admin", targets[0].ResolvedUsername(), "an omitted field inherits")
+	require.Equal(t, "campus-secret", targets[0].ResolvedPassword())
+
+	require.NotNil(t, targets[1].Username, "an explicit empty value is present, not absent")
+	require.Empty(t, targets[1].ResolvedUsername(), "and it is not overwritten by the scope")
+	require.Empty(t, targets[1].ResolvedPassword())
+}
+
+// Only one of the two can be blocked, independently.
+func TestBlockingOneCredentialLeavesTheOtherInherited(t *testing.T) {
+	m := newTestManager(t)
+	policies, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      username: admin
+      password: campus-secret
+      targets:
+        - host: 10.0.0.1
+          password: ""
+`))
+	require.NoError(t, err)
+	tgt := policies["p1"].Scope.Targets[0]
+	require.Equal(t, "admin", tgt.ResolvedUsername(), "username still inherits")
+	require.Empty(t, tgt.ResolvedPassword(), "password does not")
+}
+
+// A target with no credential fields at all and a scope with none either must not
+// end up holding empty non-nil pointers, which would block a later inherit and
+// would also mean the dialer is handed "" instead of nothing.
+func TestNoCredentialsAnywhereLeavesBothUnset(t *testing.T) {
+	m := newTestManager(t)
+	policies, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.1
+`))
+	require.NoError(t, err)
+	tgt := policies["p1"].Scope.Targets[0]
+	require.Nil(t, tgt.Username)
+	require.Nil(t, tgt.Password)
 }

--- a/orb-discovery/gnmi-discovery/policy/scope_defaults_test.go
+++ b/orb-discovery/gnmi-discovery/policy/scope_defaults_test.go
@@ -1,0 +1,60 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The single most dangerous consequence of making Target.TLS a pointer: Go
+// auto-dereferences field selectors, so every existing read compiles unchanged
+// and panics at nil. resolveEnv takes the ADDRESS of three TLS fields, and nil
+// is the default case — a policy with no tls block anywhere, which is the
+// overwhelmingly common config. There is no gin.Recovery() and no recover() in
+// this module, so an unguarded read here kills the POST with a stack trace.
+//
+// This test exists to fail loudly if the guard is ever removed.
+func TestParsePoliciesDoesNotPanicWhenNoTargetHasATLSBlock(t *testing.T) {
+	m := newTestManager(t)
+	data := []byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.1
+        - host: 10.0.0.2
+`)
+	policies, err := m.ParsePolicies(data)
+	require.NoError(t, err)
+	require.Len(t, policies["p1"].Scope.Targets, 2)
+	for _, tgt := range policies["p1"].Scope.Targets {
+		require.Nil(t, tgt.TLS, "no tls block means nil, not a zero struct")
+		tls := tgt.ResolvedTLS()
+		require.False(t, tls.SkipVerify)
+		require.False(t, tls.Insecure)
+		require.Empty(t, tls.CAFile)
+	}
+}
+
+// A target with its own tls block still has its ${VAR} paths resolved, which is
+// the behaviour the nil guard must not break.
+func TestParsePoliciesResolvesTLSPathsWhenTheBlockIsPresent(t *testing.T) {
+	t.Setenv("GNMI_CA", "/run/secrets/ca.pem")
+	m := newTestManager(t)
+	data := []byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.1
+          tls:
+            ca: ${GNMI_CA}
+        - host: 10.0.0.2
+`)
+	policies, err := m.ParsePolicies(data)
+	require.NoError(t, err)
+	targets := policies["p1"].Scope.Targets
+	require.NotNil(t, targets[0].TLS)
+	require.Equal(t, "/run/secrets/ca.pem", targets[0].TLS.CAFile)
+	require.Nil(t, targets[1].TLS)
+}

--- a/orb-discovery/gnmi-discovery/policy/scope_e2e_test.go
+++ b/orb-discovery/gnmi-discovery/policy/scope_e2e_test.go
@@ -1,8 +1,10 @@
 package policy
 
 import (
+	"bytes"
 	"context"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -85,5 +87,90 @@ func newRunnerFor(t *testing.T, policy config.Policy, dialer gnmi.Dialer) *Runne
 		"campus", policy, &recordingClient{}, dialer, store)
 	require.NoError(t, err)
 	r.backoffBase = time.Millisecond
+	return r
+}
+
+// Pinning one device inside a subnet is the documented way to give it its own
+// credentials, so it must not be reported as a duplicate — with rescan on, that
+// warning would repeat on every tick for the life of the policy. Two genuinely
+// overlapping ranges still warn.
+func TestAPinnedHostInsideASubnetIsNotWarnedAbout(t *testing.T) {
+	for name, hosts := range map[string][]string{
+		"pin first":    {"10.0.0.5", "10.0.0.0/29"},
+		"subnet first": {"10.0.0.0/29", "10.0.0.5"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var logs bytes.Buffer
+			r := runnerWithHosts(t, hosts, slog.New(slog.NewTextHandler(&logs, nil)))
+			_, _, err := r.admitTargets()
+			require.NoError(t, err)
+			require.NotContains(t, logs.String(), "duplicate",
+				"a pinned host inside its own subnet is a supported config")
+		})
+	}
+
+	var logs bytes.Buffer
+	r := runnerWithHosts(t, []string{"10.0.0.0/29", "10.0.0.0-7"}, slog.New(slog.NewTextHandler(&logs, nil)))
+	_, _, err := r.admitTargets()
+	require.NoError(t, err)
+	require.Contains(t, logs.String(), "duplicate",
+		"two overlapping ranges are a mistake worth reporting")
+}
+
+// The pinned entry's own settings survive the overlap, in either write order.
+func TestAPinnedHostInsideASubnetKeepsItsOwnSettings(t *testing.T) {
+	for name, targetList := range map[string][]config.Target{
+		"pin first": {
+			{Host: "10.0.0.5", Username: "legacy"},
+			{Host: "10.0.0.0/29"},
+		},
+		"subnet first": {
+			{Host: "10.0.0.0/29"},
+			{Host: "10.0.0.5", Username: "legacy"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			r := runnerWithTargets(t, targetList, slog.New(slog.DiscardHandler))
+			expanded, err := r.expandTargets()
+			require.NoError(t, err)
+
+			var found bool
+			for _, c := range expanded {
+				if c.target.Host == "10.0.0.5:9339" {
+					found = true
+					require.Equal(t, "legacy", c.target.Username)
+					require.True(t, c.explicit, "the pin is explicit, so it is never probed")
+				}
+			}
+			require.True(t, found)
+		})
+	}
+}
+
+func runnerWithHosts(t *testing.T, hosts []string, logger *slog.Logger) *Runner {
+	t.Helper()
+	list := make([]config.Target, 0, len(hosts))
+	for _, h := range hosts {
+		list = append(list, config.Target{Host: h})
+	}
+	return runnerWithTargets(t, list, logger)
+}
+
+func runnerWithTargets(t *testing.T, list []config.Target, logger *slog.Logger) *Runner {
+	t.Helper()
+	for i := range list {
+		if !strings.ContainsAny(list[i].Host, "/-") {
+			list[i].Host = ensurePort(list[i].Host, config.DefaultGNMIPort)
+		}
+	}
+	store, err := mapping.LoadProfiles("")
+	require.NoError(t, err)
+	r, err := NewRunner(context.Background(), logger, "p1",
+		config.Policy{
+			Config: config.PolicyConfig{Mode: config.ModeAuto, DebounceMs: 10},
+			Scope:  config.Scope{Targets: list},
+		},
+		&recordingClient{}, newPerHostDialer(nil), store)
+	require.NoError(t, err)
 	return r
 }

--- a/orb-discovery/gnmi-discovery/policy/scope_e2e_test.go
+++ b/orb-discovery/gnmi-discovery/policy/scope_e2e_test.go
@@ -121,12 +121,12 @@ func TestAPinnedHostInsideASubnetIsNotWarnedAbout(t *testing.T) {
 func TestAPinnedHostInsideASubnetKeepsItsOwnSettings(t *testing.T) {
 	for name, targetList := range map[string][]config.Target{
 		"pin first": {
-			{Host: "10.0.0.5", Username: "legacy"},
+			{Host: "10.0.0.5", Username: strPtr("legacy")},
 			{Host: "10.0.0.0/29"},
 		},
 		"subnet first": {
 			{Host: "10.0.0.0/29"},
-			{Host: "10.0.0.5", Username: "legacy"},
+			{Host: "10.0.0.5", Username: strPtr("legacy")},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -138,7 +138,7 @@ func TestAPinnedHostInsideASubnetKeepsItsOwnSettings(t *testing.T) {
 			for _, c := range expanded {
 				if c.target.Host == "10.0.0.5:9339" {
 					found = true
-					require.Equal(t, "legacy", c.target.Username)
+					require.Equal(t, "legacy", c.target.ResolvedUsername())
 					require.True(t, c.explicit, "the pin is explicit, so it is never probed")
 				}
 			}
@@ -251,3 +251,5 @@ policies:
 		return false
 	}, 3*time.Second, 10*time.Millisecond, "the subscription presents the client certificate")
 }
+
+func strPtr(v string) *string { return &v }

--- a/orb-discovery/gnmi-discovery/policy/scope_e2e_test.go
+++ b/orb-discovery/gnmi-discovery/policy/scope_e2e_test.go
@@ -74,8 +74,8 @@ policies:
 		"the scope secret was resolved from the environment, not passed through literally")
 	require.True(t, subscribed.SkipVerify, "the scope TLS block was inherited")
 
-	// The probe still carries the TLS settings: without them it cannot complete a
-	// handshake against a device that requires one.
+	// The probe still carries the server-side TLS settings: without them it
+	// cannot complete a handshake it is otherwise entitled to complete.
 	require.True(t, rejected[0].SkipVerify, "a probe uses the resolved TLS block")
 }
 
@@ -173,4 +173,81 @@ func runnerWithTargets(t *testing.T, list []config.Target, logger *slog.Logger) 
 		&recordingClient{}, newPerHostDialer(nil), store)
 	require.NoError(t, err)
 	return r
+}
+
+// A probe carries no identity of any kind, the client certificate included.
+// Presenting the agent's client identity to every address in a range hands it to
+// whatever is listening there, and admission never needs it: a device that
+// requires mTLS and receives no client cert answers "tls: certificate required",
+// which is a peer answering and is admitted. That was measured against a real
+// mTLS server rather than assumed.
+//
+// The server-side settings still go, or the probe cannot complete a handshake it
+// is entitled to complete.
+func TestAProbeWithholdsTheClientCertificateButKeepsTheServerSettings(t *testing.T) {
+	m := newTestManager(t)
+	policies, err := m.ParsePolicies([]byte(`
+policies:
+  campus:
+    scope:
+      username: admin
+      password: pw
+      tls:
+        ca: /run/secrets/ca.pem
+        cert: /run/secrets/client.pem
+        key: /run/secrets/client.key
+      targets:
+        - host: 10.0.0.0/30
+`))
+	require.NoError(t, err)
+
+	dialer := newPerHostDialer(nil)
+	dialer.defaultCapsErr = dialingErr() // reject all, so every dial is a probe
+	r := newRunnerFor(t, policies["campus"], dialer)
+	r.Start()
+	t.Cleanup(func() { _ = r.Stop() })
+
+	require.Eventually(t, func() bool {
+		return len(dialer.dialedHosts()) == 2
+	}, 3*time.Second, 10*time.Millisecond)
+
+	for _, spec := range dialer.specsSnapshot() {
+		require.Empty(t, spec.CertFile, "a probe must not present a client certificate")
+		require.Empty(t, spec.KeyFile, "a probe must not present a client key")
+		require.Empty(t, spec.Username)
+		require.Empty(t, spec.Password)
+		require.Equal(t, "/run/secrets/ca.pem", spec.CAFile,
+			"the CA verifies the server and must survive")
+	}
+}
+
+// The subscription that follows a successful probe does present the full mTLS
+// identity: withholding it there would break every device that requires it.
+func TestASubscriptionStillPresentsTheClientCertificate(t *testing.T) {
+	m := newTestManager(t)
+	policies, err := m.ParsePolicies([]byte(`
+policies:
+  campus:
+    scope:
+      tls:
+        cert: /run/secrets/client.pem
+        key: /run/secrets/client.key
+      targets:
+        - host: 10.0.0.0/31
+`))
+	require.NoError(t, err)
+
+	dialer := newPerHostDialer(nil)
+	r := newRunnerFor(t, policies["campus"], dialer)
+	r.Start()
+	t.Cleanup(func() { _ = r.Stop() })
+
+	require.Eventually(t, func() bool {
+		for _, spec := range dialer.specsSnapshot() {
+			if spec.CertFile != "" {
+				return true
+			}
+		}
+		return false
+	}, 3*time.Second, 10*time.Millisecond, "the subscription presents the client certificate")
 }

--- a/orb-discovery/gnmi-discovery/policy/scope_e2e_test.go
+++ b/orb-discovery/gnmi-discovery/policy/scope_e2e_test.go
@@ -1,0 +1,89 @@
+package policy
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/gnmi"
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/mapping"
+)
+
+// The whole feature, end to end: a policy whose scope carries credentials and a
+// CIDR, through parsing and inheritance and expansion and the probe, to the
+// subscriptions that come out the far side.
+func TestASubnetPolicyProbesWithoutCredentialsAndSubscribesWithThem(t *testing.T) {
+	t.Setenv("GNMI_PASS", "campus-secret")
+
+	m := newTestManager(t)
+	policies, err := m.ParsePolicies([]byte(`
+policies:
+  campus:
+    config:
+      mode: on_change
+    scope:
+      username: admin
+      password: ${GNMI_PASS}
+      port: 6030
+      tls:
+        skip_verify: true
+      targets:
+        - host: 10.0.0.0/30
+`))
+	require.NoError(t, err)
+
+	dialer := newPerHostDialer(map[string]error{"10.0.0.2:6030": dialingErr()})
+	r := newRunnerFor(t, policies["campus"], dialer)
+	r.Start()
+	t.Cleanup(func() { _ = r.Stop() })
+
+	require.Eventually(t, func() bool {
+		return len(r.TargetStatuses()) == 1
+	}, 3*time.Second, 10*time.Millisecond)
+	require.Equal(t, "10.0.0.1:6030", r.TargetStatuses()[0].Host,
+		"the scope port reached an address the operator never wrote")
+
+	// The probe must be anonymous. gnmic attaches credentials as gRPC metadata on
+	// every RPC including Capabilities, so a credentialed sweep would offer the
+	// campus password to all 254 addresses in a /24 — and with skip_verify, to
+	// anything at all that answers.
+	rejected := dialer.specsFor("10.0.0.2:6030")
+	require.NotEmpty(t, rejected)
+	for _, spec := range rejected {
+		require.Empty(t, spec.Username, "a probe must not carry a username")
+		require.Empty(t, spec.Password, "a probe must not carry a password")
+	}
+
+	// The subscription that follows does carry them, inherited from the scope.
+	var subscribed *gnmi.TargetSpec
+	for _, spec := range dialer.specsFor("10.0.0.1:6030") {
+		if spec.Password != "" {
+			s := spec
+			subscribed = &s
+		}
+	}
+	require.NotNil(t, subscribed, "the admitted target subscribes with credentials")
+	require.Equal(t, "admin", subscribed.Username)
+	require.Equal(t, "campus-secret", subscribed.Password,
+		"the scope secret was resolved from the environment, not passed through literally")
+	require.True(t, subscribed.SkipVerify, "the scope TLS block was inherited")
+
+	// The probe still carries the TLS settings: without them it cannot complete a
+	// handshake against a device that requires one.
+	require.True(t, rejected[0].SkipVerify, "a probe uses the resolved TLS block")
+}
+
+func newRunnerFor(t *testing.T, policy config.Policy, dialer gnmi.Dialer) *Runner {
+	t.Helper()
+	store, err := mapping.LoadProfiles("")
+	require.NoError(t, err)
+	r, err := NewRunner(context.Background(), slog.New(slog.DiscardHandler),
+		"campus", policy, &recordingClient{}, dialer, store)
+	require.NoError(t, err)
+	r.backoffBase = time.Millisecond
+	return r
+}

--- a/orb-discovery/gnmi-discovery/policy/scope_e2e_test.go
+++ b/orb-discovery/gnmi-discovery/policy/scope_e2e_test.go
@@ -27,6 +27,10 @@ policies:
   campus:
     config:
       mode: on_change
+      # This combination — a credentialed range whose server is not
+      # authenticated — is refused unless the policy opts in, precisely because
+      # of what this test then goes on to assert about where the password goes.
+      send_credentials_to_unverified_targets: true
     scope:
       username: admin
       password: ${GNMI_PASS}

--- a/orb-discovery/gnmi-discovery/policy/sweep.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep.go
@@ -343,10 +343,20 @@ func dedupeKey(host string) string {
 
 // probe asks one address whether anything is listening.
 //
-// It sends no credentials. gnmic attaches them as gRPC metadata on every RPC
-// including Capabilities, so a credentialed sweep would spray the campus
-// password across every address in the range — and with a scope-level
-// skip_verify, at anything that answers.
+// It carries no identity of any kind. gnmic attaches username and password as
+// gRPC metadata on every RPC including Capabilities, so a credentialed sweep
+// would spray the campus password across every address in the range — and with a
+// scope-level skip_verify, at anything that answers.
+//
+// The client certificate is withheld for the same reason, one step weaker: a
+// probe is not an authenticated conversation, so presenting the agent's client
+// identity to every address in a range gives it away to whatever is listening
+// there. Admission never needs it. A device that requires mTLS and gets no
+// client cert answers "tls: certificate required", which is a peer answering and
+// is admitted — measured against a real mTLS server, not assumed.
+//
+// The server-side settings do go: without the CA and skip_verify the probe
+// cannot complete a handshake it is otherwise entitled to complete.
 func (r *Runner) probe(t config.Target) error {
 	ctx, cancel := context.WithTimeout(r.ctx, r.policy.Config.ResolvedProbeTimeout())
 	defer cancel()
@@ -358,8 +368,6 @@ func (r *Runner) probe(t config.Target) error {
 		Insecure:   tls.Insecure,
 		Origin:     t.ResolvedOrigin(),
 		CAFile:     tls.CAFile,
-		CertFile:   tls.CertFile,
-		KeyFile:    tls.KeyFile,
 	})
 	if err != nil {
 		// A Dial error is usually a configuration fault — an unreadable CA file,

--- a/orb-discovery/gnmi-discovery/policy/sweep.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep.go
@@ -92,13 +92,13 @@ func (r *Runner) sweepOnce() {
 	}
 
 	status := RunStatusCompleted
-	if outcome.reachable() == 0 {
+	if outcome.total() == 0 {
 		// The operator gave a range and nothing in it answered. That is the
 		// implementable form of "the policy failed": a run they can see, rather
 		// than a silent policy that reports healthy and discovers nothing.
 		status = RunStatusFailed
 	}
-	r.runStore.FinishSweepRun(r.name, run.ID, status, outcome.summary(), outcome.reachable())
+	r.runStore.FinishSweepRun(r.name, run.ID, status, outcome.summary(), outcome.total())
 
 	// Spread the first dial once a sweep admits more than a handful. Every loop
 	// dials immediately, so 200 admitted targets means 200 simultaneous TLS
@@ -194,8 +194,10 @@ func (r *Runner) admitTargets() ([]config.Target, sweepOutcome, error) {
 		if c.explicit {
 			// The operator named this device. Dropping it because it happens to
 			// be rebooting would regress the retry-forever behaviour a named
-			// host has always had.
+			// host has always had. Counted apart from the probed addresses: it
+			// was never asked, so it cannot be reported as having answered.
 			admitted = append(admitted, c.target)
+			out.explicit++
 			continue
 		}
 		if !probed[i] {
@@ -215,7 +217,7 @@ func (r *Runner) admitTargets() ([]config.Target, sweepOutcome, error) {
 		}
 	}
 
-	out.admitted = len(admitted)
+	out.admitted = len(admitted) - out.explicit
 	out.rejected = rejected
 	out.exampleReason = reasonText(firstReason)
 
@@ -234,27 +236,45 @@ func (r *Runner) admitTargets() ([]config.Target, sweepOutcome, error) {
 
 // sweepOutcome is what the sweep run reports. Run has only EntityCount and
 // Reason to say it with, so the counts are rendered into the reason text.
+//
+// explicit is kept apart from admitted because the two are not the same claim. A
+// named host is started without being probed, so folding it into admitted
+// reported it as having answered — an unreachable single-host policy read as
+// "1 of 1 probed address(es) answered" when nothing was probed at all.
 type sweepOutcome struct {
 	scanned       int // addresses this policy expands to
 	subscribed    int // already had a target loop, so not re-probed
-	admitted      int // answered this sweep and got a loop
+	explicit      int // named by the operator, started without a probe
+	admitted      int // probed, answered, and got a loop
 	rejected      int // probed and did not answer
 	exampleReason string
 }
 
-// reachable is how many targets this policy is subscribed to once the sweep
+// probed is derived from the verdicts rather than from scanned minus subscribed,
+// which counted the addresses that skipped the probe.
+func (o sweepOutcome) probed() int { return o.admitted + o.rejected }
+
+// started is how many loops this sweep launched, however they were justified.
+func (o sweepOutcome) started() int { return o.explicit + o.admitted }
+
+// total is how many targets this policy is subscribed to once the sweep
 // finishes. It is what the run reports as its entity count, rather than the
-// number newly admitted: a rescan tick that finds nothing new is the normal
-// state of a healthy policy, and reporting 0 there would read as a policy that
-// had stopped discovering anything.
-func (o sweepOutcome) reachable() int { return o.subscribed + o.admitted }
+// number newly started: a rescan tick that finds nothing new is the normal state
+// of a healthy policy, and reporting 0 there would read as a policy that had
+// stopped discovering anything.
+func (o sweepOutcome) total() int { return o.subscribed + o.started() }
 
 func (o sweepOutcome) summary() string {
-	probed := o.scanned - o.subscribed
-	if probed == 0 {
-		return fmt.Sprintf("%d subscribed; no unsubscribed addresses left to probe", o.reachable())
+	s := fmt.Sprintf("%d subscribed", o.total())
+	if o.probed() == 0 && o.explicit == 0 {
+		return s + "; no unsubscribed addresses left to probe"
 	}
-	s := fmt.Sprintf("%d subscribed; %d of %d probed address(es) answered", o.reachable(), o.admitted, probed)
+	if o.probed() > 0 {
+		s += fmt.Sprintf("; %d of %d probed address(es) answered", o.admitted, o.probed())
+	}
+	if o.explicit > 0 {
+		s += fmt.Sprintf("; %d named target(s) started without probing", o.explicit)
+	}
 	if o.rejected > 0 {
 		s += fmt.Sprintf("; %d did not answer, e.g. %s", o.rejected, o.exampleReason)
 	}

--- a/orb-discovery/gnmi-discovery/policy/sweep.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep.go
@@ -347,17 +347,16 @@ func (r *Runner) expandTargets() ([]candidate, error) {
 	return out, nil
 }
 
-// dedupeKey collapses two spellings of one endpoint. A hostname keeps its own
-// text: Expand never resolves DNS, so a name and an address cannot be known to
-// be the same device.
+// dedupeKey collapses two spellings of one endpoint.
+//
+// It shares canonicalHost with the validation that runs earlier, so the two
+// cannot disagree about what "the same endpoint" means. They did once, and
+// validation admitted a pair that expansion then silently merged.
 func dedupeKey(host string) string {
 	if h, port, err := net.SplitHostPort(host); err == nil {
-		if ip := net.ParseIP(strings.Trim(h, "[]")); ip != nil {
-			return ip.String() + ":" + port
-		}
-		return strings.ToLower(h) + ":" + port
+		return canonicalHost(h) + ":" + port
 	}
-	return strings.ToLower(host)
+	return canonicalHost(host)
 }
 
 // probe asks one address whether anything is listening.

--- a/orb-discovery/gnmi-discovery/policy/sweep.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep.go
@@ -298,13 +298,22 @@ func (r *Runner) expandTargets() ([]candidate, error) {
 			key := dedupeKey(derived.Host)
 			if at, dup := seen[key]; dup {
 				// An explicit entry beats one produced by an expansion, so a
-				// device pinned inside a subnet keeps its own settings.
-				if literal && !out[at].explicit {
+				// device pinned inside a subnet keeps its own settings — in
+				// either order, since the two entries can be written either way
+				// round.
+				switch {
+				case literal && !out[at].explicit:
 					out[at] = candidate{target: derived, explicit: true}
-					continue
+				case out[at].explicit && !literal:
+					// Pinning a device inside a subnet is the documented way to
+					// give it its own credentials. It is not a mistake, and with
+					// rescan on, warning would repeat it on every tick forever.
+					r.logger.Debug("expansion skipped an address pinned by its own target entry",
+						"policy", r.name, "host", derived.Host)
+				default:
+					r.logger.Warn("dropping duplicate target produced by expansion",
+						"policy", r.name, "host", derived.Host)
 				}
-				r.logger.Warn("dropping duplicate target produced by expansion",
-					"policy", r.name, "host", derived.Host)
 				continue
 			}
 			seen[key] = len(out)

--- a/orb-discovery/gnmi-discovery/policy/sweep.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep.go
@@ -18,11 +18,6 @@ import (
 )
 
 const (
-	// probeTimeout bounds one Dial-plus-Capabilities probe. A gNMI probe is a
-	// TLS handshake plus a gRPC call, not a UDP walk, so it is longer than
-	// snmp-discovery's 1s equivalent.
-	probeTimeout = 3 * time.Second
-
 	// probeConcurrency bounds probes in flight. snmp uses min(256, n), but each
 	// gNMI probe holds a TLS handshake rather than a datagram, so this is lower.
 	probeConcurrency = 64
@@ -32,6 +27,11 @@ const (
 	// it on connection-refused, NXDOMAIN, unreachable and missing-port, and on
 	// nothing else — a TLS handshake failure has already reached a peer.
 	dialingMarker = "transport: Error while dialing"
+
+	// jitterThreshold is the number of admitted targets above which the first
+	// dial is spread; jitterWindow is what it is spread across.
+	jitterThreshold = 8
+	jitterWindow    = 30 * time.Second
 )
 
 // sweep expands this policy's targets, probes the ones that stand for more than
@@ -47,6 +47,28 @@ const (
 func (r *Runner) sweep() {
 	defer r.wg.Done()
 
+	r.sweepOnce()
+
+	interval := r.policy.Config.ResolvedRescanInterval()
+	if interval == 0 {
+		return
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-r.ctx.Done():
+			return
+		case <-ticker.C:
+			r.sweepOnce()
+		}
+	}
+}
+
+// sweepOnce probes what this policy is not already subscribed to and starts a
+// loop for each newcomer. It never touches a live subscription: a device that
+// answered an earlier sweep is not re-probed, so a rescan cannot disturb it.
+func (r *Runner) sweepOnce() {
 	admitted, err := r.admitTargets()
 	if err != nil {
 		r.logger.Error("sweep failed; no targets started",
@@ -54,15 +76,42 @@ func (r *Runner) sweep() {
 		return
 	}
 
-	for _, t := range admitted {
+	// Spread the first dial once a sweep admits more than a handful. Every loop
+	// dials immediately, so 200 admitted targets means 200 simultaneous TLS
+	// handshakes, then 200 initial syncs landing together, then 200 concurrent
+	// ingests through the one shared Diode client. The spread is deterministic
+	// rather than random: it guarantees the gap instead of sampling for it.
+	var gap time.Duration
+	if len(admitted) > jitterThreshold {
+		gap = jitterWindow / time.Duration(len(admitted))
+	}
+
+	for i, t := range admitted {
 		// The state entry must exist before the loop starts, or setState is a
 		// silent no-op and the target's first error is lost.
 		r.mu.Lock()
 		r.states[t.Host] = &targetState{}
+		r.subscribed[t.Host] = struct{}{}
 		r.mu.Unlock()
 		r.wg.Add(1)
-		go r.targetLoop(t)
+		go r.targetLoop(t, time.Duration(i)*gap)
 	}
+}
+
+// unsubscribed drops candidates this policy already has a loop for, before any
+// probe is sent. Filtering afterwards would re-probe every live device on every
+// rescan tick, which is the one thing a rescan must not do.
+func (r *Runner) unsubscribed(in []candidate) []candidate {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := in[:0:0]
+	for _, c := range in {
+		if _, ok := r.subscribed[c.target.Host]; ok {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
 }
 
 // admitTargets expands, dedupes, and probes, returning the targets worth
@@ -71,6 +120,10 @@ func (r *Runner) admitTargets() ([]config.Target, error) {
 	expanded, err := r.expandTargets()
 	if err != nil {
 		return nil, err
+	}
+	expanded = r.unsubscribed(expanded)
+	if len(expanded) == 0 {
+		return nil, nil
 	}
 
 	// Probe concurrently: a dead address costs the full probeTimeout, so a /22
@@ -217,7 +270,7 @@ func dedupeKey(host string) string {
 // password across every address in the range — and with a scope-level
 // skip_verify, at anything that answers.
 func (r *Runner) probe(t config.Target) error {
-	ctx, cancel := context.WithTimeout(r.ctx, probeTimeout)
+	ctx, cancel := context.WithTimeout(r.ctx, r.policy.Config.ResolvedProbeTimeout())
 	defer cancel()
 
 	tls := t.ResolvedTLS()

--- a/orb-discovery/gnmi-discovery/policy/sweep.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep.go
@@ -300,6 +300,8 @@ type candidate struct {
 func (r *Runner) expandTargets() ([]candidate, error) {
 	var out []candidate
 	seen := map[string]int{}
+	var dropped, pinned int
+	var firstDropped string
 
 	for _, t := range r.policy.Scope.Targets {
 		addrs, err := targets.Expand(t.Host)
@@ -332,17 +334,31 @@ func (r *Runner) expandTargets() ([]candidate, error) {
 					// Pinning a device inside a subnet is the documented way to
 					// give it its own credentials. It is not a mistake, and with
 					// rescan on, warning would repeat it on every tick forever.
-					r.logger.Debug("expansion skipped an address pinned by its own target entry",
-						"policy", r.name, "host", derived.Host)
+					pinned++
 				default:
-					r.logger.Warn("dropping duplicate target produced by expansion",
-						"policy", r.name, "host", derived.Host)
+					// Counted, not logged per address. Overlapping ranges produce
+					// one duplicate per shared address, so a policy with a few
+					// equivalent subnets emitted tens of thousands of lines per
+					// sweep — and with rescan on, per tick.
+					dropped++
+					if firstDropped == "" {
+						firstDropped = derived.Host
+					}
 				}
 				continue
 			}
 			seen[key] = len(out)
 			out = append(out, candidate{target: derived, explicit: literal})
 		}
+	}
+
+	if dropped > 0 {
+		r.logger.Warn("dropping duplicate targets produced by expansion",
+			"policy", r.name, "count", dropped, "example_host", firstDropped)
+	}
+	if pinned > 0 {
+		r.logger.Debug("expansion skipped addresses pinned by their own target entries",
+			"policy", r.name, "count", pinned)
 	}
 	return out, nil
 }

--- a/orb-discovery/gnmi-discovery/policy/sweep.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"strings"
 	"sync"
 	"time"
@@ -365,14 +364,21 @@ func (r *Runner) expandTargets() ([]candidate, error) {
 
 // dedupeKey collapses two spellings of one endpoint.
 //
-// It shares canonicalHost with the validation that runs earlier, so the two
-// cannot disagree about what "the same endpoint" means. They did once, and
-// validation admitted a pair that expansion then silently merged.
+// It goes through the same decomposition and canonicalization the validation
+// earlier uses, so the two cannot disagree about what "the same endpoint" means.
+// Every time they have had their own version of that question, an edge case has
+// slipped between them: the port half is the latest, where this built the key
+// from the raw text and so read 10.0.0.1:06030 as a different endpoint from
+// 10.0.0.1:6030, subscribing to one device twice with two sets of credentials.
 func dedupeKey(host string) string {
-	if h, port, err := net.SplitHostPort(host); err == nil {
-		return canonicalHost(h) + ":" + port
+	bare, port, inline := splitEffectivePort(host, 0)
+	if !inline {
+		// No usable inline port. Not the same as the default: this host carries no
+		// port at all, and inventing one here would collapse it with a host that
+		// does.
+		return canonicalHost(bare)
 	}
-	return canonicalHost(host)
+	return fmt.Sprintf("%s:%d", canonicalHost(bare), port)
 }
 
 // probe asks one address whether anything is listening.

--- a/orb-discovery/gnmi-discovery/policy/sweep.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep.go
@@ -1,0 +1,305 @@
+package policy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/gnmi"
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/targets"
+)
+
+const (
+	// probeTimeout bounds one Dial-plus-Capabilities probe. A gNMI probe is a
+	// TLS handshake plus a gRPC call, not a UDP walk, so it is longer than
+	// snmp-discovery's 1s equivalent.
+	probeTimeout = 3 * time.Second
+
+	// probeConcurrency bounds probes in flight. snmp uses min(256, n), but each
+	// gNMI probe holds a TLS handshake rather than a datagram, so this is lower.
+	probeConcurrency = 64
+
+	// dialingMarker is the only substring that distinguishes "nothing answered"
+	// from "something answered badly" within codes.Unavailable. grpc-go carries
+	// it on connection-refused, NXDOMAIN, unreachable and missing-port, and on
+	// nothing else — a TLS handshake failure has already reached a peer.
+	dialingMarker = "transport: Error while dialing"
+)
+
+// sweep expands this policy's targets, probes the ones that stand for more than
+// a single address, and starts a target loop for each that answered.
+//
+// It runs in its own goroutine rather than inside StartPolicy for two reasons.
+// The agent's policy POST times out after 10s and a /24 sweep takes longer, so a
+// synchronous probe would mark a working policy FailedToApply and then 409 on
+// every retry. And StartPolicy holds the manager lock, which GetPolicyStatuses
+// also takes — the agent health-checks /status every 10s with a 2s budget and
+// restarts the backend when it times out, so probing under that lock would
+// restart-loop the whole process on any policy update.
+func (r *Runner) sweep() {
+	defer r.wg.Done()
+
+	admitted, err := r.admitTargets()
+	if err != nil {
+		r.logger.Error("sweep failed; no targets started",
+			"policy", r.name, "error", err)
+		return
+	}
+
+	for _, t := range admitted {
+		// The state entry must exist before the loop starts, or setState is a
+		// silent no-op and the target's first error is lost.
+		r.mu.Lock()
+		r.states[t.Host] = &targetState{}
+		r.mu.Unlock()
+		r.wg.Add(1)
+		go r.targetLoop(t)
+	}
+}
+
+// admitTargets expands, dedupes, and probes, returning the targets worth
+// subscribing to.
+func (r *Runner) admitTargets() ([]config.Target, error) {
+	expanded, err := r.expandTargets()
+	if err != nil {
+		return nil, err
+	}
+
+	// Probe concurrently: a dead address costs the full probeTimeout, so a /22
+	// probed one at a time would take the better part of an hour.
+	verdicts := make([]error, len(expanded))
+	probed := make([]bool, len(expanded))
+	sem := make(chan struct{}, probeConcurrency)
+	var wg sync.WaitGroup
+
+	for i, c := range expanded {
+		if c.explicit {
+			continue
+		}
+		// Select on cancellation between items, not just at the start. Stop
+		// blocks on this sweep, so without this a DELETE would wait for the
+		// whole range.
+		select {
+		case sem <- struct{}{}:
+		case <-r.ctx.Done():
+			wg.Wait()
+			return nil, r.ctx.Err()
+		}
+		wg.Add(1)
+		go func(i int, t config.Target) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			verdicts[i] = r.probe(t)
+			probed[i] = true
+		}(i, c.target)
+	}
+	wg.Wait()
+
+	if r.ctx.Err() != nil {
+		return nil, r.ctx.Err()
+	}
+
+	var admitted []config.Target
+	var rejected int
+	var firstReason error
+
+	for i, c := range expanded {
+		if c.explicit {
+			// The operator named this device. Dropping it because it happens to
+			// be rebooting would regress the retry-forever behaviour a named
+			// host has always had.
+			admitted = append(admitted, c.target)
+			continue
+		}
+		if !probed[i] {
+			continue
+		}
+		err := verdicts[i]
+		switch {
+		case isCanceled(err):
+			return nil, err
+		case admits(err):
+			admitted = append(admitted, c.target)
+		default:
+			rejected++
+			if firstReason == nil {
+				firstReason = err
+			}
+		}
+	}
+
+	if rejected > 0 {
+		// One line, not one per address: an operator who scanned a sparse /24
+		// does not need 251 warnings, but must never be told a count without
+		// being told why.
+		r.logger.Info("target sweep complete",
+			"policy", r.name,
+			"admitted", len(admitted),
+			"rejected", rejected,
+			"example_reason", reasonText(firstReason))
+	}
+	return admitted, nil
+}
+
+// candidate pairs an expanded target with whether the operator wrote it
+// literally. An explicit entry skips the probe and wins any dedupe.
+type candidate struct {
+	target   config.Target
+	explicit bool
+}
+
+func (r *Runner) expandTargets() ([]candidate, error) {
+	var out []candidate
+	seen := map[string]int{}
+
+	for _, t := range r.policy.Scope.Targets {
+		addrs, err := targets.Expand(t.Host)
+		if err != nil {
+			return nil, fmt.Errorf("target %q: %w", t.Host, err)
+		}
+		// snmp's rule, matched exactly: a netbox_id survives only when the
+		// operator wrote the single address itself. Any CIDR or range form,
+		// /32 and 10.0.0.5-5 included, drops it — one NetBox device id cannot
+		// describe a range, and a /32 is still range syntax.
+		literal := len(addrs) == 1 && addrs[0] == t.Host
+
+		for _, addr := range addrs {
+			derived := t
+			derived.Host = ensurePort(addr, resolvedPort(t.Port))
+			if !literal {
+				derived.NetboxID = nil
+			}
+
+			key := dedupeKey(derived.Host)
+			if at, dup := seen[key]; dup {
+				// An explicit entry beats one produced by an expansion, so a
+				// device pinned inside a subnet keeps its own settings.
+				if literal && !out[at].explicit {
+					out[at] = candidate{target: derived, explicit: true}
+					continue
+				}
+				r.logger.Warn("dropping duplicate target produced by expansion",
+					"policy", r.name, "host", derived.Host)
+				continue
+			}
+			seen[key] = len(out)
+			out = append(out, candidate{target: derived, explicit: literal})
+		}
+	}
+	return out, nil
+}
+
+// dedupeKey collapses two spellings of one endpoint. A hostname keeps its own
+// text: Expand never resolves DNS, so a name and an address cannot be known to
+// be the same device.
+func dedupeKey(host string) string {
+	if h, port, err := net.SplitHostPort(host); err == nil {
+		if ip := net.ParseIP(strings.Trim(h, "[]")); ip != nil {
+			return ip.String() + ":" + port
+		}
+		return strings.ToLower(h) + ":" + port
+	}
+	return strings.ToLower(host)
+}
+
+// probe asks one address whether anything is listening.
+//
+// It sends no credentials. gnmic attaches them as gRPC metadata on every RPC
+// including Capabilities, so a credentialed sweep would spray the campus
+// password across every address in the range — and with a scope-level
+// skip_verify, at anything that answers.
+func (r *Runner) probe(t config.Target) error {
+	ctx, cancel := context.WithTimeout(r.ctx, probeTimeout)
+	defer cancel()
+
+	tls := t.ResolvedTLS()
+	sess, err := r.dialer.Dial(ctx, gnmi.TargetSpec{
+		Host:       t.Host,
+		SkipVerify: tls.SkipVerify,
+		Insecure:   tls.Insecure,
+		Origin:     t.ResolvedOrigin(),
+		CAFile:     tls.CAFile,
+		CertFile:   tls.CertFile,
+		KeyFile:    tls.KeyFile,
+	})
+	if err != nil {
+		// A Dial error is a configuration fault, not a verdict: it fails
+		// identically for every address, so it is reported once by the caller
+		// rather than counted as N rejections.
+		return err
+	}
+	// gnmic dials without WithBlock, so this session is live even for a dead
+	// address and will reconnect in the background until closed.
+	defer func() { _ = sess.Close() }()
+
+	_, capErr := sess.Capabilities(ctx)
+	return capErr
+}
+
+// admits reports whether a probe result means something is listening.
+//
+// This is a deny-list, and deliberately so. An allow-list of "good" codes was
+// tried and got it wrong in both directions: it missed real handshake failures
+// (an mTLS device probed without a client cert, a campus of self-signed certs),
+// and it denied real peer responses like ResourceExhausted from a device whose
+// gNMI agent was still warming up. Only silence is absence.
+//
+// It also fails in the safe direction. If grpc-go ever changes the string below,
+// the gate degrades to admitting everything — which is the retry-forever
+// behaviour this backend had before the sweep existed — rather than to admitting
+// nothing, which would report a healthy campus as empty.
+func admits(err error) bool {
+	if err == nil {
+		return true
+	}
+	if isCanceled(err) {
+		return false
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+	switch st.Code() {
+	case codes.DeadlineExceeded:
+		// Nothing came back: a dropped packet, or a peer that accepted the TCP
+		// connection and then said nothing.
+		return false
+	case codes.Unavailable:
+		// Refused and "TLS handshake failed" share this code and differ only in
+		// message. A handshake failure means a peer answered.
+		return !strings.Contains(st.Message(), dialingMarker)
+	default:
+		// Any other code can only come from a server-sent status or an
+		// HTTP-status mapping, so a peer spoke.
+		return true
+	}
+}
+
+// isCanceled reports whether a probe ended because the sweep was torn down, as
+// happens on Stop and on a rescan tick. Those are not rejections and must not be
+// counted as any.
+func isCanceled(err error) bool {
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+	st, ok := status.FromError(err)
+	return ok && st.Code() == codes.Canceled
+}
+
+func reasonText(err error) string {
+	if err == nil {
+		return ""
+	}
+	if st, ok := status.FromError(err); ok {
+		return st.Message()
+	}
+	return err.Error()
+}

--- a/orb-discovery/gnmi-discovery/policy/sweep.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep.go
@@ -68,7 +68,17 @@ func (r *Runner) sweep() {
 // loop for each newcomer. It never touches a live subscription: a device that
 // answered an earlier sweep is not re-probed, so a rescan cannot disturb it.
 func (r *Runner) sweepOnce() {
-	run := r.runStore.CreateSweepRun(r.name, r.originalHosts())
+	// A sweep run reports the outcome of probing, and a policy of named hosts
+	// probes nothing — the run would only restate the policy back. It is also a
+	// compatibility boundary: before ranges existed every run was a per-device
+	// flush, so consumers read "a completed run" as "something was ingested", and
+	// a sweep run completes long before the first flush has subscribed. Emitting
+	// one for a policy written before this feature would change what its status
+	// means without the operator changing anything.
+	var runID string
+	if r.hasRangedTarget() {
+		runID = r.runStore.CreateSweepRun(r.name, r.originalHosts()).ID
+	}
 
 	admitted, outcome, err := r.admitTargets()
 	switch {
@@ -77,7 +87,7 @@ func (r *Runner) sweepOnce() {
 		// not a failure, and logging it at Error would put a red line in the log
 		// on every ordinary policy removal.
 		r.logger.Debug("sweep canceled", "policy", r.name)
-		r.runStore.FinishSweepRun(r.name, run.ID, RunStatusFailed, "sweep canceled", 0)
+		r.finishSweepRun(runID, RunStatusFailed, "sweep canceled", 0)
 		return
 	case err != nil:
 		// Report and keep going. There is no path to failing the policy itself:
@@ -86,7 +96,7 @@ func (r *Runner) sweepOnce() {
 		// here would also kill rescan and leave the policy permanently dead.
 		r.logger.Error("sweep failed; no targets started",
 			"policy", r.name, "error", err)
-		r.runStore.FinishSweepRun(r.name, run.ID, RunStatusFailed, err.Error(), 0)
+		r.finishSweepRun(runID, RunStatusFailed, err.Error(), 0)
 		return
 	}
 
@@ -105,7 +115,7 @@ func (r *Runner) sweepOnce() {
 		reason += fmt.Sprintf("; credentials are being sent to targets whose server is not"+
 			" authenticated (%d range target(s))", n)
 	}
-	r.runStore.FinishSweepRun(r.name, run.ID, status, reason, outcome.total())
+	r.finishSweepRun(runID, status, reason, outcome.total())
 
 	// Spread the first dial once a sweep admits more than a handful. Every loop
 	// dials immediately, so 200 admitted targets means 200 simultaneous TLS
@@ -285,6 +295,26 @@ func (o sweepOutcome) summary() string {
 		s += fmt.Sprintf("; %d did not answer, e.g. %s", o.rejected, o.exampleReason)
 	}
 	return s
+}
+
+// finishSweepRun closes the sweep run when there is one.
+func (r *Runner) finishSweepRun(runID string, status RunStatus, reason string, count int) {
+	if runID == "" {
+		return
+	}
+	r.runStore.FinishSweepRun(r.name, runID, status, reason, count)
+}
+
+// hasRangedTarget reports whether any target stands for more than one address,
+// which is what makes a sweep worth reporting.
+func (r *Runner) hasRangedTarget() bool {
+	for _, t := range r.policy.Scope.Targets {
+		bare, _, _ := splitEffectivePort(t.Host, t.Port)
+		if !targets.IsSingleEndpoint(bare) {
+			return true
+		}
+	}
+	return false
 }
 
 // unverifiedCredentialTargets counts the ranged targets that carry a password

--- a/orb-discovery/gnmi-discovery/policy/sweep.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep.go
@@ -91,14 +91,14 @@ func (r *Runner) sweepOnce() {
 		return
 	}
 
-	status, reason := RunStatusCompleted, outcome.summary()
-	if outcome.subscribed == 0 && outcome.admitted == 0 {
+	status := RunStatusCompleted
+	if outcome.reachable() == 0 {
 		// The operator gave a range and nothing in it answered. That is the
 		// implementable form of "the policy failed": a run they can see, rather
 		// than a silent policy that reports healthy and discovers nothing.
 		status = RunStatusFailed
 	}
-	r.runStore.FinishSweepRun(r.name, run.ID, status, reason, outcome.admitted)
+	r.runStore.FinishSweepRun(r.name, run.ID, status, outcome.summary(), outcome.reachable())
 
 	// Spread the first dial once a sweep admits more than a handful. Every loop
 	// dials immediately, so 200 admitted targets means 200 simultaneous TLS
@@ -242,14 +242,19 @@ type sweepOutcome struct {
 	exampleReason string
 }
 
+// reachable is how many targets this policy is subscribed to once the sweep
+// finishes. It is what the run reports as its entity count, rather than the
+// number newly admitted: a rescan tick that finds nothing new is the normal
+// state of a healthy policy, and reporting 0 there would read as a policy that
+// had stopped discovering anything.
+func (o sweepOutcome) reachable() int { return o.subscribed + o.admitted }
+
 func (o sweepOutcome) summary() string {
-	if o.scanned == o.subscribed && o.scanned > 0 {
-		return fmt.Sprintf("%d target(s) already subscribed; nothing new to probe", o.subscribed)
+	probed := o.scanned - o.subscribed
+	if probed == 0 {
+		return fmt.Sprintf("%d subscribed; no unsubscribed addresses left to probe", o.reachable())
 	}
-	s := fmt.Sprintf("%d of %d address(es) answered", o.admitted, o.scanned-o.subscribed)
-	if o.subscribed > 0 {
-		s += fmt.Sprintf("; %d already subscribed", o.subscribed)
-	}
+	s := fmt.Sprintf("%d subscribed; %d of %d probed address(es) answered", o.reachable(), o.admitted, probed)
 	if o.rejected > 0 {
 		s += fmt.Sprintf("; %d did not answer, e.g. %s", o.rejected, o.exampleReason)
 	}

--- a/orb-discovery/gnmi-discovery/policy/sweep.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep.go
@@ -97,7 +97,15 @@ func (r *Runner) sweepOnce() {
 		// than a silent policy that reports healthy and discovers nothing.
 		status = RunStatusFailed
 	}
-	r.runStore.FinishSweepRun(r.name, run.ID, status, outcome.summary(), outcome.total())
+	reason := outcome.summary()
+	if n := r.unverifiedCredentialTargets(); n > 0 {
+		// Surfaced on the run, not only in the log. An opt-in that is invisible
+		// after the day it was set is the failure mode the flag exists to avoid:
+		// this way the risk shows in Fleet on every sweep.
+		reason += fmt.Sprintf("; credentials are being sent to targets whose server is not"+
+			" authenticated (%d range target(s))", n)
+	}
+	r.runStore.FinishSweepRun(r.name, run.ID, status, reason, outcome.total())
 
 	// Spread the first dial once a sweep admits more than a handful. Every loop
 	// dials immediately, so 200 admitted targets means 200 simultaneous TLS
@@ -277,6 +285,28 @@ func (o sweepOutcome) summary() string {
 		s += fmt.Sprintf("; %d did not answer, e.g. %s", o.rejected, o.exampleReason)
 	}
 	return s
+}
+
+// unverifiedCredentialTargets counts the ranged targets that carry a password
+// without TLS authenticating the server. Validation refuses these unless the
+// policy opts in, so a non-zero count here means the operator opted in.
+func (r *Runner) unverifiedCredentialTargets() int {
+	n := 0
+	for _, t := range r.policy.Scope.Targets {
+		if t.ResolvedPassword() == "" {
+			continue
+		}
+		tls := t.ResolvedTLS()
+		if !tls.SkipVerify && !tls.Insecure {
+			continue
+		}
+		bare, _, _ := splitEffectivePort(t.Host, t.Port)
+		if targets.IsSingleEndpoint(bare) {
+			continue
+		}
+		n++
+	}
+	return n
 }
 
 // originalHosts returns the host strings the operator wrote, so the sweep run

--- a/orb-discovery/gnmi-discovery/policy/sweep.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep.go
@@ -72,7 +72,15 @@ func (r *Runner) sweepOnce() {
 	run := r.runStore.CreateSweepRun(r.name, r.originalHosts())
 
 	admitted, outcome, err := r.admitTargets()
-	if err != nil {
+	switch {
+	case err != nil && isCanceled(err):
+		// A policy DELETE cancels mid-sweep. That is the expected end of a sweep,
+		// not a failure, and logging it at Error would put a red line in the log
+		// on every ordinary policy removal.
+		r.logger.Debug("sweep canceled", "policy", r.name)
+		r.runStore.FinishSweepRun(r.name, run.ID, RunStatusFailed, "sweep canceled", 0)
+		return
+	case err != nil:
 		// Report and keep going. There is no path to failing the policy itself:
 		// PolicyData.State is set only from the ApplyPolicy HTTP result, the 201
 		// has already returned, and a runner holds no manager reference. Exiting
@@ -340,9 +348,11 @@ func (r *Runner) probe(t config.Target) error {
 		KeyFile:    tls.KeyFile,
 	})
 	if err != nil {
-		// A Dial error is a configuration fault, not a verdict: it fails
-		// identically for every address, so it is reported once by the caller
-		// rather than counted as N rejections.
+		// A Dial error is usually a configuration fault — an unreadable CA file,
+		// a malformed cert — so it fails identically for every address and lands
+		// as N rejections sharing one reason. That is the useful shape: the run's
+		// example_reason then names the file, rather than reporting an empty
+		// subnet with no explanation.
 		return err
 	}
 	// gnmic dials without WithBlock, so this session is live even for a dead

--- a/orb-discovery/gnmi-discovery/policy/sweep.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep.go
@@ -69,12 +69,28 @@ func (r *Runner) sweep() {
 // loop for each newcomer. It never touches a live subscription: a device that
 // answered an earlier sweep is not re-probed, so a rescan cannot disturb it.
 func (r *Runner) sweepOnce() {
-	admitted, err := r.admitTargets()
+	run := r.runStore.CreateSweepRun(r.name, r.originalHosts())
+
+	admitted, outcome, err := r.admitTargets()
 	if err != nil {
+		// Report and keep going. There is no path to failing the policy itself:
+		// PolicyData.State is set only from the ApplyPolicy HTTP result, the 201
+		// has already returned, and a runner holds no manager reference. Exiting
+		// here would also kill rescan and leave the policy permanently dead.
 		r.logger.Error("sweep failed; no targets started",
 			"policy", r.name, "error", err)
+		r.runStore.FinishSweepRun(r.name, run.ID, RunStatusFailed, err.Error(), 0)
 		return
 	}
+
+	status, reason := RunStatusCompleted, outcome.summary()
+	if outcome.subscribed == 0 && outcome.admitted == 0 {
+		// The operator gave a range and nothing in it answered. That is the
+		// implementable form of "the policy failed": a run they can see, rather
+		// than a silent policy that reports healthy and discovers nothing.
+		status = RunStatusFailed
+	}
+	r.runStore.FinishSweepRun(r.name, run.ID, status, reason, outcome.admitted)
 
 	// Spread the first dial once a sweep admits more than a handful. Every loop
 	// dials immediately, so 200 admitted targets means 200 simultaneous TLS
@@ -116,14 +132,16 @@ func (r *Runner) unsubscribed(in []candidate) []candidate {
 
 // admitTargets expands, dedupes, and probes, returning the targets worth
 // subscribing to.
-func (r *Runner) admitTargets() ([]config.Target, error) {
+func (r *Runner) admitTargets() ([]config.Target, sweepOutcome, error) {
 	expanded, err := r.expandTargets()
 	if err != nil {
-		return nil, err
+		return nil, sweepOutcome{}, err
 	}
+	out := sweepOutcome{scanned: len(expanded)}
 	expanded = r.unsubscribed(expanded)
+	out.subscribed = out.scanned - len(expanded)
 	if len(expanded) == 0 {
-		return nil, nil
+		return nil, out, nil
 	}
 
 	// Probe concurrently: a dead address costs the full probeTimeout, so a /22
@@ -144,7 +162,7 @@ func (r *Runner) admitTargets() ([]config.Target, error) {
 		case sem <- struct{}{}:
 		case <-r.ctx.Done():
 			wg.Wait()
-			return nil, r.ctx.Err()
+			return nil, sweepOutcome{}, r.ctx.Err()
 		}
 		wg.Add(1)
 		go func(i int, t config.Target) {
@@ -157,7 +175,7 @@ func (r *Runner) admitTargets() ([]config.Target, error) {
 	wg.Wait()
 
 	if r.ctx.Err() != nil {
-		return nil, r.ctx.Err()
+		return nil, sweepOutcome{}, r.ctx.Err()
 	}
 
 	var admitted []config.Target
@@ -178,7 +196,7 @@ func (r *Runner) admitTargets() ([]config.Target, error) {
 		err := verdicts[i]
 		switch {
 		case isCanceled(err):
-			return nil, err
+			return nil, sweepOutcome{}, err
 		case admits(err):
 			admitted = append(admitted, c.target)
 		default:
@@ -189,17 +207,55 @@ func (r *Runner) admitTargets() ([]config.Target, error) {
 		}
 	}
 
+	out.admitted = len(admitted)
+	out.rejected = rejected
+	out.exampleReason = reasonText(firstReason)
+
 	if rejected > 0 {
 		// One line, not one per address: an operator who scanned a sparse /24
 		// does not need 251 warnings, but must never be told a count without
 		// being told why.
 		r.logger.Info("target sweep complete",
 			"policy", r.name,
-			"admitted", len(admitted),
+			"admitted", out.admitted,
 			"rejected", rejected,
-			"example_reason", reasonText(firstReason))
+			"example_reason", out.exampleReason)
 	}
-	return admitted, nil
+	return admitted, out, nil
+}
+
+// sweepOutcome is what the sweep run reports. Run has only EntityCount and
+// Reason to say it with, so the counts are rendered into the reason text.
+type sweepOutcome struct {
+	scanned       int // addresses this policy expands to
+	subscribed    int // already had a target loop, so not re-probed
+	admitted      int // answered this sweep and got a loop
+	rejected      int // probed and did not answer
+	exampleReason string
+}
+
+func (o sweepOutcome) summary() string {
+	if o.scanned == o.subscribed && o.scanned > 0 {
+		return fmt.Sprintf("%d target(s) already subscribed; nothing new to probe", o.subscribed)
+	}
+	s := fmt.Sprintf("%d of %d address(es) answered", o.admitted, o.scanned-o.subscribed)
+	if o.subscribed > 0 {
+		s += fmt.Sprintf("; %d already subscribed", o.subscribed)
+	}
+	if o.rejected > 0 {
+		s += fmt.Sprintf("; %d did not answer, e.g. %s", o.rejected, o.exampleReason)
+	}
+	return s
+}
+
+// originalHosts returns the host strings the operator wrote, so the sweep run
+// names the CIDR itself rather than a synthesized pseudo-host.
+func (r *Runner) originalHosts() []string {
+	hosts := make([]string, 0, len(r.policy.Scope.Targets))
+	for _, t := range r.policy.Scope.Targets {
+		hosts = append(hosts, t.Host)
+	}
+	return hosts
 }
 
 // candidate pairs an expanded target with whether the operator wrote it

--- a/orb-discovery/gnmi-discovery/policy/sweep.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep.go
@@ -154,7 +154,7 @@ func (r *Runner) admitTargets() ([]config.Target, sweepOutcome, error) {
 
 	// Probe concurrently: a dead address costs the full probeTimeout, so a /22
 	// probed one at a time would take the better part of an hour.
-	verdicts := make([]error, len(expanded))
+	verdicts := make([]probeResult, len(expanded))
 	probed := make([]bool, len(expanded))
 	sem := make(chan struct{}, probeConcurrency)
 	var wg sync.WaitGroup
@@ -203,17 +203,16 @@ func (r *Runner) admitTargets() ([]config.Target, sweepOutcome, error) {
 		if !probed[i] {
 			continue
 		}
-		err := verdicts[i]
-		switch {
-		case isCanceled(err):
-			return nil, sweepOutcome{}, err
-		case admits(err):
+		// Shutdown is decided by r.ctx above, never by a peer's status. Reading
+		// codes.Canceled as "the policy is going away" let one device abandon the
+		// whole sweep, discarding every address the other probes had admitted.
+		if admits(verdicts[i]) {
 			admitted = append(admitted, c.target)
-		default:
-			rejected++
-			if firstReason == nil {
-				firstReason = err
-			}
+			continue
+		}
+		rejected++
+		if firstReason == nil {
+			firstReason = verdicts[i].err
 		}
 	}
 
@@ -377,7 +376,7 @@ func dedupeKey(host string) string {
 //
 // The server-side settings do go: without the CA and skip_verify the probe
 // cannot complete a handshake it is otherwise entitled to complete.
-func (r *Runner) probe(t config.Target) error {
+func (r *Runner) probe(t config.Target) probeResult {
 	ctx, cancel := context.WithTimeout(r.ctx, r.policy.Config.ResolvedProbeTimeout())
 	defer cancel()
 
@@ -395,14 +394,27 @@ func (r *Runner) probe(t config.Target) error {
 		// as N rejections sharing one reason. That is the useful shape: the run's
 		// example_reason then names the file, rather than reporting an empty
 		// subnet with no explanation.
-		return err
+		return probeResult{err: err}
 	}
 	// gnmic dials without WithBlock, so this session is live even for a dead
 	// address and will reconnect in the background until closed.
 	defer func() { _ = sess.Close() }()
 
 	_, capErr := sess.Capabilities(ctx)
-	return capErr
+	// Whether OUR context ended this is the only reliable way to tell silence
+	// from an answer. A gRPC code cannot: a server may send DeadlineExceeded or
+	// Canceled itself, which means a peer replied, and those are the same codes
+	// grpc-go produces locally when the probe's own deadline fires.
+	return probeResult{err: capErr, localStop: ctx.Err() != nil}
+}
+
+// probeResult is one address's answer, plus whether the probe's own context is
+// what ended the call.
+type probeResult struct {
+	err error
+	// localStop is true when the probe's context expired or was canceled, so
+	// nothing came back from the peer at all.
+	localStop bool
 }
 
 // admits reports whether a probe result means something is listening.
@@ -417,42 +429,44 @@ func (r *Runner) probe(t config.Target) error {
 // the gate degrades to admitting everything — which is the retry-forever
 // behaviour this backend had before the sweep existed — rather than to admitting
 // nothing, which would report a healthy campus as empty.
-func admits(err error) bool {
-	if err == nil {
+func admits(res probeResult) bool {
+	if res.err == nil {
+		// Answered. Checked before localStop, because a deadline that fires just
+		// after a successful reply must not retract it.
 		return true
 	}
-	if isCanceled(err) {
+	if res.localStop {
+		// Our own deadline or cancellation ended the call, so nothing came back:
+		// a dropped packet, or a peer that accepted the TCP connection and then
+		// said nothing. This is the only branch that means silence, and it is
+		// decided by the local context rather than by a status code — a server
+		// can send DeadlineExceeded or Canceled itself, and those arrive with the
+		// same codes grpc-go produces locally.
 		return false
 	}
-	st, ok := status.FromError(err)
+	st, ok := status.FromError(res.err)
 	if !ok {
+		// Not a gRPC status at all: a dial or TLS configuration fault.
 		return false
 	}
-	switch st.Code() {
-	case codes.DeadlineExceeded:
-		// Nothing came back: a dropped packet, or a peer that accepted the TCP
-		// connection and then said nothing.
+	// Refused and "TLS handshake failed" share codes.Unavailable and differ only
+	// in message. A handshake failure means a peer answered.
+	if st.Code() == codes.Unavailable && strings.Contains(st.Message(), dialingMarker) {
 		return false
-	case codes.Unavailable:
-		// Refused and "TLS handshake failed" share this code and differ only in
-		// message. A handshake failure means a peer answered.
-		return !strings.Contains(st.Message(), dialingMarker)
-	default:
-		// Any other code can only come from a server-sent status or an
-		// HTTP-status mapping, so a peer spoke.
-		return true
 	}
+	// Anything else reached a peer, including a server-sent DeadlineExceeded or
+	// Canceled.
+	return true
 }
 
-// isCanceled reports whether a probe ended because the sweep was torn down, as
-// happens on Stop and on a rescan tick. Those are not rejections and must not be
-// counted as any.
+// isCanceled reports whether an error is this runner's own cancellation, as
+// happens on Stop and on a policy DELETE.
+//
+// It is applied only to errors admitTargets produces from r.ctx, never to a
+// probe result. A peer is free to answer with codes.Canceled, and treating that
+// as a local shutdown abandoned the sweep.
 func isCanceled(err error) bool {
-	if errors.Is(err, context.Canceled) {
-		return true
-	}
-	st, ok := status.FromError(err)
-	return ok && st.Code() == codes.Canceled
+	return errors.Is(err, context.Canceled)
 }
 
 func reasonText(err error) string {

--- a/orb-discovery/gnmi-discovery/policy/sweep_run_test.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep_run_test.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -118,4 +119,39 @@ func TestAFailedSweepStillRescans(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return len(r.Runs()) >= 2
 	}, 3*time.Second, 10*time.Millisecond, "the sweep keeps ticking after finding nothing")
+}
+
+// A /22 policy holds up to three runs for each of a thousand targets, and the
+// agent marshals the whole list every 10s with a 2s budget before it restarts
+// the backend. The cap is what keeps a large policy from becoming a restart loop.
+func TestRunsForAPolicyAreCapped(t *testing.T) {
+	rs := NewRunStore()
+	for i := range 400 {
+		host := fmt.Sprintf("10.0.%d.%d:9339", i/256, i%256)
+		run := rs.CreateRun("p1", host)
+		rs.UpdateRun("p1", host, run.ID, RunStatusCompleted, nil, 1)
+	}
+	require.LessOrEqual(t, len(rs.GetRunsForPolicy("p1")), maxRunsPerPolicy)
+}
+
+// The sweep run is the one record describing the policy as a whole, and a busy
+// range produces device runs continuously — so it must not be what the cap drops.
+func TestTheSweepRunSurvivesTheCap(t *testing.T) {
+	rs := NewRunStore()
+	sweep := rs.CreateSweepRun("p1", []string{"10.0.0.0/22"})
+	rs.FinishSweepRun("p1", sweep.ID, RunStatusCompleted, "2 of 1022 address(es) answered", 2)
+
+	for i := range 400 {
+		host := fmt.Sprintf("10.0.%d.%d:9339", i/256, i%256)
+		run := rs.CreateRun("p1", host)
+		rs.UpdateRun("p1", host, run.ID, RunStatusCompleted, nil, 1)
+	}
+
+	var found bool
+	for _, r := range rs.GetRunsForPolicy("p1") {
+		if r.ID == sweep.ID {
+			found = true
+		}
+	}
+	require.True(t, found, "the sweep run is exempt from the cap")
 }

--- a/orb-discovery/gnmi-discovery/policy/sweep_run_test.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep_run_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -193,4 +194,28 @@ func TestACanceledSweepIsNotLoggedAsAFailure(t *testing.T) {
 
 	require.NotContains(t, logs.String(), "level=ERROR",
 		"an ordinary policy removal must not log an error")
+}
+
+// entity_count reports how many targets the policy is subscribed to, not how
+// many this particular tick newly admitted. A rescan that finds nothing new is
+// the normal state of a healthy policy, and reporting 0 there would read as a
+// policy that had stopped discovering anything.
+func TestASweepReportsTheReachableTotalNotTheDelta(t *testing.T) {
+	dialer := newPerHostDialer(map[string]error{"10.0.0.2:9339": dialingErr()})
+	r := newRescanRunner(t, "10.0.0.0/30", dialer, 40*time.Millisecond)
+	r.Start()
+	t.Cleanup(func() { _ = r.Stop() })
+
+	// Wait for a rescan tick that admitted nothing new: only .1 ever answers.
+	require.Eventually(t, func() bool {
+		for _, run := range r.Runs() {
+			if run.Status == RunStatusCompleted && run.EntityCount == 1 &&
+				strings.Contains(run.Reason, "1 subscribed") &&
+				strings.Contains(run.Reason, "0 of 1 probed") {
+				return true
+			}
+		}
+		return false
+	}, 3*time.Second, 10*time.Millisecond,
+		"a tick with no newcomers still reports the one target that is subscribed")
 }

--- a/orb-discovery/gnmi-discovery/policy/sweep_run_test.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep_run_test.go
@@ -1,0 +1,121 @@
+package policy
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Runs are the only channel the agent consumes: PolicyStatus carries {Name,
+// Status, Runs} and nothing else, so a TargetStatus never leaves the container.
+// PolicyStatusRun decodes `targets` and has no `target` field at all, which means
+// every gnmi run — the pre-existing per-device ones included — reached the fleet
+// with no target on it.
+func TestRunSerializesTheTargetsFieldTheAgentActuallyReads(t *testing.T) {
+	rs := NewRunStore()
+	run := rs.CreateRun("p1", "10.0.0.1:9339")
+
+	var decoded struct {
+		Targets []string `json:"targets"`
+	}
+	raw, err := json.Marshal(run)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	require.Equal(t, []string{"10.0.0.1:9339"}, decoded.Targets)
+}
+
+// The sweep run is keyed apart from per-device runs. Without that, a policy whose
+// only target is one host would have its sweep run and its device runs share a
+// key and evict each other under the per-target cap.
+func TestSweepRunDoesNotEvictThePerDeviceRunsOfTheSameHost(t *testing.T) {
+	rs := NewRunStore()
+	for range 3 {
+		d := rs.CreateRun("p1", "10.0.0.5:9339")
+		rs.UpdateRun("p1", "10.0.0.5:9339", d.ID, RunStatusCompleted, nil, 1)
+	}
+	sweep := rs.CreateSweepRun("p1", []string{"10.0.0.5:9339"})
+	rs.FinishSweepRun("p1", sweep.ID, RunStatusCompleted, "1 of 1 address(es) answered", 1)
+
+	runs := rs.GetRunsForPolicy("p1")
+	require.Len(t, runs, 4, "three device runs plus the sweep run")
+}
+
+// The sweep run names the operator's own host strings, so an operator reading
+// /status sees the CIDR they wrote rather than a synthesized pseudo-host.
+func TestSweepRunCarriesTheOriginalHostStrings(t *testing.T) {
+	rs := NewRunStore()
+	sweep := rs.CreateSweepRun("p1", []string{"10.0.0.0/24", "switch-a.example.com"})
+	require.Equal(t, []string{"10.0.0.0/24", "switch-a.example.com"}, sweep.Targets)
+	require.Contains(t, sweep.Target, "10.0.0.0/24")
+	require.Equal(t, RunStatusRunning, sweep.Status,
+		"created at sweep start, so a hung sweep is visible while it runs")
+}
+
+// A successful sweep still has something to say, and UpdateRun fills Reason only
+// from a non-nil error. Reporting the counts through a fabricated error would
+// mark a healthy sweep failed.
+func TestFinishSweepRunReportsCountsWithoutAnError(t *testing.T) {
+	rs := NewRunStore()
+	sweep := rs.CreateSweepRun("p1", []string{"10.0.0.0/24"})
+	rs.FinishSweepRun("p1", sweep.ID, RunStatusCompleted, "3 of 254 address(es) answered", 3)
+
+	runs := rs.GetRunsForPolicy("p1")
+	require.Len(t, runs, 1)
+	require.Equal(t, RunStatusCompleted, runs[0].Status)
+	require.Equal(t, 3, runs[0].EntityCount)
+	require.Contains(t, runs[0].Reason, "3 of 254")
+}
+
+// Sorting on CreatedAt buried the sweep run: it is created before every run it
+// starts, so it is always the oldest thing in the store.
+func TestRunsSortByMostRecentActivityNotCreation(t *testing.T) {
+	rs := NewRunStore()
+	sweep := rs.CreateSweepRun("p1", []string{"10.0.0.0/30"})
+	device := rs.CreateRun("p1", "10.0.0.1:9339")
+	rs.UpdateRun("p1", "10.0.0.1:9339", device.ID, RunStatusCompleted, nil, 7)
+
+	time.Sleep(2 * time.Millisecond)
+	rs.FinishSweepRun("p1", sweep.ID, RunStatusCompleted, "1 of 2 address(es) answered", 1)
+
+	runs := rs.GetRunsForPolicy("p1")
+	require.Equal(t, sweep.ID, runs[0].ID,
+		"the sweep finished last, so it sorts first despite being created first")
+}
+
+// A range where nothing answered is the implementable form of "the policy
+// failed": there is no path to failing the policy itself, so the operator has to
+// be able to see it as a run.
+func TestASweepThatFindsNothingIsReportedFailed(t *testing.T) {
+	dialer := newPerHostDialer(nil)
+	dialer.defaultCapsErr = dialingErr()
+	r := newSweepRunner(t, "10.0.0.0/30", dialer)
+	r.Start()
+	t.Cleanup(func() { _ = r.Stop() })
+
+	require.Eventually(t, func() bool {
+		runs := r.Runs()
+		return len(runs) == 1 && runs[0].Status == RunStatusFailed
+	}, 3*time.Second, 10*time.Millisecond, "an empty range is a failed sweep run")
+
+	run := r.Runs()[0]
+	require.Equal(t, []string{"10.0.0.0/30"}, run.Targets)
+	require.Zero(t, run.EntityCount)
+	require.Contains(t, run.Reason, "did not answer",
+		"a count is never reported without the reason behind it")
+}
+
+// A sweep that admits nothing must not kill the runner: exiting would take
+// rescan with it and leave the policy permanently dead.
+func TestAFailedSweepStillRescans(t *testing.T) {
+	dialer := newPerHostDialer(nil)
+	dialer.defaultCapsErr = dialingErr()
+	r := newRescanRunner(t, "10.0.0.0/30", dialer, 60*time.Millisecond)
+	r.Start()
+	t.Cleanup(func() { _ = r.Stop() })
+
+	require.Eventually(t, func() bool {
+		return len(r.Runs()) >= 2
+	}, 3*time.Second, 10*time.Millisecond, "the sweep keeps ticking after finding nothing")
+}

--- a/orb-discovery/gnmi-discovery/policy/sweep_run_test.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep_run_test.go
@@ -287,3 +287,76 @@ func sweepRunFor(t *testing.T, r *Runner) *Run {
 	}, 5*time.Second, 10*time.Millisecond, "a finished sweep run")
 	return found
 }
+
+// A run still in flight must survive the cap. Activity order drops it first: a
+// run's UpdatedAt is stamped at creation and not touched again until it finishes,
+// so the longer an ingest hangs the further it sinks. deriveStatus looks for
+// RunStatusRunning in this result alone, so truncating the hung run made the
+// policy report completed and hid the one record that explained it.
+func TestAnInFlightRunSurvivesTheCap(t *testing.T) {
+	rs := NewRunStore()
+	hung := rs.CreateRun("p1", "10.0.0.9:9339") // created first, never finished
+
+	for i := range 400 {
+		host := fmt.Sprintf("10.0.%d.%d:9339", i/256, i%256)
+		run := rs.CreateRun("p1", host)
+		rs.UpdateRun("p1", host, run.ID, RunStatusCompleted, nil, 1)
+	}
+
+	runs := rs.GetRunsForPolicy("p1")
+	require.LessOrEqual(t, len(runs), maxRunsPerPolicy, "still capped")
+
+	var found bool
+	for _, r := range runs {
+		if r.ID == hung.ID {
+			found = true
+		}
+	}
+	require.True(t, found, "the hung run is the one thing that must not be dropped")
+	require.Equal(t, string(RunStatusRunning), deriveStatus(runs),
+		"a policy with a hung ingest must not report completed")
+}
+
+// If in-flight runs alone exceed the budget, the stalest are kept: they are the
+// most stuck, and so the ones worth showing.
+func TestWhenInFlightRunsExceedTheBudgetTheStalestAreKept(t *testing.T) {
+	rs := NewRunStore()
+	var first, last *Run
+	for i := range maxRunsPerPolicy + 20 {
+		host := fmt.Sprintf("10.0.1.%d:9339", i)
+		run := rs.CreateRun("p1", host)
+		if i == 0 {
+			first = run
+		}
+		last = run
+	}
+
+	runs := rs.GetRunsForPolicy("p1")
+	require.LessOrEqual(t, len(runs), maxRunsPerPolicy, "the payload stays bounded")
+
+	ids := map[string]bool{}
+	for _, r := range runs {
+		ids[r.ID] = true
+	}
+	require.True(t, ids[first.ID], "the stalest in-flight run is kept")
+	require.False(t, ids[last.ID], "the newest is what gets trimmed")
+	require.Equal(t, string(RunStatusRunning), deriveStatus(runs))
+}
+
+// The sweep run still outranks everything, including in-flight device runs.
+func TestTheSweepRunOutranksInFlightRuns(t *testing.T) {
+	rs := NewRunStore()
+	sweep := rs.CreateSweepRun("p1", []string{"10.0.0.0/22"})
+	rs.FinishSweepRun("p1", sweep.ID, RunStatusCompleted, "2 subscribed", 2)
+	for i := range maxRunsPerPolicy + 20 {
+		rs.CreateRun("p1", fmt.Sprintf("10.0.1.%d:9339", i))
+	}
+
+	var found bool
+	for _, r := range rs.GetRunsForPolicy("p1") {
+		if r.ID == sweep.ID {
+			found = true
+		}
+	}
+	require.True(t, found, "the sweep run is still exempt")
+}

--- a/orb-discovery/gnmi-discovery/policy/sweep_run_test.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep_run_test.go
@@ -216,26 +216,58 @@ func TestASweepReportsTheReachableTotalNotTheDelta(t *testing.T) {
 		"a tick with no newcomers still reports the one target that is subscribed")
 }
 
-// A named host is started without being probed, so it must never be reported as
-// having answered. Folding it into the admitted count made an unreachable
-// single-host policy read "1 of 1 probed address(es) answered" when nothing was
-// probed at all.
-func TestANamedHostIsNotReportedAsHavingAnswered(t *testing.T) {
-	dialer := newPerHostDialer(map[string]error{"10.0.0.5:9339": dialingErr()})
+// A policy of named hosts probes nothing, so there is no sweep outcome to report
+// and no sweep run is created. That is also a compatibility boundary: before
+// ranges existed every run was a per-device flush, and consumers read "a
+// completed run" as "something was ingested". A sweep run completes long before
+// the first flush has subscribed, so emitting one for a policy written before
+// this feature would change what its status means without the operator changing
+// anything. Measured against a live gNMI server, it made an external check pass
+// about two seconds early.
+func TestAnAllExplicitPolicyEmitsNoSweepRun(t *testing.T) {
+	dialer := newPerHostDialer(nil)
 	r := newSweepRunner(t, "10.0.0.5", dialer)
 	r.Start()
 	t.Cleanup(func() { _ = r.Stop() })
 
-	run := sweepRunFor(t, r)
+	// Wait for the target loop to produce its flush run.
+	require.Eventually(t, func() bool {
+		for _, run := range r.Runs() {
+			if run.Kind == RunKindFlush {
+				return true
+			}
+		}
+		return false
+	}, 3*time.Second, 10*time.Millisecond)
 
-	require.NotContains(t, run.Reason, "answered",
+	for _, run := range r.Runs() {
+		require.NotEqual(t, RunKindSweep, run.Kind,
+			"a policy of named hosts reports no sweep run")
+	}
+}
+
+// The accounting a named host must not corrupt, tested where it lives. A named
+// host is started without being probed, so folding it into the admitted count
+// reported it as having answered — an unreachable single-host policy read as
+// "1 of 1 probed address(es) answered" when nothing was probed at all.
+func TestASweepOutcomeNeverReportsAnUnprobedTargetAsAnswered(t *testing.T) {
+	// One named host, nothing probed.
+	only := sweepOutcome{scanned: 1, explicit: 1}
+	require.NotContains(t, only.summary(), "answered",
 		"nothing was probed, so nothing can have answered")
-	require.Contains(t, run.Reason, "1 named target(s) started without probing")
-	// Still subscribed, and still not a failure: naming the host is the operator
-	// asserting it exists, and dropping it for being mid-reboot is the regression
-	// the no-probe rule exists to avoid.
-	require.Equal(t, RunStatusCompleted, run.Status)
-	require.Equal(t, 1, run.EntityCount)
+	require.Contains(t, only.summary(), "1 named target(s) started without probing")
+	require.Equal(t, 1, only.total(), "it is still subscribed")
+	require.Zero(t, only.probed())
+
+	// A range alongside it: the two counts stay apart.
+	mixed := sweepOutcome{
+		scanned: 6, explicit: 1, admitted: 1, rejected: 4,
+		exampleReason: "connection refused",
+	}
+	require.Contains(t, mixed.summary(), "1 of 5 probed address(es) answered")
+	require.Contains(t, mixed.summary(), "1 named target(s) started without probing")
+	require.Contains(t, mixed.summary(), "4 did not answer")
+	require.Equal(t, 2, mixed.total())
 }
 
 // A sweep that mixes both kinds must keep the two counts distinct rather than

--- a/orb-discovery/gnmi-discovery/policy/sweep_run_test.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep_run_test.go
@@ -1,12 +1,18 @@
 package policy
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/mapping"
 )
 
 // Runs are the only channel the agent consumes: PolicyStatus carries {Name,
@@ -154,4 +160,37 @@ func TestTheSweepRunSurvivesTheCap(t *testing.T) {
 		}
 	}
 	require.True(t, found, "the sweep run is exempt from the cap")
+}
+
+// A policy DELETE cancels the sweep mid-probe. That is how a sweep is supposed
+// to end, so it must not be logged at Error: an operator removing policies would
+// get a red line for every one of them.
+func TestACanceledSweepIsNotLoggedAsAFailure(t *testing.T) {
+	dialer := newPerHostDialer(nil)
+	dialer.blockOn = make(chan struct{})
+
+	var logs bytes.Buffer
+	handler := slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})
+	policy := config.Policy{
+		Config: config.PolicyConfig{Mode: config.ModeAuto, DebounceMs: 10},
+		Scope:  config.Scope{Targets: []config.Target{{Host: "10.0.0.0/24"}}},
+	}
+	store, err := mapping.LoadProfiles("")
+	require.NoError(t, err)
+	r, err := NewRunner(context.Background(), slog.New(handler), "p1", policy,
+		&recordingClient{}, dialer, store)
+	require.NoError(t, err)
+
+	r.Start()
+	require.Eventually(t, func() bool {
+		return len(dialer.dialedHosts()) > 0
+	}, 3*time.Second, 5*time.Millisecond)
+
+	stopped := make(chan struct{})
+	go func() { _ = r.Stop(); close(stopped) }()
+	close(dialer.blockOn)
+	<-stopped
+
+	require.NotContains(t, logs.String(), "level=ERROR",
+		"an ordinary policy removal must not log an error")
 }

--- a/orb-discovery/gnmi-discovery/policy/sweep_run_test.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep_run_test.go
@@ -102,12 +102,8 @@ func TestASweepThatFindsNothingIsReportedFailed(t *testing.T) {
 	r.Start()
 	t.Cleanup(func() { _ = r.Stop() })
 
-	require.Eventually(t, func() bool {
-		runs := r.Runs()
-		return len(runs) == 1 && runs[0].Status == RunStatusFailed
-	}, 3*time.Second, 10*time.Millisecond, "an empty range is a failed sweep run")
-
-	run := r.Runs()[0]
+	run := sweepRunFor(t, r)
+	require.Equal(t, RunStatusFailed, run.Status, "an empty range is a failed sweep run")
 	require.Equal(t, []string{"10.0.0.0/30"}, run.Targets)
 	require.Zero(t, run.EntityCount)
 	require.Contains(t, run.Reason, "did not answer",
@@ -218,4 +214,76 @@ func TestASweepReportsTheReachableTotalNotTheDelta(t *testing.T) {
 		return false
 	}, 3*time.Second, 10*time.Millisecond,
 		"a tick with no newcomers still reports the one target that is subscribed")
+}
+
+// A named host is started without being probed, so it must never be reported as
+// having answered. Folding it into the admitted count made an unreachable
+// single-host policy read "1 of 1 probed address(es) answered" when nothing was
+// probed at all.
+func TestANamedHostIsNotReportedAsHavingAnswered(t *testing.T) {
+	dialer := newPerHostDialer(map[string]error{"10.0.0.5:9339": dialingErr()})
+	r := newSweepRunner(t, "10.0.0.5", dialer)
+	r.Start()
+	t.Cleanup(func() { _ = r.Stop() })
+
+	run := sweepRunFor(t, r)
+
+	require.NotContains(t, run.Reason, "answered",
+		"nothing was probed, so nothing can have answered")
+	require.Contains(t, run.Reason, "1 named target(s) started without probing")
+	// Still subscribed, and still not a failure: naming the host is the operator
+	// asserting it exists, and dropping it for being mid-reboot is the regression
+	// the no-probe rule exists to avoid.
+	require.Equal(t, RunStatusCompleted, run.Status)
+	require.Equal(t, 1, run.EntityCount)
+}
+
+// A sweep that mixes both kinds must keep the two counts distinct rather than
+// letting the pinned host inflate the answered figure.
+func TestAMixedSweepSeparatesProbedAnswersFromNamedStarts(t *testing.T) {
+	dialer := newPerHostDialer(map[string]error{
+		"10.0.0.2:9339": dialingErr(),
+		"10.0.0.3:9339": dialingErr(),
+		"10.0.0.4:9339": dialingErr(),
+		"10.0.0.5:9339": dialingErr(), // pinned, unreachable, never probed
+		"10.0.0.6:9339": dialingErr(),
+	})
+	r := runnerWithTargets(t, []config.Target{
+		{Host: "10.0.0.0/29"}, // .1-.6
+		{Host: "10.0.0.5"},    // pinned inside it
+	}, slog.New(slog.DiscardHandler))
+	r.dialer = dialer
+	r.Start()
+	t.Cleanup(func() { _ = r.Stop() })
+
+	run := sweepRunFor(t, r)
+	require.Contains(t, run.Reason, "1 of 5 probed address(es) answered",
+		"the pinned host is not one of the five probed")
+	require.Contains(t, run.Reason, "1 named target(s) started without probing")
+	require.Contains(t, run.Reason, "4 did not answer")
+	require.Equal(t, 2, run.EntityCount, "one probed answer plus one named start")
+}
+
+// sweepRunFor returns the policy's finished sweep run.
+//
+// It reads the store's sweep bucket rather than picking by position or by target
+// list. Position is not an identifier — runs sort by most recent activity, so a
+// device run that flushed after the sweep sorts ahead of it — and for a
+// single-host policy the sweep run and that host's device run carry the same
+// target list, so neither is a discriminator.
+func sweepRunFor(t *testing.T, r *Runner) *Run {
+	t.Helper()
+	var found *Run
+	require.Eventually(t, func() bool {
+		r.runStore.mu.RLock()
+		defer r.runStore.mu.RUnlock()
+		for _, run := range r.runStore.runs[r.name][sweepRunKey] {
+			if run.Status != RunStatusRunning {
+				found = copyRun(run)
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 10*time.Millisecond, "a finished sweep run")
+	return found
 }

--- a/orb-discovery/gnmi-discovery/policy/sweep_run_test.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep_run_test.go
@@ -360,3 +360,39 @@ func TestTheSweepRunOutranksInFlightRuns(t *testing.T) {
 	}
 	require.True(t, found, "the sweep run is still exempt")
 }
+
+// Nothing else in the payload distinguishes a sweep run from a flush run: for a
+// single-host policy both carry the same target list, and both report completed.
+// A consumer asking "has this policy ingested anything?" read the sweep run —
+// which for a named host finishes before the first flush has even subscribed — as
+// a yes. Measured against the real backend and a live gNMI server, where it made
+// an external check pass roughly two seconds early.
+func TestSweepAndFlushRunsAreDistinguishable(t *testing.T) {
+	rs := NewRunStore()
+
+	flush := rs.CreateRun("p1", "10.0.0.1:9339")
+	rs.UpdateRun("p1", "10.0.0.1:9339", flush.ID, RunStatusCompleted, nil, 31)
+
+	sweep := rs.CreateSweepRun("p1", []string{"10.0.0.1:9339"})
+	rs.FinishSweepRun("p1", sweep.ID, RunStatusCompleted, "1 subscribed", 1)
+
+	kinds := map[string]string{}
+	for _, r := range rs.GetRunsForPolicy("p1") {
+		kinds[r.ID] = r.Kind
+	}
+	require.Equal(t, RunKindFlush, kinds[flush.ID])
+	require.Equal(t, RunKindSweep, kinds[sweep.ID])
+
+	// The ambiguity this resolves: the target lists really are identical.
+	var flushRun, sweepRun *Run
+	for _, r := range rs.GetRunsForPolicy("p1") {
+		switch r.ID {
+		case flush.ID:
+			flushRun = r
+		case sweep.ID:
+			sweepRun = r
+		}
+	}
+	require.Equal(t, flushRun.Targets, sweepRun.Targets,
+		"same targets, so kind is the only discriminator")
+}

--- a/orb-discovery/gnmi-discovery/policy/sweep_test.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep_test.go
@@ -1,9 +1,11 @@
 package policy
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -396,4 +398,25 @@ func TestAnAddressThatNeverRepliesIsRejected(t *testing.T) {
 	require.Equal(t, 1, run.EntityCount, "only .2 answered; .1 went silent")
 	require.NotContains(t, r.TargetStatuses()[0].Host, "10.0.0.1",
 		"a silent address gets no subscription")
+}
+
+// Overlapping ranges produce one duplicate per shared address, so logging each
+// one meant tens of thousands of lines per sweep — and per rescan tick. The
+// count and one example carry the same information.
+func TestDuplicateTargetsAreReportedOnceNotPerAddress(t *testing.T) {
+	var logs bytes.Buffer
+	r := runnerWithTargets(t, []config.Target{
+		{Host: "10.0.0.0/24"},
+		{Host: "10.0.0.1-10.0.0.200"},
+	}, slog.New(slog.NewTextHandler(&logs, nil)))
+
+	expanded, err := r.expandTargets()
+	require.NoError(t, err)
+	require.Equal(t, 254, len(expanded), "the union of the two")
+
+	out := logs.String()
+	require.Equal(t, 1, strings.Count(out, "dropping duplicate targets"),
+		"one line, whatever the overlap")
+	require.Contains(t, out, "count=200")
+	require.Contains(t, out, "example_host=")
 }

--- a/orb-discovery/gnmi-discovery/policy/sweep_test.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep_test.go
@@ -1,0 +1,291 @@
+package policy
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/config"
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/gnmi"
+	"github.com/netboxlabs/orb-agent/orb-discovery/gnmi-discovery/mapping"
+)
+
+// perHostDialer answers differently per address, which the shared FakeDialer
+// cannot do: it holds one session and ignores the TargetSpec entirely. The
+// classification matrix needs a distinct verdict per host, and concurrent probes
+// need distinct sessions or the -race detector fires on FakeSession's fields.
+type perHostDialer struct {
+	capsErr        map[string]error // by host:port; absent falls back to defaultCapsErr
+	defaultCapsErr error            // nil means the probe succeeds
+	dialErr        error
+
+	mu       sync.Mutex
+	dialed   []string
+	closed   map[string]int
+	inFlight int
+	peak     int
+	blockOn  chan struct{} // when non-nil, Capabilities waits on it
+}
+
+func newPerHostDialer(capsErr map[string]error) *perHostDialer {
+	return &perHostDialer{capsErr: capsErr, closed: map[string]int{}}
+}
+
+func (d *perHostDialer) Dial(_ context.Context, spec gnmi.TargetSpec) (gnmi.Session, error) {
+	if d.dialErr != nil {
+		return nil, d.dialErr
+	}
+	d.mu.Lock()
+	d.dialed = append(d.dialed, spec.Host)
+	d.mu.Unlock()
+	// Embed a real FakeSession so an admitted target's loop can run: it needs
+	// Subscribe and the rest of the interface, not just the two methods the
+	// probe touches.
+	return &perHostSession{
+		FakeSession: &gnmi.FakeSession{
+			Caps:            &gnmi.CapabilitiesResult{Vendor: "Arista"},
+			OnChangeSupport: true,
+			OnChangeStream: []gnmi.Notification{
+				{Updates: []gnmi.Update{{Path: "/system/state/hostname", Value: "r1"}}},
+				{SyncDone: true},
+			},
+		},
+		dialer: d, host: spec.Host,
+	}, nil
+}
+
+func (d *perHostDialer) dialedHosts() []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]string(nil), d.dialed...)
+}
+
+func (d *perHostDialer) closeCount(host string) int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.closed[host]
+}
+
+type perHostSession struct {
+	*gnmi.FakeSession
+	dialer *perHostDialer
+	host   string
+}
+
+func (s *perHostSession) Capabilities(_ context.Context) (*gnmi.CapabilitiesResult, error) {
+	s.dialer.mu.Lock()
+	s.dialer.inFlight++
+	if s.dialer.inFlight > s.dialer.peak {
+		s.dialer.peak = s.dialer.inFlight
+	}
+	s.dialer.mu.Unlock()
+	defer func() {
+		s.dialer.mu.Lock()
+		s.dialer.inFlight--
+		s.dialer.mu.Unlock()
+	}()
+
+	if s.dialer.blockOn != nil {
+		// Deliberately NOT selecting on ctx: this simulates a probe already past
+		// the point of cancellation, so the test measures whether Stop waits for
+		// the sweep goroutine rather than whether cancellation propagates.
+		<-s.dialer.blockOn
+	}
+	if err, ok := s.dialer.capsErr[s.host]; ok {
+		return nil, err
+	}
+	if s.dialer.defaultCapsErr != nil {
+		return nil, s.dialer.defaultCapsErr
+	}
+	return &gnmi.CapabilitiesResult{Vendor: "Arista"}, nil
+}
+
+func (s *perHostSession) Close() error {
+	s.dialer.mu.Lock()
+	s.dialer.closed[s.host]++
+	s.dialer.mu.Unlock()
+	return s.FakeSession.Close()
+}
+
+func handshakeErr(msg string) error {
+	return status.Error(codes.Unavailable, "connection error: desc = \"transport: "+msg+"\"")
+}
+
+func dialingErr() error {
+	return status.Error(codes.Unavailable,
+		"connection error: desc = \"transport: Error while dialing: dial tcp: connect: connection refused\"")
+}
+
+// The gate may only conclude "something is listening on the gNMI port". Anything
+// that answered — even by rejecting the RPC, even by failing a TLS handshake —
+// is a device. Only silence is absence.
+//
+// The handshake cases are the ones an allow-list got wrong: a campus of devices
+// with self-signed certs, or an mTLS device probed without a client cert, all
+// answer with codes.Unavailable and would read as an empty subnet.
+func TestAdmissionAdmitsAnythingThatAnswered(t *testing.T) {
+	admitted := map[string]error{
+		"ok":            nil,
+		"unauthed":      status.Error(codes.Unauthenticated, "no credentials"),
+		"forbidden":     status.Error(codes.PermissionDenied, "denied"),
+		"no gnmi svc":   status.Error(codes.Unimplemented, "unknown service gnmi.gNMI"),
+		"self-signed":   handshakeErr("authentication handshake failed: x509: certificate signed by unknown authority"),
+		"mtls required": handshakeErr("error reading server preface: remote error: tls: certificate required"),
+		"loaded device": status.Error(codes.ResourceExhausted, "busy"),
+	}
+	for name, err := range admitted {
+		if got := admits(err); !got {
+			t.Errorf("%s: admits(%v) = false, want true", name, err)
+		}
+	}
+
+	rejected := map[string]error{
+		"refused":  dialingErr(),
+		"timeout":  status.Error(codes.DeadlineExceeded, "context deadline exceeded"),
+		"canceled": status.Error(codes.Canceled, "context canceled"),
+	}
+	for name, err := range rejected {
+		if got := admits(err); got {
+			t.Errorf("%s: admits(%v) = true, want false", name, err)
+		}
+	}
+}
+
+// A sweep is cancelled by Stop and by a rescan tick. Counting those probes as
+// rejections would report a fabricated tally on every shutdown.
+func TestCanceledProbesAreNotCountedAsRejections(t *testing.T) {
+	require.True(t, isCanceled(status.Error(codes.Canceled, "context canceled")))
+	require.True(t, isCanceled(context.Canceled))
+	require.False(t, isCanceled(dialingErr()))
+}
+
+func TestSweepSubscribesOnlyToRespondingAddresses(t *testing.T) {
+	dialer := newPerHostDialer(map[string]error{
+		"10.0.0.2:9339": dialingErr(),
+		"10.0.0.3:9339": dialingErr(),
+	})
+	r := newSweepRunner(t, "10.0.0.0/30", dialer)
+	r.Start()
+	t.Cleanup(func() { _ = r.Stop() })
+
+	require.Eventually(t, func() bool {
+		return len(r.TargetStatuses()) == 1
+	}, 3*time.Second, 10*time.Millisecond, "only the responding address becomes a target")
+	require.Equal(t, "10.0.0.1:9339", r.TargetStatuses()[0].Host)
+}
+
+// Every probed session must be closed on every path. gnmic dials without
+// WithBlock, so Dial hands back a live ClientConn even for a dead address; an
+// unclosed one reconnect-loops in the background, per rejected address, per
+// sweep and per rescan tick.
+func TestEveryProbedSessionIsClosedIncludingRejections(t *testing.T) {
+	dialer := newPerHostDialer(map[string]error{"10.0.0.2:9339": dialingErr()})
+	r := newSweepRunner(t, "10.0.0.0/30", dialer)
+	r.Start()
+	t.Cleanup(func() { _ = r.Stop() })
+
+	require.Eventually(t, func() bool {
+		return len(dialer.dialedHosts()) >= 2
+	}, 3*time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		return dialer.closeCount("10.0.0.2:9339") == 1
+	}, 3*time.Second, 10*time.Millisecond, "a rejected probe still closes its session")
+}
+
+// A single host is the operator asserting the device exists. Probing it would
+// regress today's retry-forever behaviour: a device that is merely rebooting
+// would be dropped for the life of the policy.
+func TestASingleHostIsNeverProbed(t *testing.T) {
+	dialer := newPerHostDialer(map[string]error{"10.0.0.5:9339": dialingErr()})
+	r := newSweepRunner(t, "10.0.0.5", dialer)
+	r.Start()
+	t.Cleanup(func() { _ = r.Stop() })
+
+	require.Eventually(t, func() bool {
+		return len(r.TargetStatuses()) == 1
+	}, 3*time.Second, 10*time.Millisecond, "a named host is admitted without a probe")
+}
+
+// Stop must not return while the sweep goroutine is still running. Start does
+// wg.Add on its own side of the return precisely so that wg.Add happens-before
+// any wg.Wait; an uncounted sweep would let Stop report success while the sweep
+// carried on probing, outliving its own runner.
+//
+// Cancellation is a separate concern and works: a probe that honours ctx exits
+// promptly on Stop, which is what keeps DELETE from blocking. This test blocks
+// past that point on purpose.
+func TestStopWaitsForAnInFlightSweep(t *testing.T) {
+	dialer := newPerHostDialer(nil)
+	dialer.blockOn = make(chan struct{})
+	r := newSweepRunner(t, "10.0.0.0/24", dialer)
+	r.Start()
+
+	// Wait for a probe to actually be in flight. The sweep checks for
+	// cancellation before each probe, so a Stop that races Start exits at once —
+	// correct, but it would make this assertion vacuous.
+	require.Eventually(t, func() bool {
+		return len(dialer.dialedHosts()) > 0
+	}, 3*time.Second, 5*time.Millisecond)
+
+	stopped := make(chan struct{})
+	go func() {
+		_ = r.Stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+		t.Fatal("Stop returned while the sweep was still probing")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(dialer.blockOn)
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop did not return after the sweep was released")
+	}
+}
+
+func newSweepRunner(t *testing.T, host string, dialer gnmi.Dialer) *Runner {
+	t.Helper()
+	policy := config.Policy{
+		Config: config.PolicyConfig{Mode: config.ModeAuto, DebounceMs: 10},
+		Scope:  config.Scope{Targets: []config.Target{{Host: host}}},
+	}
+	store, err := mapping.LoadProfiles("")
+	require.NoError(t, err)
+	r, err := NewRunner(context.Background(), slog.New(slog.DiscardHandler),
+		"p1", policy, &recordingClient{}, dialer, store)
+	require.NoError(t, err)
+	r.backoffBase = time.Millisecond
+	return r
+}
+
+// A dead address costs the full probe timeout, so the sweep probes in parallel —
+// but bounded, because each probe holds a TLS handshake rather than a datagram.
+func TestProbesRunConcurrentlyButBounded(t *testing.T) {
+	dialer := newPerHostDialer(nil)
+	// Reject everything, so the only dials are probes: an admitted target starts
+	// a loop that dials again, which would make the count unstable.
+	dialer.defaultCapsErr = dialingErr()
+	r := newSweepRunner(t, "10.0.0.0/24", dialer)
+	r.Start()
+	t.Cleanup(func() { _ = r.Stop() })
+
+	require.Eventually(t, func() bool {
+		return len(dialer.dialedHosts()) == 254
+	}, 5*time.Second, 10*time.Millisecond, "all addresses probed")
+
+	dialer.mu.Lock()
+	peak := dialer.peak
+	dialer.mu.Unlock()
+	require.Greater(t, peak, 1, "probes must not be sequential")
+	require.LessOrEqual(t, peak, probeConcurrency, "probes must stay bounded")
+}

--- a/orb-discovery/gnmi-discovery/policy/sweep_test.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep_test.go
@@ -420,3 +420,57 @@ func TestDuplicateTargetsAreReportedOnceNotPerAddress(t *testing.T) {
 	require.Contains(t, out, "count=200")
 	require.Contains(t, out, "example_host=")
 }
+
+// Go resolves 06030 and 6030 to the same TCP port, so a pinned target written
+// with a zero-padded inline port names the same endpoint as the subnet-derived
+// candidate. Building the key from the raw text made them differ, so the pinned
+// entry never replaced the derived one and the device got two subscriptions with
+// two sets of credentials — two dials, two ingests, conflicting values.
+func TestAZeroPaddedInlinePortIsTheSameEndpoint(t *testing.T) {
+	m := newTestManager(t)
+	policies, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      port: 6030
+      username: campus
+      targets:
+        - host: 10.0.0.0/30
+        - host: 10.0.0.1:06030
+          username: pinned
+`))
+	require.NoError(t, err)
+
+	r := runnerWithTargets(t, policies["p1"].Scope.Targets, slog.New(slog.DiscardHandler))
+	expanded, err := r.expandTargets()
+	require.NoError(t, err)
+	require.Len(t, expanded, 2, "a /30 is two addresses, and the pin is one of them")
+
+	var pinned *candidate
+	for i := range expanded {
+		if canonicalHost(mustBare(t, expanded[i].target.Host)) == "10.0.0.1" {
+			pinned = &expanded[i]
+		}
+	}
+	require.NotNil(t, pinned)
+	require.True(t, pinned.explicit, "the pinned entry wins, so it is never probed")
+	require.Equal(t, "pinned", pinned.target.ResolvedUsername(),
+		"and it keeps its own credentials")
+}
+
+func mustBare(t *testing.T, host string) string {
+	t.Helper()
+	bare, _, _ := splitEffectivePort(host, 0)
+	return bare
+}
+
+// The key normalizes the port numerically, so equivalent spellings collapse while
+// genuinely different ports stay apart.
+func TestDedupeKeyNormalizesThePort(t *testing.T) {
+	require.Equal(t, dedupeKey("10.0.0.1:6030"), dedupeKey("10.0.0.1:06030"))
+	require.Equal(t, dedupeKey("[2001:db8::1]:6030"), dedupeKey("[2001:db8::1]:06030"))
+	require.NotEqual(t, dedupeKey("10.0.0.1:6030"), dedupeKey("10.0.0.1:57400"))
+	// A host with no port is not the same as one carrying the default: inventing
+	// a port here would collapse two entries that are not the same endpoint.
+	require.NotEqual(t, dedupeKey("10.0.0.1"), dedupeKey("10.0.0.1:9339"))
+}

--- a/orb-discovery/gnmi-discovery/policy/sweep_test.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep_test.go
@@ -27,6 +27,7 @@ type perHostDialer struct {
 
 	mu       sync.Mutex
 	dialed   []string
+	specs    []gnmi.TargetSpec
 	closed   map[string]int
 	inFlight int
 	peak     int
@@ -43,6 +44,7 @@ func (d *perHostDialer) Dial(_ context.Context, spec gnmi.TargetSpec) (gnmi.Sess
 	}
 	d.mu.Lock()
 	d.dialed = append(d.dialed, spec.Host)
+	d.specs = append(d.specs, spec)
 	d.mu.Unlock()
 	// Embed a real FakeSession so an admitted target's loop can run: it needs
 	// Subscribe and the rest of the interface, not just the two methods the
@@ -64,6 +66,18 @@ func (d *perHostDialer) dialedHosts() []string {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	return append([]string(nil), d.dialed...)
+}
+
+func (d *perHostDialer) specsFor(host string) []gnmi.TargetSpec {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	var out []gnmi.TargetSpec
+	for _, s := range d.specs {
+		if s.Host == host {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 func (d *perHostDialer) closeCount(host string) int {

--- a/orb-discovery/gnmi-discovery/policy/sweep_test.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep_test.go
@@ -68,6 +68,12 @@ func (d *perHostDialer) dialedHosts() []string {
 	return append([]string(nil), d.dialed...)
 }
 
+func (d *perHostDialer) specsSnapshot() []gnmi.TargetSpec {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]gnmi.TargetSpec(nil), d.specs...)
+}
+
 func (d *perHostDialer) specsFor(host string) []gnmi.TargetSpec {
 	d.mu.Lock()
 	defer d.mu.Unlock()

--- a/orb-discovery/gnmi-discovery/policy/sweep_test.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep_test.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"sync"
 	"testing"
@@ -31,11 +32,12 @@ type perHostDialer struct {
 	closed   map[string]int
 	inFlight int
 	peak     int
-	blockOn  chan struct{} // when non-nil, Capabilities waits on it
+	hang     map[string]bool // hosts whose Capabilities waits for ctx
+	blockOn  chan struct{}   // when non-nil, Capabilities waits on it
 }
 
 func newPerHostDialer(capsErr map[string]error) *perHostDialer {
-	return &perHostDialer{capsErr: capsErr, closed: map[string]int{}}
+	return &perHostDialer{capsErr: capsErr, closed: map[string]int{}, hang: map[string]bool{}}
 }
 
 func (d *perHostDialer) Dial(_ context.Context, spec gnmi.TargetSpec) (gnmi.Session, error) {
@@ -98,7 +100,7 @@ type perHostSession struct {
 	host   string
 }
 
-func (s *perHostSession) Capabilities(_ context.Context) (*gnmi.CapabilitiesResult, error) {
+func (s *perHostSession) Capabilities(ctx context.Context) (*gnmi.CapabilitiesResult, error) {
 	s.dialer.mu.Lock()
 	s.dialer.inFlight++
 	if s.dialer.inFlight > s.dialer.peak {
@@ -110,6 +112,16 @@ func (s *perHostSession) Capabilities(_ context.Context) (*gnmi.CapabilitiesResu
 		s.dialer.inFlight--
 		s.dialer.mu.Unlock()
 	}()
+
+	s.dialer.mu.Lock()
+	hang := s.dialer.hang[s.host]
+	s.dialer.mu.Unlock()
+	if hang {
+		// Never returns on its own: the probe's own deadline has to end it, which
+		// is what produces a genuine localStop.
+		<-ctx.Done()
+		return nil, status.FromContextError(ctx.Err()).Err()
+	}
 
 	if s.dialer.blockOn != nil {
 		// Deliberately NOT selecting on ctx: this simulates a probe already past
@@ -155,30 +167,42 @@ func dialingErr() error {
 // The handshake cases are the ones an allow-list got wrong: a campus of devices
 // with self-signed certs, or an mTLS device probed without a client cert, all
 // answer with codes.Unavailable and would read as an empty subnet.
+//
+// The two deadline/cancel cases are the ones a code-only classifier got wrong in
+// the opposite direction. grpc-go produces DeadlineExceeded and Canceled locally
+// when the probe's own context ends, and a server may also send either of them
+// itself — so the code cannot separate them and the local context has to.
 func TestAdmissionAdmitsAnythingThatAnswered(t *testing.T) {
-	admitted := map[string]error{
-		"ok":            nil,
-		"unauthed":      status.Error(codes.Unauthenticated, "no credentials"),
-		"forbidden":     status.Error(codes.PermissionDenied, "denied"),
-		"no gnmi svc":   status.Error(codes.Unimplemented, "unknown service gnmi.gNMI"),
-		"self-signed":   handshakeErr("authentication handshake failed: x509: certificate signed by unknown authority"),
-		"mtls required": handshakeErr("error reading server preface: remote error: tls: certificate required"),
-		"loaded device": status.Error(codes.ResourceExhausted, "busy"),
+	admitted := map[string]probeResult{
+		"ok":            {},
+		"unauthed":      {err: status.Error(codes.Unauthenticated, "no credentials")},
+		"forbidden":     {err: status.Error(codes.PermissionDenied, "denied")},
+		"no gnmi svc":   {err: status.Error(codes.Unimplemented, "unknown service gnmi.gNMI")},
+		"self-signed":   {err: handshakeErr("authentication handshake failed: x509: certificate signed by unknown authority")},
+		"mtls required": {err: handshakeErr("error reading server preface: remote error: tls: certificate required")},
+		"loaded device": {err: status.Error(codes.ResourceExhausted, "busy")},
+		// Server-sent, with the probe's own context still live: a peer answered.
+		"server deadline": {err: status.Error(codes.DeadlineExceeded, "deadline_exceeded")},
+		"server canceled": {err: status.Error(codes.Canceled, "rpc canceled by server")},
+		// A deadline that fires just after a successful reply must not retract it.
+		"answered then expired": {localStop: true},
 	}
-	for name, err := range admitted {
-		if got := admits(err); !got {
-			t.Errorf("%s: admits(%v) = false, want true", name, err)
+	for name, res := range admitted {
+		if got := admits(res); !got {
+			t.Errorf("%s: admits(%+v) = false, want true", name, res)
 		}
 	}
 
-	rejected := map[string]error{
-		"refused":  dialingErr(),
-		"timeout":  status.Error(codes.DeadlineExceeded, "context deadline exceeded"),
-		"canceled": status.Error(codes.Canceled, "context canceled"),
+	rejected := map[string]probeResult{
+		"refused": {err: dialingErr()},
+		// Our own deadline or cancellation ended the call, so nothing came back.
+		"local timeout":  {err: status.Error(codes.DeadlineExceeded, "context deadline exceeded"), localStop: true},
+		"local cancel":   {err: status.Error(codes.Canceled, "context canceled"), localStop: true},
+		"dial/tls fault": {err: errors.New("open /run/secrets/ca.pem: no such file or directory")},
 	}
-	for name, err := range rejected {
-		if got := admits(err); got {
-			t.Errorf("%s: admits(%v) = true, want false", name, err)
+	for name, res := range rejected {
+		if got := admits(res); got {
+			t.Errorf("%s: admits(%+v) = true, want false", name, res)
 		}
 	}
 }
@@ -186,9 +210,11 @@ func TestAdmissionAdmitsAnythingThatAnswered(t *testing.T) {
 // A sweep is cancelled by Stop and by a rescan tick. Counting those probes as
 // rejections would report a fabricated tally on every shutdown.
 func TestCanceledProbesAreNotCountedAsRejections(t *testing.T) {
-	require.True(t, isCanceled(status.Error(codes.Canceled, "context canceled")))
 	require.True(t, isCanceled(context.Canceled))
 	require.False(t, isCanceled(dialingErr()))
+	// A peer answering with codes.Canceled is not this runner shutting down.
+	require.False(t, isCanceled(status.Error(codes.Canceled, "rpc canceled by server")),
+		"a remote status must never read as a local shutdown")
 }
 
 func TestSweepSubscribesOnlyToRespondingAddresses(t *testing.T) {
@@ -314,4 +340,60 @@ func TestProbesRunConcurrentlyButBounded(t *testing.T) {
 	dialer.mu.Unlock()
 	require.Greater(t, peak, 1, "probes must not be sequential")
 	require.LessOrEqual(t, peak, probeConcurrency, "probes must stay bounded")
+}
+
+// One device answering with codes.Canceled must not abandon the sweep. Reading a
+// peer's status as "the policy is going away" discarded every address the other
+// probes had already admitted and started no subscriptions at all — a single
+// misbehaving device silently killing discovery for the whole subnet, with only a
+// Debug line to show for it.
+func TestAPeerAnsweringCanceledDoesNotAbandonTheSweep(t *testing.T) {
+	dialer := newPerHostDialer(map[string]error{
+		"10.0.0.1:9339": status.Error(codes.Canceled, "rpc canceled by server"),
+	})
+	r := newSweepRunner(t, "10.0.0.0/29", dialer) // .1 through .6
+	r.Start()
+	t.Cleanup(func() { _ = r.Stop() })
+
+	require.Eventually(t, func() bool {
+		return len(r.TargetStatuses()) == 6
+	}, 3*time.Second, 10*time.Millisecond,
+		"every address answered, the Canceled one included")
+}
+
+// A server that sends DeadlineExceeded itself has answered, so the address holds
+// a device. Classifying on the code alone dropped it as silence.
+func TestAServerSentDeadlineIsAdmitted(t *testing.T) {
+	dialer := newPerHostDialer(map[string]error{
+		"10.0.0.1:9339": status.Error(codes.DeadlineExceeded, "deadline_exceeded"),
+		"10.0.0.2:9339": dialingErr(),
+	})
+	r := newSweepRunner(t, "10.0.0.0/30", dialer)
+	r.Start()
+	t.Cleanup(func() { _ = r.Stop() })
+
+	require.Eventually(t, func() bool {
+		return len(r.TargetStatuses()) == 1
+	}, 3*time.Second, 10*time.Millisecond)
+	require.Equal(t, "10.0.0.1:9339", r.TargetStatuses()[0].Host,
+		"the server answered; only the refused address is absent")
+}
+
+// The probe's own deadline expiring is still the one thing that means silence.
+func TestAnAddressThatNeverRepliesIsRejected(t *testing.T) {
+	dialer := newPerHostDialer(nil)
+	dialer.hang = map[string]bool{"10.0.0.1:9339": true}
+	policy := config.Policy{
+		Config: config.PolicyConfig{Mode: config.ModeAuto, DebounceMs: 10, ProbeTimeoutMs: 80},
+		Scope:  config.Scope{Targets: []config.Target{{Host: "10.0.0.0/30"}}},
+	}
+	r := newRunnerFor(t, policy, dialer)
+	r.Start()
+	t.Cleanup(func() { _ = r.Stop() })
+
+	run := sweepRunFor(t, r)
+	require.Equal(t, RunStatusCompleted, run.Status)
+	require.Equal(t, 1, run.EntityCount, "only .2 answered; .1 went silent")
+	require.NotContains(t, r.TargetStatuses()[0].Host, "10.0.0.1",
+		"a silent address gets no subscription")
 }

--- a/orb-discovery/gnmi-discovery/policy/sweep_test.go
+++ b/orb-discovery/gnmi-discovery/policy/sweep_test.go
@@ -97,11 +97,17 @@ func (s *perHostSession) Capabilities(_ context.Context) (*gnmi.CapabilitiesResu
 		// the sweep goroutine rather than whether cancellation propagates.
 		<-s.dialer.blockOn
 	}
-	if err, ok := s.dialer.capsErr[s.host]; ok {
+	// Under the lock: the rescan tests bring a device up mid-run by mutating
+	// capsErr while probes are in flight.
+	s.dialer.mu.Lock()
+	err, scripted := s.dialer.capsErr[s.host]
+	fallback := s.dialer.defaultCapsErr
+	s.dialer.mu.Unlock()
+	if scripted {
 		return nil, err
 	}
-	if s.dialer.defaultCapsErr != nil {
-		return nil, s.dialer.defaultCapsErr
+	if fallback != nil {
+		return nil, fallback
 	}
 	return &gnmi.CapabilitiesResult{Vendor: "Arista"}, nil
 }

--- a/orb-discovery/gnmi-discovery/policy/target_bounds_test.go
+++ b/orb-discovery/gnmi-discovery/policy/target_bounds_test.go
@@ -181,3 +181,28 @@ func TestAHostWithControlCharactersIsRejected(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "control character")
 }
+
+// A policy name reaches a log line on nearly every path through this backend, so
+// it gets the same treatment as a host.
+func TestAPolicyNameWithControlCharactersIsRejected(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte("policies:\n  \"p1\\nlevel=ERROR msg=forged\":\n    scope:\n      targets:\n        - host: 10.0.0.1\n"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "policy name")
+	require.Contains(t, err.Error(), "control character")
+}
+
+// A tab is a control character but a legitimate part of nothing here, and an
+// ordinary name still passes.
+func TestOrdinaryNamesAndHostsStillPass(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  campus-fabric_01:
+    scope:
+      targets:
+        - host: switch-a.example.com
+        - host: 10.0.0.0/24
+`))
+	require.NoError(t, err)
+}

--- a/orb-discovery/gnmi-discovery/policy/target_bounds_test.go
+++ b/orb-discovery/gnmi-discovery/policy/target_bounds_test.go
@@ -618,3 +618,51 @@ policies:
 	}
 	require.Equal(t, []string{"[2001:db8::1]:6030", "[2001:db8::2]:57400"}, hosts)
 }
+
+// net.SplitHostPort accepts a service name and Go's dialer resolves one, so
+// "10.0.0.1:http" reaches port 80 while every check here read it as an unported
+// host named "10.0.0.1:http". A pinned target written that way never matched the
+// numeric candidate a range produced, and the device got two subscriptions with
+// two sets of credentials.
+//
+// Rejected rather than resolved: resolving would make a policy's meaning depend
+// on the /etc/services of whichever host parsed it.
+func TestANonNumericInlinePortIsRejected(t *testing.T) {
+	m := newTestManager(t)
+	for _, host := range []string{
+		"10.0.0.1:http",
+		"[2001:db8::1]:gnmi",
+		"10.0.0.1:99999", // out of range, and silently a hostname before
+		"10.0.0.1:",      // trailing colon, likewise
+	} {
+		_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: "` + host + `"
+`))
+		require.Error(t, err, "host %q must be rejected", host)
+		require.Contains(t, err.Error(), "inline port", "the error names the port, host %q", host)
+	}
+}
+
+// Numeric ports, IPv6 literals without brackets, and portless hosts are all
+// untouched by the check.
+func TestNumericAndPortlessHostsStillPass(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.1:6030
+        - host: 10.0.0.2
+        - host: "[2001:db8::1]:57400"
+        - host: 2001:db8::2
+        - host: fe80::1%br-lan
+        - host: switch-a.example.com
+        - host: 10.0.1.0/24
+`))
+	require.NoError(t, err)
+}

--- a/orb-discovery/gnmi-discovery/policy/target_bounds_test.go
+++ b/orb-discovery/gnmi-discovery/policy/target_bounds_test.go
@@ -353,3 +353,25 @@ policies:
 		require.Contains(t, err.Error(), "port", "the error points at the port field")
 	}
 }
+
+// End to end: a zoned IPv6 host whose interface name contains a hyphen is a
+// valid endpoint and must reach the runner bracketed and ported, not fail the
+// whole policy.
+func TestAZonedIPv6HostWithAHyphenIsAccepted(t *testing.T) {
+	m := newTestManager(t)
+	policies, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      port: 6030
+      targets:
+        - host: fe80::1%br-lan
+        - host: fe80::2%eth0
+`))
+	require.NoError(t, err, "a hyphen in the zone must not fail the policy")
+	hosts := []string{}
+	for _, tgt := range policies["p1"].Scope.Targets {
+		hosts = append(hosts, tgt.Host)
+	}
+	require.Equal(t, []string{"[fe80::1%br-lan]:6030", "[fe80::2%eth0]:6030"}, hosts)
+}

--- a/orb-discovery/gnmi-discovery/policy/target_bounds_test.go
+++ b/orb-discovery/gnmi-discovery/policy/target_bounds_test.go
@@ -555,3 +555,66 @@ policies:
 `))
 	require.NoError(t, err, "a subnet, pinned hosts inside it, and a nested prefix")
 }
+
+// bare is what Count, Span, IsSingleEndpoint and canonicalHost are all asked
+// about, and it was normalized on one path and not the other. canonicalHost trims
+// its own input, so a bracketed literal collapsed with the plain address for
+// identity while Span refused to parse it and counted a separate endpoint — a /22
+// plus three bracketed pinned hosts inside it was rejected as 1025 addresses that
+// expansion resolves to 1022.
+func TestBracketedHostsInsideASubnetDoNotCountTwice(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.0/22
+        - host: "[10.0.0.1]"
+          username: a
+        - host: "[10.0.0.2]"
+          username: b
+        - host: "[10.0.0.3]"
+          username: c
+`))
+	require.NoError(t, err, "the bracketed hosts are inside the /22")
+}
+
+// A bracketed literal and its plain form are one endpoint, so naming both is the
+// duplicate it looks like.
+func TestABracketedAndAPlainAddressAreOneEndpoint(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: "[10.0.0.5]"
+          username: alice
+        - host: 10.0.0.5
+          username: bob
+`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "two entries")
+}
+
+// Bracketed IPv6 keeps working, with and without an inline port, since brackets
+// are how it is written at all.
+func TestBracketedIPv6StillWorks(t *testing.T) {
+	m := newTestManager(t)
+	policies, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      port: 6030
+      targets:
+        - host: "[2001:db8::1]"
+        - host: "[2001:db8::2]:57400"
+`))
+	require.NoError(t, err)
+	hosts := []string{}
+	for _, tgt := range policies["p1"].Scope.Targets {
+		hosts = append(hosts, tgt.Host)
+	}
+	require.Equal(t, []string{"[2001:db8::1]:6030", "[2001:db8::2]:57400"}, hosts)
+}

--- a/orb-discovery/gnmi-discovery/policy/target_bounds_test.go
+++ b/orb-discovery/gnmi-discovery/policy/target_bounds_test.go
@@ -426,3 +426,74 @@ policies:
 `))
 	require.Error(t, err, "1022 + 3 is over it: real IPv6 hosts are not inside the /22")
 }
+
+// A zone identifier is an interface name, and Linux interface names are
+// case-sensitive. net.ParseIP refuses any address carrying a zone, so the whole
+// value fell to the lower-casing path meant for hostnames — collapsing two
+// different links into one and rejecting the policy.
+func TestCaseDistinctIPv6ZonesAreDifferentEndpoints(t *testing.T) {
+	m := newTestManager(t)
+	policies, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: fe80::1%eth0
+        - host: fe80::1%Eth0
+`))
+	require.NoError(t, err, "eth0 and Eth0 are two links on Linux")
+	require.Len(t, policies["p1"].Scope.Targets, 2)
+}
+
+// The same fallback also failed to canonicalize the address half, so one address
+// written two ways counted as two endpoints. Both halves are handled now.
+func TestTwoSpellingsOfOneZonedAddressAreOneEndpoint(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: fe80::0001%eth0
+          username: alice
+        - host: fe80::1%eth0
+          username: bob
+`))
+	require.Error(t, err, "same address, same zone: one endpoint")
+	require.Contains(t, err.Error(), "two entries")
+}
+
+// canonicalHost is shared with the expansion dedupe, so the two must still agree
+// on every zoned form — that sharing is what keeps validation from admitting
+// something expansion silently merges.
+func TestValidationAndExpansionAgreeOnZonedAddresses(t *testing.T) {
+	same := [][2]string{
+		{"fe80::0001%eth0", "fe80::1%eth0"},
+		{"FE80::1%eth0", "fe80::1%eth0"},
+	}
+	for _, pair := range same {
+		require.Equal(t, canonicalHost(pair[0]), canonicalHost(pair[1]),
+			"%q and %q are one endpoint", pair[0], pair[1])
+		require.Equal(t,
+			dedupeKey(ensurePort(pair[0], 9339)),
+			dedupeKey(ensurePort(pair[1], 9339)),
+			"expansion must agree for %q and %q", pair[0], pair[1])
+	}
+
+	differ := [][2]string{
+		{"fe80::1%eth0", "fe80::1%Eth0"},
+		{"fe80::1%eth0", "fe80::1%eth1"},
+		{"fe80::1%eth0", "fe80::2%eth0"},
+	}
+	for _, pair := range differ {
+		require.NotEqual(t, canonicalHost(pair[0]), canonicalHost(pair[1]),
+			"%q and %q are different endpoints", pair[0], pair[1])
+		require.NotEqual(t,
+			dedupeKey(ensurePort(pair[0], 9339)),
+			dedupeKey(ensurePort(pair[1], 9339)),
+			"expansion must agree for %q and %q", pair[0], pair[1])
+	}
+
+	// Unchanged: a mapped IPv4 form still collapses onto the plain address.
+	require.Equal(t, canonicalHost("::ffff:10.0.0.1"), canonicalHost("10.0.0.1"))
+}

--- a/orb-discovery/gnmi-discovery/policy/target_bounds_test.go
+++ b/orb-discovery/gnmi-discovery/policy/target_bounds_test.go
@@ -294,3 +294,62 @@ func TestValidationAndExpansionAgreeOnEndpointIdentity(t *testing.T) {
 	}
 	require.NotEqual(t, canonicalHost("2001:db8::1"), canonicalHost("2001:db8::2"))
 }
+
+// A hostname may legally begin with an address and a hyphen. Expand passes it
+// through as one endpoint, because it contains letters — so the port has to be
+// appended, and a syntactic guess that saw "address, hyphen" assumed a range and
+// skipped it, leaving gnmic to fail the dial for a missing port.
+func TestAHostnameBeginningWithAnAddressStillGetsItsPort(t *testing.T) {
+	m := newTestManager(t)
+	policies, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      port: 6030
+      targets:
+        - host: 10.0.0.1-switch.example.com
+        - host: 10.0.0.1-
+`))
+	require.NoError(t, err)
+	hosts := []string{}
+	for _, tgt := range policies["p1"].Scope.Targets {
+		hosts = append(hosts, tgt.Host)
+	}
+	require.Equal(t, []string{
+		"10.0.0.1-switch.example.com:6030",
+		"10.0.0.1-:6030",
+	}, hosts, "Expand treats both as hostnames, so both take the port")
+}
+
+// The other half of the same confusion: such a hostname carrying an inline port
+// was rejected outright, with an error blaming a CIDR or range it is not.
+func TestAHostnameBeginningWithAnAddressMayCarryAnInlinePort(t *testing.T) {
+	m := newTestManager(t)
+	policies, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.1-switch.example.com:6030
+`))
+	require.NoError(t, err, "this is a hostname with a port, not a range")
+	require.Equal(t, "10.0.0.1-switch.example.com:6030", policies["p1"].Scope.Targets[0].Host)
+}
+
+// A real range carrying an inline port is still rejected, which is what that
+// check exists for: Expand would read it as a DNS name and retry a nonexistent
+// host forever with only a generic dial error.
+func TestARealRangeWithAnInlinePortIsStillRejected(t *testing.T) {
+	m := newTestManager(t)
+	for _, host := range []string{"10.0.0.1-10:6030", "10.0.0.0/24:6030", "10.0.0.1-10.0.0.9:6030"} {
+		_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: ` + host + `
+`))
+		require.Error(t, err, "host %q must be rejected", host)
+		require.Contains(t, err.Error(), "port", "the error points at the port field")
+	}
+}

--- a/orb-discovery/gnmi-discovery/policy/target_bounds_test.go
+++ b/orb-discovery/gnmi-discovery/policy/target_bounds_test.go
@@ -1,0 +1,183 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Two ports on one address are two endpoints, whichever way the port is
+// written. Keying the host and the port from different decisions — the host from
+// hostWithoutPort, the port from the field alone — collapsed both of these to
+// one key and rejected a valid policy.
+func TestTwoInlinePortsOnOneHostAreTwoEndpoints(t *testing.T) {
+	m := newTestManager(t)
+	policies, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.5:6030
+        - host: 10.0.0.5:57400
+`))
+	require.NoError(t, err, "two inline ports on one host are two endpoints")
+	require.Len(t, policies["p1"].Scope.Targets, 2)
+}
+
+// The converse: one endpoint written two ways is a duplicate, and used not to be
+// caught because the two spellings produced different keys.
+func TestAnInlinePortAndThePortFieldNamingOneEndpointIsADuplicate(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.5:6030
+        - host: 10.0.0.5
+          port: 6030
+`))
+	require.Error(t, err, "inline :6030 and port: 6030 name the same endpoint")
+	require.Contains(t, err.Error(), "two entries")
+}
+
+// The scope port participates too: a bare host inherits it, so a target naming
+// the same address inline at that port is the same endpoint.
+func TestTheScopePortIsUsedWhenMatchingDuplicates(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      port: 6030
+      targets:
+        - host: 10.0.0.5
+        - host: 10.0.0.5:6030
+`))
+	require.Error(t, err)
+
+	_, err = m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      port: 6030
+      targets:
+        - host: 10.0.0.5
+        - host: 10.0.0.5:57400
+`))
+	require.NoError(t, err, "a different inline port is a different endpoint")
+}
+
+// The cap counts distinct addresses, not the sum of what each entry spans.
+// Pinning hosts inside a subnet to give them their own credentials is the
+// documented pattern, and against a /22 — the largest prefix the cap allows —
+// summing rejected a policy that expands to 1022 targets, under the limit.
+func TestPinnedHostsInsideASubnetDoNotCountTwiceAgainstTheCap(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.0/22
+        - host: 10.0.0.5
+          username: legacy
+        - host: 10.0.0.6
+          username: legacy
+        - host: 10.0.0.7
+          username: legacy
+`))
+	require.NoError(t, err, "a /22 plus three hosts inside it is still 1022 endpoints")
+}
+
+// Overlap only cancels at the same port. The same address reached on two ports is
+// two subscriptions, so merging across ports would let a policy exceed the cap.
+func TestOverlapAtADifferentPortStillCounts(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.0/22
+        - host: 10.1.0.0/22
+`))
+	require.Error(t, err, "two non-overlapping /22s are 2044 endpoints")
+
+	_, err = m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      port: 6030
+      targets:
+        - host: 10.0.0.0/22
+        - host: 10.0.0.0/22
+          port: 57400
+`))
+	require.Error(t, err, "the same /22 at two ports is 2044 subscriptions, not 1022")
+
+	// And the same /22 at the same port really is just 1022.
+	_, err = m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.0/22
+        - host: 10.0.0.1-10
+`))
+	require.NoError(t, err, "a range wholly inside the subnet adds nothing")
+}
+
+// A hostname is one endpoint and cannot be compared with an address, so it is
+// counted rather than merged.
+func TestHostnamesAreCountedIndividually(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.0/22
+        - host: switch-a.example.com
+        - host: switch-b.example.com
+`))
+	require.NoError(t, err, "1022 + 2 is 1024, exactly the cap")
+
+	_, err = m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.0/22
+        - host: switch-a.example.com
+        - host: switch-b.example.com
+        - host: switch-c.example.com
+`))
+	require.Error(t, err, "1022 + 3 is over the cap")
+}
+
+// A single oversized entry names itself as the offender rather than being blamed
+// on whichever target happened to come last.
+func TestAnOversizedTargetIsNamedInTheError(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.0/20
+`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "10.0.0.0/20")
+}
+
+// No hostname, IP, CIDR or range holds a control character, and a host holding a
+// newline is the only route by which policy text could forge a whole log record
+// rather than fill one field.
+func TestAHostWithControlCharactersIsRejected(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte("policies:\n  p1:\n    scope:\n      targets:\n" +
+		"        - host: \"10.0.0.1\\nlevel=ERROR msg=forged\"\n"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "control character")
+}

--- a/orb-discovery/gnmi-discovery/policy/target_bounds_test.go
+++ b/orb-discovery/gnmi-discovery/policy/target_bounds_test.go
@@ -375,3 +375,54 @@ policies:
 	}
 	require.Equal(t, []string{"[fe80::1%br-lan]:6030", "[fe80::2%eth0]:6030"}, hosts)
 }
+
+// The cap must use the same notion of endpoint identity as expansion. An
+// IPv4-mapped form is not Is4, so it counted as an endpoint of its own while
+// canonicalHost and dedupeKey collapsed it with the plain address — and a /22
+// plus three pinned mapped hosts inside it was rejected as 1025 endpoints that
+// expansion resolves to 1022.
+func TestMappedIPv4HostsInsideASubnetDoNotCountTwice(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.0/22
+        - host: "::ffff:10.0.0.1"
+          username: a
+        - host: "::ffff:10.0.0.2"
+          username: b
+        - host: "::ffff:10.0.0.3"
+          username: c
+`))
+	require.NoError(t, err, "the mapped hosts are inside the /22, so this is 1022 endpoints")
+}
+
+// A genuine IPv6 address is still not merged into an IPv4 span, and still counts
+// as its own endpoint.
+func TestARealIPv6HostStillCountsSeparately(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.0/22
+        - host: 2001:db8::1
+        - host: 2001:db8::2
+`))
+	require.NoError(t, err, "1022 + 2 is exactly the cap")
+
+	_, err = m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.0/22
+        - host: 2001:db8::1
+        - host: 2001:db8::2
+        - host: 2001:db8::3
+`))
+	require.Error(t, err, "1022 + 3 is over it: real IPv6 hosts are not inside the /22")
+}

--- a/orb-discovery/gnmi-discovery/policy/target_bounds_test.go
+++ b/orb-discovery/gnmi-discovery/policy/target_bounds_test.go
@@ -206,3 +206,91 @@ policies:
 `))
 	require.NoError(t, err)
 }
+
+// Validation and expansion must agree on what "the same endpoint" means.
+// Validation lowercased the raw text while expansion canonicalized through
+// net.ParseIP, so two spellings of one IPv6 address passed validation as two
+// targets with two sets of credentials and were then merged by the expansion
+// dedupe — leaving the effective config to depend on entry order, with only a
+// warning to show for it.
+func TestTwoSpellingsOfOneIPv6AddressAreRejectedAsADuplicate(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 2001:db8::1
+          username: alice
+        - host: 2001:0db8::1
+          username: bob
+`))
+	require.Error(t, err, "the expansion would have merged these; validation must say so")
+	require.Contains(t, err.Error(), "two entries")
+}
+
+// Upper-case hex is the same address too.
+func TestIPv6CaseDoesNotMakeANewEndpoint(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 2001:DB8::1
+        - host: 2001:db8::1
+`))
+	require.Error(t, err)
+}
+
+// An IPv4-mapped form names the same endpoint as the plain address, which is what
+// the expansion dedupe already concluded.
+func TestAnIPv4MappedAddressIsTheSameEndpoint(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.1
+        - host: "::ffff:10.0.0.1"
+`))
+	require.Error(t, err)
+}
+
+// Two genuinely different addresses still pass, and a hostname is never compared
+// against an address: Expand does not resolve DNS, so they cannot be known to be
+// the same device.
+func TestDistinctAddressesAndNamesStillPass(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 2001:db8::1
+        - host: 2001:db8::2
+        - host: switch-a.example.com
+        - host: 10.0.0.1
+`))
+	require.NoError(t, err)
+}
+
+// The two layers must reach the same verdict for the same input. If they drift
+// again, validation admits something expansion silently merges.
+func TestValidationAndExpansionAgreeOnEndpointIdentity(t *testing.T) {
+	for _, pair := range [][2]string{
+		{"2001:db8::1", "2001:0db8::1"},
+		{"2001:DB8::1", "2001:db8::1"},
+		{"10.0.0.1", "::ffff:10.0.0.1"},
+		{"SWITCH-A.example.com", "switch-a.example.com"},
+	} {
+		require.Equal(t, canonicalHost(pair[0]), canonicalHost(pair[1]),
+			"%q and %q name one endpoint", pair[0], pair[1])
+		require.Equal(t,
+			dedupeKey(ensurePort(pair[0], 9339)),
+			dedupeKey(ensurePort(pair[1], 9339)),
+			"expansion must agree for %q and %q", pair[0], pair[1])
+	}
+	require.NotEqual(t, canonicalHost("2001:db8::1"), canonicalHost("2001:db8::2"))
+}

--- a/orb-discovery/gnmi-discovery/policy/target_bounds_test.go
+++ b/orb-discovery/gnmi-discovery/policy/target_bounds_test.go
@@ -1,6 +1,8 @@
 package policy
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -496,4 +498,60 @@ func TestValidationAndExpansionAgreeOnZonedAddresses(t *testing.T) {
 
 	// Unchanged: a mapped IPv4 form still collapses onto the plain address.
 	require.Equal(t, canonicalHost("::ffff:10.0.0.1"), canonicalHost("10.0.0.1"))
+}
+
+// 10.0.0.1/22 names the same subnet as 10.0.0.0/22, so two such entries are one
+// endpoint set written twice — and the second expansion is discarded wholesale,
+// which is the duplicate case for prefixes.
+func TestEquivalentPrefixesAreADuplicate(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.0/22
+          username: alice
+        - host: 10.0.0.1/22
+          username: bob
+`))
+	require.Error(t, err, "both name 10.0.0.0/22")
+	require.Contains(t, err.Error(), "two entries")
+}
+
+// Bounding the union bounds the subscriptions, which is what the cap is for, but
+// not the work: every entry is expanded before the results are deduplicated. A
+// handful of heavily overlapping ranges therefore cost the sum while yielding the
+// union, on every sweep and every rescan tick.
+func TestHeavilyOverlappingRangesAreRefused(t *testing.T) {
+	m := newTestManager(t)
+	var sb strings.Builder
+	sb.WriteString("policies:\n  p1:\n    scope:\n      targets:\n")
+	// Distinct spans, near-identical coverage: prefix masking cannot collapse
+	// these, so only a work bound catches them.
+	for i := range 40 {
+		fmt.Fprintf(&sb, "        - host: 10.0.0.%d-10.0.3.254\n", i+1)
+	}
+	_, err := m.ParsePolicies([]byte(sb.String()))
+	require.Error(t, err, "40 overlapping ranges enumerate ~40k addresses for 1022 endpoints")
+	require.Contains(t, err.Error(), "enumerate")
+}
+
+// The legitimate shapes the union allowance exists for must still pass.
+func TestOverlapWithinReasonStillPasses(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    scope:
+      targets:
+        - host: 10.0.0.0/22
+        - host: 10.0.0.5
+          username: legacy
+        - host: 10.0.0.6
+          username: legacy
+        - host: 10.0.1.0/24
+          username: other
+`))
+	require.NoError(t, err, "a subnet, pinned hosts inside it, and a nested prefix")
 }

--- a/orb-discovery/gnmi-discovery/targets/subnet_test.go
+++ b/orb-discovery/gnmi-discovery/targets/subnet_test.go
@@ -174,3 +174,51 @@ func TestExpandRefusesMoreThanMaxExpand(t *testing.T) {
 		t.Errorf("Expand(10.0.0.0/22) = %d addresses, want 1022", len(got))
 	}
 }
+
+// An IPv6 zone is an interface name and may contain a hyphen — br-lan and
+// veth-* are ordinary. The range heuristic read the colon and the hyphen as
+// range syntax and failed the whole policy with "only IPv4 addresses are
+// supported", for an endpoint ensurePort goes out of its way to bracket.
+func TestZonedIPv6WithAHyphenInTheZoneIsOneEndpoint(t *testing.T) {
+	for _, target := range []string{
+		"fe80::1%eth-0",
+		"fe80::1%br-lan",
+		"fe80::1%veth-abc123",
+		"fe80::1%eth0", // unchanged: no hyphen at all
+	} {
+		if !IsSingleEndpoint(target) {
+			t.Errorf("IsSingleEndpoint(%q) = false, want true", target)
+		}
+		n, err := Count(target)
+		if err != nil {
+			t.Errorf("Count(%q) returned error: %v", target, err)
+			continue
+		}
+		if n != 1 {
+			t.Errorf("Count(%q) = %d, want 1", target, n)
+		}
+		got, err := Expand(target)
+		if err != nil {
+			t.Errorf("Expand(%q) returned error: %v", target, err)
+			continue
+		}
+		if len(got) != 1 || got[0] != target {
+			t.Errorf("Expand(%q) = %v, want [%q]", target, got, target)
+		}
+	}
+}
+
+// A real range is still a range, and an IPv6 range is still refused: the fix
+// exempts complete addresses, not anything containing a colon and a hyphen.
+func TestTheRangeHeuristicStillCatchesRealRanges(t *testing.T) {
+	for _, target := range []string{"10.0.0.1-10", "10.0.0.1-10.0.0.9", "10.0.0.0-255"} {
+		if IsSingleEndpoint(target) {
+			t.Errorf("IsSingleEndpoint(%q) = true, want false", target)
+		}
+	}
+	// An IPv6 range does not parse as one address, so it still reaches the range
+	// branch and is refused there.
+	if _, err := Count("2001:db8::1-5"); err == nil {
+		t.Error("Count(2001:db8::1-5) = nil error, want an error")
+	}
+}

--- a/orb-discovery/gnmi-discovery/targets/subnet_test.go
+++ b/orb-discovery/gnmi-discovery/targets/subnet_test.go
@@ -1,0 +1,176 @@
+package targets
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// A CIDR names a subnet, so its network and broadcast addresses are not hosts.
+// A range is an operator enumerating addresses, so every one they wrote is kept.
+// The two forms therefore disagree on the same address set, deliberately.
+func TestExpandPrefixExcludesNetworkAndBroadcast(t *testing.T) {
+	tests := []struct {
+		target string
+		want   int
+	}{
+		{"10.0.0.0/24", 254},
+		{"10.0.0.0/23", 510},
+		{"10.0.0.0/22", 1022},
+		{"10.0.0.0/30", 2},
+		{"10.0.0.0/31", 2},
+		{"10.0.0.5/32", 1},
+		// A range keeps what the operator wrote, including .0 and .255.
+		{"10.0.0.0-255", 256},
+	}
+	for _, tt := range tests {
+		got, err := Expand(tt.target)
+		if err != nil {
+			t.Errorf("Expand(%q) returned error: %v", tt.target, err)
+			continue
+		}
+		if len(got) != tt.want {
+			t.Errorf("Expand(%q) = %d addresses, want %d", tt.target, len(got), tt.want)
+		}
+	}
+}
+
+func TestExpandPrefixDropsTheRightAddresses(t *testing.T) {
+	got, err := Expand("10.0.0.0/30")
+	if err != nil {
+		t.Fatalf("Expand returned error: %v", err)
+	}
+	want := []string{"10.0.0.1", "10.0.0.2"}
+	if len(got) != len(want) {
+		t.Fatalf("Expand = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Expand[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// A /31 and /32 have no network/broadcast pair to strip. Stripping anyway drives
+// endVal below startVal, and the original post-test loop then wraps uint32 and
+// appends ~4.29 billion entries. host: 10.0.0.5/32 is the most ordinary config
+// an operator writes, so this is an OOM reachable from a single policy line.
+func TestExpandDoesNotRunAwayOnSmallPrefixes(t *testing.T) {
+	for _, target := range []string{
+		"10.0.0.5/32",
+		"10.0.0.4/31",
+		// The top of the address space is the second runaway class: a pre-test
+		// loop written in uint32 never terminates here, because val++ wraps
+		// past endVal = MaxUint32.
+		"255.255.255.255/32",
+		"255.255.255.254/31",
+	} {
+		done := make(chan int, 1)
+		go func() {
+			ips, err := Expand(target)
+			if err != nil {
+				done <- -1
+				return
+			}
+			done <- len(ips)
+		}()
+		select {
+		case n := <-done:
+			if n < 0 {
+				t.Errorf("Expand(%q) returned an error, want addresses", target)
+			}
+			if n > 2 {
+				t.Errorf("Expand(%q) = %d addresses, want at most 2", target, n)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Expand(%q) did not terminate: runaway loop", target)
+		}
+	}
+}
+
+// Count must agree with Expand for every form, because it is the only thing
+// standing between a policy save and enumerating a /8. If they can drift, the
+// cap is enforced against a different interpretation than the one used.
+func TestCountAgreesWithExpand(t *testing.T) {
+	for _, target := range []string{
+		"10.0.0.0/24", "10.0.0.0/23", "10.0.0.0/30", "10.0.0.0/31", "10.0.0.5/32",
+		"255.255.255.255/32", "255.255.255.254/31",
+		"10.0.0.1-5", "10.0.0.0-255", "10.0.0.1-10.0.0.9",
+		"10.0.0.5", "switch-a.example.com",
+	} {
+		n, err := Count(target)
+		if err != nil {
+			t.Errorf("Count(%q) returned error: %v", target, err)
+			continue
+		}
+		ips, err := Expand(target)
+		if err != nil {
+			t.Errorf("Expand(%q) returned error: %v", target, err)
+			continue
+		}
+		if n != uint64(len(ips)) {
+			t.Errorf("Count(%q) = %d, but Expand yielded %d", target, n, len(ips))
+		}
+	}
+}
+
+// Count must answer without enumerating, or it cannot protect against the very
+// input it exists to reject.
+func TestCountDoesNotEnumerate(t *testing.T) {
+	done := make(chan struct{})
+	var got uint64
+	var err error
+	go func() {
+		got, err = Count("10.0.0.0/8")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Count(10.0.0.0/8) took over 100ms: it is enumerating")
+	}
+	if err != nil {
+		t.Fatalf("Count returned error: %v", err)
+	}
+	if got != 16777214 {
+		t.Errorf("Count(10.0.0.0/8) = %d, want 16777214", got)
+	}
+}
+
+func TestCountRejectsWhatExpandRejects(t *testing.T) {
+	for _, target := range []string{"2001:db8::/64", "10.0.0.0/33", "10.0.0.1-300"} {
+		if _, err := Count(target); err == nil {
+			t.Errorf("Count(%q) = nil error, want an error", target)
+		}
+	}
+}
+
+// A /64 is the standard IPv6 subnet and is not enumerable. The error has to say
+// that rather than "only IPv4 supported", which reads as an arbitrary limit.
+func TestExpandRejectsIPv6PrefixWithAReasonAboutSize(t *testing.T) {
+	_, err := Expand("2001:db8::/64")
+	if err == nil {
+		t.Fatal("Expand(2001:db8::/64) = nil error, want an error")
+	}
+	if !strings.Contains(err.Error(), "enumerat") {
+		t.Errorf("error %q does not explain that the prefix is not enumerable", err)
+	}
+}
+
+// Expand carries its own cap even though the policy layer checks Count first.
+// The runner is the only enumerator now, so a caller that forgets the check
+// must not be able to allocate its way to an OOM.
+func TestExpandRefusesMoreThanMaxExpand(t *testing.T) {
+	if _, err := Expand("10.0.0.0/8"); err == nil {
+		t.Fatal("Expand(10.0.0.0/8) = nil error, want a cap error")
+	}
+	// A /22 is 1022 hosts and must still be allowed: it is the largest prefix
+	// under the cap, and the cap exists to stop /8, not to stop a campus.
+	got, err := Expand("10.0.0.0/22")
+	if err != nil {
+		t.Fatalf("Expand(10.0.0.0/22) returned error: %v", err)
+	}
+	if len(got) != 1022 {
+		t.Errorf("Expand(10.0.0.0/22) = %d addresses, want 1022", len(got))
+	}
+}

--- a/orb-discovery/gnmi-discovery/targets/subnet_test.go
+++ b/orb-discovery/gnmi-discovery/targets/subnet_test.go
@@ -222,3 +222,50 @@ func TestTheRangeHeuristicStillCatchesRealRanges(t *testing.T) {
 		t.Error("Count(2001:db8::1-5) = nil error, want an error")
 	}
 }
+
+// Span, Count and Expand must agree about a mapped IPv4 literal, since the cap
+// is enforced with Span and the endpoints come from Expand.
+func TestMappedIPv4LiteralIsOneEnumerableAddress(t *testing.T) {
+	const target = "::ffff:10.0.0.1"
+
+	start, end, enumerable, err := Span(target)
+	if err != nil {
+		t.Fatalf("Span(%q) returned error: %v", target, err)
+	}
+	if !enumerable {
+		t.Errorf("Span(%q) enumerable = false, want true: it is an IPv4 address", target)
+	}
+	if start != end {
+		t.Errorf("Span(%q) = [%d,%d], want a one-element span", target, start, end)
+	}
+	// It occupies the same slot as the plain form, which is what lets it merge
+	// into a subnet containing that address.
+	plainStart, _, _, err := Span("10.0.0.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if start != plainStart {
+		t.Errorf("Span(%q) start = %d, want %d (the plain address)", target, start, plainStart)
+	}
+
+	n, err := Count(target)
+	if err != nil || n != 1 {
+		t.Errorf("Count(%q) = %d, %v; want 1, nil", target, n, err)
+	}
+	got, err := Expand(target)
+	if err != nil || len(got) != 1 {
+		t.Errorf("Expand(%q) = %v, %v; want one address", target, got, err)
+	}
+}
+
+// A real IPv6 address is still not enumerable: it is one endpoint that cannot be
+// compared with an IPv4 span.
+func TestARealIPv6LiteralIsNotEnumerable(t *testing.T) {
+	_, _, enumerable, err := Span("2001:db8::1")
+	if err != nil {
+		t.Fatalf("Span returned error: %v", err)
+	}
+	if enumerable {
+		t.Error("Span(2001:db8::1) enumerable = true, want false")
+	}
+}

--- a/orb-discovery/gnmi-discovery/targets/targets.go
+++ b/orb-discovery/gnmi-discovery/targets/targets.go
@@ -59,7 +59,18 @@ const MaxExpand = 1024
 // which branch a target takes, and Count exists precisely to be trustworthy
 // about a target Expand has not enumerated yet.
 func isRangeCandidate(target string) bool {
-	return strings.Contains(target, "-") && (strings.Contains(target, ":") || !hasLetters(target))
+	if !strings.Contains(target, "-") {
+		return false
+	}
+	// A complete address is never a range, whatever punctuation it contains. An
+	// IPv6 zone is an interface name and may hold a hyphen — fe80::1%br-lan is
+	// an ordinary bridge — and the heuristic below reads the colon and the hyphen
+	// as range syntax, then fails the whole policy with "only IPv4 addresses are
+	// supported" for an endpoint ensurePort goes out of its way to support.
+	if _, err := netip.ParseAddr(target); err == nil {
+		return false
+	}
+	return strings.Contains(target, ":") || !hasLetters(target)
 }
 
 // IsSingleEndpoint reports whether Expand passes target through unchanged as one

--- a/orb-discovery/gnmi-discovery/targets/targets.go
+++ b/orb-discovery/gnmi-discovery/targets/targets.go
@@ -61,6 +61,29 @@ func isRangeCandidate(target string) bool {
 	return strings.Contains(target, "-") && (strings.Contains(target, ":") || !hasLetters(target))
 }
 
+// LooksLikeMultiAddress reports whether a target is *written* as a CIDR or a
+// range, judged syntactically so it still answers for malformed input that
+// Count would reject.
+//
+// Callers use it to refuse a form that cannot carry an inline port: neither
+// "10.0.0.0/24:6030" nor "10.0.0.1-10:6030" means what an operator carrying the
+// documented "10.0.0.11:6030" habit forward would expect, and the second is the
+// dangerous one — Expand treats it as a DNS name, so it fails as a lookup rather
+// than as a syntax error.
+func LooksLikeMultiAddress(target string) bool {
+	if strings.Contains(target, "/") {
+		return true
+	}
+	base, _, ok := strings.Cut(target, "-")
+	if !ok {
+		return false
+	}
+	// A hyphen only separates a range when what precedes it is an address;
+	// "switch-a.example.com" is a hostname.
+	_, err := netip.ParseAddr(strings.TrimSpace(base))
+	return err == nil
+}
+
 // Count returns how many addresses a target expands to, without enumerating.
 // It is the guard callers apply before Expand: enumerating a /8 allocates
 // hundreds of megabytes, so the size has to be knowable from the bounds alone.

--- a/orb-discovery/gnmi-discovery/targets/targets.go
+++ b/orb-discovery/gnmi-discovery/targets/targets.go
@@ -1,0 +1,324 @@
+package targets
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net/netip"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// Expand takes a target string and returns a slice of individual IP addresses or hostnames.
+// It supports the following formats:
+// - CIDR notation (e.g., 10.10.10.0/24)
+// - IP range notation (e.g., 10.10.10.0-100 or 10.10.10.0-10.10.10.100)
+// - Single IP address (e.g., 192.168.1.1)
+// - Hostname (e.g., example.com)
+func Expand(target string) ([]string, error) {
+	// Attempt IP range expansion first so we can gracefully skip hostnames that contain hyphens.
+	if isRangeCandidate(target) {
+		ips, err := expandIPRange(target)
+		if err == nil {
+			return ips, nil
+		}
+		if !errors.Is(err, errNotRange) {
+			return nil, err
+		}
+	}
+
+	// Try parsing as CIDR (only when not handled as a range above)
+	if strings.Contains(target, "/") {
+		return expandCIDR(target)
+	}
+
+	// Try parsing as single IP
+	if _, err := netip.ParseAddr(target); err == nil {
+		return []string{target}, nil
+	}
+
+	// If not an IP, assume it's a hostname
+	return []string{target}, nil
+}
+
+// maxPrealloc avoids huge upfront allocations for very large networks.
+const maxPrealloc = 1_048_576
+
+// MaxExpand caps how many addresses one target may expand to.
+//
+// Callers are expected to sum Count across a policy's targets and reject before
+// calling Expand, but Expand enforces the cap itself as well: it is the only
+// enumerator, and an unguarded /8 allocates hundreds of megabytes inside
+// whatever goroutine called it.
+const MaxExpand = 1024
+
+// isRangeCandidate reports whether a target should be tried as an IP range.
+// Expand and Count must use the same predicate or they will disagree about
+// which branch a target takes, and Count exists precisely to be trustworthy
+// about a target Expand has not enumerated yet.
+func isRangeCandidate(target string) bool {
+	return strings.Contains(target, "-") && (strings.Contains(target, ":") || !hasLetters(target))
+}
+
+// Count returns how many addresses a target expands to, without enumerating.
+// It is the guard callers apply before Expand: enumerating a /8 allocates
+// hundreds of megabytes, so the size has to be knowable from the bounds alone.
+//
+// Count and Expand share every bounds computation, so a target that Count
+// accepts at size N yields exactly N addresses from Expand, and a target Count
+// rejects is rejected identically by Expand.
+func Count(target string) (uint64, error) {
+	if isRangeCandidate(target) {
+		start, end, err := rangeBounds(target)
+		if err == nil {
+			return uint64(end-start) + 1, nil
+		}
+		if !errors.Is(err, errNotRange) {
+			return 0, err
+		}
+	}
+
+	if strings.Contains(target, "/") {
+		start, end, err := cidrBounds(target)
+		if err != nil {
+			return 0, err
+		}
+		return uint64(end-start) + 1, nil
+	}
+
+	// A single address or a hostname. Expand passes hostnames through verbatim
+	// rather than resolving them, so this is one target either way.
+	return 1, nil
+}
+
+// cidrBounds returns the inclusive host range of an IPv4 prefix.
+//
+// A prefix names a subnet, so its network and broadcast addresses are not hosts
+// and are excluded — matching device-discovery, and avoiding a probe aimed at a
+// broadcast address. A /31 and /32 have no such pair to exclude: stripping them
+// would put end below start, which the enumeration cannot represent.
+func cidrBounds(cidr string) (start, end uint32, err error) {
+	prefix, err := netip.ParsePrefix(cidr)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid CIDR notation: %w", err)
+	}
+
+	if !prefix.Addr().Is4() {
+		return 0, 0, fmt.Errorf(
+			"only IPv4 prefixes can be enumerated; an IPv6 prefix such as a /64 spans 2^64 addresses")
+	}
+
+	prefix = prefix.Masked()
+	start = addrToUint32(prefix.Addr())
+	count := uint64(1) << (32 - prefix.Bits())
+	end = uint32(uint64(start) + count - 1)
+
+	if prefix.Bits() <= 30 {
+		start++
+		end--
+	}
+
+	return start, end, nil
+}
+
+// expandCIDR expands a CIDR notation into individual host addresses.
+func expandCIDR(cidr string) ([]string, error) {
+	start, end, err := cidrBounds(cidr)
+	if err != nil {
+		return nil, err
+	}
+	return checkedEnumerate(cidr, start, end)
+}
+
+// checkedEnumerate refuses a range wider than MaxExpand before allocating.
+func checkedEnumerate(target string, start, end uint32) ([]string, error) {
+	if total := uint64(end-start) + 1; total > MaxExpand {
+		return nil, fmt.Errorf(
+			"%s expands to %d addresses, more than the %d supported per target",
+			target, total, MaxExpand)
+	}
+	return enumerate(start, end), nil
+}
+
+// enumerate walks an inclusive uint32 range.
+//
+// The counter is uint64 deliberately. With end == MaxUint32 a uint32 counter
+// wraps to zero and the loop condition never goes false, which turns
+// 255.255.255.255/32 into an unbounded append.
+func enumerate(start, end uint32) []string {
+	total := uint64(end-start) + 1
+	capacity := 0
+	if total <= maxPrealloc {
+		capacity = int(total)
+	}
+
+	ips := make([]string, 0, capacity)
+	for val := uint64(start); val <= uint64(end); val++ {
+		ips = append(ips, uint32ToAddr(uint32(val)).String())
+	}
+	return ips
+}
+
+// errNotRange indicates the input does not represent an IP range and should be treated as a hostname.
+var errNotRange = errors.New("not an IP range")
+
+// expandIPRange expands an IP range notation (e.g., 10.10.10.0-100 or
+// 10.10.10.0-10.10.10.100) into individual IP addresses. If the input does not
+// resemble an IP range (e.g., a hostname with a hyphen), it returns errNotRange
+// so callers can fall back.
+func expandIPRange(rangeStr string) ([]string, error) {
+	start, end, err := rangeBounds(rangeStr)
+	if err != nil {
+		return nil, err
+	}
+	return checkedEnumerate(rangeStr, start, end)
+}
+
+// rangeBounds returns the inclusive range an IP-range target covers.
+//
+// A range keeps every address the operator wrote, including a .0 or a .255,
+// because they enumerated it explicitly. This deliberately differs from a CIDR
+// spanning the same addresses, which excludes network and broadcast: the two
+// forms answer different questions, so 10.0.0.0-255 yields 256 where
+// 10.0.0.0/24 yields 254.
+func rangeBounds(rangeStr string) (start, end uint32, err error) {
+	baseRaw, endRaw, ok := strings.Cut(rangeStr, "-")
+	if !ok {
+		return 0, 0, errNotRange
+	}
+	if strings.Contains(endRaw, "-") {
+		if looksLikeIPNotation(strings.TrimSpace(baseRaw)) {
+			return 0, 0, fmt.Errorf("invalid IP range format")
+		}
+		return 0, 0, errNotRange
+	}
+
+	baseIP, looksLikeBase, err := parseRangeAddrPart(baseRaw)
+	if !looksLikeBase {
+		return 0, 0, errNotRange
+	}
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid base IP address: %w", err)
+	}
+
+	endRaw = strings.TrimSpace(endRaw)
+	if endNum, convErr := strconv.Atoi(stripCIDR(endRaw)); convErr == nil {
+		return lastOctetBounds(baseIP, endNum)
+	}
+
+	endIP, looksLikeEnd, parseErr := parseRangeAddrPart(endRaw)
+	if !looksLikeEnd {
+		return 0, 0, errNotRange
+	}
+	if parseErr != nil {
+		return 0, 0, fmt.Errorf("invalid end IP address: %w", parseErr)
+	}
+
+	return fullRangeBounds(baseIP, endIP)
+}
+
+// lastOctetBounds handles ranges like 10.10.10.0-100.
+func lastOctetBounds(baseIP netip.Addr, endNum int) (start, end uint32, err error) {
+	if endNum < 0 || endNum > 255 {
+		return 0, 0, fmt.Errorf("end number must be between 0 and 255")
+	}
+
+	base4 := baseIP.As4()
+	baseNum := int(base4[3])
+	if endNum < baseNum {
+		return 0, 0, fmt.Errorf("end number must be greater than or equal to the last octet of the base IP")
+	}
+
+	start = addrToUint32(baseIP)
+	return start, start + uint32(endNum-baseNum), nil
+}
+
+// fullRangeBounds handles ranges like 10.10.10.0-10.10.10.100 (CIDR suffixes on
+// either endpoint are ignored by parseRangeAddrPart).
+func fullRangeBounds(baseIP, endIP netip.Addr) (start, end uint32, err error) {
+	start = addrToUint32(baseIP)
+	end = addrToUint32(endIP)
+
+	if end < start {
+		return 0, 0, fmt.Errorf("end IP must be greater than or equal to the base IP")
+	}
+
+	return start, end, nil
+}
+
+// parseRangeAddrPart parses a part of a range, returning whether the part resembled an IP and the parsed IPv4 address if possible.
+func parseRangeAddrPart(part string) (netip.Addr, bool, error) {
+	clean := stripCIDR(strings.TrimSpace(part))
+	if clean == "" {
+		return netip.Addr{}, false, nil
+	}
+
+	parsed, err := netip.ParseAddr(clean)
+	if err == nil {
+		if !parsed.Is4() {
+			return netip.Addr{}, true, fmt.Errorf("only IPv4 addresses are supported")
+		}
+		return parsed, true, nil
+	}
+
+	if isIPv4Like(clean) {
+		return netip.Addr{}, true, fmt.Errorf("invalid IP address")
+	}
+
+	return netip.Addr{}, false, nil
+}
+
+// looksLikeIPNotation returns true if the string resembles an IP (even if invalid).
+func looksLikeIPNotation(part string) bool {
+	_, looksLike, _ := parseRangeAddrPart(part)
+	return looksLike
+}
+
+// stripCIDR removes any CIDR suffix from an IP/CIDR string.
+func stripCIDR(value string) string {
+	if idx := strings.Index(value, "/"); idx != -1 {
+		return value[:idx]
+	}
+	return value
+}
+
+// isIPv4Like checks whether a string resembles an IPv4 address (digits and three dots).
+func isIPv4Like(value string) bool {
+	parts := strings.Split(value, ".")
+	if len(parts) != 4 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" {
+			return false
+		}
+		for _, r := range part {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// hasLetters reports whether the string contains alphabetic characters.
+func hasLetters(value string) bool {
+	for _, r := range value {
+		if unicode.IsLetter(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func addrToUint32(ip netip.Addr) uint32 {
+	ip4 := ip.As4()
+	return binary.BigEndian.Uint32(ip4[:])
+}
+
+func uint32ToAddr(val uint32) netip.Addr {
+	var ip4 [4]byte
+	binary.BigEndian.PutUint32(ip4[:], val)
+	return netip.AddrFrom4(ip4)
+}

--- a/orb-discovery/gnmi-discovery/targets/targets.go
+++ b/orb-discovery/gnmi-discovery/targets/targets.go
@@ -391,9 +391,17 @@ func Span(target string) (start, end uint32, enumerable bool, err error) {
 
 	// A bare IPv4 address is a one-element span, which is what lets it merge
 	// into a subnet that already contains it.
-	if addr, perr := netip.ParseAddr(target); perr == nil && addr.Is4() {
-		v := addrToUint32(addr)
-		return v, v, true, nil
+	//
+	// Unmapped first: an IPv4-mapped form such as ::ffff:10.0.0.1 is not Is4, so
+	// without this it counted as an endpoint of its own while canonicalHost and
+	// dedupeKey collapsed it with the plain address — and a /22 plus three pinned
+	// mapped hosts inside it was rejected as 1025 endpoints that expansion
+	// resolves to 1022.
+	if addr, perr := netip.ParseAddr(target); perr == nil {
+		if addr = addr.Unmap(); addr.Is4() {
+			v := addrToUint32(addr)
+			return v, v, true, nil
+		}
 	}
 
 	// A hostname, or an IPv6 literal: one endpoint, not comparable to a range.

--- a/orb-discovery/gnmi-discovery/targets/targets.go
+++ b/orb-discovery/gnmi-discovery/targets/targets.go
@@ -62,27 +62,30 @@ func isRangeCandidate(target string) bool {
 	return strings.Contains(target, "-") && (strings.Contains(target, ":") || !hasLetters(target))
 }
 
-// LooksLikeMultiAddress reports whether a target is *written* as a CIDR or a
-// range, judged syntactically so it still answers for malformed input that
-// Count would reject.
+// IsSingleEndpoint reports whether Expand passes target through unchanged as one
+// endpoint — a bare address or a hostname — rather than expanding it.
 //
-// Callers use it to refuse a form that cannot carry an inline port: neither
-// "10.0.0.0/24:6030" nor "10.0.0.1-10:6030" means what an operator carrying the
-// documented "10.0.0.11:6030" habit forward would expect, and the second is the
-// dangerous one — Expand treats it as a DNS name, so it fails as a lookup rather
-// than as a syntax error.
-func LooksLikeMultiAddress(target string) bool {
+// It mirrors Expand's branch decisions exactly, without enumerating, so callers
+// deciding "may I append a port to this?" cannot disagree with what Expand will
+// actually do. A syntactic guess did disagree: "10.0.0.1-switch.example.com" is a
+// legal hostname that Expand passes through, because it contains letters, while
+// anything that merely began with an address and a hyphen was assumed to be a
+// range.
+func IsSingleEndpoint(target string) bool {
+	if isRangeCandidate(target) {
+		_, _, err := rangeBounds(target)
+		if err == nil {
+			return false // a real range
+		}
+		if !errors.Is(err, errNotRange) {
+			return false // malformed range syntax; not one endpoint either
+		}
+		// errNotRange: Expand falls through to the hostname branch, as here.
+	}
 	if strings.Contains(target, "/") {
-		return true
+		return false // a prefix, valid or not
 	}
-	base, _, ok := strings.Cut(target, "-")
-	if !ok {
-		return false
-	}
-	// A hyphen only separates a range when what precedes it is an address;
-	// "switch-a.example.com" is a hostname.
-	_, err := netip.ParseAddr(strings.TrimSpace(base))
-	return err == nil
+	return true
 }
 
 // Count returns how many addresses a target expands to, without enumerating.

--- a/orb-discovery/gnmi-discovery/targets/targets.go
+++ b/orb-discovery/gnmi-discovery/targets/targets.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode"
@@ -344,4 +345,72 @@ func uint32ToAddr(val uint32) netip.Addr {
 	var ip4 [4]byte
 	binary.BigEndian.PutUint32(ip4[:], val)
 	return netip.AddrFrom4(ip4)
+}
+
+// Span reports the inclusive address range a target covers, when it covers one.
+//
+// It exists so a caller can measure the *union* of several targets instead of
+// their sum: a policy that names a subnet and then pins three hosts inside it to
+// give them their own credentials describes the same endpoints as the subnet
+// alone, and summing the two double-counts the overlap.
+//
+// enumerable is false for a hostname, which stands for one endpoint that cannot
+// be compared with any address.
+func Span(target string) (start, end uint32, enumerable bool, err error) {
+	if isRangeCandidate(target) {
+		start, end, err = rangeBounds(target)
+		if err == nil {
+			return start, end, true, nil
+		}
+		if !errors.Is(err, errNotRange) {
+			return 0, 0, false, err
+		}
+	}
+
+	if strings.Contains(target, "/") {
+		start, end, err = cidrBounds(target)
+		if err != nil {
+			return 0, 0, false, err
+		}
+		return start, end, true, nil
+	}
+
+	// A bare IPv4 address is a one-element span, which is what lets it merge
+	// into a subnet that already contains it.
+	if addr, perr := netip.ParseAddr(target); perr == nil && addr.Is4() {
+		v := addrToUint32(addr)
+		return v, v, true, nil
+	}
+
+	// A hostname, or an IPv6 literal: one endpoint, not comparable to a range.
+	return 0, 0, false, nil
+}
+
+// UnionSize returns how many distinct addresses a set of spans covers.
+//
+// Spans must already be grouped by port by the caller: the same address at two
+// ports is two endpoints, so merging across ports would undercount.
+func UnionSize(spans [][2]uint32) uint64 {
+	if len(spans) == 0 {
+		return 0
+	}
+	sorted := append([][2]uint32(nil), spans...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i][0] < sorted[j][0] })
+
+	var total uint64
+	curStart, curEnd := sorted[0][0], sorted[0][1]
+	for _, s := range sorted[1:] {
+		// Adjacent as well as overlapping: [1,5] and [6,9] are one run of 9, and
+		// counting them separately would still be correct here, but merging keeps
+		// the interval list short.
+		if uint64(s[0]) <= uint64(curEnd)+1 {
+			if s[1] > curEnd {
+				curEnd = s[1]
+			}
+			continue
+		}
+		total += uint64(curEnd-curStart) + 1
+		curStart, curEnd = s[0], s[1]
+	}
+	return total + uint64(curEnd-curStart) + 1
 }

--- a/orb-discovery/gnmi-discovery/targets/targets_test.go
+++ b/orb-discovery/gnmi-discovery/targets/targets_test.go
@@ -1,0 +1,226 @@
+package targets
+
+import (
+	"testing"
+)
+
+func TestExpand(t *testing.T) {
+	tests := []struct {
+		name        string
+		target      string
+		want        []string
+		shouldError bool
+	}{
+		{
+			name:   "Single IP",
+			target: "192.168.1.1",
+			want:   []string{"192.168.1.1"},
+		},
+		{
+			name:   "Hostname",
+			target: "example.com",
+			want:   []string{"example.com"},
+		},
+		{
+			name:   "Hostname With Hyphen",
+			target: "my-hostname",
+			want:   []string{"my-hostname"},
+		},
+		{
+			name:   "Hostname Starting With IP And Hyphen",
+			target: "10.10.10.1-host",
+			want:   []string{"10.10.10.1-host"},
+		},
+		{
+			name:        "Invalid CIDR",
+			target:      "192.168.1.1/33",
+			shouldError: true,
+		},
+		{
+			name:        "Invalid IP Range",
+			target:      "192.168.1.1-300",
+			shouldError: true,
+		},
+		{
+			name:        "Invalid IP Range Format",
+			target:      "192.168.1.1-2-3",
+			shouldError: true,
+		},
+		{
+			name:        "Invalid Base IP",
+			target:      "256.0.0.1-5",
+			shouldError: true,
+		},
+		{
+			name:        "Range End Less Than Start",
+			target:      "192.168.1.100-50",
+			shouldError: true,
+		},
+		{
+			name:        "IPv6 CIDR",
+			target:      "2001:db8::/32",
+			shouldError: true,
+		},
+		{
+			name:        "IPv6 Range",
+			target:      "2001:db8::1-100",
+			shouldError: true,
+		},
+		{
+			name:   "Full IP Range",
+			target: "10.10.10.0-10.10.10.2",
+			want:   []string{"10.10.10.0", "10.10.10.1", "10.10.10.2"},
+		},
+		{
+			name:   "Full IP Range With CIDR Suffix",
+			target: "10.10.10.0/24-10.10.10.2/24",
+			want:   []string{"10.10.10.0", "10.10.10.1", "10.10.10.2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Expand(tt.target)
+			if (err != nil) != tt.shouldError {
+				t.Errorf("Expand() error = %v, shouldError %v", err, tt.shouldError)
+				return
+			}
+			if !tt.shouldError && !compareStringSlices(got, tt.want) {
+				t.Errorf("Expand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Counts here are host counts, not address counts: a prefix excludes its network
+// and broadcast addresses. This is the one place this package deliberately
+// diverges from the snmp-discovery original it was ported from, which returns
+// every address in the prefix. See cidrBounds.
+func TestExpandCIDR(t *testing.T) {
+	tests := []struct {
+		name        string
+		cidr        string
+		want        int // expected number of host IPs
+		shouldError bool
+	}{
+		{
+			name: "Valid /24 CIDR",
+			cidr: "192.168.1.0/24",
+			want: 254,
+		},
+		{
+			name: "Valid /30 CIDR",
+			cidr: "192.168.1.0/30",
+			want: 2,
+		},
+		{
+			name: "Valid /32 CIDR",
+			cidr: "192.168.1.1/32",
+			want: 1,
+		},
+		{
+			name:        "Invalid CIDR",
+			cidr:        "192.168.1.1/33",
+			shouldError: true,
+		},
+		{
+			name:        "Invalid IP",
+			cidr:        "256.168.1.0/24",
+			shouldError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := expandCIDR(tt.cidr)
+			if (err != nil) != tt.shouldError {
+				t.Errorf("expandCIDR() error = %v, shouldError %v", err, tt.shouldError)
+				return
+			}
+			if !tt.shouldError && len(got) != tt.want {
+				t.Errorf("expandCIDR() returned %d IPs, want %d", len(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandIPRange(t *testing.T) {
+	tests := []struct {
+		name        string
+		rangeStr    string
+		want        int // expected number of IPs
+		shouldError bool
+	}{
+		{
+			name:     "Valid Range",
+			rangeStr: "192.168.1.1-5",
+			want:     5,
+		},
+		{
+			name:     "Single IP Range",
+			rangeStr: "192.168.1.1-1",
+			want:     1,
+		},
+		{
+			name:        "Invalid Range Format",
+			rangeStr:    "192.168.1.1-2-3",
+			shouldError: true,
+		},
+		{
+			name:        "Invalid Base IP",
+			rangeStr:    "256.0.0.1-5",
+			shouldError: true,
+		},
+		{
+			name:        "Range End Less Than Start",
+			rangeStr:    "192.168.1.100-50",
+			shouldError: true,
+		},
+		{
+			name:        "Range End Too Large",
+			rangeStr:    "192.168.1.1-300",
+			shouldError: true,
+		},
+		{
+			name:        "Non-numeric Range End",
+			rangeStr:    "192.168.0.0-ten",
+			shouldError: true,
+		},
+		{
+			name:     "Full IP Range",
+			rangeStr: "10.10.10.0-10.10.10.2",
+			want:     3,
+		},
+		{
+			name:     "Full IP Range With CIDR Suffix",
+			rangeStr: "10.10.10.0/24-10.10.10.2/24",
+			want:     3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := expandIPRange(tt.rangeStr)
+			if (err != nil) != tt.shouldError {
+				t.Errorf("expandIPRange() error = %v, shouldError %v", err, tt.shouldError)
+				return
+			}
+			if !tt.shouldError && len(got) != tt.want {
+				t.Errorf("expandIPRange() returned %d IPs, want %d", len(got), tt.want)
+			}
+		})
+	}
+}
+
+// Helper function to compare string slices
+func compareStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/orb-discovery/network-discovery/Makefile
+++ b/orb-discovery/network-discovery/Makefile
@@ -27,4 +27,4 @@ test-coverage:
 	@mkdir -p .coverage
 	@go test -race -cover -json -coverprofile=.coverage/cover.out.tmp ./... | grep -Ev "cmd" | tparse -format=markdown > .coverage/test-report.md
 	@cat .coverage/cover.out.tmp | grep -Ev "cmd" > .coverage/cover.out
-	@go tool cover -func=.coverage/cover.out | grep total | awk '{print substr($$3, 1, length($$3)-1)}' > .coverage/coverage.txt
+	@go tool cover -func=.coverage/cover.out | grep -E '^total:' | awk '{print substr($$3, 1, length($$3)-1)}' > .coverage/coverage.txt

--- a/orb-discovery/snmp-discovery/Makefile
+++ b/orb-discovery/snmp-discovery/Makefile
@@ -37,7 +37,7 @@ test-coverage:
 	@mkdir -p .coverage
 	@go test -race -cover -json -coverprofile=.coverage/cover.out.tmp ./... | grep -Ev "cmd" | tparse -format=markdown > .coverage/test-report.md
 	@cat .coverage/cover.out.tmp | grep -Ev "cmd" > .coverage/cover.out
-	@go tool cover -func=.coverage/cover.out | grep total | awk '{print substr($$3, 1, length($$3)-1)}' > .coverage/coverage.txt
+	@go tool cover -func=.coverage/cover.out | grep -E '^total:' | awk '{print substr($$3, 1, length($$3)-1)}' > .coverage/coverage.txt
 	@gcov2lcov -infile=.coverage/cover.out -outfile=.coverage/lcov.info
 
 .PHONY: test


### PR DESCRIPTION
Closes ENGHLP-1633.

`gnmi-discovery` accepted only one endpoint per target entry, so a campus meant one YAML block per device with the credentials repeated in each. This brings it in line with `snmp-discovery` and `device-discovery`: a target's `host` may now be a CIDR or a range, and a `scope` carries settings its targets inherit.

Because the backend is experimental, this takes the breaking changes rather than layering a second pattern on top of the existing one.

## Why a sweep, and not just expansion

A gNMI subscription is a persistent stream, not a poll. Expanding a `/24` the naive way would leave ~250 goroutines redialling addresses that hold no device, every 30 seconds, for the life of the policy. So each expanded address is probed once, and only what answers gets subscribed.

The sweep runs in its own goroutine because it cannot run where it is called from. The agent's policy POST times out after 10s, so a synchronous probe would mark a working policy `FailedToApply` and then 409 forever on retry; and `StartPolicy` holds the manager lock that `GetPolicyStatuses` also takes, while the agent health-checks `/status` every 10s with a 2s budget and restarts the backend when that times out.

**Admission is a deny-list: anything that answered is a device, and only silence is absence.** An allow-list of "good" gRPC codes was tried and got it wrong both ways — it missed real handshake failures, so a campus of self-signed certs or an mTLS device probed without a client cert read as an empty subnet, and it denied genuine peer responses like `ResourceExhausted` from a device still warming up. It also fails safely: if grpc-go changes its dialing marker, the gate degrades to admitting everything, which is the retry-forever behaviour this backend had before, rather than to reporting a healthy campus as empty.

**Probes send no credentials.** gnmic attaches them to every RPC including `Capabilities`, so a probe built the obvious way would offer the scope password to all 254 addresses in a `/24` — and with a scope-level `skip_verify`, to anything that answers.

A single named host is never probed. The operator asserted it exists, and dropping it for being mid-reboot would regress behaviour a named host has always had.

## What else is here

- **`rescan_interval_ms`** picks up devices that were down at apply time. Nothing else re-applies a policy periodically: the config manager returns early on an unchanged git ref, and on a new commit whose diff touches no matching policy file. Already-subscribed addresses are filtered *before* the probe, so a tick never disturbs a live subscription. A value under 60s is rejected rather than clamped.
- **The sweep reports itself as a run**, since `PolicyStatus` carries `{Name, Status, Runs}` and nothing else — a `TargetStatus` never leaves the container.
- **The first dial is spread** once a sweep admits more than a handful, so a campus does not arrive at NetBox as one 200-device burst through the shared Diode client.
- **Scope, target, tls and the defaults blocks join the closed-key check.** A misspelled scope-level `usernme` is the expensive one: the permissive decode drops it and every target in the range then authenticates with no username, a whole subnet failing for a reason nothing reports.

## Pre-existing bugs fixed along the way

- **A sweep run covering several scope entries reached the fleet as one target.** The backend joins the originals into `target` for compatibility and carries them individually in `targets`; the agent's `gnmiStatusResponse` decoded only the singular field, so two scope entries arrived as `"10.0.0.0/24,10.1.0.0/24"`. The array is now preferred, with the singular field kept as the fallback. (An earlier revision of this description claimed *all* gnmi runs reached the fleet target-less — that was wrong: the agent already had this normalization layer, and per-device runs were fine.)
- **A failed HTTP request in `agent/backend/utils.go` reported the wrong variable** — `err` instead of `getErr`, and `err` is nil there by construction — so every refused dial and timeout arrived as `received error from payload error=<nil>`.
- **A request skipped because the backend is not running returned a nil error**, so a policy that was never delivered was recorded as `Running` instead of `FailedToApply`. ⚠️ `CommonRequest` is shared by all four discovery backends, so this corrects the reported state for device-, network- and snmp-discovery as well.
- **The policy body was logged on apply.** A gnmi policy may carry a literal password, and a scope credential now covers a subnet rather than one device. The sibling backends log the same way and are left alone here.

## Behaviour changes

- `Target.TLS` is now a pointer, so `tls:` written with nothing under it means "inherit the scope's block" rather than "no TLS settings". A bare `tls:` key is warned about for exactly this reason.
- Runs now sort by most recent activity rather than creation. The sweep run is created before every run it starts, so under `CreatedAt` ordering it was permanently the oldest thing in the store. Per-device runs consequently order by activity too.
- `/status` caps what one policy reports at 100 runs. A `/22` policy holds three runs for each of a thousand targets, and the whole list is marshalled on every health check. Sweep runs are exempt.
- A CIDR excludes network and broadcast (`/24` → 254); a range does not (`10.0.0.0-255` → 256). The two forms deliberately disagree, and both are pinned by tests. `device-discovery` is internally inconsistent here and this arbitrates rather than inheriting the inconsistency.

## Verification

Unit and race tests across the module, plus a run of the actual binary against a live socket:

- A plain TCP listener on the gNMI port answered with `tls: first record does not look like a TLS handshake` and **was admitted** — the exact case an allow-list would have discarded as an empty subnet.
- The silent address in the same `/31` timed out and was rejected; only the responding one got a target loop.
- The sweep run carried `targets: ["127.0.0.0/31"]`, the operator's own string, with the count and the reason.
- The rescan tick fired at 62s and probed **1** address, not 2 — the subscribed target was skipped — while `entity_count` held at 1 rather than dropping to 0.
- `POST` of a dead `/24` returned 201 immediately; `DELETE` mid-sweep returned in **2ms**, against ~12s concurrent or ~12min serial without cancellation. Zero `ERROR` lines across the whole run.

## Codex review round

Four findings, all reproduced before fixing and all addressed (`3ae563c8`, `65befe60`):

- **P1** — the probe forwarded `CertFile`/`KeyFile`, offering the agent's client identity to every address in a range. Dropped; verified against a real `tls.RequireAnyClientCert` server that a certless probe gets `tls: certificate required`, which the deny-list already admits, so admission is unchanged.
- **P2** — the duplicate key took the host and the port from different decisions, so `10.0.0.5:6030` and `10.0.0.5:57400` collided while inline `:6030` and `port: 6030` did not.
- **P2** — the cap summed spans instead of unioning them, rejecting a `/22` plus three pinned hosts at 1025 when expansion yields 1022. Spans now merge per port, since one address on two ports is two subscriptions.
- **P2** — the agent-side `targets` decoding above.

The seven CodeQL log-injection alerts are addressed at the source: a policy name or host containing control characters is now rejected outright. One residual is called out in those threads and is deliberately not fixed here — `sweep.go` logs a gRPC error whose text comes from the remote peer, which is true of every error logged in this repo and belongs in a repo-wide change rather than spot fixes.

A test also pins both documented samples through `ParsePolicies`, which was written against a real bug it caught: the new knobs were one indent level too deep in the README, inside `defaults` rather than `config`, where the permissive decode would have silently dropped them for anyone who copied it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

