### PR TITLE
chore(repo): allow the snmp-telemetry scope in PR titles

### DIFF
--- a/.github/workflows/pr-title-lint.yaml
+++ b/.github/workflows/pr-title-lint.yaml
@@ -35,6 +35,7 @@ jobs:
             gnmi-discovery
             network-discovery
             snmp-discovery
+            snmp-telemetry
             worker
             ci
             docs


### PR DESCRIPTION
One line, so that #564 can pass its own title check.

`pr-title-lint` runs on `pull_request_target`, which means GitHub evaluates the workflow
definition from the **base** branch rather than from the PR branch. #564 adds
`snmp-telemetry` to the scope allowlist, but the check that runs against it reads
develop's copy, which does not have the scope yet. So #564 fails its own title check no
matter what it contains.

Landing the scope on develop first breaks that circularity. #564 keeps the matching
`CONTRIBUTING.md` documentation and the `agent.releaserc.json` no-release rule for the
same scope, so this PR is deliberately just the one line.

This PR's own title uses `repo`, which is already allowlisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)