### PR TITLE
fix(device-discovery): stop netbox_id payloads sending placeholder site and role

### DIFF
--- a/orb-discovery/device-discovery/device_discovery/policy/models.py
+++ b/orb-discovery/device-discovery/device_discovery/policy/models.py
@@ -142,12 +142,21 @@ class PrefixParameters(IpamParameters):
     scope_location: str | None = Field(default=None, description="Prefix scope location, optional")
 
 
+#: Stand-in used when the operator configured no site or role. NetBox requires
+#: both on a Device, so a create has to carry something; everywhere else this
+#: string means "no value was configured" and is suppressed rather than sent.
+#: See translate_device and the prefix-scope cascade in interface.py.
+UNDEFINED_PLACEHOLDER = "undefined"
+
+
 class Defaults(BaseModel):
     """Model for default configuration."""
 
-    site: str | None = Field(default="undefined", description="Site name, optional")
+    site: str | None = Field(
+        default=UNDEFINED_PLACEHOLDER, description="Site name, optional"
+    )
     role: str | None = Field(
-        default="undefined", description="Device Role name, optional"
+        default=UNDEFINED_PLACEHOLDER, description="Device Role name, optional"
     )
     if_type: str | None = Field(default="other", description="Interface type, optional")
     interface_patterns: list[InterfacePattern] | None = Field(

--- a/orb-discovery/device-discovery/device_discovery/translate.py
+++ b/orb-discovery/device-discovery/device_discovery/translate.py
@@ -28,6 +28,7 @@ from netboxlabs.diode.sdk.ingester import (
 from device_discovery.device_name import apply_device_name_emission
 from device_discovery.interface import build_interface_entities
 from device_discovery.policy.models import (
+    UNDEFINED_PLACEHOLDER,
     Defaults,
     Options,
     TenantParameters,
@@ -86,6 +87,26 @@ def translate_vrf(
     return VRF(name=vrf)
 
 
+def _drop_unconfigured_placeholder(value: str | None, *, is_update: bool) -> str | None:
+    """
+    Drop the "nothing was configured" placeholder from a value bound for an update.
+
+    ``Defaults`` carries ``UNDEFINED_PLACEHOLDER`` for site and role when the
+    operator set neither. A payload carrying ``source_match.netbox_id`` binds an
+    existing device by primary key, so the plugin skips matching entirely and
+    applies every field the payload contains. Sending the placeholder there
+    repoints a real device's site and role at the placeholder objects, which
+    makes netbox_id cause the overwrite rather than prevent it.
+
+    On a create the placeholder has to stay: NetBox requires both fields on a
+    Device, and netbox_id is the only signal distinguishing an update from a
+    create.
+    """
+    if is_update and value == UNDEFINED_PLACEHOLDER:
+        return None
+    return value
+
+
 def translate_device(
     device_info: dict,
     defaults: Defaults,
@@ -127,8 +148,11 @@ def translate_device(
         manufacturer = defaults.device.manufacturer or manufacturer
         platform = defaults.device.platform or platform
 
+    site = _drop_unconfigured_placeholder(defaults.site, is_update=netbox_id is not None)
+    role = _drop_unconfigured_placeholder(defaults.role, is_update=netbox_id is not None)
+
     if defaults.location:
-        location = Location(name=defaults.location, site=defaults.site)
+        location = Location(name=defaults.location, site=site)
 
     serial_number = device_info.get("serial_number")
     if isinstance(serial_number, list | tuple):
@@ -161,7 +185,7 @@ def translate_device(
         "name": blank_to_none(device_info.get("hostname")),
         "device_type": DeviceType(model=model, manufacturer=manufacturer),
         "platform": Platform(name=platform, manufacturer=manufacturer),
-        "role": defaults.role,
+        "role": role,
         "serial": serial_number,
         # asset_tag is the highest-precedence dcim.device matcher and comes straight
         # from policy. Blanking it here keeps the rich entity consistent with the
@@ -170,14 +194,14 @@ def translate_device(
         if defaults.device
         else None,
         "status": "active",
-        "site": defaults.site,
+        "site": site,
         "tags": tags,
         "location": location,
         # Attach the location to the rack too: without it NetBox has no
         # site+location+name key to match on and duplicates the rack.
         # `location` is None when no location default is set, leaving the rack's
         # location unset (site+name only) as before.
-        "rack": Rack(name=defaults.rack, site=defaults.site, location=location)
+        "rack": Rack(name=defaults.rack, site=site, location=location)
         if defaults.rack
         else None,
         "tenant": translate_tenant(defaults.tenant),

--- a/orb-discovery/device-discovery/tests/test_translate.py
+++ b/orb-discovery/device-discovery/tests/test_translate.py
@@ -1179,6 +1179,63 @@ def test_translate_device_without_netbox_id(sample_device_info, sample_defaults)
     assert "source_match" not in device.metadata
 
 
+def test_translate_device_netbox_id_omits_placeholder_site_and_role(sample_device_info):
+    """
+    A netbox_id scope with no configured site/role omits both fields.
+
+    ``netbox_id`` binds an existing device by PK, so the plugin skips matching
+    and applies every field present in the payload. Sending the literal
+    "undefined" placeholder therefore repoints a real device's site and role at
+    the placeholder objects: netbox_id made the overwrite deterministic instead
+    of preventing it.
+    """
+    device = translate_device(sample_device_info, Defaults(), netbox_id=42)
+
+    assert device.metadata["source_match"]["netbox_id"] == 42
+    assert not device.HasField("site"), "placeholder site must not be sent"
+    assert not device.HasField("role"), "placeholder role must not be sent"
+
+
+def test_translate_device_netbox_id_keeps_explicitly_configured_site_and_role(
+    sample_device_info,
+):
+    """Suppression is for the placeholder only; real values still go out."""
+    defaults = Defaults(site="New York", role="access-switch")
+
+    device = translate_device(sample_device_info, defaults, netbox_id=42)
+
+    assert device.site.name == "New York"
+    assert device.role.name == "access-switch"
+
+
+def test_translate_device_without_netbox_id_keeps_placeholders(sample_device_info):
+    """
+    Without netbox_id the placeholders must survive.
+
+    NetBox requires both site and role on a Device, so a create has to carry
+    something. Only netbox_id tells us the payload is an update, which is why
+    the suppression is keyed on it rather than on the value being unset.
+    """
+    device = translate_device(sample_device_info, Defaults())
+
+    assert device.site.name == "undefined"
+    assert device.role.name == "undefined"
+
+
+def test_translate_device_netbox_id_omits_placeholder_site_from_location(
+    sample_device_info,
+):
+    """An explicit location must not smuggle the placeholder site back in."""
+    defaults = Defaults(location="floor-1")
+
+    device = translate_device(sample_device_info, defaults, netbox_id=42)
+
+    assert device.location.name == "floor-1"
+    assert not device.location.HasField("site"), (
+        "the placeholder site must not ride along inside the location"
+    )
+
+
 def test_translate_data_with_config_disabled(sample_device_info):
     """Test that config is not captured when flags are disabled."""
     config_info = {


### PR DESCRIPTION
Fixes [MON-331](https://linear.app/netboxlabs/issue/MON-331/device-discovery-undefined-siterole-placeholders-override-real-values). 

### What

`Defaults.site` and `Defaults.role` are pydantic defaults of the literal string `"undefined"`, and `translate_device` attached them unconditionally. Setting `netbox_id` on a scope only added the source_match metadata; it did nothing about the placeholders.

A payload carrying `source_match.netbox_id` binds an existing device by primary key, so the plugin skips matching and the defaults pass and applies **every field present in the payload**. The placeholder therefore repointed a real device's site and role at the `"undefined"` objects. `netbox_id` made the ENGHLP-751 overwrite deterministic instead of preventing it.

Measured end to end through `translate_data` with an empty policy:

| | site | role |
|---|---|---|
| before, with `netbox_id` | `'undefined'` | `'undefined'` |
| after, with `netbox_id` | **omitted** | **omitted** |
| after, no `netbox_id` | `'undefined'` | `'undefined'` |

### Why keyed on netbox_id rather than on the value being unset

The ticket offered two approaches and preferred option 1: change the defaults to `None` and omit the fields whenever they are unset. The code rules that out. **NetBox requires both `site` and `role` on a Device**, so a create has to carry something, and `netbox_id` is the only signal that separates an update from a create. Option 1 therefore collapses into option 2 for exactly these two fields.

That is not a judgment call, it is testable: suppressing unconditionally instead of only on `netbox_id` fails three pre-existing tests (`test_translate_device`, `test_translate_data`, `test_translate_data_handles_none_defaults_and_options`) plus the new guard. The constraint shows up directly.

This also matches `snmp-discovery` and `gnmi-discovery`, which omit site/role when the defaults are empty so netbox_id already gives a clean partial update there. device-discovery was the only backend with an always-attached placeholder.

### Also fixed

The placeholder rode along **inside `Location` and `Rack`**, both of which take a site. An explicit `location` with no configured site would have smuggled `site='undefined'` back into the payload through the nested object. Both now use the suppressed value, covered by its own test.

### Cleanup

`UNDEFINED_PLACEHOLDER` replaces the bare literal in the `Defaults` model so the sentinel has one authoritative home. `interface.py`'s prefix-scope cascade already compares against the same string and its comment already points at the Defaults model; I left that call site alone to keep the diff to the bug.

`_drop_unconfigured_placeholder` is a helper rather than inline branching because inlining pushed `translate_device` past the C901 complexity ceiling. It carries the reasoning above.

### Tests

Four new tests on the emitted proto, asserting presence rather than value since `site` and `role` are message fields:

- `netbox_id` + no configured site/role → both omitted (`HasField` false)
- `netbox_id` + explicitly configured site/role → both preserved, so the suppression cannot overreach
- no `netbox_id` → placeholders still sent, so creates keep working
- `netbox_id` + explicit location → the location does not carry the placeholder site

Both directions of the guard were mutation-verified: never suppressing fails the two suppression tests and nothing else; always suppressing fails the create-path tests.

`2402 passed, 160 skipped`, ruff clean. Baseline on develop was `2398 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
