### PR TITLE
fix(device-discovery): budget target expansion across the policy, not per entry

### DIFF
--- a/docs/backends/device_discovery/README.md
+++ b/docs/backends/device_discovery/README.md
@@ -213,6 +213,28 @@ The scope defines a list of devices that can be accessed and pulled data.
 | override_defaults | map | no | Allows overriding of any defaults for a specific device in the scope |
 | netbox_id | integer | no | NetBox device primary key. When set, the diode plugin matches the device by PK instead of by name. Ignored when hostname is a subnet or IP range. |
 
+#### Subnet and range expansion
+
+A CIDR excludes its network and broadcast addresses, so `10.0.0.0/24` is 254
+addresses and `10.0.0.0/22` is 1022. A `/31` and a `/32` have no such pair to
+exclude and stay 2 and 1. IPv6 has no broadcast, so only the network address is
+excluded: `fd00::/126` is 3. A range excludes nothing, because someone who
+wrote `0` and `255` meant them, so `10.0.0.0-255` is 256.
+
+A policy may expand to at most **65536** addresses in total, counted across all
+its scope entries before any expansion happens. The budget spans the policy
+rather than one entry, so sixteen `/16` scopes are refused together even though
+each is under the limit on its own. A policy over the budget is rejected when it
+is written, naming the total and the limit:
+
+```
+policy scopes expand to 1048544 addresses in total, more than the limit of 65536
+```
+
+A single entry over the limit is also refused at expansion time as a backstop:
+it is skipped, named in an error, and recorded as a failed run, leaving the rest
+of the policy unaffected.
+
 ### SSH Configuration and Jumphost Support
 
 For advanced SSH scenarios including bastion/jumphost connectivity, VRF-aware connections, and multi-hop SSH configurations, see the dedicated guide: [SSH Configuration and Jumphost Support](./ssh.md).

--- a/orb-discovery/device-discovery/device_discovery/policy/models.py
+++ b/orb-discovery/device-discovery/device_discovery/policy/models.py
@@ -10,8 +10,12 @@ from enum import Enum
 from typing import Any, Literal
 
 from croniter import CroniterBadCronError, croniter
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
+from device_discovery.policy.portscan import (
+    MAX_EXPANDED_HOSTS as _MAX_EXPANDED_HOSTS,
+)
+from device_discovery.policy.portscan import count_hostnames
 from device_discovery.policy.unknown_keys import WarnUnknownKeys
 from device_discovery.stack_naming import (
     DEFAULT_STACK_MEMBER_TEMPLATE,
@@ -147,6 +151,11 @@ class PrefixParameters(IpamParameters):
 #: string means "no value was configured" and is suppressed rather than sent.
 #: See translate_device and the prefix-scope cascade in interface.py.
 UNDEFINED_PLACEHOLDER = "undefined"
+
+
+#: Re-exported so a policy's budget and a single target's backstop are the same
+#: number, and so callers have one place to import it from.
+MAX_EXPANDED_HOSTS = _MAX_EXPANDED_HOSTS
 
 
 class Defaults(BaseModel):
@@ -478,6 +487,32 @@ class Policy(BaseModel):
 
     config: Config | None = Field(default=None, description="Configuration data")
     scope: list[Napalm]
+
+    @model_validator(mode="after")
+    def validate_expansion_budget(self):
+        """
+        Reject a policy whose scopes together expand past MAX_EXPANDED_HOSTS.
+
+        The budget spans the policy rather than one scope entry. A per-entry
+        ceiling bounds one entry and nothing else: sixteen /16 scopes each sit
+        under it while the policy expands to about a million addresses, and
+        every one of those becomes a port-scan target and then possibly an SSH
+        session. There is one number rather than a per-entry ceiling and a
+        larger policy-wide one, so there is one thing to reason about.
+
+        Charged from ``count_hostnames``, which reads a target the way
+        ``expand_hostnames`` does rather than parsing the notation a second
+        time, so no target shape can mean one thing here and another to the
+        expander. Rejecting at validation means a policy this large fails the
+        write instead of failing later inside a scheduled job.
+        """
+        total = sum(count_hostnames(entry.hostname) for entry in self.scope)
+        if total > MAX_EXPANDED_HOSTS:
+            raise ValueError(
+                f"policy scopes expand to {total} addresses in total, "
+                f"more than the limit of {MAX_EXPANDED_HOSTS}"
+            )
+        return self
 
 
 class PolicyRequest(BaseModel):

--- a/orb-discovery/device-discovery/device_discovery/policy/portscan.py
+++ b/orb-discovery/device-discovery/device_discovery/policy/portscan.py
@@ -113,6 +113,53 @@ def expand_hostnames(hostname: str) -> tuple[list[str], bool]:
     return [sanitized_hostname], False
 
 
+def _network_host_count(network) -> int:
+    """
+    Host count for a network, without materializing anything.
+
+    Mirrors what ``network.hosts()`` yields. A /31 and a /32 have no network and
+    broadcast pair to exclude and stay 2 and 1, and the same holds for /127 and
+    /128. IPv6 has no broadcast, so only the network address is excluded.
+    """
+    if network.prefixlen >= network.max_prefixlen - 1:
+        return network.num_addresses
+    return network.num_addresses - (2 if network.version == 4 else 1)
+
+
+def count_hostnames(hostname: str) -> int:
+    """
+    Report how many addresses ``expand_hostnames`` would return, without expanding.
+
+    A policy is charged against this before any target is expanded, so the two
+    must never disagree about what a target means: this follows the same
+    dispatch, calls the same endpoint parser, and treats anything unparseable as
+    the single hostname the expander falls back to.
+
+    The count is reported for targets the expander refuses as well. A refused
+    target still has a size, and the size is exactly what the budget needs in
+    order to refuse it before anything is allocated.
+    """
+    sanitized_hostname = hostname.strip()
+
+    if "-" in sanitized_hostname:
+        start_part, end_part = sanitized_hostname.split("-", 1)
+        start_ip = _parse_range_endpoint(start_part)
+        end_ip = _parse_range_endpoint(end_part, base=start_ip)
+        if not start_ip or not end_ip or start_ip.version != end_ip.version:
+            return 1
+        start_int, end_int = sorted((int(start_ip), int(end_ip)))
+        return end_int - start_int + 1
+
+    if "/" in sanitized_hostname:
+        try:
+            network = ipaddress.ip_network(sanitized_hostname, strict=False)
+        except ValueError:
+            return 1
+        return _network_host_count(network)
+
+    return 1
+
+
 def _probe_port(hostname: str, port: int, timeout: float) -> bool:
     """Return True if the TCP port is reachable using sockets."""
     try:

--- a/orb-discovery/device-discovery/tests/policy/test_models.py
+++ b/orb-discovery/device-discovery/tests/policy/test_models.py
@@ -178,3 +178,49 @@ def test_options_emit_prefix_vlan_boolean_true_disables_rather_than_raising(text
     assert any("names no mode" in r.getMessage() for r in caplog.records), (
         "a value that silently disables the feature must be discoverable in the log"
     )
+
+
+def _scope(hostname: str) -> dict:
+    return {"hostname": hostname, "username": "u", "password": "p"}
+
+
+def test_policy_rejects_targets_that_together_exceed_the_budget():
+    """
+    The budget spans the policy, not one entry.
+
+    This is the hole a per-entry ceiling leaves: each of these scopes is well
+    under the limit on its own, so an entry-by-entry check waves the whole
+    policy through while it expands to roughly a million addresses.
+    """
+    from device_discovery.policy.models import MAX_EXPANDED_HOSTS, Policy
+
+    scopes = [_scope(f"10.{octet}.0.0/16") for octet in range(16)]
+    assert all(
+        h < MAX_EXPANDED_HOSTS
+        for h in (65534,) * len(scopes)
+    ), "each scope must be individually legal for this test to mean anything"
+
+    with pytest.raises(ValidationError) as excinfo:
+        Policy(scope=scopes)
+
+    message = str(excinfo.value)
+    assert "expand" in message
+    assert str(MAX_EXPANDED_HOSTS) in message
+
+
+def test_policy_accepts_targets_within_the_budget():
+    """A policy under the budget is untouched by the guard."""
+    from device_discovery.policy.models import Policy
+
+    policy = Policy(scope=[_scope("10.0.0.0/24"), _scope("10.1.0.0/24")])
+
+    assert len(policy.scope) == 2
+
+
+def test_policy_budget_ignores_plain_hostnames():
+    """A hostname counts as the single address it expands to, not as a range."""
+    from device_discovery.policy.models import Policy
+
+    policy = Policy(scope=[_scope(f"router-{n}.example.com") for n in range(200)])
+
+    assert len(policy.scope) == 200

--- a/orb-discovery/device-discovery/tests/policy/test_portscan.py
+++ b/orb-discovery/device-discovery/tests/policy/test_portscan.py
@@ -210,3 +210,50 @@ def test_expand_hostnames_keeps_small_ipv6_prefixes():
     assert parsed is True
     assert len(hosts) == 255
     assert hosts[0] == "2001:db8::1"
+
+
+def test_count_hostnames_agrees_with_expand_for_every_shape():
+    """
+    Counting and expanding must never disagree about what a target means.
+
+    The policy budget is charged from count_hostnames against notation the
+    expander has not run yet, so a shape the two read differently would let a
+    policy pay one price and allocate another. Cross-checked here rather than
+    asserted per-shape, so a new branch in one has to be added to the other.
+    """
+    shapes = [
+        "10.0.0.0/24",
+        "10.0.0.0/22",
+        "10.0.0.4/31",
+        "10.0.0.5/32",
+        "fd00::/126",
+        "2001:db8::/120",
+        "10.0.0.0-255",
+        "192.168.1.10-20",
+        "10.0.0.3-10.0.0.1",
+        "192.168.3.22/28-192.168.4.22/28",
+        "router-alpha-beta",
+        "plain-hostname.example.com",
+        "10.0.0.1",
+    ]
+
+    for shape in shapes:
+        expanded, _ = portscan.expand_hostnames(shape)
+        assert portscan.count_hostnames(shape) == len(expanded), (
+            f"{shape}: count and expand disagree"
+        )
+
+
+def test_count_hostnames_does_not_materialize_an_oversized_target():
+    """
+    A target the expander refuses is still counted, and counted cheaply.
+
+    The whole point of counting is to price a policy before paying for it, so
+    the count has to be available for exactly the targets expansion would
+    decline. A /64 has 2**64 addresses and must come back as that number
+    rather than as the empty list the expander returns.
+    """
+    # Host counts, matching what expansion would have returned: IPv6 drops the
+    # network address, IPv4 drops network and broadcast.
+    assert portscan.count_hostnames("2001:db8::/64") == 2**64 - 1
+    assert portscan.count_hostnames("0.0.0.0/0") == 2**32 - 2


### PR DESCRIPTION
Follow-up to #566. Reworked — the first version of this PR lowered the cap to 1024, which I no longer think was the right fix. See the comment above for why; in short, I had surveyed only one of the two siblings.

### What

#566 capped expansion at 65536 addresses **per scope entry**. That bounds one entry and nothing else:

```
16 x /16, each legal on its own  ->  policy expands to 1048544 addresses
```

So the unbounded expansion MON-328 was about is still reachable, just spelled differently. The cap needs to be a policy budget, not an entry ceiling.

### What the siblings do

| backend | limit | shape |
|---|---|---|
| gnmi-discovery | 1024 | per-policy, summed via `Count` before expanding |
| snmp-telemetry (#564) | 65536 | per-policy, `checkPolicyExpansion` |
| device-discovery (before) | 65536 | **per-entry** |

Both siblings budget the policy. device-discovery was the only one bounding a single entry, which is the actual divergence — not the number. `snmp-telemetry`'s comment states the case directly:

> The budget spans the policy rather than one entry. A per-target ceiling bounds a single target and nothing else: sixteen /16 entries each sit under it while the policy expands to 1048576 addresses.

**65536 rather than gnmi's 1024**, because the numbers differ for a reason. gnmi is 1024 because each address becomes a *persistent subscription*; snmp-telemetry is 65536 because each becomes a *recurring poll job*. device-discovery port-scans and then maybe opens an SSH session, which is the second cost model. Lowering to 1024 would have broken `/21` and `/20` scopes to fix nothing.

### How

`count_hostnames` reports what `expand_hostnames` would return without building any of it. It follows the same dispatch and calls the same endpoint parser, so no target shape can mean one thing to the budget and another to the expander. A test cross-checks the two across every accepted shape rather than asserting each in isolation, so a new branch in one has to be added to the other or the test fails.

The check is a model validator, so an oversized policy **fails the write** rather than failing later inside a scheduled job:

```
policy scopes expand to 1048544 addresses in total, more than the limit of 65536
```

The per-entry check stays as a backstop against the same constant, the way gnmi keeps `MaxExpand` inside `Expand`. One number, so there is one thing to reason about.

### Verified

```
16 x /16 (each legal alone)    REJECTED   1048544 addresses
one /24 + one /22              ACCEPTED
single /8                      REJECTED  16777214 addresses
```

Two mutations, each failing exactly the test that covers it and nothing else: summing changed to `max()` (the per-entry behaviour this PR replaces), and the validator removed entirely.

`2407 passed, 160 skipped`, ruff clean. Baseline on develop was `2398 passed`.

### Also

device-discovery had no documentation of expansion semantics at all, while gnmi documents them fully. Added: what a CIDR excludes and why a range does not, the IPv6 difference, the budget, and what a refused target does. Every number verified against the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
