### PR TITLE
fix(snmp-discovery): stop the range probe leaking credentials it does not need to send

### DIFF
--- a/docs/backends/snmp_discovery/README.md
+++ b/docs/backends/snmp_discovery/README.md
@@ -170,6 +170,32 @@ Each target in the `targets` list can include:
 | override_defaults | map | no | Allows overriding of any defaults for a specific target in the scope |
 | netbox_id | integer | no | NetBox device primary key. When set, the diode plugin matches the device by PK instead of by name. Ignored when host is a subnet or IP range. |
 
+#### Subnet and range scanning
+
+A subnet excludes its network and broadcast addresses, so `192.168.1.0/24` is
+scanned as 254 addresses, `.1` through `.254`. A `/31` is a point-to-point link
+and a `/32` a single host, so neither has a pair to exclude. A range excludes
+nothing, because it is an operator enumerating addresses rather than naming a
+subnet: `192.168.1.0-255` is 256 addresses, `.0` and `.255` included.
+
+Each address is probed for reachability before any discovery job is scheduled,
+and only addresses that answer are discovered.
+
+**What the probe puts on the wire.** With SNMPv3 the probe presents a
+placeholder user and does not authenticate, so neither the configured user nor
+any passphrase reaches an address that has not answered. Presence comes from
+the credential-free engine discovery exchange the protocol performs before any
+authenticated request.
+
+With **SNMPv1 and SNMPv2c there is no equivalent**, and the probe carries the
+community string to every address in the subnet or range. The community is the
+credential in those versions and is sent in cleartext, so scanning a range with
+v1 or v2c puts it in front of anything listening on the scanned port across that
+range. A conformant agent silently discards a request bearing the wrong
+community, so there is no substitute value the probe could send instead without
+turning every device into a false negative. Use SNMPv3 for range scanning where
+the segment is not trusted, or name targets individually.
+
 #### Authentication Parameters
 | Parameter | Type | Required | Description |
 |:---------:|:----:|:--------:|:-----------:|

--- a/orb-discovery/snmp-discovery/policy/runner.go
+++ b/orb-discovery/snmp-discovery/policy/runner.go
@@ -299,6 +299,55 @@ func (r *Runner) resolveTargetDefaults(target config.Target) *config.Defaults {
 	return &r.config.Defaults
 }
 
+// probeProbeUser is the USM user the v3 probe presents instead of the
+// operator's. gosnmp rejects an empty user name, so the probe needs some
+// value; this one is never a credential and is only ever seen by an agent that
+// has already answered engine discovery.
+const probeProbeUser = "orb-probe"
+
+// engineDiscoverer is answered by a client that learned a peer's SNMPv3
+// authoritative engine ID.
+//
+// Asserted rather than added to snmp.Walker so a walker that cannot report it
+// keeps the walk-error admission rule, which is the only one v1 and v2c have.
+type engineDiscoverer interface {
+	EngineDiscovered() bool
+}
+
+// probeAuthentication returns the credentials the reachability probe may send
+// to an address that has not yet proven anything is there.
+//
+// SNMPv3 carries a credential-free engine discovery exchange before any
+// authenticated request (RFC 3414 section 4), so the probe presents a
+// placeholder user at noAuthNoPriv: the operator's user never reaches a
+// scanned address, and without an authenticated request there is no HMAC to
+// capture and attack offline. Presence comes from the discovery answer, so
+// nothing is lost by not authenticating.
+//
+// v1 and v2c are returned unchanged, and this is the exposure the probe cannot
+// close: the community IS the credential and there is no discovery exchange to
+// stand in for it. A conformant agent silently discards a request bearing the
+// wrong community, so substituting one turns every device into a false
+// negative rather than protecting anything. Whether a v2c range may be scanned
+// at all is a policy question, not one the probe can answer.
+func probeAuthentication(auth *config.Authentication) *config.Authentication {
+	if auth == nil || auth.ProtocolVersion != snmp.ProtocolVersion3 {
+		return auth
+	}
+
+	// Copied rather than mutated: the caller's authentication is the policy's
+	// own and is reused for the real run.
+	probe := *auth
+	probe.Username = probeProbeUser
+	probe.SecurityLevel = "noAuthNoPriv"
+	probe.AuthProtocol = ""
+	probe.AuthPassphrase = ""
+	probe.PrivProtocol = ""
+	probe.PrivPassphrase = ""
+	probe.ContextName = ""
+	return &probe
+}
+
 func (r *Runner) probeTarget(ctx context.Context, target config.Target) bool {
 	select {
 	case <-ctx.Done():
@@ -306,7 +355,7 @@ func (r *Runner) probeTarget(ctx context.Context, target config.Target) bool {
 	default:
 	}
 
-	auth := r.resolveTargetAuthentication(target)
+	auth := probeAuthentication(r.resolveTargetAuthentication(target))
 
 	snmpClient, err := r.ClientFactory(target.Host, target.Port, 0, r.snmpProbeTimeout, auth, r.logger)
 	if err != nil {
@@ -321,7 +370,16 @@ func (r *Runner) probeTarget(ctx context.Context, target config.Target) bool {
 	}
 
 	_, err = snmpClient.Walk(defaultSNMPProbeOID, 0)
-	return err == nil
+	if err == nil {
+		return true
+	}
+
+	// The v3 probe deliberately cannot authenticate, so its walk fails against
+	// a live agent too. Answering engine discovery is what proves one is there.
+	if discoverer, ok := snmpClient.(engineDiscoverer); ok {
+		return discoverer.EngineDiscovered()
+	}
+	return false
 }
 
 // run runs the policy for a single target (no parent)

--- a/orb-discovery/snmp-discovery/policy/runner.go
+++ b/orb-discovery/snmp-discovery/policy/runner.go
@@ -340,9 +340,14 @@ func probeAuthentication(auth *config.Authentication) *config.Authentication {
 	probe := *auth
 	probe.Username = probeProbeUser
 	probe.SecurityLevel = "noAuthNoPriv"
-	probe.AuthProtocol = ""
+	// The sentinels rather than empty strings: getAuthProtocol and
+	// getPrivProtocol accept "NoAuth" and "NoPriv" and reject everything else
+	// they do not recognise, the empty string included. Clearing these to ""
+	// makes the client factory fail before it connects, which rejects every
+	// address and quietly turns off v3 range scanning altogether.
+	probe.AuthProtocol = "NoAuth"
 	probe.AuthPassphrase = ""
-	probe.PrivProtocol = ""
+	probe.PrivProtocol = "NoPriv"
 	probe.PrivPassphrase = ""
 	probe.ContextName = ""
 	return &probe

--- a/orb-discovery/snmp-discovery/policy/runner_internal_test.go
+++ b/orb-discovery/snmp-discovery/policy/runner_internal_test.go
@@ -1297,3 +1297,29 @@ func TestProbeTargetV3RejectsWithoutEngineDiscovery(t *testing.T) {
 
 	assert.False(t, runner.probeTarget(context.Background(), config.Target{Host: "127.0.0.1", Port: 161}))
 }
+
+func TestProbeAuthenticationBuildsARealClient(t *testing.T) {
+	// The other probe tests inject a fake ClientFactory, so none of them
+	// exercises snmp.NewClient. That is how an earlier revision shipped a
+	// probe authentication the real factory rejected outright: it cleared the
+	// protocol fields to "", and getAuthProtocol/getPrivProtocol accept
+	// "NoAuth"/"NoPriv" but not the empty string, so every v3 address was
+	// refused before a packet was sent and no v3 range scan found anything.
+	for _, level := range []string{"noAuthNoPriv", "authNoPriv", "authPriv"} {
+		t.Run(level, func(t *testing.T) {
+			probe := probeAuthentication(&config.Authentication{
+				ProtocolVersion: snmp.ProtocolVersion3,
+				SecurityLevel:   level,
+				Username:        "netbox-monitor",
+				AuthProtocol:    "SHA",
+				AuthPassphrase:  "auth-secret",
+				PrivProtocol:    "AES",
+				PrivPassphrase:  "priv-secret",
+			})
+
+			client, err := snmp.NewClient("127.0.0.1", 161, 0, time.Second, probe, slog.New(slog.NewTextHandler(io.Discard, nil)))
+			require.NoError(t, err, "the real factory must accept the probe authentication")
+			require.NotNil(t, client)
+		})
+	}
+}

--- a/orb-discovery/snmp-discovery/policy/runner_internal_test.go
+++ b/orb-discovery/snmp-discovery/policy/runner_internal_test.go
@@ -1197,3 +1197,103 @@ func TestAssetTagClaimer_NilMapLazyInit(t *testing.T) {
 	assert.False(t, r.assetTagClaimer("10.0.0.2:161")("TAG-001"),
 		"ownership recorded in the lazily-created map must suppress cross-target claims")
 }
+
+// engineWalker answers Walk with an error but reports that the credential-free
+// v3 engine discovery exchange completed, which is what a real agent does when
+// the probe's placeholder user is not one it knows.
+type engineWalker struct {
+	testWalker
+	discovered bool
+}
+
+func (e *engineWalker) EngineDiscovered() bool { return e.discovered }
+
+func TestProbeAuthenticationStripsV3Credentials(t *testing.T) {
+	real := &config.Authentication{
+		ProtocolVersion: snmp.ProtocolVersion3,
+		SecurityLevel:   "authPriv",
+		Username:        "netbox-monitor",
+		AuthProtocol:    "SHA",
+		AuthPassphrase:  "auth-secret",
+		PrivProtocol:    "AES",
+		PrivPassphrase:  "priv-secret",
+		ContextName:     "vrf-mgmt",
+	}
+
+	probe := probeAuthentication(real)
+
+	assert.NotEqual(t, real.Username, probe.Username, "the operator's user must not reach a scanned address")
+	assert.NotEmpty(t, probe.Username, "gosnmp rejects an empty USM user")
+	assert.Empty(t, probe.AuthPassphrase)
+	assert.Empty(t, probe.PrivPassphrase)
+	assert.Equal(t, "noAuthNoPriv", probe.SecurityLevel, "no HMAC means no offline attack material")
+	assert.Equal(t, "netbox-monitor", real.Username, "the caller's authentication must not be mutated")
+}
+
+func TestProbeAuthenticationLeavesV2cUnchanged(t *testing.T) {
+	// Documents the gap rather than hiding it: v2c has no credential-free
+	// exchange, and a wrong community is silently discarded by a conformant
+	// agent, so substituting one would turn every device into a false negative.
+	real := &config.Authentication{
+		ProtocolVersion: snmp.ProtocolVersion2c,
+		Community:       "s3cret",
+	}
+
+	probe := probeAuthentication(real)
+
+	assert.Equal(t, "s3cret", probe.Community)
+}
+
+func TestProbeTargetV3AdmitsOnEngineDiscovery(t *testing.T) {
+	walker := &engineWalker{discovered: true}
+	walker.walkErr = errors.New("unknown user name")
+	var gotAuth *config.Authentication
+
+	runner := &Runner{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		scope: config.Scope{Authentication: config.Authentication{
+			ProtocolVersion: snmp.ProtocolVersion3,
+			SecurityLevel:   "authPriv",
+			Username:        "netbox-monitor",
+			AuthProtocol:    "SHA",
+			AuthPassphrase:  "auth-secret",
+			PrivProtocol:    "AES",
+			PrivPassphrase:  "priv-secret",
+		}},
+		snmpProbeTimeout: time.Second,
+		ClientFactory: func(_ string, _ uint16, _ int, _ time.Duration, auth *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
+			gotAuth = auth
+			return walker, nil
+		},
+	}
+
+	ok := runner.probeTarget(context.Background(), config.Target{Host: "127.0.0.1", Port: 161})
+
+	require.True(t, ok, "an agent that answered engine discovery is present")
+	require.NotNil(t, gotAuth)
+	assert.NotEqual(t, "netbox-monitor", gotAuth.Username)
+	assert.Empty(t, gotAuth.AuthPassphrase)
+	assert.Empty(t, gotAuth.PrivPassphrase)
+}
+
+func TestProbeTargetV3RejectsWithoutEngineDiscovery(t *testing.T) {
+	walker := &engineWalker{discovered: false}
+	walker.walkErr = errors.New("request timeout")
+
+	runner := &Runner{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		scope: config.Scope{Authentication: config.Authentication{
+			ProtocolVersion: snmp.ProtocolVersion3,
+			SecurityLevel:   "authPriv",
+			Username:        "netbox-monitor",
+			AuthProtocol:    "SHA",
+			AuthPassphrase:  "auth-secret",
+		}},
+		snmpProbeTimeout: time.Second,
+		ClientFactory: func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
+			return walker, nil
+		},
+	}
+
+	assert.False(t, runner.probeTarget(context.Background(), config.Target{Host: "127.0.0.1", Port: 161}))
+}

--- a/orb-discovery/snmp-discovery/policy/runner_internal_test.go
+++ b/orb-discovery/snmp-discovery/policy/runner_internal_test.go
@@ -1209,7 +1209,7 @@ type engineWalker struct {
 func (e *engineWalker) EngineDiscovered() bool { return e.discovered }
 
 func TestProbeAuthenticationStripsV3Credentials(t *testing.T) {
-	real := &config.Authentication{
+	configured := &config.Authentication{
 		ProtocolVersion: snmp.ProtocolVersion3,
 		SecurityLevel:   "authPriv",
 		Username:        "netbox-monitor",
@@ -1220,26 +1220,26 @@ func TestProbeAuthenticationStripsV3Credentials(t *testing.T) {
 		ContextName:     "vrf-mgmt",
 	}
 
-	probe := probeAuthentication(real)
+	probe := probeAuthentication(configured)
 
-	assert.NotEqual(t, real.Username, probe.Username, "the operator's user must not reach a scanned address")
+	assert.NotEqual(t, configured.Username, probe.Username, "the operator's user must not reach a scanned address")
 	assert.NotEmpty(t, probe.Username, "gosnmp rejects an empty USM user")
 	assert.Empty(t, probe.AuthPassphrase)
 	assert.Empty(t, probe.PrivPassphrase)
 	assert.Equal(t, "noAuthNoPriv", probe.SecurityLevel, "no HMAC means no offline attack material")
-	assert.Equal(t, "netbox-monitor", real.Username, "the caller's authentication must not be mutated")
+	assert.Equal(t, "netbox-monitor", configured.Username, "the caller's authentication must not be mutated")
 }
 
 func TestProbeAuthenticationLeavesV2cUnchanged(t *testing.T) {
 	// Documents the gap rather than hiding it: v2c has no credential-free
 	// exchange, and a wrong community is silently discarded by a conformant
 	// agent, so substituting one would turn every device into a false negative.
-	real := &config.Authentication{
+	configured := &config.Authentication{
 		ProtocolVersion: snmp.ProtocolVersion2c,
 		Community:       "s3cret",
 	}
 
-	probe := probeAuthentication(real)
+	probe := probeAuthentication(configured)
 
 	assert.Equal(t, "s3cret", probe.Community)
 }

--- a/orb-discovery/snmp-discovery/snmp/snmp.go
+++ b/orb-discovery/snmp-discovery/snmp/snmp.go
@@ -148,6 +148,21 @@ func (c *Client) Close() error {
 	return nil
 }
 
+// EngineDiscovered reports whether the peer answered the SNMPv3 engine
+// discovery exchange.
+//
+// That exchange carries no credentials (RFC 3414 section 4, and gosnmp builds
+// it with empty security parameters), so it is the one signal available to a
+// probe that deliberately does not authenticate. A learned authoritative
+// engine ID means an agent replied; nothing else populates it.
+//
+// False for v1 and v2c, which have no USM parameters and whose probe admission
+// stays the walk result.
+func (c *Client) EngineDiscovered() bool {
+	usm, ok := c.SecurityParameters.(*gosnmp.UsmSecurityParameters)
+	return ok && usm.AuthoritativeEngineID != ""
+}
+
 // Walk implements the Walker interface by walking the SNMP tree
 func (c *Client) Walk(objectIDs string, identifierSize int) (map[string]PDU, error) {
 	pdu, err := c.WalkAll(objectIDs)

--- a/orb-discovery/snmp-discovery/snmp/snmp_test.go
+++ b/orb-discovery/snmp-discovery/snmp/snmp_test.go
@@ -749,3 +749,31 @@ func TestMapPDU(t *testing.T) {
 		})
 	}
 }
+
+func TestClientEngineDiscoveredReflectsAuthoritativeEngineID(t *testing.T) {
+	// The v3 probe cannot authenticate, so a learned engine ID is the only
+	// thing that separates a live agent from an address holding nothing.
+	client := &snmp.Client{GoSNMP: &gosnmp.GoSNMP{
+		Version:       gosnmp.Version3,
+		SecurityModel: gosnmp.UserSecurityModel,
+		SecurityParameters: &gosnmp.UsmSecurityParameters{
+			UserName: "orb-probe",
+		},
+	}}
+
+	assert.False(t, client.EngineDiscovered(), "nothing answered yet")
+
+	client.SecurityParameters.(*gosnmp.UsmSecurityParameters).AuthoritativeEngineID = "\x80\x00\x1f\x88"
+	assert.True(t, client.EngineDiscovered(), "a learned engine ID means an agent answered")
+}
+
+func TestClientEngineDiscoveredIsFalseForV2c(t *testing.T) {
+	// v2c has no USM parameters at all, so the assertion must not panic and
+	// must not claim presence: v2c admission stays the walk result.
+	client := &snmp.Client{GoSNMP: &gosnmp.GoSNMP{
+		Version:   gosnmp.Version2c,
+		Community: "public",
+	}}
+
+	assert.False(t, client.EngineDiscovered())
+}

--- a/orb-discovery/snmp-discovery/targets/targets.go
+++ b/orb-discovery/snmp-discovery/targets/targets.go
@@ -61,6 +61,20 @@ func expandCIDR(cidr string) ([]string, error) {
 	count := uint64(1) << hostBits
 	endVal := uint32(uint64(startVal) + count - 1)
 
+	// A CIDR names a subnet, and its network and broadcast addresses are not
+	// hosts. Probing the broadcast address is worse than merely useless here:
+	// an SNMP request sent there is delivered to every host on the segment, so
+	// a credentialed probe aimed at it hands the community to all of them at
+	// once rather than to the single address being scanned.
+	//
+	// A /31 is a point-to-point link and a /32 a single host, so neither has a
+	// pair to exclude. A range is left alone entirely: it is an operator
+	// enumerating addresses, and someone who wrote .0 meant it.
+	if prefix.Bits() <= 30 {
+		startVal++
+		endVal--
+	}
+
 	rangeLen := uint64(endVal-startVal) + 1
 	capacity := 0
 	if rangeLen <= maxPrealloc {

--- a/orb-discovery/snmp-discovery/targets/targets_test.go
+++ b/orb-discovery/snmp-discovery/targets/targets_test.go
@@ -102,12 +102,17 @@ func TestExpandCIDR(t *testing.T) {
 		{
 			name: "Valid /24 CIDR",
 			cidr: "192.168.1.0/24",
-			want: 256,
+			want: 254, // network and broadcast are not hosts
 		},
 		{
 			name: "Valid /30 CIDR",
 			cidr: "192.168.1.0/30",
-			want: 4,
+			want: 2, // network and broadcast are not hosts
+		},
+		{
+			name: "Valid /31 CIDR",
+			cidr: "192.168.1.0/31",
+			want: 2, // a point-to-point link has no pair to exclude
 		},
 		{
 			name: "Valid /32 CIDR",
@@ -219,4 +224,50 @@ func compareStringSlices(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+func TestExpandCIDRNeverProbesTheBroadcastAddress(t *testing.T) {
+	// An SNMP request to a broadcast address is delivered to every host on the
+	// segment, so a credentialed probe aimed there hands the community to all
+	// of them at once rather than to the one address being scanned. The
+	// network address is excluded for the same reason it is everywhere else:
+	// it is not a host.
+	ips, err := Expand("192.168.1.0/24")
+	if err != nil {
+		t.Fatalf("Expand() error = %v", err)
+	}
+
+	for _, ip := range ips {
+		if ip == "192.168.1.255" {
+			t.Error("the broadcast address must never be probed")
+		}
+		if ip == "192.168.1.0" {
+			t.Error("the network address is not a host")
+		}
+	}
+	if len(ips) != 254 {
+		t.Errorf("len = %d, want 254", len(ips))
+	}
+	if ips[0] != "192.168.1.1" {
+		t.Errorf("first = %s, want 192.168.1.1", ips[0])
+	}
+	if ips[len(ips)-1] != "192.168.1.254" {
+		t.Errorf("last = %s, want 192.168.1.254", ips[len(ips)-1])
+	}
+}
+
+func TestExpandRangeKeepsEveryAddressTheOperatorWrote(t *testing.T) {
+	// A range is an operator enumerating addresses rather than naming a
+	// subnet, so someone who wrote .0 meant it. Only the CIDR form excludes.
+	ips, err := Expand("192.168.1.0-192.168.1.255")
+	if err != nil {
+		t.Fatalf("Expand() error = %v", err)
+	}
+
+	if len(ips) != 256 {
+		t.Errorf("len = %d, want 256", len(ips))
+	}
+	if ips[0] != "192.168.1.0" || ips[len(ips)-1] != "192.168.1.255" {
+		t.Errorf("range must keep both endpoints, got %s..%s", ips[0], ips[len(ips)-1])
+	}
 }


### PR DESCRIPTION
Fixes [MON-330](https://linear.app/netboxlabs/issue/MON-330/snmp-discovery-the-range-probe-sends-credentials-to-every-address-it).

### What

`probeTarget` resolved the target's authentication and handed it to the client, so the reachability probe preceding a range scan was credentialed. A policy scanning `10.0.0.0/24` put credentials on the wire to 256 addresses to find the three devices actually there.

### The v3 fix

SNMPv3 carries a **credential-free engine discovery exchange** before any authenticated request (RFC 3414 §4). gosnmp builds that packet with empty security parameters:

```go
blankPacket := &SnmpPacket{
    MsgFlags:           Reportable | NoAuthNoPriv,
    SecurityParameters: &UsmSecurityParameters{Logger: sp.Logger},  // no user, no passphrases
```

So the probe now presents a **placeholder user at noAuthNoPriv**. The operator's user never reaches a scanned address, and because no authenticated request is sent there is no HMAC to capture and attack offline. gosnmp rejects an empty USM user (`securityParameters.UserName is required` at every level), which is why the probe presents a placeholder rather than nothing.

Presence then comes from the discovery answer, since a probe that cannot authenticate cannot complete a walk. `Client.EngineDiscovered` reports the learned authoritative engine ID — nothing else populates it. It is **asserted** on the walker rather than added to `snmp.Walker`, so a walker that cannot report it keeps the walk-error rule, which is the only one v1 and v2c have.

### Scope, stated precisely

I want to be exact about what this protects, because the ticket's summary is broader than what is achievable.

For v3 the passphrases were **never** sent — they compute an HMAC. What leaked to a non-responder was the **username plus HMAC**, which is offline-dictionary material against the auth passphrase. Real, but not the bearer credential that v2c's community is. This PR closes that.

### The v1/v2c half: the broadcast address

The remaining exposure looked like it needed a policy decision. Most of it did not.

`expandCIDR` enumerated a prefix from its masked network address **through its broadcast address**, so a `/24` was scanned as 256 addresses rather than 254. gnmi-discovery already excluded both; snmp-discovery did not.

For SNMP that is not a wasted probe, it is the worst case in the whole ticket. **A request sent to a broadcast address is delivered to every host on the segment**, so the credentialed probe handed the community to all of them at once rather than to the single address being scanned. Removing it needs no decision from anyone.

```
192.168.1.0/24        254 addresses   192.168.1.1 .. 192.168.1.254
192.168.1.0/30          2 addresses   192.168.1.1 .. 192.168.1.2
192.168.1.0/31          2 addresses   192.168.1.0 .. 192.168.1.1
192.168.1.1/32          1 addresses   192.168.1.1 .. 192.168.1.1
192.168.1.0-255       256 addresses   192.168.1.0 .. 192.168.1.255
```

A `/31` is a point-to-point link and a `/32` a single host, so neither has a pair to exclude. A **range is untouched** — it is an operator enumerating addresses, and someone who wrote `.0` meant it. Both are pinned, because the two forms now deliberately disagree about the same address set.

### What remains, and why it is not a code change

With v1/v2c the community still reaches every *unicast* address in the range. That is irreducible: the community IS the credential, and a conformant agent silently discards a request bearing the wrong one, so there is no substitute value the probe could send without turning every device into a false negative.

The ticket's option 2 — refuse credentialed range scans for v2c — would also be inconsistent with the rest of the product: `orb-telemetry/snmp-telemetry` has **no probe at all** and attaches `Authentication` to every expanded address as a recurring poll job, so a `/24` telemetry target sends the community to 256 addresses on every cycle, indefinitely. Refusing it here while that stands would protect nothing.

So that part is **documented** instead, in the backend README: what the probe puts on the wire per version, that v3 sends neither user nor passphrase, that v1/v2c sends the community in cleartext to the whole range, and that the answer is v3 or individually named targets where the segment is not trusted.

### Behaviour change reviewers should see

v3 admission moves from *"an authenticated walk succeeded"* to *"an agent answered"*. An address whose credentials are wrong is now admitted, and its run fails with an authentication error where before it was skipped silently.

I think that is the better of the two: an operator with a wrong passphrase previously saw an empty scan and no reason for it. But it does mean more scheduled runs on a misconfigured policy, and it is the one thing here that is a judgement call rather than a strict improvement.

### Tests

Nine, covering both halves:

- v3 probe authentication carries no passphrases, a different user, and `noAuthNoPriv` — and does not mutate the caller's authentication
- v2c probe authentication is unchanged, pinning the known gap rather than hiding it
- a v3 walker that fails its walk but answered discovery is admitted, and the factory received no real credentials
- a v3 walker that answered nothing is refused
- `Client.EngineDiscovered` tracks the engine ID, and is false for v2c rather than panicking on the type assertion
- a `/24` contains neither `.0` nor `.255`, starts at `.1` and ends at `.254`
- a `/31` keeps both addresses, a `/32` keeps its one
- a range keeps every address the operator wrote, `.0` and `.255` included
- the existing `/24` and `/30` expectations move from 256 and 4 to 254 and 2

Three mutations, each failing exactly its own tests: passing the real credentials to the probe, ignoring engine discovery, and dropping the network/broadcast exclusion.

`go test ./...` clean, `golangci-lint run ./...` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
