### PR TITLE
fix(repo): let a failing test fail the build again in the Go backends

### DIFF
--- a/orb-discovery/gnmi-discovery/Makefile
+++ b/orb-discovery/gnmi-discovery/Makefile
@@ -1,3 +1,8 @@
+# Every target runs outside the repository workspace, which is what CI does and
+# what keeps this module buildable on its own. Without it a generated go.work
+# puts the build in workspace mode, where -mod=mod is rejected.
+export GOWORK = off
+
 CGO_ENABLED ?= 0
 BUILD_DIR ?= ./build
 GOARCH ?= $(shell go env GOARCH)
@@ -32,11 +37,19 @@ lint:
 fix-lint:
 	@golangci-lint run ./... --config ../../.github/golangci.yaml --fix
 
+# go test writes its events to a file so its exit status is kept: piping it
+# straight into the cmd filter let a failing cmd test leave the build green,
+# because the filter dropped the failure event and reported its own status.
+# Both filters are anchored to the package so a test name or a line of output
+# containing "cmd" is not dropped with it.
 .PHONY: test-coverage
 test-coverage:
 	@mkdir -p .coverage
-	@go test -race -cover -json -coverprofile=.coverage/cover.out.tmp ./... | grep -Ev "cmd" | tparse -format=markdown > .coverage/test-report.md
-	@cat .coverage/cover.out.tmp | grep -Ev "cmd" > .coverage/cover.out
+	@go test -race -cover -json -coverprofile=.coverage/cover.out.tmp ./... > .coverage/test-events.json; \
+		status=$$?; \
+		grep -Ev '"Package":"[^"]*/cmd"' .coverage/test-events.json | tparse -format=markdown > .coverage/test-report.md || status=$$?; \
+		exit $$status
+	@grep -Ev '/cmd/' .coverage/cover.out.tmp > .coverage/cover.out
 	@go tool cover -func=.coverage/cover.out | grep -E '^total:' | awk '{print substr($$3, 1, length($$3)-1)}' > .coverage/coverage.txt
 	@gcov2lcov -infile=.coverage/cover.out -outfile=.coverage/lcov.info
 

--- a/orb-discovery/network-discovery/Makefile
+++ b/orb-discovery/network-discovery/Makefile
@@ -1,3 +1,8 @@
+# Every target runs outside the repository workspace, which is what CI does and
+# what keeps this module buildable on its own. Without it a generated go.work
+# puts the build in workspace mode, where -mod=mod is rejected.
+export GOWORK = off
+
 CGO_ENABLED ?= 0
 BUILD_DIR ?= ./build
 GOARCH ?= $(shell go env GOARCH)
@@ -22,9 +27,17 @@ fix-lint:
 test:
 	@go test -race ./...
 
+# go test writes its events to a file so its exit status is kept: piping it
+# straight into the cmd filter let a failing cmd test leave the build green,
+# because the filter dropped the failure event and reported its own status.
+# Both filters are anchored to the package so a test name or a line of output
+# containing "cmd" is not dropped with it.
 .PHONY: test-coverage
 test-coverage:
 	@mkdir -p .coverage
-	@go test -race -cover -json -coverprofile=.coverage/cover.out.tmp ./... | grep -Ev "cmd" | tparse -format=markdown > .coverage/test-report.md
-	@cat .coverage/cover.out.tmp | grep -Ev "cmd" > .coverage/cover.out
+	@go test -race -cover -json -coverprofile=.coverage/cover.out.tmp ./... > .coverage/test-events.json; \
+		status=$$?; \
+		grep -Ev '"Package":"[^"]*/cmd"' .coverage/test-events.json | tparse -format=markdown > .coverage/test-report.md || status=$$?; \
+		exit $$status
+	@grep -Ev '/cmd/' .coverage/cover.out.tmp > .coverage/cover.out
 	@go tool cover -func=.coverage/cover.out | grep -E '^total:' | awk '{print substr($$3, 1, length($$3)-1)}' > .coverage/coverage.txt

--- a/orb-discovery/snmp-discovery/Makefile
+++ b/orb-discovery/snmp-discovery/Makefile
@@ -1,3 +1,8 @@
+# Every target runs outside the repository workspace, which is what CI does and
+# what keeps this module buildable on its own. Without it a generated go.work
+# puts the build in workspace mode, where -mod=mod is rejected.
+export GOWORK = off
+
 CGO_ENABLED ?= 0
 BUILD_DIR ?= ./build
 GOARCH ?= $(shell go env GOARCH)
@@ -32,11 +37,19 @@ lint:
 fix-lint:
 	@golangci-lint run ./... --config ../../.github/golangci.yaml --fix
 
+# go test writes its events to a file so its exit status is kept: piping it
+# straight into the cmd filter let a failing cmd test leave the build green,
+# because the filter dropped the failure event and reported its own status.
+# Both filters are anchored to the package so a test name or a line of output
+# containing "cmd" is not dropped with it.
 .PHONY: test-coverage
 test-coverage:
 	@mkdir -p .coverage
-	@go test -race -cover -json -coverprofile=.coverage/cover.out.tmp ./... | grep -Ev "cmd" | tparse -format=markdown > .coverage/test-report.md
-	@cat .coverage/cover.out.tmp | grep -Ev "cmd" > .coverage/cover.out
+	@go test -race -cover -json -coverprofile=.coverage/cover.out.tmp ./... > .coverage/test-events.json; \
+		status=$$?; \
+		grep -Ev '"Package":"[^"]*/cmd"' .coverage/test-events.json | tparse -format=markdown > .coverage/test-report.md || status=$$?; \
+		exit $$status
+	@grep -Ev '/cmd/' .coverage/cover.out.tmp > .coverage/cover.out
 	@go tool cover -func=.coverage/cover.out | grep -E '^total:' | awk '{print substr($$3, 1, length($$3)-1)}' > .coverage/coverage.txt
 	@gcov2lcov -infile=.coverage/cover.out -outfile=.coverage/lcov.info
 


### PR DESCRIPTION
Fixes [MON-332](https://linear.app/netboxlabs/issue/MON-332/orb-discovery-backends-a-failing-test-in-cmd-cannot-fail-the-build). Ports the fix from #564 (`9e5059e0` and its anchoring follow-up) to the three sibling backends, where the recipe was byte-identical.

### What

`make test-coverage` could report success while a test failed, in **all three** Go backends. Two mechanisms, both needed:

1. `grep -Ev "cmd"` stripped every JSON event for the `cmd` package — **including its failure event** — so `tparse` saw a clean stream and exited 0.
2. The recipe is a pipeline with no `pipefail`, so `go test`'s nonzero status was masked by the last stage's.

CI invokes only `make test-coverage`, never the separate `make test`, so nothing else caught it.

**Reproduced before fixing.** A `t.Fatal` test under `orb-discovery/snmp-discovery/cmd/`, then `make test-coverage`:

```
exit status: 0
```

### The fix

`go test` writes its events to a file and its status is captured on the same continued recipe line, so the filters run against **artifacts** rather than against the invocation.

`set -o pipefail` was considered and rejected: make runs each recipe line in a fresh shell, so it would need `SHELL := /bin/bash` plus `.SHELLFLAGS` globally — changing every recipe and adding a bash dependency where the rest are POSIX.

Both filters are also **anchored to the package**. `grep -Ev "cmd"` matched the substring anywhere on a line, so a package path, a test name, or a line of test output containing `cmd` would have been silently dropped from the report and the coverage profile alike. Latent rather than live, but the same class of silent drop.

None of the three has tests under `cmd/` today, which is why this had not bitten yet. It was still live: **a `cmd` package that fails to build** also emits a failure event the grep stripped.

### Verified, four directions per backend

| | snmp | network | gnmi |
|---|---|---|---|
| failing test under `cmd/` | exit 2 | exit 2 | exit 2 |
| failing test outside `cmd/` | exit 2 | — | — |
| `cmd` package fails to build | exit 2 | — | — |
| passing suite | exit 0 | exit 0 | exit 0 |

Passing runs produce a `cmd`-free report, a `cmd`-free coverage profile and a one-line `coverage.txt` (89.1 / 85.5 / 93.0). The middle two rows were exercised on snmp-discovery; the recipe is identical across all three.

### Third item: `make build` under a workspace

`make build` failed in each backend once a repository workspace existed. After `make work` generates `go.work` the build is in workspace mode, where Go rejects the `-mod=mod` flag the recipe passes:

```
Remove the -mod flag to use the default readonly value,
or set GOWORK=off to disable workspace mode.
make: *** [build] Error 1
```

That matters because `make work` is the documented way to get a working local workspace, and the backend's advertised build target then stops working.

`GOWORK` is now exported off from each module Makefile, so every target behaves the way CI already runs them rather than patching the one recipe. Verified by generating `go.work` and confirming `make build` succeeds in all three — and, as a negative control, that it fails again with the export commented out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
