### PR TITLE
feat(snmp-telemetry): support the ordered matches_list sysDescr redirect

### DIFF
--- a/orb-telemetry/snmp-telemetry/profiles/loader.go
+++ b/orb-telemetry/snmp-telemetry/profiles/loader.go
@@ -284,13 +284,18 @@ func (l *Loader) resolvePath(key string) (*Profile, error) {
 	defer delete(l.resolving, key)
 
 	merged := &Profile{
-		FileName:         p.FileName,
-		RelPath:          p.RelPath,
-		Origin:           p.Origin,
-		ReplacesBundled:  p.ReplacesBundled,
-		Provider:         p.Provider,
-		SysObjectID:      p.SysObjectID,
+		FileName:        p.FileName,
+		RelPath:         p.RelPath,
+		Origin:          p.Origin,
+		ReplacesBundled: p.ReplacesBundled,
+		Provider:        p.Provider,
+		SysObjectID:     p.SysObjectID,
+		// Both redirect forms are the declaring file's own. The extends
+		// merge below carries metrics and tags and touches neither, which is
+		// what upstream does too, so a redirect never crosses an extends edge
+		// and there is no parent list for a child's to interleave with.
 		Matches:          p.Matches,
+		MatchesList:      p.MatchesList,
 		NoUseBulkWalkAll: p.NoUseBulkWalkAll,
 	}
 

--- a/orb-telemetry/snmp-telemetry/profiles/loader_test.go
+++ b/orb-telemetry/snmp-telemetry/profiles/loader_test.go
@@ -633,3 +633,68 @@ metrics:
 	assert.Contains(t, out, "sysobjectid=*", "a bare star must be named")
 	assert.Contains(t, out, "starry.yml")
 }
+
+// A profile's sysDescr redirects are its own. resolvePath copies `matches`
+// from the file being resolved and the extends merge does not touch it, which
+// is what upstream does too: its merge carries metrics, tags and the
+// sysobjectid map and leaves the redirects behind. `matches_list` is treated
+// the same way, so neither form crosses an extends edge and the ordering rule
+// has no parent list to interleave with.
+func TestResolve_RedirectsAreNotInheritedThroughExtends(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, dir, "base.yml", `
+matches:
+  parent-pattern: parent-target.yml
+matches_list:
+  - regex: parent-regex
+    target: parent-target.yml
+metrics:
+  - symbol:
+      name: sysUpTime
+      OID: 1.3.6.1.2.1.1.3.0
+`)
+	writeYAML(t, dir, "device.yml", `
+sysobjectid: 1.3.6.1.4.1.9.1.46
+extends:
+  - base.yml
+`)
+	l, err := NewLoader(dir, silentLogger)
+	require.NoError(t, err)
+
+	child, err := l.Resolve("device.yml")
+	require.NoError(t, err)
+	assert.Empty(t, child.Matches, "a matches map is not inherited through extends")
+	assert.Empty(t, child.MatchesList, "matches_list is inherited the same way, which is not at all")
+
+	parent, err := l.Resolve("base.yml")
+	require.NoError(t, err)
+	assert.Equal(t, []Match{{Regex: "parent-regex", Target: "parent-target.yml"}}, parent.MatchesList,
+		"the declaring profile keeps its own ordered redirects")
+	assert.Equal(t, map[string]string{"parent-pattern": "parent-target.yml"}, parent.Matches)
+}
+
+// The order a file writes its ordered redirects in has to reach the resolved
+// profile, since that order is the whole reason the form exists.
+func TestResolve_MatchesListKeepsTheOrderTheFileDeclares(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, dir, "device.yml", `
+sysobjectid: 1.3.6.1.4.1.9.1.46
+matches_list:
+  - regex: "^first"
+    target: first.yml
+  - regex: "^second"
+    target: second.yml
+  - regex: "^third"
+    target: third.yml
+`)
+	l, err := NewLoader(dir, silentLogger)
+	require.NoError(t, err)
+
+	p, err := l.Resolve("device.yml")
+	require.NoError(t, err)
+	assert.Equal(t, []Match{
+		{Regex: "^first", Target: "first.yml"},
+		{Regex: "^second", Target: "second.yml"},
+		{Regex: "^third", Target: "third.yml"},
+	}, p.MatchesList)
+}

--- a/orb-telemetry/snmp-telemetry/profiles/matcher.go
+++ b/orb-telemetry/snmp-telemetry/profiles/matcher.go
@@ -14,8 +14,8 @@ type wildcardEntry struct {
 	profile *Profile
 }
 
-// matchRedirect is one compiled `matches` entry: a sysDescr pattern and the
-// profile it redirects to.
+// matchRedirect is one compiled redirect entry, from either `matches` or
+// `matches_list`: a sysDescr pattern and the profile it redirects to.
 type matchRedirect struct {
 	re   *regexp.Regexp
 	file string
@@ -25,8 +25,8 @@ type matchRedirect struct {
 type Matcher struct {
 	exactIndex    map[string]*Profile          // normalized OID -> profile (exact matches)
 	wildcardIndex []wildcardEntry              // sorted longest-prefix-first for wildcard matches
-	profileByFile map[string]*Profile          // filename -> profile (for matches redirects)
-	redirects     map[*Profile][]matchRedirect // profile -> compiled matches patterns, in evaluation order
+	profileByFile map[string]*Profile          // filename -> profile (for sysDescr redirects)
+	redirects     map[*Profile][]matchRedirect // profile -> compiled redirect patterns, in evaluation order
 }
 
 // keyClaims holds every profile claiming one index key, in the order the
@@ -82,9 +82,10 @@ func (c keyClaims) pick(keep func(*Profile) bool) *Profile {
 // stable order (Loader.AllResolved sorts them) so a tie between two profiles of
 // the same origin does not move between restarts.
 //
-// Each `matches` redirect is compiled and its destination looked up here, so a
-// pattern that cannot compile and one naming a file no profile carries are both
-// reported once rather than per poll. Neither fails the load: the bundled set
+// Each sysDescr redirect a profile declares, under either `matches_list` or
+// `matches`, is compiled and its destination looked up here, so a pattern that
+// cannot compile and one naming a file no profile carries are both reported
+// once rather than per poll. Neither fails the load: the bundled set
 // already ships an unresolvable one, and the operator-facing case is a typo in
 // an override, which should degrade rather than take the backend down at
 // startup.
@@ -138,12 +139,9 @@ func NewMatcher(profiles []*Profile, logger *slog.Logger) *Matcher {
 
 	m.redirects = make(map[*Profile][]matchRedirect)
 	for _, p := range profiles {
-		if len(p.Matches) == 0 {
-			continue
-		}
-		// Sort patterns for deterministic evaluation order.
 		var compiled []matchRedirect
-		for _, pattern := range slices.Sorted(maps.Keys(p.Matches)) {
+		for _, decl := range declaredRedirects(p) {
+			pattern, target := decl.pattern, decl.target
 			re, err := regexp.Compile("(?i)" + pattern)
 			if err != nil {
 				if logger != nil {
@@ -152,7 +150,6 @@ func NewMatcher(profiles []*Profile, logger *slog.Logger) *Matcher {
 				}
 				continue
 			}
-			target := p.Matches[pattern]
 			// A destination no loaded profile carries can never be reached, so
 			// a device the pattern describes silently keeps collecting this
 			// profile's symbols instead of the ones it was sent to. Reporting
@@ -173,6 +170,36 @@ func NewMatcher(profiles []*Profile, logger *slog.Logger) *Matcher {
 	}
 
 	return m
+}
+
+// redirectSource is one sysDescr redirect a profile declares, before its
+// pattern is compiled.
+type redirectSource struct {
+	pattern string
+	target  string
+}
+
+// declaredRedirects returns a profile's sysDescr redirects in the order they
+// are evaluated: every `matches_list` entry in the order the file writes it,
+// then the `matches` map by sorted pattern.
+//
+// The list comes first because it is the form that carries an order, and a
+// profile writes it precisely when more than one of its patterns can match one
+// sysDescr. Upstream evaluates it first for that reason, so a profile carrying
+// both forms resolves to the list's target either way.
+//
+// The map has no order of its own, so its patterns are sorted here rather than
+// ranged: ranging a map would settle a profile whose sysDescr satisfies two
+// patterns differently on each restart.
+func declaredRedirects(p *Profile) []redirectSource {
+	out := make([]redirectSource, 0, len(p.MatchesList)+len(p.Matches))
+	for _, entry := range p.MatchesList {
+		out = append(out, redirectSource{pattern: entry.Regex, target: entry.Target})
+	}
+	for _, pattern := range slices.Sorted(maps.Keys(p.Matches)) {
+		out = append(out, redirectSource{pattern: pattern, target: p.Matches[pattern]})
+	}
+	return out
 }
 
 // reportShadowed warns about keys a profile added under the override directory
@@ -218,7 +245,7 @@ func reportShadowed(claims map[string]keyClaims, logger *slog.Logger, kind strin
 
 // Match returns the best-matching profile for the given device sysObjectID.
 // Exact matches take priority over wildcard matches. Among wildcards, the longest prefix wins.
-// Use MatchWithDescr when sysDescr is also available to support matches-redirect profiles.
+// Use MatchWithDescr when sysDescr is also available to support redirect profiles.
 func (m *Matcher) Match(deviceSysOID string) (*Profile, bool) {
 	normalized := normalizeOID(deviceSysOID)
 
@@ -238,10 +265,11 @@ func (m *Matcher) Match(deviceSysOID string) (*Profile, bool) {
 }
 
 // MatchWithDescr returns the best-matching profile using both sysObjectID and sysDescr.
-// If the OID-matched profile has a matches section, the sysDescr is tested against each
-// pattern (case-insensitive, compiled once in NewMatcher) and the first matching
-// pattern's profile is returned instead. This mirrors how ktranslate handles devices
-// that share a sysOID but differ by description.
+// If the OID-matched profile declares sysDescr redirects, the sysDescr is tested against
+// each pattern (case-insensitive, compiled once in NewMatcher) in the order
+// declaredRedirects fixes, and the first matching pattern's profile is returned instead.
+// This mirrors how ktranslate handles devices that share a sysOID but differ by
+// description.
 func (m *Matcher) MatchWithDescr(deviceSysOID, sysDescr string) (*Profile, bool) {
 	profile, ok := m.Match(deviceSysOID)
 	if !ok {

--- a/orb-telemetry/snmp-telemetry/profiles/matcher.go
+++ b/orb-telemetry/snmp-telemetry/profiles/matcher.go
@@ -280,6 +280,18 @@ func (m *Matcher) MatchWithDescr(deviceSysOID, sysDescr string) (*Profile, bool)
 		return profile, true
 	}
 
+	// The winner is the first declared redirect whose pattern matches and whose
+	// target is loaded, not simply the first whose pattern matches. A matched
+	// entry naming a target no profile carries is passed over and the next
+	// entry is tried, which is what upstream ktranslate does: its checkMatch
+	// logs the missing target and continues the loop rather than returning.
+	//
+	// Passing over it is also the more useful of the two readings. The
+	// alternative, treating the first matched entry as decisive, would hand the
+	// device the declaring profile's generic symbols instead of a redirect the
+	// operator also declared and which resolves. The unresolved target is not
+	// lost either way: NewMatcher reports it once at load, naming the profile,
+	// the pattern and the file.
 	for _, r := range redirects {
 		if !r.re.MatchString(sysDescr) {
 			continue
@@ -289,7 +301,8 @@ func (m *Matcher) MatchWithDescr(deviceSysOID, sysDescr string) (*Profile, bool)
 		}
 	}
 
-	// No redirect matched; use original profile.
+	// No redirect matched, or every matched one named a target that is not
+	// loaded, so the declaring profile serves.
 	return profile, true
 }
 

--- a/orb-telemetry/snmp-telemetry/profiles/matcher_test.go
+++ b/orb-telemetry/snmp-telemetry/profiles/matcher_test.go
@@ -3,6 +3,8 @@ package profiles
 import (
 	"bytes"
 	"log/slog"
+	"maps"
+	"slices"
 	"strings"
 	"testing"
 
@@ -543,5 +545,197 @@ func TestNewMatcher_BundledUnresolvableRedirectsAreReported(t *testing.T) {
 			}
 		}
 		assert.True(t, matched, "no report names %s -> %s in %s", r.pattern, r.target, r.relPath)
+	}
+}
+
+// The ordered form exists because Go map iteration is unordered, so the order
+// a profile writes its entries in is the whole point of it. Both entries here
+// match the sysDescr and the declaration order alone decides the verdict.
+func TestMatchWithDescr_MatchesListEvaluatedInDeclaredOrder(t *testing.T) {
+	first := &Profile{FileName: "first.yml"}
+	second := &Profile{FileName: "second.yml"}
+
+	forward := &Profile{
+		FileName:    "forward.yml",
+		SysObjectID: StringOrSlice{"1.3.6.1.4.1.9.*"},
+		MatchesList: []Match{
+			{Regex: "storage", Target: "first.yml"},
+			{Regex: "array", Target: "second.yml"},
+		},
+	}
+	m := NewMatcher([]*Profile{forward, first, second}, silentLogger)
+
+	got, ok := m.MatchWithDescr("1.3.6.1.4.1.9.1.46", "storage array controller")
+	require.True(t, ok)
+	assert.Equal(t, first, got, "the first declared entry that matches wins")
+
+	// The same two entries written the other way round must answer the other
+	// way round. Nothing but the declaration order differs.
+	reversed := &Profile{
+		FileName:    "reversed.yml",
+		SysObjectID: StringOrSlice{"1.3.6.1.4.1.10.*"},
+		MatchesList: []Match{
+			{Regex: "array", Target: "second.yml"},
+			{Regex: "storage", Target: "first.yml"},
+		},
+	}
+	m2 := NewMatcher([]*Profile{reversed, first, second}, silentLogger)
+
+	got2, ok := m2.MatchWithDescr("1.3.6.1.4.1.10.1.46", "storage array controller")
+	require.True(t, ok)
+	assert.Equal(t, second, got2, "reversing the declaration reverses the verdict")
+}
+
+// Upstream evaluates the ordered list before the map, and the map is the form
+// with no order at all, so a profile carrying both resolves to the list.
+func TestMatchWithDescr_EveryMatchesListEntryIsTriedBeforeTheMap(t *testing.T) {
+	ordered := &Profile{FileName: "ordered.yml"}
+	mapped := &Profile{FileName: "mapped.yml"}
+	base := &Profile{
+		FileName:    "base.yml",
+		SysObjectID: StringOrSlice{"1.3.6.1.4.1.9.*"},
+		// The map pattern sorts ahead of both list patterns, so an
+		// implementation that merged the two forms and sorted the result would
+		// answer with the map's target.
+		Matches: map[string]string{"^access": "mapped.yml"},
+		MatchesList: []Match{
+			{Regex: "never-present", Target: "ordered.yml"},
+			{Regex: "switch", Target: "ordered.yml"},
+		},
+	}
+	m := NewMatcher([]*Profile{base, ordered, mapped}, silentLogger)
+
+	got, ok := m.MatchWithDescr("1.3.6.1.4.1.9.1.46", "access switch")
+	require.True(t, ok)
+	assert.Equal(t, ordered, got, "every matches_list entry is tried before any matches entry")
+}
+
+// The ordered form must be case insensitive in the same way the map form is,
+// which TestMatchWithDescr_CaseInsensitiveBothDirections pins for the map.
+func TestMatchWithDescr_MatchesListCaseInsensitiveBothDirections(t *testing.T) {
+	target := &Profile{FileName: "switch.yml"}
+
+	base := &Profile{
+		FileName:    "base.yml",
+		SysObjectID: StringOrSlice{"1.3.6.1.4.1.9.*"},
+		MatchesList: []Match{{Regex: "Switch", Target: "switch.yml"}},
+	}
+	m := NewMatcher([]*Profile{base, target}, silentLogger)
+
+	got, ok := m.MatchWithDescr("1.3.6.1.4.1.9.1.46", "access switch 24p")
+	require.True(t, ok)
+	assert.Equal(t, target, got, "an uppercase pattern must match a lowercase subject")
+
+	base2 := &Profile{
+		FileName:    "base2.yml",
+		SysObjectID: StringOrSlice{"1.3.6.1.4.1.10.*"},
+		MatchesList: []Match{{Regex: "switch", Target: "switch.yml"}},
+	}
+	m2 := NewMatcher([]*Profile{base2, target}, silentLogger)
+
+	got2, ok := m2.MatchWithDescr("1.3.6.1.4.1.10.1.46", "ACCESS SWITCH 24P")
+	require.True(t, ok)
+	assert.Equal(t, target, got2, "a lowercase pattern must match an uppercase subject")
+}
+
+// A `matches_list` regex that cannot compile is handled exactly as a malformed
+// `matches` pattern is: reported once at construction and skipped, leaving the
+// entries after it in force.
+func TestNewMatcher_MatchesListMalformedPatternSkipped(t *testing.T) {
+	target := &Profile{FileName: "switch.yml"}
+	base := &Profile{
+		FileName:    "base.yml",
+		RelPath:     "override/base.yml",
+		SysObjectID: StringOrSlice{"1.3.6.1.4.1.9.*"},
+		MatchesList: []Match{
+			{Regex: "(unclosed", Target: "switch.yml"},
+			{Regex: "switch", Target: "switch.yml"},
+		},
+	}
+
+	logger, buf := captureLogger()
+	m := NewMatcher([]*Profile{base, target}, logger)
+
+	out := buf.String()
+	assert.Contains(t, out, "override/base.yml")
+	assert.Contains(t, out, "(unclosed")
+	assert.Equal(t, 1, strings.Count(out, "\n"), "the malformed pattern must be reported exactly once")
+
+	got, ok := m.MatchWithDescr("1.3.6.1.4.1.9.1.46", "access switch 24p")
+	require.True(t, ok)
+	assert.Equal(t, target, got, "the entries after a malformed one must still be evaluated")
+}
+
+// Both forms feed one redirect machinery, so a `matches_list` target no loaded
+// profile carries reaches the same report a `matches` target does.
+func TestNewMatcher_MatchesListUnresolvableRedirectReported(t *testing.T) {
+	base := &Profile{
+		FileName:    "base.yml",
+		RelPath:     "vendor/base.yml",
+		SysObjectID: StringOrSlice{"1.3.6.1.4.1.9.*"},
+		MatchesList: []Match{{Regex: "^single phase", Target: "vendor-ups.yml"}},
+	}
+
+	logger, buf := captureLogger()
+	m := NewMatcher([]*Profile{base}, logger)
+
+	lines := warnLinesMentioning(buf.String(), unresolvableRedirectMsg)
+	require.Len(t, lines, 1, "an unresolvable matches_list redirect must be reported exactly once")
+	assert.Contains(t, lines[0], "vendor/base.yml", "the report must name the profile that declares the redirect")
+	assert.Contains(t, lines[0], "^single phase", "the report must name the pattern")
+	assert.Contains(t, lines[0], "vendor-ups.yml", "the report must name the file it cannot find")
+
+	got, ok := m.MatchWithDescr("1.3.6.1.4.1.9.1.46", "Single Phase 1Gb UPS")
+	require.True(t, ok)
+	assert.Equal(t, base, got, "an unresolvable redirect still returns the original profile")
+}
+
+// The two bundled profiles that mention the key both write an empty list. An
+// empty one must register no redirect at all, so such a profile answers
+// exactly as it did while the field was being dropped.
+func TestNewMatcher_EmptyMatchesListIsANoOp(t *testing.T) {
+	base := &Profile{
+		FileName:    "base.yml",
+		SysObjectID: StringOrSlice{"1.3.6.1.4.1.9.*"},
+		MatchesList: []Match{},
+	}
+	m := NewMatcher([]*Profile{base}, silentLogger)
+	assert.Empty(t, m.redirects, "an empty matches_list registers no redirect")
+
+	got, ok := m.MatchWithDescr("1.3.6.1.4.1.9.1.46", "anything at all")
+	require.True(t, ok)
+	assert.Equal(t, base, got)
+}
+
+// Reading a key the decode used to drop must not move a single bundled
+// verdict. The tree writes `matches_list` in two files and writes an empty
+// list in both, and redirect behaviour is decided entirely by
+// declaredRedirects, so showing that still equals each profile's `matches` map
+// alone shows nothing bundled changed.
+func TestNewMatcher_BundledMatchesListMovesNoVerdict(t *testing.T) {
+	l, err := LoadProfiles("", silentLogger)
+	require.NoError(t, err)
+	all, err := l.AllResolved()
+	require.NoError(t, err)
+
+	byPath := make(map[string]*Profile, len(all))
+	for _, p := range all {
+		byPath[p.RelPath] = p
+		assert.Empty(t, p.MatchesList, "%s declares a matches_list entry", p.RelPath)
+
+		want := make([]redirectSource, 0, len(p.Matches))
+		for _, pattern := range slices.Sorted(maps.Keys(p.Matches)) {
+			want = append(want, redirectSource{pattern: pattern, target: p.Matches[pattern]})
+		}
+		assert.Equal(t, want, declaredRedirects(p),
+			"%s must evaluate exactly the redirects its matches map declares", p.RelPath)
+	}
+
+	// The empty lists are read rather than skipped, so the no-op above is the
+	// field being handled and not the field being absent.
+	for _, rel := range []string{"nutanix/nutanix.yml", "vmware/vmware-nsx.yml"} {
+		p := byPath[rel]
+		require.NotNil(t, p, "%s must be loaded", rel)
+		assert.NotNil(t, p.MatchesList, "the empty list in %s must be read, not dropped", rel)
 	}
 }

--- a/orb-telemetry/snmp-telemetry/profiles/matcher_test.go
+++ b/orb-telemetry/snmp-telemetry/profiles/matcher_test.go
@@ -739,3 +739,46 @@ func TestNewMatcher_BundledMatchesListMovesNoVerdict(t *testing.T) {
 		assert.NotNil(t, p.MatchesList, "the empty list in %s must be read, not dropped", rel)
 	}
 }
+
+// A matched entry whose target is not loaded is passed over and the next entry
+// is tried, so the winner is the first declared redirect that matches and
+// resolves rather than simply the first that matches. This mirrors upstream
+// ktranslate, whose checkMatch logs the missing target and continues its loop.
+//
+// Verified against a real device: polling the orb-test-lab C2960X simulator
+// with a profile whose first list entry named an absent file served the second
+// entry's profile, and the absent target was reported once at load.
+func TestMatchWithDescr_AnUnresolvableListEntryDoesNotStopLaterEntries(t *testing.T) {
+	resolvable := &Profile{FileName: "resolvable.yml"}
+	declaring := &Profile{
+		FileName:    "declaring.yml",
+		SysObjectID: StringOrSlice{"1.3.6.1.4.1.9.*"},
+		MatchesList: []Match{
+			{Regex: "storage", Target: "absent.yml"},
+			{Regex: "array", Target: "resolvable.yml"},
+		},
+	}
+	m := NewMatcher([]*Profile{declaring, resolvable}, silentLogger)
+
+	got, ok := m.MatchWithDescr("1.3.6.1.4.1.9.1.46", "storage array controller")
+	require.True(t, ok)
+	assert.Equal(t, resolvable, got,
+		"an entry naming a target no profile carries is passed over, not treated as decisive")
+}
+
+// The same rule spans the two forms: a list entry that matches but cannot be
+// resolved does not stop the map from being tried.
+func TestMatchWithDescr_AnUnresolvableListEntryDoesNotStopTheMap(t *testing.T) {
+	viaMap := &Profile{FileName: "via-map.yml"}
+	declaring := &Profile{
+		FileName:    "declaring.yml",
+		SysObjectID: StringOrSlice{"1.3.6.1.4.1.9.*"},
+		MatchesList: []Match{{Regex: "storage", Target: "absent.yml"}},
+		Matches:     map[string]string{"array": "via-map.yml"},
+	}
+	m := NewMatcher([]*Profile{declaring, viaMap}, silentLogger)
+
+	got, ok := m.MatchWithDescr("1.3.6.1.4.1.9.1.46", "storage array controller")
+	require.True(t, ok)
+	assert.Equal(t, viaMap, got, "an unresolvable list entry does not consume the device's verdict")
+}

--- a/orb-telemetry/snmp-telemetry/profiles/profile.go
+++ b/orb-telemetry/snmp-telemetry/profiles/profile.go
@@ -43,6 +43,14 @@ const (
 	OriginOverride Origin = "override"
 )
 
+// Match is one entry of the ordered `matches_list` form of a sysDescr
+// redirect: the pattern to test a device's sysDescr against, and the basename
+// of the profile a device it describes is collected with instead.
+type Match struct {
+	Regex  string `yaml:"regex"`
+	Target string `yaml:"target"`
+}
+
 // Profile is the top-level representation of a ktranslate-compatible SNMP profile file.
 type Profile struct {
 	// FileName is the base filename, populated by the Loader (not from YAML).
@@ -62,6 +70,13 @@ type Profile struct {
 	Provider    string            `yaml:"provider"`
 	SysObjectID StringOrSlice     `yaml:"sysobjectid"`
 	Matches     map[string]string `yaml:"matches"`
+	// MatchesList is the ordered spelling of the same sysDescr redirect
+	// Matches carries. It is not an alias: a map has no order, so a profile
+	// whose sysDescr satisfies two of its patterns has no stable answer under
+	// Matches alone, and this form is what a profile in that position is meant
+	// to use. Its entries are evaluated in the order written, and all of them
+	// before any Matches entry.
+	MatchesList []Match `yaml:"matches_list"`
 	// NoUseBulkWalkAll marks an agent that answers GETBULK badly or not at all.
 	// A profile that sets it is walked with GETNEXT, one request per value.
 	NoUseBulkWalkAll bool `yaml:"no_use_bulkwalkall"`

--- a/orb-telemetry/snmp-telemetry/profiles/profile_test.go
+++ b/orb-telemetry/snmp-telemetry/profiles/profile_test.go
@@ -665,3 +665,32 @@ func TestSymbol_MetricName(t *testing.T) {
 	assert.Equal(t, "snmp.cpu", (&Symbol{Name: "hostLoad", Tag: "cpu"}).MetricName(),
 		"two export names differing only in case are one metric name")
 }
+
+// `matches_list` is the ordered spelling of a sysDescr redirect. Its entries
+// carry the pattern under `regex` and the destination under `target`, and the
+// order the file writes them in has to survive the decode.
+func TestProfile_MatchesListDecodesInDeclaredOrder(t *testing.T) {
+	var p Profile
+	require.NoError(t, yaml.Unmarshal([]byte(`
+matches_list:
+  - regex: "^first"
+    target: first.yml
+  - regex: "^second"
+    target: second.yml
+`), &p))
+
+	assert.Equal(t, []Match{
+		{Regex: "^first", Target: "first.yml"},
+		{Regex: "^second", Target: "second.yml"},
+	}, p.MatchesList)
+}
+
+// Two bundled profiles write the key with an empty sequence. That has to
+// decode to a list carrying nothing rather than to an error or an entry.
+func TestProfile_EmptyMatchesListDecodesToNoEntries(t *testing.T) {
+	var p Profile
+	require.NoError(t, yaml.Unmarshal([]byte("matches_list: []\n"), &p))
+
+	assert.NotNil(t, p.MatchesList, "the key is present, so the list is read")
+	assert.Empty(t, p.MatchesList, "and it carries no entry")
+}


### PR DESCRIPTION
Closes MON-345.

A profile can express a sysDescr redirect in two forms. This backend supported the unordered `matches` map and silently ignored the ordered `matches_list`: the key was dropped by the permissive decode, no redirect was registered, and nothing was reported. The profile looked like it loaded correctly while the device was collected with the wrong symbols.

`matches_list` is not a deprecated alias. Upstream evaluates it **before** the map, and it exists because Go map iteration is unordered, which makes `matches` unpredictable when more than one pattern can match a sysDescr. The ordered form is what upstream steers people toward for exactly that case, so an operator writing a profile against upstream's documentation reaches for it precisely when order matters.

## What changed

`Profile` gains `MatchesList []Match` with `Match{Regex, Target}`, matching upstream's schema.

The evaluation order now lives in one function, `declaredRedirects`: every `matches_list` entry in file order, then the `matches` map by sorted pattern. `NewMatcher` ranges that instead of the map, so both forms feed the single existing redirect machinery, including the case-insensitive compile, the skip-and-warn on an uncompilable pattern, and the unresolvable-target report added in `dbf37a53`. There is no second reporting path.

## Redirects are not inherited, and now consistently so

Worth stating because it was checked rather than assumed. `matches` is not inherited through `extends` today: `resolvePath` copies it from the file being resolved, and the merge loop carries only `Metrics`, `MetricTags` and `NoUseBulkWalkAll`. That mirrors upstream, whose merge leaves both redirect forms behind.

`matches_list` follows the same rule. That also sidesteps how a parent's ordered list and a child's would interleave, which has no defensible answer. Pinned by a test asserting the child inherits neither form while the parent keeps both of its own.

## The bundled set is unaffected

Two bundled profiles already name the key, `nutanix/nutanix.yml` and `vmware/vmware-nsx.yml`, both writing `matches_list: []`. They stop being ignored the moment the field exists, so this is verified rather than assumed: a test loads the real embedded set and asserts that for every resolved profile `MatchesList` is empty and `declaredRedirects` equals exactly the sorted `matches` map. Since redirect behaviour is entirely determined by that function, no bundled verdict can have moved. The same test asserts both files decode to a present, empty list, so the empty lists are genuinely read rather than the field being absent.

Nothing under `profiles/snmp-profiles/` changed.

## Tests

Eleven added, covering declared order (including the same two entries reversed, giving the other verdict), every list entry being tried before any map entry, case-insensitivity in both directions, a malformed regex reported once with later entries still evaluated, an unresolvable list target reaching the existing report while still serving the declaring profile, an empty list as a no-op, non-inheritance through `extends`, and decode order.

The map-before-list test uses a map pattern that deliberately sorts ahead of both list patterns, so an implementation that merged and sorted the two forms together would fail it.

## Verification

Every assertion was mutation tested. The two that matter, since ordering is the whole point of the feature, are reversing the `matches_list` iteration and evaluating the map first; each is caught by exactly one dedicated test.

The pre-existing `NewMatcher` and `MatchWithDescr` suite was re-checked with mutants rather than by reading, since a test quietly ceasing to guard its subject has happened three times in this module's recent history. Removing the map path fails eleven of them, so they still guard what they claim.

Gates: build, vet, `-race`, `make lint` at 0 issues, and the root and `orb-discovery/snmp-discovery` modules still build.