### PR TITLE
fix(snmp-telemetry): keep a device whose run was cut short by its own deadline

### DIFF
--- a/orb-telemetry/snmp-telemetry/cmd/main.go
+++ b/orb-telemetry/snmp-telemetry/cmd/main.go
@@ -44,12 +44,14 @@ type stopper interface {
 //
 // The flush comes first, before anything has been cancelled. Every runner
 // context derives from the root one, so cancelling it makes an in-flight
-// collection return a context error, and a collection that returns an error has
-// its device forgotten: the observations it had stored are deleted. A flush
-// placed after that cancellation races the deletion for exactly the readings it
-// is there to export, and a deletion that wins empties the final export.
-// Exporting first settles the race, since the store the flush reads still holds
-// every device.
+// collection return a context error, and a collection whose run was cut short
+// that way keeps its device only for a bounded number of consecutive
+// interruptions before the observations it had stored are deleted. A flush
+// placed after the cancellation therefore races that deletion for exactly the
+// readings it is there to export, on any device already interrupted on the
+// preceding cycles, and a deletion that wins empties the final export for it.
+// Exporting first settles the race for every device rather than for most of
+// them, since the store the flush reads still holds them all.
 //
 // The cancellation then comes before the server stop, which is what lets
 // srv.Stop return: stopping the server first would wait on collections that

--- a/orb-telemetry/snmp-telemetry/collector/collector.go
+++ b/orb-telemetry/snmp-telemetry/collector/collector.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"maps"
 	"math"
 	"net"
 	"regexp"
@@ -370,8 +371,9 @@ func (c *MetricsCollector) pollDue(key deviceKey, sym *profiles.Symbol) bool {
 // answered with: a device that does not implement an OID has still been asked,
 // and re-asking it every cycle is what the poll window is there to prevent.
 // A device forgotten after a failed run loses these timestamps with the rest of
-// its state, so the two rules agree that nothing throttles what was not
-// collected.
+// its state, and a run that ends before publishing its store has the timestamps
+// it wrote put back as they were by restorePollWindows, so every rule agrees
+// that nothing throttles a reading no series carries.
 func (c *MetricsCollector) markPolled(key deviceKey, sym *profiles.Symbol) {
 	if sym.PollTimeSec <= 0 || pollPeriodPastBound(sym) {
 		// A refused period leaves no window to start, so writing a timestamp
@@ -384,6 +386,37 @@ func (c *MetricsCollector) markPolled(key deviceKey, sym *profiles.Symbol) {
 		c.pollState[key] = make(map[string]time.Time)
 	}
 	c.pollState[key][symbolDeclKey(sym)] = time.Now()
+}
+
+// snapshotPollWindows copies a device's poll windows as they stand. The copy is
+// what makes it a snapshot: markPolled writes into the device's own map, so
+// keeping the map itself would follow this run's writes rather than record what
+// preceded them.
+func (c *MetricsCollector) snapshotPollWindows(key deviceKey) map[string]time.Time {
+	c.pollMu.Lock()
+	defer c.pollMu.Unlock()
+	return maps.Clone(c.pollState[key])
+}
+
+// restorePollWindows puts a device's poll windows back the way
+// snapshotPollWindows found them, undoing every window the run since started.
+//
+// A run restores them when it returns without publishing its store, so a
+// declaration is never throttled against a reading nothing can read. Restoring
+// rather than deleting the entries the run wrote: a declaration this run marked
+// was reported due, so its previous timestamp had expired, and putting the
+// expired timestamp back throttles exactly as little as dropping the entry
+// would. It also needs nothing threaded through the collection paths.
+func (c *MetricsCollector) restorePollWindows(key deviceKey, windows map[string]time.Time) {
+	c.pollMu.Lock()
+	defer c.pollMu.Unlock()
+	if windows == nil {
+		// A device with no windows at all holds no entry rather than an empty
+		// one, which is the shape forgetDevice leaves too.
+		delete(c.pollState, key)
+		return
+	}
+	c.pollState[key] = windows
 }
 
 // ensureInstrument lazily registers an observable gauge callback for metricName.
@@ -718,6 +751,30 @@ func (c *MetricsCollector) collect(ctx context.Context, key deviceKey, target co
 	c.noteProfile(key, profileID(profile))
 	c.reviewProfile(profile)
 
+	// The poll windows as they stand before this run walks any of the profile's
+	// metrics, and a restore on every way out that does not publish the store.
+	//
+	// The two are written at different times: markPolled starts a declaration's
+	// window the moment its walk comes back, while the store is written once, at
+	// the end. A run that returns in between has therefore throttled
+	// declarations whose readings nothing published, and each one is skipped
+	// until poll_time_sec elapses while its series carries the run before it, or
+	// nothing at all. The windows that existed before the run are kept, since
+	// those belong to readings that were published: that is what makes the cycle
+	// after an interruption a cheap one.
+	//
+	// Taken here rather than at the top of collect: noteProfile drops the
+	// windows of a profile no longer matched, and a restore of a snapshot taken
+	// before it would put that dropped profile's windows back. Nothing past this
+	// point drops them, so a restore has no other decision to undo.
+	prevWindows := c.snapshotPollWindows(key)
+	storePublished := false
+	defer func() {
+		if !storePublished {
+			c.restorePollWindows(key, prevWindows)
+		}
+	}()
+
 	// Everything from here walks the profile's tables, which is where the round
 	// trips are. The two walks above chose the profile, so this is the first
 	// point at which the device's tolerance for GETBULK is known.
@@ -823,6 +880,7 @@ func (c *MetricsCollector) collect(ctx context.Context, key deviceKey, target co
 	emptyRun := len(newStore) == 0
 	if !emptyRun || failed == 0 {
 		c.deviceStore[key] = newStore
+		storePublished = true
 	}
 	c.storeMu.Unlock()
 

--- a/orb-telemetry/snmp-telemetry/collector/collector.go
+++ b/orb-telemetry/snmp-telemetry/collector/collector.go
@@ -288,6 +288,15 @@ type MetricsCollector struct {
 	profileMu     sync.Mutex
 	deviceProfile map[deviceKey]string // device -> profileID
 
+	// Consecutive runs cut short by their own context, per device. A mutex of
+	// its own rather than storeMu: forgetDevice takes storeMu and CollectTarget
+	// decides whether to call it from this count, so sharing the lock would
+	// have the decision hold what forgetDevice goes on to take. It is not
+	// pollMu's either, since a collection reads a poll window per declaration
+	// and this is read once a run.
+	interruptMu     sync.Mutex
+	interruptedRuns map[deviceKey]int // device -> consecutive interrupted runs
+
 	// Observable gauge store: device -> metricName -> observations.
 	// Updated after each CollectTarget run; read by OTLP callbacks on every export cycle.
 	storeMu     sync.RWMutex
@@ -314,6 +323,7 @@ func NewMetricsCollector(clientFactory snmp.ClientFactory, matcher *profiles.Mat
 		logger:           logger,
 		pollState:        make(map[deviceKey]map[string]time.Time),
 		deviceProfile:    make(map[deviceKey]string),
+		interruptedRuns:  make(map[deviceKey]int),
 		deviceStore:      make(map[deviceKey]map[string][]observedPoint),
 		instruments:      make(map[string]metric.Int64ObservableGauge),
 		reviewedProfiles: make(map[string]struct{}),
@@ -456,6 +466,10 @@ func (c *MetricsCollector) Close() {
 	c.deviceProfile = make(map[deviceKey]string)
 	c.profileMu.Unlock()
 
+	c.interruptMu.Lock()
+	c.interruptedRuns = make(map[deviceKey]int)
+	c.interruptMu.Unlock()
+
 	c.reviewMu.Lock()
 	c.reviewedProfiles = make(map[string]struct{})
 	c.reviewMu.Unlock()
@@ -488,6 +502,14 @@ func (c *MetricsCollector) ForgetPolicy(policyName string) {
 		}
 	}
 	c.profileMu.Unlock()
+
+	c.interruptMu.Lock()
+	for key := range c.interruptedRuns {
+		if key.policy == policyName {
+			delete(c.interruptedRuns, key)
+		}
+	}
+	c.interruptMu.Unlock()
 }
 
 // profileID names a matched profile. The relative path tells apart two profiles
@@ -526,6 +548,10 @@ func (c *MetricsCollector) noteProfile(key deviceKey, id string) {
 // so staleness is visible as an absent series. Clearing the poll timestamps too
 // means the next successful run repopulates every metric instead of throttling
 // some of them against a window that has nothing left to carry forward.
+//
+// The interrupted-run count goes with them: it counts interruptions of the
+// state being dropped here, so a device starting again from nothing starts the
+// count from nothing too.
 func (c *MetricsCollector) forgetDevice(key deviceKey) {
 	c.storeMu.Lock()
 	delete(c.deviceStore, key)
@@ -534,6 +560,10 @@ func (c *MetricsCollector) forgetDevice(key deviceKey) {
 	c.pollMu.Lock()
 	delete(c.pollState, key)
 	c.pollMu.Unlock()
+
+	c.interruptMu.Lock()
+	delete(c.interruptedRuns, key)
+	c.interruptMu.Unlock()
 }
 
 // appendIdentityAttrs renders every dimension of a device key as an attribute.
@@ -592,19 +622,61 @@ func reservedTagName(name string) bool {
 	return reserved
 }
 
+// maxInterruptedRuns bounds how many consecutive runs cut short by their own
+// context a device keeps its state through. Reaching it forgets the device, so
+// its readings are at most this many metrics_interval old.
+//
+// A constant rather than a policy field: it is a safety bound on staleness
+// rather than a knob, and three cycles is short enough that a device whose runs
+// keep overrunning still disappears within a few of them.
+const maxInterruptedRuns = 3
+
 // CollectTarget collects SNMP metrics from a single target using its matched profile.
 // Returns nil if the device has no matching profile (not an error condition).
-// A run that fails leaves nothing behind for the device it was polling.
+// A run that the device failed leaves nothing behind for the device it was
+// polling; a run the collector cut short keeps what the device left, up to
+// maxInterruptedRuns cycles running.
 func (c *MetricsCollector) CollectTarget(ctx context.Context, target config.Target, auth *config.Authentication, policyName string, dial DialOptions) error {
 	key := deviceKey{policy: policyName, host: target.Host, port: target.Port, id: target.ID}
 	if auth != nil {
 		key.context = auth.ContextName
 	}
-	if err := c.collect(ctx, key, target, auth, dial); err != nil {
-		c.forgetDevice(key)
+	err := c.collect(ctx, key, target, auth, dial)
+	if err == nil {
+		c.clearInterruptedRuns(key)
+		return nil
+	}
+	// The context decides, not the error. collect's early returns wrap the
+	// deadline out of existence: creating the client, connecting and getting
+	// sysObjectID all carry neither context.Canceled nor DeadlineExceeded even
+	// when the context is what killed them, so inspecting the error would read
+	// a run the collector ended as a device that failed. A live context here
+	// means the device failed, and the device's series goes empty so the
+	// absence is visible; a done one means the run overran its own deadline,
+	// which is evidence about us and no reason to discard the device.
+	if ctx.Err() != nil && c.noteInterruptedRun(key) < maxInterruptedRuns {
 		return err
 	}
-	return nil
+	c.forgetDevice(key)
+	return err
+}
+
+// noteInterruptedRun counts one more consecutive interrupted run for the device
+// and returns the new total.
+func (c *MetricsCollector) noteInterruptedRun(key deviceKey) int {
+	c.interruptMu.Lock()
+	defer c.interruptMu.Unlock()
+	c.interruptedRuns[key]++
+	return c.interruptedRuns[key]
+}
+
+// clearInterruptedRuns ends a run of consecutive interruptions. A run that
+// completed spends nothing of the bound, so an occasional overrun costs the
+// device nothing while a persistent one still drops it within a few cycles.
+func (c *MetricsCollector) clearInterruptedRuns(key deviceKey) {
+	c.interruptMu.Lock()
+	defer c.interruptMu.Unlock()
+	delete(c.interruptedRuns, key)
 }
 
 func (c *MetricsCollector) collect(ctx context.Context, key deviceKey, target config.Target, auth *config.Authentication, dial DialOptions) error {

--- a/orb-telemetry/snmp-telemetry/collector/collector.go
+++ b/orb-telemetry/snmp-telemetry/collector/collector.go
@@ -656,19 +656,33 @@ func reservedTagName(name string) bool {
 }
 
 // maxInterruptedRuns bounds how many consecutive runs cut short by their own
-// context a device keeps its state through. Reaching it forgets the device, so
-// its readings are at most this many metrics_interval old.
+// context a device keeps its state through. Reaching it forgets the device.
 //
-// A constant rather than a policy field: it is a safety bound on staleness
-// rather than a knob, and three cycles is short enough that a device whose runs
-// keep overrunning still disappears within a few of them.
+// The bound counts attempts, not elapsed time, and the two are not
+// interchangeable here. A run's deadline is the whole metrics_interval, so an
+// interrupted run occupies its entire cycle, and the scheduler runs each target
+// under gocron.LimitModeReschedule, which drops a tick that arrives while the
+// previous run is still going rather than queueing it. Consecutive interrupted
+// attempts are therefore spaced further apart than one interval, and a reading
+// can outlive this many intervals of wall clock. Anything needing a real
+// maximum age would have to measure time rather than count attempts.
+//
+// Counting attempts is what this bound is for. The failure it exists to break
+// is a feedback loop, where forgetting a device clears its poll windows and
+// makes the next cycle the most expensive one the profile can produce, which
+// makes the next overrun likelier. That loop advances per attempt, so attempts
+// are the unit that matches it.
+//
+// A constant rather than a policy field: it is a safety bound rather than a
+// knob, and three attempts is few enough that a device whose runs keep
+// overrunning still disappears rather than exporting a stale reading forever.
 const maxInterruptedRuns = 3
 
 // CollectTarget collects SNMP metrics from a single target using its matched profile.
 // Returns nil if the device has no matching profile (not an error condition).
 // A run that the device failed leaves nothing behind for the device it was
-// polling; a run the collector cut short keeps what the device left, up to
-// maxInterruptedRuns cycles running.
+// polling; a run the collector cut short keeps what the device left, for up to
+// maxInterruptedRuns consecutive such runs.
 func (c *MetricsCollector) CollectTarget(ctx context.Context, target config.Target, auth *config.Authentication, policyName string, dial DialOptions) error {
 	key := deviceKey{policy: policyName, host: target.Host, port: target.Port, id: target.ID}
 	if auth != nil {

--- a/orb-telemetry/snmp-telemetry/collector/collector_test.go
+++ b/orb-telemetry/snmp-telemetry/collector/collector_test.go
@@ -1533,6 +1533,197 @@ func TestForgetPolicyAndClose_DropTheMatchedProfiles(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Interrupted runs
+// ---------------------------------------------------------------------------
+
+// A run cut short by its own context is evidence about the collector rather
+// than about the device: nothing bounds a run below the metrics interval, since
+// snmp_timeout and the retry ceiling are per request, so a profile with enough
+// OIDs overruns on wall clock while every request stays inside its own timeout.
+// Forgetting the device there discards the poll windows that make the next
+// cycle cheap, so the cycle after an overrun is the most expensive one the
+// profile can produce and the device can settle into exporting nothing.
+const (
+	interruptHost    = "10.0.0.130"
+	interruptSysObj  = "1.3.6.1.4.1.9999.130"
+	interruptSlow    = "1.3.6.1.4.1.9999.130.1"
+	interruptFast    = "1.3.6.1.4.1.9999.130.2"
+	interruptSysObjB = "1.3.6.1.4.1.9999.131"
+)
+
+// interruptionProfile declares one throttled metric and one polled every cycle.
+// The throttled one is what shows whether an interrupted run kept the device's
+// poll windows: a window that survived leaves it unwalked on the next cycle.
+func interruptionProfile(sysObj, filename string) *profiles.Profile {
+	return profileWithOID(sysObj, filename, []profiles.MetricEntry{
+		{Symbol: &profiles.Symbol{Name: "slowMetric", OID: interruptSlow, PollTimeSec: 300}},
+		{Symbol: &profiles.Symbol{Name: "fastMetric", OID: interruptFast}},
+	})
+}
+
+func interruptionWalker(sysObj string) *recordingWalker {
+	return &recordingWalker{responses: map[string]map[string]snmp.PDU{
+		sysObjectIDOID: {sysObjectIDOID: oIDPDU(sysObj)},
+		sysDescrOID:    {},
+		interruptSlow:  {interruptSlow: intPDU(interruptSlow, 7)},
+		interruptFast:  {interruptFast: intPDU(interruptFast, 1)},
+	}}
+}
+
+// runCollection performs one complete run and returns the walker it used, so a
+// caller can see which declarations were polled.
+func runCollection(t *testing.T, c *MetricsCollector, policy, sysObj string) *recordingWalker {
+	t.Helper()
+	w := interruptionWalker(sysObj)
+	c.clientFactory = walkerFactory(w)
+	require.NoError(t, c.CollectTarget(context.Background(), mustTarget(interruptHost), mustAuth(), policy, DialOptions{}))
+	return w
+}
+
+// runInterrupted performs one run cut short by its own context, the way a run
+// that overruns its metrics_interval is. The cancellation lands on the first
+// walk, which is late enough for the profile to be matched and early enough
+// that no metric is collected, so the run leaves the store untouched.
+func runInterrupted(t *testing.T, c *MetricsCollector, policy, sysObj string) {
+	t.Helper()
+	w := interruptionWalker(sysObj)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.onWalk = func(string) { cancel() }
+	c.clientFactory = walkerFactory(w)
+	require.ErrorIs(t, c.CollectTarget(ctx, mustTarget(interruptHost), mustAuth(), policy, DialOptions{}),
+		context.Canceled)
+}
+
+// interruptionCount reads a device's consecutive-interruption count and whether
+// it is recorded at all, which is what tells a cleared counter from a zero one.
+func interruptionCount(c *MetricsCollector, policy string) (int, bool) {
+	c.interruptMu.Lock()
+	defer c.interruptMu.Unlock()
+	n, ok := c.interruptedRuns[testKey(policy, interruptHost)]
+	return n, ok
+}
+
+func TestCollectTarget_AnInterruptedRunKeepsTheReadingsAndThePollWindows(t *testing.T) {
+	c := newCollector(nil, interruptionProfile(interruptSysObj, "interrupted.yml"))
+	runCollection(t, c, "p", interruptSysObj)
+	require.Len(t, c.testDeviceStore("p", interruptHost)["snmp.slowmetric"], 1)
+
+	runInterrupted(t, c, "p", interruptSysObj)
+
+	assert.Len(t, c.testDeviceStore("p", interruptHost)["snmp.slowmetric"], 1,
+		"a run the collector cut short is not evidence the device stopped answering")
+
+	// The poll windows are the half that matters. A device that kept its
+	// readings but lost its windows finds every declaration due on the next
+	// cycle, which is the most expensive cycle the profile can produce and the
+	// one most likely to overrun again.
+	w := runCollection(t, c, "p", interruptSysObj)
+	assert.NotContains(t, w.walkCalls, interruptSlow,
+		"the throttled declaration was re-polled, so the interrupted run dropped its poll window")
+	assert.Contains(t, w.walkCalls, interruptFast,
+		"a declaration with no window is still polled")
+}
+
+func TestCollectTarget_ADeviceFailureForgetsEvenAfterAnInterruptedRun(t *testing.T) {
+	c := newCollector(nil, interruptionProfile(interruptSysObj, "interrupted.yml"))
+	runCollection(t, c, "p", interruptSysObj)
+	runInterrupted(t, c, "p", interruptSysObj)
+	require.NotEmpty(t, c.testDeviceStore("p", interruptHost))
+
+	// The context stays live, so the failure is evidence about the device.
+	c.clientFactory = func(_ context.Context, _ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
+		return nil, assert.AnError
+	}
+	require.Error(t, c.CollectTarget(context.Background(), mustTarget(interruptHost), mustAuth(), "p", DialOptions{}))
+
+	assert.Nil(t, c.testDeviceStore("p", interruptHost),
+		"a device that failed stops exporting immediately, whatever it was granted for being interrupted")
+	_, counted := interruptionCount(c, "p")
+	assert.False(t, counted, "the count is part of the device's state and goes with it")
+}
+
+func TestCollectTarget_ASuccessfulRunResetsTheInterruptionCount(t *testing.T) {
+	c := newCollector(nil, interruptionProfile(interruptSysObj, "interrupted.yml"))
+	runCollection(t, c, "p", interruptSysObj)
+
+	// Four interruptions in all, but never three running: a transient overrun
+	// costs the device nothing.
+	runInterrupted(t, c, "p", interruptSysObj)
+	runInterrupted(t, c, "p", interruptSysObj)
+	runCollection(t, c, "p", interruptSysObj)
+	_, counted := interruptionCount(c, "p")
+	assert.False(t, counted, "a run that completed is not a run that was interrupted")
+
+	runInterrupted(t, c, "p", interruptSysObj)
+	runInterrupted(t, c, "p", interruptSysObj)
+	assert.NotEmpty(t, c.testDeviceStore("p", interruptHost),
+		"the bound counts consecutive interruptions, so the run in between clears what came before")
+}
+
+func TestCollectTarget_TheThirdConsecutiveInterruptionForgetsTheDevice(t *testing.T) {
+	c := newCollector(nil, interruptionProfile(interruptSysObj, "interrupted.yml"))
+	runCollection(t, c, "p", interruptSysObj)
+
+	runInterrupted(t, c, "p", interruptSysObj)
+	require.NotEmpty(t, c.testDeviceStore("p", interruptHost), "one interruption is within the bound")
+	runInterrupted(t, c, "p", interruptSysObj)
+	require.NotEmpty(t, c.testDeviceStore("p", interruptHost), "two interruptions are within the bound")
+
+	runInterrupted(t, c, "p", interruptSysObj)
+	assert.Nil(t, c.testDeviceStore("p", interruptHost),
+		"the bound is what keeps staleness finite: three interrupted runs running and the device goes")
+
+	c.pollMu.Lock()
+	_, polls := c.pollState[testKey("p", interruptHost)]
+	c.pollMu.Unlock()
+	assert.False(t, polls, "the poll windows go with the readings, as they do on any other forgotten device")
+}
+
+func TestCollectTarget_AProfileChangeDropsTheInterruptionCount(t *testing.T) {
+	c := newCollectorWithProfiles(nil,
+		interruptionProfile(interruptSysObj, "a.yml"),
+		interruptionProfile(interruptSysObjB, "b.yml"))
+	runCollection(t, c, "p", interruptSysObj)
+	runInterrupted(t, c, "p", interruptSysObj)
+	n, counted := interruptionCount(c, "p")
+	require.True(t, counted)
+	require.Equal(t, 1, n)
+
+	// The address now answers as a device the other profile covers. Everything
+	// the old device left is dropped, so the new one starts from nothing rather
+	// than inheriting a grace the old one had spent.
+	runInterrupted(t, c, "p", interruptSysObjB)
+
+	assert.Nil(t, c.testDeviceStore("p", interruptHost))
+	n, counted = interruptionCount(c, "p")
+	assert.True(t, counted)
+	assert.Equal(t, 1, n, "the replaced device's count must not carry into the new one's")
+}
+
+// The count is per device, so the two paths that drop a device's state have to
+// drop it too or the map grows for the process's life.
+func TestForgetPolicyAndClose_DropTheInterruptionCounts(t *testing.T) {
+	c := newCollector(nil, interruptionProfile(interruptSysObj, "interrupted.yml"))
+	runCollection(t, c, "doomed", interruptSysObj)
+	runInterrupted(t, c, "doomed", interruptSysObj)
+	runCollection(t, c, "keeper", interruptSysObj)
+	runInterrupted(t, c, "keeper", interruptSysObj)
+
+	c.ForgetPolicy("doomed")
+	_, doomed := interruptionCount(c, "doomed")
+	_, keeper := interruptionCount(c, "keeper")
+	assert.False(t, doomed, "a stopped policy must not leave a row per device behind")
+	assert.True(t, keeper, "another policy's devices must keep theirs")
+
+	c.Close()
+	c.interruptMu.Lock()
+	left := len(c.interruptedRuns)
+	c.interruptMu.Unlock()
+	assert.Zero(t, left, "Close must release the counts with the rest")
+}
+
+// ---------------------------------------------------------------------------
 // Per-dial settings
 // ---------------------------------------------------------------------------
 

--- a/orb-telemetry/snmp-telemetry/collector/collector_test.go
+++ b/orb-telemetry/snmp-telemetry/collector/collector_test.go
@@ -1561,11 +1561,21 @@ func interruptionProfile(sysObj, filename string) *profiles.Profile {
 	})
 }
 
+// interruptionSlowValue is what the throttled declaration answers unless a test
+// asks for another value.
+const interruptionSlowValue = 7
+
 func interruptionWalker(sysObj string) *recordingWalker {
+	return interruptionWalkerValued(sysObj, interruptionSlowValue)
+}
+
+// interruptionWalkerValued answers the throttled declaration with slowValue, so
+// a test that runs several cycles can tell which one a retained point came from.
+func interruptionWalkerValued(sysObj string, slowValue int) *recordingWalker {
 	return &recordingWalker{responses: map[string]map[string]snmp.PDU{
 		sysObjectIDOID: {sysObjectIDOID: oIDPDU(sysObj)},
 		sysDescrOID:    {},
-		interruptSlow:  {interruptSlow: intPDU(interruptSlow, 7)},
+		interruptSlow:  {interruptSlow: intPDU(interruptSlow, slowValue)},
 		interruptFast:  {interruptFast: intPDU(interruptFast, 1)},
 	}}
 }
@@ -1574,7 +1584,14 @@ func interruptionWalker(sysObj string) *recordingWalker {
 // caller can see which declarations were polled.
 func runCollection(t *testing.T, c *MetricsCollector, policy, sysObj string) *recordingWalker {
 	t.Helper()
-	w := interruptionWalker(sysObj)
+	return runCollectionValued(t, c, policy, sysObj, interruptionSlowValue)
+}
+
+// runCollectionValued performs one complete run whose throttled declaration, if
+// this run polls it, answers with slowValue.
+func runCollectionValued(t *testing.T, c *MetricsCollector, policy, sysObj string, slowValue int) *recordingWalker {
+	t.Helper()
+	w := interruptionWalkerValued(sysObj, slowValue)
 	c.clientFactory = walkerFactory(w)
 	require.NoError(t, c.CollectTarget(context.Background(), mustTarget(interruptHost), mustAuth(), policy, DialOptions{}))
 	return w
@@ -1593,6 +1610,39 @@ func runInterrupted(t *testing.T, c *MetricsCollector, policy, sysObj string) {
 	c.clientFactory = walkerFactory(w)
 	require.ErrorIs(t, c.CollectTarget(ctx, mustTarget(interruptHost), mustAuth(), policy, DialOptions{}),
 		context.Canceled)
+}
+
+// runInterruptedAt performs one run cut short by its own context once the given
+// OID has come back, which is where a run that overruns its metrics_interval
+// part way through a profile ends. runInterrupted cancels on the very first
+// walk, before any declaration has been polled; here declarations have been
+// polled and the run still publishes nothing.
+func runInterruptedAt(t *testing.T, c *MetricsCollector, policy, sysObj, at string, slowValue int) *recordingWalker {
+	t.Helper()
+	w := interruptionWalkerValued(sysObj, slowValue)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.onWalk = func(oid string) {
+		if oid == at {
+			cancel()
+		}
+	}
+	c.clientFactory = walkerFactory(w)
+	require.ErrorIs(t, c.CollectTarget(ctx, mustTarget(interruptHost), mustAuth(), policy, DialOptions{}),
+		context.Canceled)
+	return w
+}
+
+// expirePollWindows backdates every poll window a device holds, so a test can
+// reach the cycle on which its throttled declaration is due again without
+// waiting out poll_time_sec.
+func expirePollWindows(c *MetricsCollector, policy string) {
+	c.pollMu.Lock()
+	defer c.pollMu.Unlock()
+	windows := c.pollState[testKey(policy, interruptHost)]
+	for decl, at := range windows {
+		windows[decl] = at.Add(-time.Hour)
+	}
 }
 
 // interruptionCount reads a device's consecutive-interruption count and whether
@@ -1721,6 +1771,97 @@ func TestForgetPolicyAndClose_DropTheInterruptionCounts(t *testing.T) {
 	left := len(c.interruptedRuns)
 	c.interruptMu.Unlock()
 	assert.Zero(t, left, "Close must release the counts with the rest")
+}
+
+// A run cut short leaves the store it never published, so a declaration it
+// walked has a poll window open on a reading nothing can read. The window has
+// to go with the reading: this is the device's first run, so the series is
+// empty until the next cycle polls the declaration again.
+func TestCollectTarget_AnInterruptedRunDoesNotThrottleAReadingItNeverPublished(t *testing.T) {
+	c := newCollector(nil, interruptionProfile(interruptSysObj, "interrupted.yml"))
+
+	w := runInterruptedAt(t, c, "p", interruptSysObj, interruptSlow, interruptionSlowValue)
+	require.Contains(t, w.walkCalls, interruptSlow,
+		"the run has to reach the throttled declaration for this to test anything")
+	require.Nil(t, c.testDeviceStore("p", interruptHost), "an interrupted run publishes no store")
+
+	w = runCollection(t, c, "p", interruptSysObj)
+
+	assert.Contains(t, w.walkCalls, interruptSlow,
+		"the interrupted run published no reading for the declaration it walked, so the next cycle must poll it again")
+	assert.Len(t, c.testDeviceStore("p", interruptHost)["snmp.slowmetric"], 1,
+		"a window kept for an unpublished reading leaves the series empty for the whole poll period")
+}
+
+// The same in steady state: the series already carries a reading, and a window
+// kept for the reading the interrupted run never published freezes it at the
+// value before, for as long as poll_time_sec says.
+func TestCollectTarget_AnInterruptedRunDoesNotHoldASeriesAtTheReadingBeforeIt(t *testing.T) {
+	c := newCollector(nil, interruptionProfile(interruptSysObj, "interrupted.yml"))
+	runCollectionValued(t, c, "p", interruptSysObj, 7)
+	require.Equal(t, int64(7), c.testDeviceStore("p", interruptHost)["snmp.slowmetric"][0].value)
+
+	// The window this run opened has run out, so the declaration is due again.
+	expirePollWindows(c, "p")
+	w := runInterruptedAt(t, c, "p", interruptSysObj, interruptSlow, 8)
+	require.Contains(t, w.walkCalls, interruptSlow,
+		"the run has to reach the throttled declaration for this to test anything")
+
+	w = runCollectionValued(t, c, "p", interruptSysObj, 9)
+
+	assert.Contains(t, w.walkCalls, interruptSlow,
+		"a reading walked by an interrupted run never reached the store, so it cannot throttle the next cycle")
+	assert.Equal(t, int64(9), c.testDeviceStore("p", interruptHost)["snmp.slowmetric"][0].value,
+		"the series must carry this cycle's reading, not the one the interrupted run replaced nothing with")
+}
+
+// The other half of the same rule, and what tells this apart from clearing the
+// windows outright: an interrupted run keeps every window that existed before
+// it, so a declaration it was right to skip stays skipped. Without this the
+// cycle after an overrun re-polls the whole profile, which is the most
+// expensive cycle it can produce and the one most likely to overrun again.
+func TestCollectTarget_AnInterruptedRunKeepsAWindowItDidNotWalk(t *testing.T) {
+	c := newCollector(nil, interruptionProfile(interruptSysObj, "interrupted.yml"))
+	runCollectionValued(t, c, "p", interruptSysObj, 7)
+
+	// Cut short after the declaration polled every cycle, which is the last of
+	// the profile. The throttled one is not due, so this run never walks it.
+	w := runInterruptedAt(t, c, "p", interruptSysObj, interruptFast, 8)
+	require.NotContains(t, w.walkCalls, interruptSlow,
+		"the throttled declaration must not be due for this to test anything")
+
+	w = runCollection(t, c, "p", interruptSysObj)
+
+	assert.NotContains(t, w.walkCalls, interruptSlow,
+		"the window belongs to the run before the interrupted one, which published the reading it carries")
+	assert.Contains(t, w.walkCalls, interruptFast, "a declaration with no window is still polled")
+	assert.Equal(t, int64(7), c.testDeviceStore("p", interruptHost)["snmp.slowmetric"][0].value,
+		"the surviving window carries forward the reading that opened it")
+}
+
+// The windows a run keeps are the ones the device it is polling left. A device
+// replaced at the address matches another profile, and every declaration the
+// two profiles share has one declaration key, so windows carried across the
+// change would throttle the new device against the old one's readings, which
+// went with it.
+func TestCollectTarget_AnInterruptedRunKeepsNoWindowOfTheDeviceItReplaced(t *testing.T) {
+	c := newCollectorWithProfiles(nil,
+		interruptionProfile(interruptSysObj, "a.yml"),
+		interruptionProfile(interruptSysObjB, "b.yml"))
+	runCollectionValued(t, c, "p", interruptSysObj, 7)
+
+	// The address now answers as a device the other profile covers, and the run
+	// is cut short after both declarations have been walked.
+	w := runInterruptedAt(t, c, "p", interruptSysObjB, interruptFast, 8)
+	require.Contains(t, w.walkCalls, interruptSlow,
+		"the profile change drops the windows, so this run finds every declaration due")
+
+	w = runCollectionValued(t, c, "p", interruptSysObjB, 9)
+
+	assert.Contains(t, w.walkCalls, interruptSlow,
+		"the new device has no reading of its own yet, so nothing may throttle its first one")
+	assert.Equal(t, int64(9), c.testDeviceStore("p", interruptHost)["snmp.slowmetric"][0].value,
+		"the series must carry the new device's reading")
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes MON-343.

`CollectTarget` forgot a device on any non-nil error from `collect`, and `collect` returns `ctx.Err()` from four points. So a run cut short by its own deadline discarded that device's state, which is a failure of ours read as a failure of the device.

Nothing bounds a run below its policy interval: `runMetrics` builds the run context with `context.WithTimeout(r.ctx, r.metricsInterval)`, and `snmp_timeout` and the retry ceiling are per request, not per run. A profile with enough OIDs, or a slow device, overruns on wall clock while every individual request stays inside its own timeout.

**It compounded.** `forgetDevice` clears `pollState` as well as `deviceStore`, and the poll windows are what make a cycle cheap: a declaration with `poll_time_sec` set is skipped between its due times, and the bundled profiles use 60, 300 and 3600. So the cycle after an overrun found every declaration due and was the most expensive cycle the profile can produce, which made the next overrun likelier. A device could settle into exporting nothing while re-polling its whole profile every cycle.

## The rule

The context decides, not the error. `collect`'s early returns wrap the deadline out of existence: creating the client, connecting and getting sysObjectID carry neither `context.Canceled` nor `DeadlineExceeded` even when the context is what killed them, so inspecting the error would read a run the collector ended as a device that failed. `ctx.Err()` at the decision point is reliable and says the thing that matters.

- A live context means the device failed. It is forgotten immediately, as before, so its series goes empty and the absence stays visible.
- A done context means the run overran. The device keeps both its readings and its poll windows, so the next cycle is cheap and the loop is broken.
- Retention is bounded at three consecutive interrupted runs, a documented constant rather than a policy field. A successful run resets the count, so a transient overrun costs nothing and a persistent one still drops the device rather than exporting a stale reading forever.

The bound counts attempts, not elapsed time, and the two are not interchangeable: a run's deadline is the whole `metrics_interval`, so an interrupted run occupies its entire cycle, and `gocron.LimitModeReschedule` drops a tick arriving while the previous run is still going rather than queueing it. Consecutive interrupted attempts are therefore spaced further apart than one interval, and a retained reading can outlive three of them. Attempts are the right unit regardless, because the feedback loop this breaks advances per attempt: forgetting a device clears its poll windows, which makes the next cycle the most expensive the profile can produce, which makes the next overrun likelier. A real maximum age would mean carrying the interval into the collector and timestamping retained state, which nothing has asked for.

**No collection timestamp was added to `observedPoint`.** The ticket sketched that, and it was set aside: the bound that matters is how many polls have been missed, which a count expresses directly without touching the export model. That also leaves MON-344 and MON-347 unblocked rather than waiting on a larger change.

## Lifecycle

The counter is per device, so it gets the same treatment as the other per-device maps: cleared by `forgetDevice`, dropped per policy by `ForgetPolicy`, reset by `Close`, and dropped through `forgetDevice` when `noteProfile` sees a device change profile. Without the `ForgetPolicy` case the map would leak a row per device for the life of the process.

It sits under its own mutex rather than `storeMu`. `CollectTarget` decides whether to call `forgetDevice` from the count, and `forgetDevice` takes `storeMu`, so sharing it would self-deadlock on Go's non-reentrant mutex.

## Verification

Six tests. The one that matters asserts the poll windows survived by observing that a `poll_time_sec` declaration is **not walked** on the next cycle, rather than merely that the store is non-empty. That distinction is the whole fix: a mutant that keeps the readings but drops the windows fails it with "the throttled declaration was re-polled, so the interrupted run dropped its poll window".

The bound test is written as literal steps rather than in terms of the constant, so the bound cannot move undetected.

Twelve production mutants, no survivors, including: removing the `ctx.Err()` check so every error forgets, which is today's behaviour; moving the bound in both directions; not resetting on a successful run; and each of the four lifecycle paths keeping the count. All 24 new assertions were also flipped individually.

Eight existing tests were re-checked by mutant rather than by reading, since a test quietly ceasing to guard its subject has happened three times in this module's recent history. One pre-existing weakness was found and left alone: `ACancelledTagDistributionExportsNothing`'s `assert.Empty(store)` never guarded `forgetDevice`, because its cancelled run is the device's first, so the store was empty either way. Its stated claim is still true and still guarded by its walk-list assertion.

## Shutdown

Verified rather than assumed. `shutdown` is `flush(); cancelRoot(); srv.Stop()` since `f1733b3a`, so the final export still precedes any cancellation. In-flight collections at `cancelRoot()` now retain instead of forget, which removes the deletion-versus-export race rather than only ordering around it. The second commit corrects that function's doc comment, which justified the ordering with an unconditional forget that no longer happens.

Gates: build, vet, `-race`, `make lint` at 0 issues, `./cmd/` run directly, and the root and `orb-discovery/snmp-discovery` modules still build.
