### PR TITLE
feat(snmp-telemetry): receive SNMP traps on a socket the backend owns

### DIFF
--- a/orb-telemetry/snmp-telemetry/README.md
+++ b/orb-telemetry/snmp-telemetry/README.md
@@ -228,9 +228,10 @@ trap is past what that ceiling accommodates. Name the devices you expect traps
 from. The backend bounds its own series at that ceiling: real series stop a
 hundred short of it, a trap for a series that does not exist yet is then
 counted under its policy with `device_ip` and `trap_name` both `other`, and
-once that room is used up too a trap whose policy has no overflow series yet
-is counted as a `series_limit` drop rather than under a series no policy
-owns. A sender spoofing addresses inside a wide prefix can fill the ceiling
+once that room is used up too a datagram that no claiming policy can count,
+because none has an overflow series yet, is a `series_limit` drop rather
+than a count under a series no policy owns; it is one drop per datagram,
+and a datagram one policy counts is not a drop. A sender spoofing addresses inside a wide prefix can fill the ceiling
 but cannot grow memory past it, the SDK never folds a series the backend
 chose to keep, and every series is withdrawn with the policy that made it. The clocks the receiver keeps for v3 engines are bounded the
 same way, at ten thousand engines, evicting the one used longest ago, in an

--- a/orb-telemetry/snmp-telemetry/README.md
+++ b/orb-telemetry/snmp-telemetry/README.md
@@ -201,8 +201,9 @@ A trap is counted, not stored. Three metrics describe what arrived:
   authenticated v3 trap whose engine boots are lower than last seen from that
   engine, or whose engine time is more than 150 seconds behind the clock the
   receiver keeps for it: RFC 3414's bound on replaying a captured message. The
-  clocks are learned per sending address and engine, in memory, and relearned
-  after a restart, so a device can only ever poison its own clock.
+  clocks are learned per sending address, credential and engine, in memory,
+  and relearned after a restart, so a device can only ever poison the clock
+  its own credential is judged by.
 - `snmp.traps_datagrams` counts every datagram read from any socket. Every
   datagram read ends as one drop or as one trap, and it is counted together
   with that outcome, so `traps_datagrams` equals `traps_dropped` plus the

--- a/orb-telemetry/snmp-telemetry/README.md
+++ b/orb-telemetry/snmp-telemetry/README.md
@@ -200,8 +200,9 @@ A trap is counted, not stored. Three metrics describe what arrived:
   clocks are learned per sending address and engine, in memory, and relearned
   after a restart, so a device can only ever poison its own clock.
 - `snmp.traps_datagrams` counts every datagram read from any socket. Every
-  datagram read ends as one drop or as one trap, so `traps_datagrams` equals
-  `traps_dropped` plus the datagrams that produced a trap. `traps_received` is
+  datagram read ends as one drop or as one trap, and it is counted together
+  with that outcome, so `traps_datagrams` equals `traps_dropped` plus the
+  datagrams that produced a trap in every export, the final one included. `traps_received` is
   not that second number: a trap counts once under every policy on the socket
   that names its source, so when two policies name the same device the
   per-policy series add up to more than the datagrams behind them. Use
@@ -225,7 +226,8 @@ answering questions about any of them. Trap series are the product of the
 addresses your policies name, the trap names above and the three SNMP
 versions, so a policy naming a whole `/16` whose every host sends every kind of
 trap is past what that ceiling accommodates. Name the devices you expect traps
-from. The backend bounds its own series at that ceiling: real series stop a
+from. The backend bounds its own series one short of that ceiling, since the
+SDK keeps its last slot for its own overflow point: real series stop a
 hundred short of it, a trap for a series that does not exist yet is then
 counted under its policy with `device_ip` and `trap_name` both `other`, and
 once that room is used up too a datagram that no claiming policy can count,

--- a/orb-telemetry/snmp-telemetry/README.md
+++ b/orb-telemetry/snmp-telemetry/README.md
@@ -173,7 +173,9 @@ A trap is counted, not stored. Three metrics describe what arrived:
   with the same `device_ip` and `policy` labels every polled series carries.
 - `snmp.traps_dropped{reason}` counts datagrams that produced no trap:
   `unknown_source`, `oversized`, `malformed`, `unsupported_pdu`,
-  `v3_unauthenticated`, `v3_not_in_time_window` or `no_trap_oid`. Hostile v3 traffic lands under
+  `unsupported_version`, `v3_unauthenticated`, `v3_not_in_time_window` or
+  `no_trap_oid`. `unsupported_version` is a wire version other than 1, 2c
+  and 3, such as SNMPv2u's 2, which is never counted as 2c. Hostile v3 traffic lands under
   `malformed` when it names a username no policy carries and under
   `v3_unauthenticated` when it names a known one without asking to be
   authenticated, and the second is the one worth looking at, since it may mean
@@ -229,9 +231,10 @@ unknown addresses are never acknowledged, so the socket does not answer
 strangers.
 
 **Trap contents are unauthenticated unless the sender uses SNMPv3 with
-authentication**, in which case the backend authenticates it with a USM user a
-policy on that socket carries. No trap-specific credentials are
-configured. v1 and v2c traps are never authenticated by any setting: the
+authentication**, in which case the backend authenticates it with a USM user
+carried by a policy naming that device. A credential another policy on the
+socket carries under the same username is not tried. No trap-specific
+credentials are configured. v1 and v2c traps are never authenticated by any setting: the
 community they carry is not checked, because a check would be mistaken for
 authentication and would protect nothing against a sender who can read the
 community off the wire.
@@ -253,8 +256,8 @@ devices; a target written without a zone matches the address on any
 interface, and `device_ip` carries the zone. A policy target written as a
 hostname rather than an address is not matched against trap sources, so its traps count as
 `unknown_source`; a policy declaring `traps` whose targets are all hostnames
-starts with a warning saying so, and still contributes its USM user to the set
-the socket can authenticate against. And a device behind a trap relay or NAT
+starts with a warning saying so, and its USM user is never tried, since it
+claims no device for the user to authenticate. And a device behind a trap relay or NAT
 arrives as the relay's address; a v1 trap whose agent-addr field names a
 polled device is attributed to that device, but v2c and v3 traps are
 attributed to the address they arrive from.

--- a/orb-telemetry/snmp-telemetry/README.md
+++ b/orb-telemetry/snmp-telemetry/README.md
@@ -208,10 +208,14 @@ answering questions about any of them. Trap series are the product of the
 addresses your policies name, the trap names above and the three SNMP
 versions, so a policy naming a whole `/16` whose every host sends every kind of
 trap is past what that ceiling accommodates. Name the devices you expect traps
-from. The backend holds the same ten thousand series itself: past that, a trap
-for a series that does not exist yet is counted under its policy with
-`device_ip` and `trap_name` both `other`, so a sender spoofing addresses
-inside a wide prefix can fill the ceiling but cannot grow memory past it.
+from. The backend bounds its own series at that ceiling: real series stop a
+hundred short of it, a trap for a series that does not exist yet is then
+counted under its policy with `device_ip` and `trap_name` both `other`, and
+once that room is nearly used up it is counted with `policy` as `other` too.
+A sender spoofing addresses inside a wide prefix can fill the ceiling but
+cannot grow memory past it, and the SDK never folds a series the backend
+chose to keep. The clocks the receiver keeps for v3 engines are bounded the
+same way, at ten thousand engines, evicting the one seen longest ago.
 
 **What the source address list is, and is not.** A trap from an address that
 no policy on that socket names is dropped and counted as `unknown_source`,

--- a/orb-telemetry/snmp-telemetry/README.md
+++ b/orb-telemetry/snmp-telemetry/README.md
@@ -171,6 +171,10 @@ A trap is counted, not stored. Three metrics describe what arrived:
 - `snmp.traps_received{device_ip, policy, trap_name, version}` counts traps
   from a device a policy on that socket names, once per policy naming it,
   with the same `device_ip` and `policy` labels every polled series carries.
+  The counter is monotonic: a deleted policy's series stop being exported but
+  keep their totals, so a policy recreated under the same name continues
+  the count rather than restarting it, and nothing downstream sees a
+  decrease.
 - `snmp.traps_dropped{reason}` counts datagrams that produced no trap:
   `unknown_source`, `oversized`, `malformed`, `unsupported_pdu`,
   `unsupported_version`, `v3_unauthenticated`, `v3_not_in_time_window` or
@@ -186,7 +190,8 @@ A trap is counted, not stored. Three metrics describe what arrived:
   authenticated v3 trap whose engine boots are lower than last seen from that
   engine, or whose engine time is more than 150 seconds behind the clock the
   receiver keeps for it: RFC 3414's bound on replaying a captured message. The
-  clocks are learned per engine, in memory, and relearned after a restart.
+  clocks are learned per sending address and engine, in memory, and relearned
+  after a restart, so a device can only ever poison its own clock.
 - `snmp.traps_datagrams` counts every datagram read from any socket. Every
   datagram read ends as one drop or as one trap, so `traps_datagrams` equals
   `traps_dropped` plus the datagrams that produced a trap. `traps_received` is
@@ -231,10 +236,10 @@ unknown addresses are never acknowledged, so the socket does not answer
 strangers.
 
 **Trap contents are unauthenticated unless the sender uses SNMPv3 with
-authentication**, in which case the backend authenticates it with a USM user
-carried by a policy naming that device. A credential another policy on the
-socket carries under the same username is not tried. No trap-specific
-credentials are configured. v1 and v2c traps are never authenticated by any setting: the
+authentication**, in which case the backend authenticates it with the USM
+user the policy polls that device with, and no other: a credential a policy
+assigned to a different device, or another policy carries under the same
+username, is not tried. No trap-specific credentials are configured. v1 and v2c traps are never authenticated by any setting: the
 community they carry is not checked, because a check would be mistaken for
 authentication and would protect nothing against a sender who can read the
 community off the wire.

--- a/orb-telemetry/snmp-telemetry/README.md
+++ b/orb-telemetry/snmp-telemetry/README.md
@@ -55,10 +55,12 @@ Usage of snmp-telemetry:
 The policy API has no authentication. Anyone who can reach the listener can
 create a policy, and a policy names the SNMP credentials to send and the host to
 send them to, so reaching the listener is enough to make the backend poll
-arbitrary hosts with whatever credentials the caller supplies. `--host`
-therefore defaults to `localhost`: the agent runs this backend as a child
-process and reaches it over the loopback interface, so nothing legitimate needs
-a wider bind.
+arbitrary hosts with whatever credentials the caller supplies. A policy body
+also makes the process bind a UDP socket, on any local address and port it is
+permitted to bind, one per distinct `listen` string and with no cap on how many
+it opens. `--host` therefore defaults to `localhost`: the agent runs this
+backend as a child process and reaches it over the loopback interface, so
+nothing legitimate needs a wider bind.
 
 Passing `--host 0.0.0.0` publishes that unauthenticated API on every interface.
 Do it only behind access control of your own, such as a network policy or a
@@ -209,8 +211,8 @@ unknown addresses are never acknowledged, so the socket does not answer
 strangers.
 
 **Trap contents are unauthenticated unless the sender uses SNMPv3 with
-authentication**, in which case the backend authenticates it with the USM user
-the policy for that device carries. No trap-specific credentials are
+authentication**, in which case the backend authenticates it with a USM user a
+policy on that socket carries. No trap-specific credentials are
 configured. v1 and v2c traps are never authenticated by any setting: the
 community they carry is not checked, because a check would be mistaken for
 authentication and would protect nothing against a sender who can read the

--- a/orb-telemetry/snmp-telemetry/README.md
+++ b/orb-telemetry/snmp-telemetry/README.md
@@ -175,7 +175,11 @@ A trap is counted, not stored. Three metrics describe what arrived:
   keep their totals, so a policy recreated under the same name continues
   the count rather than restarting it, and nothing downstream sees a
   decrease. A trap that was already in hand when its policy was deleted is
-  kept the same way and stays unexported until the policy comes back.
+  kept the same way and stays unexported until the policy comes back. A
+  retained series that has to make way for a live one leaves its total in a
+  baseline tier of the same size as the series ceiling, from which it
+  resumes if it reappears, so the backend holds at most twice the ceiling
+  in memory.
 - `snmp.traps_dropped{reason}` counts datagrams that produced no trap:
   `unknown_source`, `oversized`, `malformed`, `unsupported_pdu`,
   `unsupported_version`, `v3_unauthenticated`, `v3_not_in_time_window`,

--- a/orb-telemetry/snmp-telemetry/README.md
+++ b/orb-telemetry/snmp-telemetry/README.md
@@ -179,7 +179,9 @@ A trap is counted, not stored. Three metrics describe what arrived:
   retained series that has to make way for a live one leaves its total in a
   baseline tier of the same size as the series ceiling, from which it
   resumes if it reappears, so the backend holds at most twice the ceiling
-  in memory.
+  in memory. Only once more than ten thousand distinct withdrawn series
+  have been evicted does the oldest baseline go, and a series returning
+  after that restarts, which a consumer reads as a counter reset.
 - `snmp.traps_dropped{reason}` counts datagrams that produced no trap:
   `unknown_source`, `oversized`, `malformed`, `unsupported_pdu`,
   `unsupported_version`, `v3_unauthenticated`, `v3_not_in_time_window`,

--- a/orb-telemetry/snmp-telemetry/README.md
+++ b/orb-telemetry/snmp-telemetry/README.md
@@ -185,8 +185,12 @@ A trap is counted, not stored. Three metrics describe what arrived:
 - `snmp.traps_dropped{reason}` counts datagrams that produced no trap:
   `unknown_source`, `oversized`, `malformed`, `unsupported_pdu`,
   `unsupported_version`, `v3_unauthenticated`, `v3_not_in_time_window`,
-  `no_trap_oid` or `series_limit`. `unsupported_version` is a wire version other than 1, 2c
-  and 3, such as SNMPv2u's 2, which is never counted as 2c. Hostile v3 traffic lands under
+  `no_trap_oid` or `series_limit`. `unsupported_version` is a wire version
+  other than 1, 2c and 3, such as SNMPv2u's 2, which is never counted as 2c.
+  `unsupported_pdu` is a PDU that is not a trap or inform, or one carried
+  under the wrong version: a v2 trap or inform under version 1, or a v1
+  Trap-PDU under 2c or 3, is dropped rather than read with the wrong fields.
+  Hostile v3 traffic lands under
   `malformed` when it names a username no policy carries and under
   `v3_unauthenticated` when it names a known one without asking to be
   authenticated, and the second is the one worth looking at, since it may mean
@@ -233,7 +237,10 @@ counted under its policy with `device_ip` and `trap_name` both `other`, and
 once that room is used up too a datagram that no claiming policy can count,
 because none has an overflow series yet, is a `series_limit` drop rather
 than a count under a series no policy owns; it is one drop per datagram,
-and a datagram one policy counts is not a drop. A sender spoofing addresses inside a wide prefix can fill the ceiling
+and a datagram one policy counts is not a drop. An inform refused this way
+is still acknowledged, since it parsed and was attributed and the limit is
+the backend's, not the device's. A sender spoofing addresses inside a wide
+prefix can fill the ceiling
 but cannot grow memory past it, the SDK never folds a series the backend
 chose to keep, and every series is withdrawn with the policy that made it. The clocks the receiver keeps for v3 engines are bounded the
 same way, at ten thousand engines, evicting the one used longest ago, in an

--- a/orb-telemetry/snmp-telemetry/README.md
+++ b/orb-telemetry/snmp-telemetry/README.md
@@ -229,7 +229,14 @@ The actual boundary is a network control on the trap port, a firewall rule
 or a management VRF, the same way the actual boundary for polling is the
 segment the credentials cross.
 
-Two limits in this release. A policy target written as a hostname rather than
+Three limits in this release. SNMPv3 informs are not supported: an inform
+makes the receiver the authoritative engine, so the sender first probes for
+the receiver's engine ID and localises its keys against it, and this receiver
+has no engine ID to offer. The probe carries no username and is dropped as
+`malformed`, and the inform is never acknowledged, so the sender retries and
+gives up. SNMPv3 traps are authenticated and counted, and v1 and v2c informs
+are acknowledged; a device that must use informs sends them as v2c for now.
+A policy target written as a hostname rather than
 an address is not matched against trap sources, so its traps count as
 `unknown_source`; a policy declaring `traps` whose targets are all hostnames
 starts with a warning saying so, and still contributes its USM user to the set

--- a/orb-telemetry/snmp-telemetry/README.md
+++ b/orb-telemetry/snmp-telemetry/README.md
@@ -136,8 +136,11 @@ A trap is counted, not stored. Three metrics describe what arrived:
   `v3_unauthenticated` or `no_trap_oid`. Hostile v3 traffic lands under
   `malformed` when it names a username no policy carries and under
   `v3_unauthenticated` when it names a known one without asking to be
-  authenticated, and the second is the one worth alerting on, since it means
-  someone holds a valid username.
+  authenticated, and the second is the one worth looking at, since it may mean
+  someone holds a valid username. It has a benign cause too: a v3 target polled
+  at `noAuthNoPriv` is a supported configuration, and every trap it sends
+  carries no authentication either, so all of its traps are dropped under this
+  reason. This release cannot count them.
 - `snmp.traps_datagrams` counts every datagram read from the socket. Its gap
   against the other two is loss you cannot otherwise see.
 
@@ -146,6 +149,15 @@ the trap definitions bundled with the profiles, about two hundred names. Any
 other trap is labelled `other`. A raw OID never appears as a label, because a
 sender chooses its own trap OID and a metric label a sender controls is
 unbounded.
+
+There is still a ceiling on how many distinct series one metric can carry: ten
+thousand attribute sets per instrument, after which the SDK folds every new
+series into a single `otel.metric.overflow` bucket and the metric stops
+answering questions about any of them. Trap series are the product of the
+addresses your policies name, the trap names above and the three SNMP
+versions, so a policy naming a whole `/16` whose every host sends every kind of
+trap is past what that ceiling accommodates. Name the devices you expect traps
+from.
 
 **What the source address list is, and is not.** A trap from an address no
 running policy names is dropped and counted as `unknown_source`. That is a
@@ -158,7 +170,11 @@ backend visibly polls.
 
 `--trap-accept-unknown` counts traps from unknown addresses too, labelled by
 the source address with an empty `policy`. Informs from such addresses are
-counted but never acknowledged, so the socket does not answer strangers.
+counted but never acknowledged, so the socket does not answer strangers. A
+source address is spoofable, so the number of unknown addresses that get a
+`device_ip` of their own is capped at a thousand; every unknown source past
+that is still counted, under the `device_ip` value `other`. The flag is a
+debugging aid for a registration gap, not a way to watch the network.
 
 **Trap contents are unauthenticated unless the sender uses SNMPv3 with
 authentication**, in which case the backend authenticates it with the USM user

--- a/orb-telemetry/snmp-telemetry/README.md
+++ b/orb-telemetry/snmp-telemetry/README.md
@@ -178,8 +178,8 @@ A trap is counted, not stored. Three metrics describe what arrived:
   kept the same way and stays unexported until the policy comes back.
 - `snmp.traps_dropped{reason}` counts datagrams that produced no trap:
   `unknown_source`, `oversized`, `malformed`, `unsupported_pdu`,
-  `unsupported_version`, `v3_unauthenticated`, `v3_not_in_time_window` or
-  `no_trap_oid`. `unsupported_version` is a wire version other than 1, 2c
+  `unsupported_version`, `v3_unauthenticated`, `v3_not_in_time_window`,
+  `no_trap_oid` or `series_limit`. `unsupported_version` is a wire version other than 1, 2c
   and 3, such as SNMPv2u's 2, which is never counted as 2c. Hostile v3 traffic lands under
   `malformed` when it names a username no policy carries and under
   `v3_unauthenticated` when it names a known one without asking to be
@@ -222,11 +222,13 @@ trap is past what that ceiling accommodates. Name the devices you expect traps
 from. The backend bounds its own series at that ceiling: real series stop a
 hundred short of it, a trap for a series that does not exist yet is then
 counted under its policy with `device_ip` and `trap_name` both `other`, and
-once that room is nearly used up it is counted with `policy` as `other` too.
-A sender spoofing addresses inside a wide prefix can fill the ceiling but
-cannot grow memory past it, and the SDK never folds a series the backend
-chose to keep. The clocks the receiver keeps for v3 engines are bounded the
-same way, at ten thousand engines, evicting the one seen longest ago.
+once that room is used up too a trap whose policy has no overflow series yet
+is counted as a `series_limit` drop rather than under a series no policy
+owns. A sender spoofing addresses inside a wide prefix can fill the ceiling
+but cannot grow memory past it, the SDK never folds a series the backend
+chose to keep, and every series is withdrawn with the policy that made it. The clocks the receiver keeps for v3 engines are bounded the
+same way, at ten thousand engines, evicting the one used longest ago, in an
+order kept as they are used so an eviction costs no scan.
 
 **What the source address list is, and is not.** A trap from an address that
 no policy on that socket names is dropped and counted as `unknown_source`,

--- a/orb-telemetry/snmp-telemetry/README.md
+++ b/orb-telemetry/snmp-telemetry/README.md
@@ -173,14 +173,18 @@ A trap is counted, not stored. Three metrics describe what arrived:
   with the same `device_ip` and `policy` labels every polled series carries.
 - `snmp.traps_dropped{reason}` counts datagrams that produced no trap:
   `unknown_source`, `oversized`, `malformed`, `unsupported_pdu`,
-  `v3_unauthenticated` or `no_trap_oid`. Hostile v3 traffic lands under
+  `v3_unauthenticated`, `v3_not_in_time_window` or `no_trap_oid`. Hostile v3 traffic lands under
   `malformed` when it names a username no policy carries and under
   `v3_unauthenticated` when it names a known one without asking to be
   authenticated, and the second is the one worth looking at, since it may mean
   someone holds a valid username. It has a benign cause too: a v3 target polled
   at `noAuthNoPriv` is a supported configuration, and every trap it sends
   carries no authentication either, so all of its traps are dropped under this
-  reason. This release cannot count them.
+  reason. This release cannot count them. `v3_not_in_time_window` is an
+  authenticated v3 trap whose engine boots are lower than last seen from that
+  engine, or whose engine time is more than 150 seconds behind the clock the
+  receiver keeps for it: RFC 3414's bound on replaying a captured message. The
+  clocks are learned per engine, in memory, and relearned after a restart.
 - `snmp.traps_datagrams` counts every datagram read from any socket. Every
   datagram read ends as one drop or as one trap, so `traps_datagrams` equals
   `traps_dropped` plus the datagrams that produced a trap. `traps_received` is
@@ -204,7 +208,10 @@ answering questions about any of them. Trap series are the product of the
 addresses your policies name, the trap names above and the three SNMP
 versions, so a policy naming a whole `/16` whose every host sends every kind of
 trap is past what that ceiling accommodates. Name the devices you expect traps
-from.
+from. The backend holds the same ten thousand series itself: past that, a trap
+for a series that does not exist yet is counted under its policy with
+`device_ip` and `trap_name` both `other`, so a sender spoofing addresses
+inside a wide prefix can fill the ceiling but cannot grow memory past it.
 
 **What the source address list is, and is not.** A trap from an address that
 no policy on that socket names is dropped and counted as `unknown_source`,

--- a/orb-telemetry/snmp-telemetry/README.md
+++ b/orb-telemetry/snmp-telemetry/README.md
@@ -181,8 +181,15 @@ A trap is counted, not stored. Three metrics describe what arrived:
   at `noAuthNoPriv` is a supported configuration, and every trap it sends
   carries no authentication either, so all of its traps are dropped under this
   reason. This release cannot count them.
-- `snmp.traps_datagrams` counts every datagram read from any socket. Its gap
-  against the other two is loss you cannot otherwise see.
+- `snmp.traps_datagrams` counts every datagram read from any socket. Every
+  datagram read ends as one drop or as one trap, so `traps_datagrams` equals
+  `traps_dropped` plus the datagrams that produced a trap. `traps_received` is
+  not that second number: a trap counts once under every policy on the socket
+  that names its source, so when two policies name the same device the
+  per-policy series add up to more than the datagrams behind them. Use
+  `traps_datagrams` as the rate the sockets are being read at, against what
+  your devices send; a datagram the kernel discarded before the read appears
+  in none of the three.
 
 `trap_name` is drawn from a closed set: the six standard traps of RFC 1215 and
 the trap definitions bundled with the profiles, about two hundred names. Any

--- a/orb-telemetry/snmp-telemetry/README.md
+++ b/orb-telemetry/snmp-telemetry/README.md
@@ -241,10 +241,15 @@ strangers.
 
 **Trap contents are unauthenticated unless the sender uses SNMPv3 with
 authentication**, in which case the backend authenticates it with the USM
-users the policy polls that device with, and no others: a credential a policy
-assigned to a different device, or another policy carries under the same
-username, is not tried. Two targets kept at one address under different IDs
-or contexts contribute both their credentials. No trap-specific credentials are configured. v1 and v2c traps are never authenticated by any setting: the
+users the policies naming that device poll it with, and no others: a
+credential a policy assigned to a different device is not tried. Two targets
+kept at one address under different IDs or contexts contribute both their
+credentials. An authenticated v3 trap is then counted only under the policies
+holding the credential that verified it; a policy naming the same device with
+v1, v2c or a different v3 user counts the device's v1 and v2c traps and not
+its authenticated v3 ones. The policies a trap is counted under are resolved
+when it is counted, so a policy deleted while a datagram was being parsed is
+not counted and a replacement is counted only if it names the device. No trap-specific credentials are configured. v1 and v2c traps are never authenticated by any setting: the
 community they carry is not checked, because a check would be mistaken for
 authentication and would protect nothing against a sender who can read the
 community off the wire.

--- a/orb-telemetry/snmp-telemetry/README.md
+++ b/orb-telemetry/snmp-telemetry/README.md
@@ -174,7 +174,8 @@ A trap is counted, not stored. Three metrics describe what arrived:
   The counter is monotonic: a deleted policy's series stop being exported but
   keep their totals, so a policy recreated under the same name continues
   the count rather than restarting it, and nothing downstream sees a
-  decrease.
+  decrease. A trap that was already in hand when its policy was deleted is
+  kept the same way and stays unexported until the policy comes back.
 - `snmp.traps_dropped{reason}` counts datagrams that produced no trap:
   `unknown_source`, `oversized`, `malformed`, `unsupported_pdu`,
   `unsupported_version`, `v3_unauthenticated`, `v3_not_in_time_window` or
@@ -203,8 +204,11 @@ A trap is counted, not stored. Three metrics describe what arrived:
   in none of the three.
 
 `trap_name` is drawn from a closed set: the six standard traps of RFC 1215 and
-the trap definitions bundled with the profiles, about two hundred names. Any
-other trap is labelled `other`. A raw OID never appears as a label, because a
+the trap definitions in the policy's own profile set, the bundled ones plus
+whatever its `profiles_dir` adds or overrides, about two hundred names. Two
+policies on one socket may therefore name one OID differently, each under
+its own `policy` label; the RFC 1215 names win over any profile's spelling.
+Any other trap is labelled `other`. A raw OID never appears as a label, because a
 sender chooses its own trap OID and a metric label a sender controls is
 unbounded.
 
@@ -237,9 +241,10 @@ strangers.
 
 **Trap contents are unauthenticated unless the sender uses SNMPv3 with
 authentication**, in which case the backend authenticates it with the USM
-user the policy polls that device with, and no other: a credential a policy
+users the policy polls that device with, and no others: a credential a policy
 assigned to a different device, or another policy carries under the same
-username, is not tried. No trap-specific credentials are configured. v1 and v2c traps are never authenticated by any setting: the
+username, is not tried. Two targets kept at one address under different IDs
+or contexts contribute both their credentials. No trap-specific credentials are configured. v1 and v2c traps are never authenticated by any setting: the
 community they carry is not checked, because a check would be mistaken for
 authentication and would protect nothing against a sender who can read the
 community off the wire.
@@ -258,7 +263,8 @@ are acknowledged; a device that must use informs sends them as v2c for now.
 A link-local IPv6 device is matched with the interface zone the socket
 saw it on, so two devices at `fe80::1` on different interfaces are two
 devices; a target written without a zone matches the address on any
-interface, and `device_ip` carries the zone. A policy target written as a
+interface, alongside any target written with one, and `device_ip` carries
+the zone. A policy target written as a
 hostname rather than an address is not matched against trap sources, so its traps count as
 `unknown_source`; a policy declaring `traps` whose targets are all hostnames
 starts with a warning saying so, and its USM user is never tried, since it

--- a/orb-telemetry/snmp-telemetry/README.md
+++ b/orb-telemetry/snmp-telemetry/README.md
@@ -74,6 +74,11 @@ agent passes `--host localhost` explicitly to every backend it launches, so the
 wider default is what a standalone run gets, and there it is a listener nothing
 is guarding.
 
+The trap receiver, when `--trap-listen` is set, is the one listener in this
+process that has to be reachable from the device network, since devices send
+traps to it. It is off by default and opens no socket until asked. What it
+accepts and what protects it are described under **Receiving traps** below.
+
 ### What a poll puts on the wire
 
 The section above is about who can reach this backend. This one is about what
@@ -113,6 +118,68 @@ where the credential goes.
 On a segment you do not control, use SNMPv3 with `authPriv`, or name targets
 individually rather than by prefix, or both. A v2c policy over a wide prefix is
 the case that hands one shared secret to the largest number of hosts.
+
+### Receiving traps
+
+`--trap-listen host:port` opens a UDP socket for SNMP traps and informs from
+the devices policies poll. It is empty by default, and empty means no socket
+is opened. Port 162 is privileged; run with `CAP_NET_BIND_SERVICE` or choose a
+higher port and redirect to it. Do not run the backend as root to bind it.
+
+A trap is counted, not stored. Three metrics describe what arrived:
+
+- `snmp.traps_received{device_ip, policy, trap_name, version}` counts traps
+  from a device a running policy names, once per policy naming it, with the
+  same `device_ip` and `policy` labels every polled series carries.
+- `snmp.traps_dropped{reason}` counts datagrams that produced no trap:
+  `unknown_source`, `oversized`, `malformed`, `unsupported_pdu`,
+  `v3_unauthenticated` or `no_trap_oid`. Hostile v3 traffic lands under
+  `malformed` when it names a username no policy carries and under
+  `v3_unauthenticated` when it names a known one without asking to be
+  authenticated, and the second is the one worth alerting on, since it means
+  someone holds a valid username.
+- `snmp.traps_datagrams` counts every datagram read from the socket. Its gap
+  against the other two is loss you cannot otherwise see.
+
+`trap_name` is drawn from a closed set: the six standard traps of RFC 1215 and
+the trap definitions bundled with the profiles, about two hundred names. Any
+other trap is labelled `other`. A raw OID never appears as a label, because a
+sender chooses its own trap OID and a metric label a sender controls is
+unbounded.
+
+**What the source address list is, and is not.** A trap from an address no
+running policy names is dropped and counted as `unknown_source`. That is a
+noise filter and an attribution rule. It is not authentication and it is not
+access control. SNMP traps are one-way UDP with no handshake, so anyone able
+to emit a packet with a chosen source address, which on a network without
+egress filtering is anyone, can have a trap accepted and attributed to any
+device a policy names. The addresses are not secret; they are the ones this
+backend visibly polls.
+
+`--trap-accept-unknown` counts traps from unknown addresses too, labelled by
+the source address with an empty `policy`. Informs from such addresses are
+counted but never acknowledged, so the socket does not answer strangers.
+
+**Trap contents are unauthenticated unless the sender uses SNMPv3 with
+authentication**, in which case the backend authenticates it with the USM user
+the polling policy for that device carries. No trap-specific credentials are
+configured. v1 and v2c traps are never authenticated by any setting: the
+community they carry is not checked, because a check would be mistaken for
+authentication and would protect nothing against a sender who can read the
+community off the wire.
+
+The actual boundary is a network control on the trap port, a firewall rule
+or a management VRF, the same way the actual boundary for polling is the
+segment the credentials cross.
+
+Two limits in this release. A policy target written as a hostname rather than
+an address is not matched against trap sources, so its traps count as
+`unknown_source`. A policy whose targets are all hostnames but which polls
+with v3 still contributes its USM user to the set the receiver can
+authenticate against, even though it claims no address. And a device behind a
+trap relay or NAT arrives as the relay's address; a v1 trap whose agent-addr
+field names a polled device is attributed to that device, but v2c and v3
+traps are attributed to the address they arrive from.
 
 ### Policy Configuration
 

--- a/orb-telemetry/snmp-telemetry/README.md
+++ b/orb-telemetry/snmp-telemetry/README.md
@@ -74,10 +74,10 @@ agent passes `--host localhost` explicitly to every backend it launches, so the
 wider default is what a standalone run gets, and there it is a listener nothing
 is guarding.
 
-The trap receiver, when `--trap-listen` is set, is the one listener in this
-process that has to be reachable from the device network, since devices send
-traps to it. It is off by default and opens no socket until asked. What it
-accepts and what protects it are described under **Receiving traps** below.
+A trap socket, when a policy declares one, is the one listener in this process
+that has to be reachable from the device network, since devices send traps to
+it. No socket is open until a policy asks for one. What it accepts and what
+protects it are described under **Receiving traps** below.
 
 ### What a poll puts on the wire
 
@@ -121,16 +121,54 @@ the case that hands one shared secret to the largest number of hosts.
 
 ### Receiving traps
 
-`--trap-listen host:port` opens a UDP socket for SNMP traps and informs from
-the devices policies poll. It is empty by default, and empty means no socket
-is opened. Port 162 is privileged; run with `CAP_NET_BIND_SERVICE` or choose a
-higher port and redirect to it. Do not run the backend as root to bind it.
+A policy receives SNMP traps and informs from the devices its targets expand
+to by declaring the address they arrive on:
+
+```yaml
+policies:
+  core:
+    config:
+      metrics_interval: 60
+    scope:
+      authentication:
+        protocol_version: "v3"
+        security_level: "authPriv"
+        username: "netbox-poller"
+        auth_protocol: "SHA"
+        auth_passphrase: "authpass123"
+        priv_protocol: "AES"
+        priv_passphrase: "privpass123"
+      targets:
+        - host: "10.0.0.0/24"
+      traps:
+        listen: "0.0.0.0:162"
+```
+
+Without `traps`, a policy receives nothing and no socket is opened. `listen`
+is `host:port`; an empty host binds every interface, and the host must be an
+address, not a name. Port 162 is privileged; run with `CAP_NET_BIND_SERVICE`
+or choose a higher port and redirect to it. Do not run the backend as root to
+bind it.
+
+Policies naming the same `listen` string share one socket, opened when the
+first of them starts and closed when the last stops, the way pktvisor shares
+one input stream between the policies that name one tap. The string is the
+identity: `0.0.0.0:162` twice is one socket, while `0.0.0.0:162` and `:162`
+are two attempts at one port, and the second policy fails to start with the
+bind error in the API response. A policy on one socket never sees traps
+arriving on another.
+
+A policy may receive traps without polling. Omit `metrics_interval` and the
+policy schedules no collection at all; its targets are still expanded, because
+they are the addresses the socket accepts traps from, and its authentication
+still supplies the v3 users. A policy with neither `metrics_interval` nor
+`traps` is rejected as having nothing to do.
 
 A trap is counted, not stored. Three metrics describe what arrived:
 
 - `snmp.traps_received{device_ip, policy, trap_name, version}` counts traps
-  from a device a running policy names, once per policy naming it, with the
-  same `device_ip` and `policy` labels every polled series carries.
+  from a device a policy on that socket names, once per policy naming it,
+  with the same `device_ip` and `policy` labels every polled series carries.
 - `snmp.traps_dropped{reason}` counts datagrams that produced no trap:
   `unknown_source`, `oversized`, `malformed`, `unsupported_pdu`,
   `v3_unauthenticated` or `no_trap_oid`. Hostile v3 traffic lands under
@@ -141,7 +179,7 @@ A trap is counted, not stored. Three metrics describe what arrived:
   at `noAuthNoPriv` is a supported configuration, and every trap it sends
   carries no authentication either, so all of its traps are dropped under this
   reason. This release cannot count them.
-- `snmp.traps_datagrams` counts every datagram read from the socket. Its gap
+- `snmp.traps_datagrams` counts every datagram read from any socket. Its gap
   against the other two is loss you cannot otherwise see.
 
 `trap_name` is drawn from a closed set: the six standard traps of RFC 1215 and
@@ -159,26 +197,20 @@ versions, so a policy naming a whole `/16` whose every host sends every kind of
 trap is past what that ceiling accommodates. Name the devices you expect traps
 from.
 
-**What the source address list is, and is not.** A trap from an address no
-running policy names is dropped and counted as `unknown_source`. That is a
-noise filter and an attribution rule. It is not authentication and it is not
-access control. SNMP traps are one-way UDP with no handshake, so anyone able
-to emit a packet with a chosen source address, which on a network without
-egress filtering is anyone, can have a trap accepted and attributed to any
-device a policy names. The addresses are not secret; they are the ones this
-backend visibly polls.
-
-`--trap-accept-unknown` counts traps from unknown addresses too, labelled by
-the source address with an empty `policy`. Informs from such addresses are
-counted but never acknowledged, so the socket does not answer strangers. A
-source address is spoofable, so the number of unknown addresses that get a
-`device_ip` of their own is capped at a thousand; every unknown source past
-that is still counted, under the `device_ip` value `other`. The flag is a
-debugging aid for a registration gap, not a way to watch the network.
+**What the source address list is, and is not.** A trap from an address that
+no policy on that socket names is dropped and counted as `unknown_source`,
+before it is parsed. That is a noise filter and an attribution rule. It is
+not authentication and it is not access control. SNMP traps are one-way UDP
+with no handshake, so anyone able to emit a packet with a chosen source
+address, which on a network without egress filtering is anyone, can have a
+trap accepted and attributed to any device a policy names. The addresses are
+not secret; they are the ones this backend visibly polls. Informs from
+unknown addresses are never acknowledged, so the socket does not answer
+strangers.
 
 **Trap contents are unauthenticated unless the sender uses SNMPv3 with
 authentication**, in which case the backend authenticates it with the USM user
-the polling policy for that device carries. No trap-specific credentials are
+the policy for that device carries. No trap-specific credentials are
 configured. v1 and v2c traps are never authenticated by any setting: the
 community they carry is not checked, because a check would be mistaken for
 authentication and would protect nothing against a sender who can read the
@@ -190,18 +222,19 @@ segment the credentials cross.
 
 Two limits in this release. A policy target written as a hostname rather than
 an address is not matched against trap sources, so its traps count as
-`unknown_source`. A policy whose targets are all hostnames but which polls
-with v3 still contributes its USM user to the set the receiver can
-authenticate against, even though it claims no address. And a device behind a
-trap relay or NAT arrives as the relay's address; a v1 trap whose agent-addr
-field names a polled device is attributed to that device, but v2c and v3
-traps are attributed to the address they arrive from.
+`unknown_source`; a policy declaring `traps` whose targets are all hostnames
+starts with a warning saying so, and still contributes its USM user to the set
+the socket can authenticate against. And a device behind a trap relay or NAT
+arrives as the relay's address; a v1 trap whose agent-addr field names a
+polled device is attributed to that device, but v2c and v3 traps are
+attributed to the address they arrive from.
 
 ### Policy Configuration
 
 A policy names the targets to poll and the SNMP credentials to use. Each
-policy needs `metrics_interval`, the number of seconds between collection
-runs for every target in that policy.
+policy that polls needs `metrics_interval`, the number of seconds between
+collection runs for every target in that policy; a policy may omit it to
+receive traps only, as described under **Receiving traps**.
 
 Credentials go under `authentication`. Set it at the scope level as a
 fallback for every target, on individual targets, or both; a target with its

--- a/orb-telemetry/snmp-telemetry/README.md
+++ b/orb-telemetry/snmp-telemetry/README.md
@@ -245,7 +245,9 @@ prefix can fill the ceiling
 but cannot grow memory past it, the SDK never folds a series the backend
 chose to keep, and every series is withdrawn with the policy that made it. The clocks the receiver keeps for v3 engines are bounded the
 same way, at ten thousand engines, evicting the one used longest ago, in an
-order kept as they are used so an eviction costs no scan.
+order kept as they are used so an eviction costs no scan; and one device
+with one credential holds at most eight of them, evicting its own first, so
+a device cycling through engine IDs never evicts another device's clock.
 
 **What the source address list is, and is not.** A trap from an address that
 no policy on that socket names is dropped and counted as `unknown_source`,

--- a/orb-telemetry/snmp-telemetry/README.md
+++ b/orb-telemetry/snmp-telemetry/README.md
@@ -247,8 +247,11 @@ has no engine ID to offer. The probe carries no username and is dropped as
 `malformed`, and the inform is never acknowledged, so the sender retries and
 gives up. SNMPv3 traps are authenticated and counted, and v1 and v2c informs
 are acknowledged; a device that must use informs sends them as v2c for now.
-A policy target written as a hostname rather than
-an address is not matched against trap sources, so its traps count as
+A link-local IPv6 device is matched with the interface zone the socket
+saw it on, so two devices at `fe80::1` on different interfaces are two
+devices; a target written without a zone matches the address on any
+interface, and `device_ip` carries the zone. A policy target written as a
+hostname rather than an address is not matched against trap sources, so its traps count as
 `unknown_source`; a policy declaring `traps` whose targets are all hostnames
 starts with a warning saying so, and still contributes its USM user to the set
 the socket can authenticate against. And a device behind a trap relay or NAT

--- a/orb-telemetry/snmp-telemetry/cmd/main.go
+++ b/orb-telemetry/snmp-telemetry/cmd/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/env"
 	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/metrics"
 	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/policy"
-	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/profiles"
 	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/server"
 	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/traps"
 	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/version"
@@ -159,14 +158,9 @@ func main() {
 	}
 
 	profilesDir := env.ResolveEnvOrExit(*snmpProfilesDir)
-	trapNames, err := loadTrapNames(profilesDir, logger)
-	if err != nil {
-		logger.Error("Failed to load trap definitions", "error", err)
-		os.Exit(1)
-	}
 	trapTally := traps.NewTally(logger)
 	trapTally.Register()
-	pool := traps.NewPool(trapTally, trapNames, logger)
+	pool := traps.NewPool(trapTally, logger)
 	manager := policy.NewManager(rootCtx, logger, policy.Options{
 		DefaultProfilesDir: profilesDir,
 		ProfilesRoot:       env.ResolveEnvOrExit(*snmpProfilesRoot),
@@ -189,23 +183,6 @@ func main() {
 	})
 }
 
-// loadTrapNames builds the closed trap-name set from the bundled profile tree
-// plus the operator's override directory. Every receiver labels with it, so
-// it is built once here whether or not any policy declares traps; the manager
-// loads the same tree per profiles directory for its collectors and there is
-// no shared handle to borrow.
-func loadTrapNames(profilesDir string, logger *slog.Logger) (map[string]string, error) {
-	loader, err := profiles.LoadProfiles(profilesDir, logger)
-	if err != nil {
-		return nil, fmt.Errorf("loading trap definitions: %w", err)
-	}
-	all, err := loader.AllResolved()
-	if err != nil {
-		return nil, fmt.Errorf("resolving trap definitions: %w", err)
-	}
-	return traps.BuildNames(profiles.TrapNames(all)), nil
-}
-
 // trapPool adapts *traps.Pool to policy.TrapPool. The pool returns its own
 // *traps.Lease and the interface names policy.TrapLease; Go does not widen a
 // return type, so the widening happens here, and the error path returns an
@@ -222,8 +199,8 @@ func newTrapPool(pool *traps.Pool) trapPool {
 	return trapPool{pool: pool}
 }
 
-func (p trapPool) Acquire(listen, policyName string, devices []traps.Device) (policy.TrapLease, error) {
-	lease, err := p.pool.Acquire(listen, policyName, devices)
+func (p trapPool) Acquire(listen, policyName string, devices []traps.Device, names map[string]string) (policy.TrapLease, error) {
+	lease, err := p.pool.Acquire(listen, policyName, devices, names)
 	if err != nil {
 		return nil, err
 	}

--- a/orb-telemetry/snmp-telemetry/cmd/main.go
+++ b/orb-telemetry/snmp-telemetry/cmd/main.go
@@ -79,7 +79,17 @@ type closer interface {
 // completes between the two, and runs the flush's timeout while collections are
 // still going. That is one cycle of freshness against the whole interval the
 // race could cost.
-func shutdown(cancelRoot context.CancelFunc, srv stopper, flush func()) {
+//
+// Trap intake closes first. The tally is a map the export callback reads, so
+// a trap counted after that callback's final run would sit in the map and
+// never be exported, and the tally is closed right after. Closing the sockets
+// ahead of the flush means every trap the process counted is in the final
+// export, at the cost of up to the receiver's stop bound per socket spent
+// before the flush rather than after it. The poll side keeps its order: the
+// flush precedes the cancel so a running collection's observations are
+// exported before they are forgotten, and the server stops last.
+func shutdown(cancelRoot context.CancelFunc, intake closer, srv stopper, flush func()) {
+	intake.Close()
 	flush()
 	cancelRoot()
 	srv.Stop()
@@ -172,10 +182,10 @@ func main() {
 
 	serverErrCh := srv.Start()
 
-	shutdownStopper := stopAll{pool: pool, tally: trapTally, server: srv}
+	shutdownStopper := stopAll{tally: trapTally, server: srv}
 
 	waitForShutdown(rootCtx, logger, sigs, serverErrCh, func() {
-		shutdown(cancelFunc, shutdownStopper, shutdownMetrics)
+		shutdown(cancelFunc, pool, shutdownStopper, shutdownMetrics)
 	})
 }
 
@@ -220,18 +230,16 @@ func (p trapPool) Acquire(listen, policyName string, devices []traps.Device, use
 	return lease, nil
 }
 
-// stopAll closes every trap socket, then the tally, then the server. All run
-// after the final flush, so none spends the flush's budget, and the tally is
-// a map the export callback reads, so the flush carried everything counted
-// whether or not a receiver was still running.
+// stopAll closes the tally, then the server. Both run after the final flush,
+// so neither spends the flush's budget. The trap sockets are not here: they
+// close in shutdown ahead of the flush, so that everything they counted is
+// in it.
 type stopAll struct {
-	pool   closer
 	tally  closer
 	server stopper
 }
 
 func (s stopAll) Stop() {
-	s.pool.Close()
 	s.tally.Close()
 	s.server.Stop()
 }

--- a/orb-telemetry/snmp-telemetry/cmd/main.go
+++ b/orb-telemetry/snmp-telemetry/cmd/main.go
@@ -119,10 +119,6 @@ func main() {
 			"path under it, or one relative to it. Empty, the default, rejects every per-policy "+
 			"profiles_dir."+
 			" Environment variable can be used by wrapping it in ${} (e.g. ${SNMP_PROFILES_ROOT})")
-	trapListen := flag.String("trap-listen", "",
-		"address to receive SNMP traps on, e.g. 0.0.0.0:162. Empty, the default, opens no socket."+
-			" Port 162 is privileged; use CAP_NET_BIND_SERVICE or a higher port. See the README's"+
-			" inbound exposure section before binding.")
 	logLevel := flag.String("log-level", "INFO", "log level (DEBUG, INFO, WARN, ERROR)")
 	logFormat := flag.String("log-format", "TEXT", "log format (TEXT, JSON)")
 	help := flag.Bool("help", false, "show this help")
@@ -153,22 +149,21 @@ func main() {
 	}
 
 	profilesDir := env.ResolveEnvOrExit(*snmpProfilesDir)
-	trapRegistry := traps.NewRegistry()
+	trapNames, err := loadTrapNames(profilesDir, logger)
+	if err != nil {
+		logger.Error("Failed to load trap definitions", "error", err)
+		os.Exit(1)
+	}
 	trapTally := traps.NewTally(logger)
 	trapTally.Register()
+	pool := traps.NewPool(trapTally, trapNames, logger)
 	manager := policy.NewManager(rootCtx, logger, policy.Options{
 		DefaultProfilesDir: profilesDir,
 		ProfilesRoot:       env.ResolveEnvOrExit(*snmpProfilesRoot),
 		AllowedEnvVars:     splitList(*policyEnvVars),
-		TrapRegistry:       newTrapRegistration(trapRegistry, trapTally),
+		TrapPool:           newTrapPool(pool),
 	})
 	srv := server.NewServer(*host, *port, logger, manager, version.GetBuildVersion())
-
-	trapReceiver, err := startTrapReceiver(*trapListen, profilesDir, trapRegistry, trapTally, logger)
-	if err != nil {
-		logger.Error("Failed to start the trap receiver", "error", err)
-		os.Exit(1)
-	}
 
 	shutdownMetrics := func() { flushMetrics(logger, metricsFlushTimeout) }
 
@@ -177,65 +172,19 @@ func main() {
 
 	serverErrCh := srv.Start()
 
-	// trapReceiver is a *traps.Receiver; assigning it to stopAll.receiver only
-	// when it is non-nil keeps a nil case out of the interface, since a typed
-	// nil pointer stored in an interface is itself non-nil and would defeat
-	// stopAll.Stop's "if s.receiver != nil" guard.
-	shutdownStopper := stopAll{tally: trapTally, server: srv}
-	if trapReceiver != nil {
-		shutdownStopper.receiver = trapReceiver
-	}
+	shutdownStopper := stopAll{pool: pool, tally: trapTally, server: srv}
 
 	waitForShutdown(rootCtx, logger, sigs, serverErrCh, func() {
 		shutdown(cancelFunc, shutdownStopper, shutdownMetrics)
 	})
 }
 
-// trapRegistration is what a policy's lifecycle reaches, and it is two things
-// rather than one because a policy leaves two marks. The registry decides
-// whose traps are attributed to which policy, and the tally holds the counts
-// already taken.
-//
-// The registry alone satisfies policy.TrapRegistry, so passing it in bare
-// compiles and runs, and a stopped policy would go on exporting every trap
-// series it ever recorded for the life of the process. That is F6, the finding
-// the observable counter design exists to answer, and it is the contract
-// Runner.Stop documents for every other metric here.
-//
-// It lives in cmd because traps never imports policy: the registry interface
-// belongs to traps, the caller belongs to policy, and the only place that
-// knows both is the process that wires them together.
-type trapRegistration struct {
-	registry *traps.Registry
-	tally    *traps.Tally
-}
-
-func newTrapRegistration(registry *traps.Registry, tally *traps.Tally) trapRegistration {
-	return trapRegistration{registry: registry, tally: tally}
-}
-
-// Register hands the policy's addresses and users to the registry. The tally
-// has nothing to record until a trap arrives.
-func (t trapRegistration) Register(policyName string, devices []traps.Device, users []traps.V3User) {
-	t.registry.Register(policyName, devices, users)
-}
-
-// Withdraw reaches both: the registry stops attributing the policy's
-// addresses, and the tally drops the series it already holds for them.
-func (t trapRegistration) Withdraw(policyName string) {
-	t.registry.Withdraw(policyName)
-	t.tally.Withdraw(policyName)
-}
-
-// startTrapReceiver binds the trap socket when an address was given. The name
-// set is built from the bundled profile tree plus the operator's override
-// directory, loaded once here for the purpose; the manager loads the same
-// tree per profiles directory for its own collectors and there is no shared
-// handle to borrow.
-func startTrapReceiver(listen, profilesDir string, registry *traps.Registry, tally *traps.Tally, logger *slog.Logger) (*traps.Receiver, error) {
-	if listen == "" {
-		return nil, nil
-	}
+// loadTrapNames builds the closed trap-name set from the bundled profile tree
+// plus the operator's override directory. Every receiver labels with it, so
+// it is built once here whether or not any policy declares traps; the manager
+// loads the same tree per profiles directory for its collectors and there is
+// no shared handle to borrow.
+func loadTrapNames(profilesDir string, logger *slog.Logger) (map[string]string, error) {
 	loader, err := profiles.LoadProfiles(profilesDir, logger)
 	if err != nil {
 		return nil, fmt.Errorf("loading trap definitions: %w", err)
@@ -244,29 +193,45 @@ func startTrapReceiver(listen, profilesDir string, registry *traps.Registry, tal
 	if err != nil {
 		return nil, fmt.Errorf("resolving trap definitions: %w", err)
 	}
-	names := traps.BuildNames(profiles.TrapNames(all))
-	rcv, err := traps.Listen(listen, registry, tally, names, logger)
+	return traps.BuildNames(profiles.TrapNames(all)), nil
+}
+
+// trapPool adapts *traps.Pool to policy.TrapPool. The pool returns its own
+// *traps.Lease and the interface names policy.TrapLease; Go does not widen a
+// return type, so the widening happens here, and the error path returns an
+// untyped nil so the caller's nil check holds.
+//
+// It lives in cmd because traps never imports policy: the pool belongs to
+// traps, the caller belongs to policy, and the only place that knows both is
+// the process that wires them together.
+type trapPool struct {
+	pool *traps.Pool
+}
+
+func newTrapPool(pool *traps.Pool) trapPool {
+	return trapPool{pool: pool}
+}
+
+func (p trapPool) Acquire(listen, policyName string, devices []traps.Device, users []traps.V3User) (policy.TrapLease, error) {
+	lease, err := p.pool.Acquire(listen, policyName, devices, users)
 	if err != nil {
 		return nil, err
 	}
-	logger.Info("Trap receiver listening", "address", rcv.Addr().String(), "trap_names", len(names))
-	return rcv, nil
+	return lease, nil
 }
 
-// stopAll stops the trap receiver and then the server. Both run after the
-// final flush, so neither spends the flush's budget, and the tally is a map
-// the export callback reads, so the flush carried everything counted whether
-// or not the receiver was still running.
+// stopAll closes every trap socket, then the tally, then the server. All run
+// after the final flush, so none spends the flush's budget, and the tally is
+// a map the export callback reads, so the flush carried everything counted
+// whether or not a receiver was still running.
 type stopAll struct {
-	receiver stopper
-	tally    closer
-	server   stopper
+	pool   closer
+	tally  closer
+	server stopper
 }
 
 func (s stopAll) Stop() {
-	if s.receiver != nil {
-		s.receiver.Stop()
-	}
+	s.pool.Close()
 	s.tally.Close()
 	s.server.Stop()
 }

--- a/orb-telemetry/snmp-telemetry/cmd/main.go
+++ b/orb-telemetry/snmp-telemetry/cmd/main.go
@@ -24,8 +24,12 @@ import (
 // AppName is the application name
 const AppName = "snmp-telemetry"
 
-// metricsFlushTimeout bounds the final export at shutdown.
-const metricsFlushTimeout = 5 * time.Second
+// shutdownBudget bounds the trap intake close and the final export together.
+// The agent sends SIGTERM and escalates to SIGKILL after a five-second grace,
+// so the two steps that spend time before the process can exit share one
+// deadline inside it rather than each keeping a bound of their own that only
+// add up to more than the grace.
+const shutdownBudget = 5 * time.Second
 
 // defaultHost is the address the policy API binds unless --host says otherwise.
 // The API has no authentication, so anyone who can route to the listener can
@@ -83,13 +87,17 @@ type closer interface {
 // a trap counted after that callback's final run would sit in the map and
 // never be exported, and the tally is closed right after. Closing the sockets
 // ahead of the flush means every trap the process counted is in the final
-// export, at the cost of up to the receiver's stop bound per socket spent
-// before the flush rather than after it. The poll side keeps its order: the
-// flush precedes the cancel so a running collection's observations are
-// exported before they are forgotten, and the server stops last.
-func shutdown(cancelRoot context.CancelFunc, intake closer, srv stopper, flush func()) {
+// export, at the cost of up to the receiver's stop bound spent before the
+// flush rather than after it. That cost comes out of the flush's budget: the
+// deadline is taken before the intake close and the flush is handed what
+// remains, so the two together stay inside the agent's stop grace. The poll
+// side keeps its order: the flush precedes the cancel so a running
+// collection's observations are exported before they are forgotten, and the
+// server stops last.
+func shutdown(budget time.Duration, cancelRoot context.CancelFunc, intake closer, srv stopper, flush func(timeout time.Duration)) {
+	deadline := time.Now().Add(budget)
 	intake.Close()
-	flush()
+	flush(max(time.Until(deadline), 0))
 	cancelRoot()
 	srv.Stop()
 }
@@ -169,7 +177,7 @@ func main() {
 	})
 	srv := server.NewServer(*host, *port, logger, manager, version.GetBuildVersion())
 
-	shutdownMetrics := func() { flushMetrics(logger, metricsFlushTimeout) }
+	shutdownMetrics := func(timeout time.Duration) { flushMetrics(logger, timeout) }
 
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
@@ -179,7 +187,7 @@ func main() {
 	shutdownStopper := stopAll{tally: trapTally, server: srv}
 
 	waitForShutdown(rootCtx, logger, sigs, serverErrCh, func() {
-		shutdown(cancelFunc, pool, shutdownStopper, shutdownMetrics)
+		shutdown(shutdownBudget, cancelFunc, pool, shutdownStopper, shutdownMetrics)
 	})
 }
 

--- a/orb-telemetry/snmp-telemetry/cmd/main.go
+++ b/orb-telemetry/snmp-telemetry/cmd/main.go
@@ -42,6 +42,11 @@ type stopper interface {
 	Stop()
 }
 
+// closer is the part of the tally the shutdown sequence uses.
+type closer interface {
+	Close()
+}
+
 // shutdown unwinds the process in the order the export and the runners need.
 //
 // The flush comes first, before anything has been cancelled. Every runner
@@ -175,8 +180,17 @@ func main() {
 
 	serverErrCh := srv.Start()
 
+	// trapReceiver is a *traps.Receiver; assigning it to stopAll.receiver only
+	// when it is non-nil keeps a nil case out of the interface, since a typed
+	// nil pointer stored in an interface is itself non-nil and would defeat
+	// stopAll.Stop's "if s.receiver != nil" guard.
+	shutdownStopper := stopAll{tally: trapTally, server: srv}
+	if trapReceiver != nil {
+		shutdownStopper.receiver = trapReceiver
+	}
+
 	waitForShutdown(rootCtx, logger, sigs, serverErrCh, func() {
-		shutdown(cancelFunc, stopAll{receiver: trapReceiver, tally: trapTally, server: srv}, shutdownMetrics)
+		shutdown(cancelFunc, shutdownStopper, shutdownMetrics)
 	})
 }
 
@@ -211,8 +225,8 @@ func startTrapReceiver(listen, profilesDir string, acceptUnknown bool, registry 
 // the export callback reads, so the flush carried everything counted whether
 // or not the receiver was still running.
 type stopAll struct {
-	receiver *traps.Receiver
-	tally    *traps.Tally
+	receiver stopper
+	tally    closer
 	server   stopper
 }
 

--- a/orb-telemetry/snmp-telemetry/cmd/main.go
+++ b/orb-telemetry/snmp-telemetry/cmd/main.go
@@ -16,7 +16,9 @@ import (
 	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/env"
 	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/metrics"
 	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/policy"
+	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/profiles"
 	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/server"
+	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/traps"
 	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/version"
 )
 
@@ -112,6 +114,13 @@ func main() {
 			"path under it, or one relative to it. Empty, the default, rejects every per-policy "+
 			"profiles_dir."+
 			" Environment variable can be used by wrapping it in ${} (e.g. ${SNMP_PROFILES_ROOT})")
+	trapListen := flag.String("trap-listen", "",
+		"address to receive SNMP traps on, e.g. 0.0.0.0:162. Empty, the default, opens no socket."+
+			" Port 162 is privileged; use CAP_NET_BIND_SERVICE or a higher port. See the README's"+
+			" inbound exposure section before binding.")
+	trapAcceptUnknown := flag.Bool("trap-accept-unknown", false,
+		"count traps from addresses no policy names, labelled by source address with no policy."+
+			" Off by default; informs from such sources are never acknowledged.")
 	logLevel := flag.String("log-level", "INFO", "log level (DEBUG, INFO, WARN, ERROR)")
 	logFormat := flag.String("log-format", "TEXT", "log format (TEXT, JSON)")
 	help := flag.Bool("help", false, "show this help")
@@ -142,12 +151,22 @@ func main() {
 	}
 
 	profilesDir := env.ResolveEnvOrExit(*snmpProfilesDir)
+	trapRegistry := traps.NewRegistry()
 	manager := policy.NewManager(rootCtx, logger, policy.Options{
 		DefaultProfilesDir: profilesDir,
 		ProfilesRoot:       env.ResolveEnvOrExit(*snmpProfilesRoot),
 		AllowedEnvVars:     splitList(*policyEnvVars),
+		TrapRegistry:       trapRegistry,
 	})
 	srv := server.NewServer(*host, *port, logger, manager, version.GetBuildVersion())
+
+	trapTally := traps.NewTally(logger)
+	trapTally.Register()
+	trapReceiver, err := startTrapReceiver(*trapListen, profilesDir, *trapAcceptUnknown, trapRegistry, trapTally, logger)
+	if err != nil {
+		logger.Error("Failed to start the trap receiver", "error", err)
+		os.Exit(1)
+	}
 
 	shutdownMetrics := func() { flushMetrics(logger, metricsFlushTimeout) }
 
@@ -157,8 +176,52 @@ func main() {
 	serverErrCh := srv.Start()
 
 	waitForShutdown(rootCtx, logger, sigs, serverErrCh, func() {
-		shutdown(cancelFunc, srv, shutdownMetrics)
+		shutdown(cancelFunc, stopAll{receiver: trapReceiver, tally: trapTally, server: srv}, shutdownMetrics)
 	})
+}
+
+// startTrapReceiver binds the trap socket when an address was given. The name
+// set is built from the bundled profile tree plus the operator's override
+// directory, loaded once here for the purpose; the manager loads the same
+// tree per profiles directory for its own collectors and there is no shared
+// handle to borrow.
+func startTrapReceiver(listen, profilesDir string, acceptUnknown bool, registry *traps.Registry, tally *traps.Tally, logger *slog.Logger) (*traps.Receiver, error) {
+	if listen == "" {
+		return nil, nil
+	}
+	loader, err := profiles.LoadProfiles(profilesDir, logger)
+	if err != nil {
+		return nil, fmt.Errorf("loading trap definitions: %w", err)
+	}
+	all, err := loader.AllResolved()
+	if err != nil {
+		return nil, fmt.Errorf("resolving trap definitions: %w", err)
+	}
+	names := traps.BuildNames(profiles.TrapNames(all))
+	rcv, err := traps.Listen(listen, registry, tally, names, acceptUnknown, logger)
+	if err != nil {
+		return nil, err
+	}
+	logger.Info("Trap receiver listening", "address", rcv.Addr().String(), "accept_unknown", acceptUnknown, "trap_names", len(names))
+	return rcv, nil
+}
+
+// stopAll stops the trap receiver and then the server. Both run after the
+// final flush, so neither spends the flush's budget, and the tally is a map
+// the export callback reads, so the flush carried everything counted whether
+// or not the receiver was still running.
+type stopAll struct {
+	receiver *traps.Receiver
+	tally    *traps.Tally
+	server   stopper
+}
+
+func (s stopAll) Stop() {
+	if s.receiver != nil {
+		s.receiver.Stop()
+	}
+	s.tally.Close()
+	s.server.Stop()
 }
 
 // splitList reads a comma-separated flag value as its non-empty, trimmed

--- a/orb-telemetry/snmp-telemetry/cmd/main.go
+++ b/orb-telemetry/snmp-telemetry/cmd/main.go
@@ -157,16 +157,16 @@ func main() {
 
 	profilesDir := env.ResolveEnvOrExit(*snmpProfilesDir)
 	trapRegistry := traps.NewRegistry()
+	trapTally := traps.NewTally(logger)
+	trapTally.Register()
 	manager := policy.NewManager(rootCtx, logger, policy.Options{
 		DefaultProfilesDir: profilesDir,
 		ProfilesRoot:       env.ResolveEnvOrExit(*snmpProfilesRoot),
 		AllowedEnvVars:     splitList(*policyEnvVars),
-		TrapRegistry:       trapRegistry,
+		TrapRegistry:       newTrapRegistration(trapRegistry, trapTally),
 	})
 	srv := server.NewServer(*host, *port, logger, manager, version.GetBuildVersion())
 
-	trapTally := traps.NewTally(logger)
-	trapTally.Register()
 	trapReceiver, err := startTrapReceiver(*trapListen, profilesDir, *trapAcceptUnknown, trapRegistry, trapTally, logger)
 	if err != nil {
 		logger.Error("Failed to start the trap receiver", "error", err)
@@ -192,6 +192,42 @@ func main() {
 	waitForShutdown(rootCtx, logger, sigs, serverErrCh, func() {
 		shutdown(cancelFunc, shutdownStopper, shutdownMetrics)
 	})
+}
+
+// trapRegistration is what a policy's lifecycle reaches, and it is two things
+// rather than one because a policy leaves two marks. The registry decides
+// whose traps are attributed to which policy, and the tally holds the counts
+// already taken.
+//
+// The registry alone satisfies policy.TrapRegistry, so passing it in bare
+// compiles and runs, and a stopped policy would go on exporting every trap
+// series it ever recorded for the life of the process. That is F6, the finding
+// the observable counter design exists to answer, and it is the contract
+// Runner.Stop documents for every other metric here.
+//
+// It lives in cmd because traps never imports policy: the registry interface
+// belongs to traps, the caller belongs to policy, and the only place that
+// knows both is the process that wires them together.
+type trapRegistration struct {
+	registry *traps.Registry
+	tally    *traps.Tally
+}
+
+func newTrapRegistration(registry *traps.Registry, tally *traps.Tally) trapRegistration {
+	return trapRegistration{registry: registry, tally: tally}
+}
+
+// Register hands the policy's addresses and users to the registry. The tally
+// has nothing to record until a trap arrives.
+func (t trapRegistration) Register(policyName string, devices []traps.Device, users []traps.V3User) {
+	t.registry.Register(policyName, devices, users)
+}
+
+// Withdraw reaches both: the registry stops attributing the policy's
+// addresses, and the tally drops the series it already holds for them.
+func (t trapRegistration) Withdraw(policyName string) {
+	t.registry.Withdraw(policyName)
+	t.tally.Withdraw(policyName)
 }
 
 // startTrapReceiver binds the trap socket when an address was given. The name

--- a/orb-telemetry/snmp-telemetry/cmd/main.go
+++ b/orb-telemetry/snmp-telemetry/cmd/main.go
@@ -123,9 +123,6 @@ func main() {
 		"address to receive SNMP traps on, e.g. 0.0.0.0:162. Empty, the default, opens no socket."+
 			" Port 162 is privileged; use CAP_NET_BIND_SERVICE or a higher port. See the README's"+
 			" inbound exposure section before binding.")
-	trapAcceptUnknown := flag.Bool("trap-accept-unknown", false,
-		"count traps from addresses no policy names, labelled by source address with no policy."+
-			" Off by default; informs from such sources are never acknowledged.")
 	logLevel := flag.String("log-level", "INFO", "log level (DEBUG, INFO, WARN, ERROR)")
 	logFormat := flag.String("log-format", "TEXT", "log format (TEXT, JSON)")
 	help := flag.Bool("help", false, "show this help")
@@ -167,7 +164,7 @@ func main() {
 	})
 	srv := server.NewServer(*host, *port, logger, manager, version.GetBuildVersion())
 
-	trapReceiver, err := startTrapReceiver(*trapListen, profilesDir, *trapAcceptUnknown, trapRegistry, trapTally, logger)
+	trapReceiver, err := startTrapReceiver(*trapListen, profilesDir, trapRegistry, trapTally, logger)
 	if err != nil {
 		logger.Error("Failed to start the trap receiver", "error", err)
 		os.Exit(1)
@@ -235,7 +232,7 @@ func (t trapRegistration) Withdraw(policyName string) {
 // directory, loaded once here for the purpose; the manager loads the same
 // tree per profiles directory for its own collectors and there is no shared
 // handle to borrow.
-func startTrapReceiver(listen, profilesDir string, acceptUnknown bool, registry *traps.Registry, tally *traps.Tally, logger *slog.Logger) (*traps.Receiver, error) {
+func startTrapReceiver(listen, profilesDir string, registry *traps.Registry, tally *traps.Tally, logger *slog.Logger) (*traps.Receiver, error) {
 	if listen == "" {
 		return nil, nil
 	}
@@ -248,11 +245,11 @@ func startTrapReceiver(listen, profilesDir string, acceptUnknown bool, registry 
 		return nil, fmt.Errorf("resolving trap definitions: %w", err)
 	}
 	names := traps.BuildNames(profiles.TrapNames(all))
-	rcv, err := traps.Listen(listen, registry, tally, names, acceptUnknown, logger)
+	rcv, err := traps.Listen(listen, registry, tally, names, logger)
 	if err != nil {
 		return nil, err
 	}
-	logger.Info("Trap receiver listening", "address", rcv.Addr().String(), "accept_unknown", acceptUnknown, "trap_names", len(names))
+	logger.Info("Trap receiver listening", "address", rcv.Addr().String(), "trap_names", len(names))
 	return rcv, nil
 }
 

--- a/orb-telemetry/snmp-telemetry/cmd/main.go
+++ b/orb-telemetry/snmp-telemetry/cmd/main.go
@@ -222,8 +222,8 @@ func newTrapPool(pool *traps.Pool) trapPool {
 	return trapPool{pool: pool}
 }
 
-func (p trapPool) Acquire(listen, policyName string, devices []traps.Device, users []traps.V3User) (policy.TrapLease, error) {
-	lease, err := p.pool.Acquire(listen, policyName, devices, users)
+func (p trapPool) Acquire(listen, policyName string, devices []traps.Device) (policy.TrapLease, error) {
+	lease, err := p.pool.Acquire(listen, policyName, devices)
 	if err != nil {
 		return nil, err
 	}

--- a/orb-telemetry/snmp-telemetry/cmd/main_test.go
+++ b/orb-telemetry/snmp-telemetry/cmd/main_test.go
@@ -348,7 +348,7 @@ func TestShutdownFlushesBeforeACancelledCollectionForgetsTheDevice(t *testing.T)
 
 // With no --trap-listen, no socket is opened and nothing else changes.
 func TestTrapListenEmptyOpensNoSocket(t *testing.T) {
-	rcv, err := startTrapReceiver("", "", false, nil, nil, discardLogger())
+	rcv, err := startTrapReceiver("", "", nil, nil, discardLogger())
 	require.NoError(t, err)
 	assert.Nil(t, rcv)
 }
@@ -357,7 +357,7 @@ func TestTrapListenBindFailureIsAnError(t *testing.T) {
 	blocker, err := net.ListenPacket("udp", "127.0.0.1:0")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = blocker.Close() })
-	_, err = startTrapReceiver(blocker.LocalAddr().String(), "", false, traps.NewRegistry(), traps.NewTally(discardLogger()), discardLogger())
+	_, err = startTrapReceiver(blocker.LocalAddr().String(), "", traps.NewRegistry(), traps.NewTally(discardLogger()), discardLogger())
 	require.Error(t, err, "a bind failure is reported, not logged from a goroutine")
 }
 

--- a/orb-telemetry/snmp-telemetry/cmd/main_test.go
+++ b/orb-telemetry/snmp-telemetry/cmd/main_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"net/netip"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -16,10 +17,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	collectormetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	"google.golang.org/grpc"
 
 	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/metrics"
+	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/policy"
 	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/traps"
 )
 
@@ -387,4 +391,66 @@ func TestStopAllOrder(t *testing.T) {
 		assert.NotPanics(t, sa.Stop)
 		assert.Equal(t, []string{"tally", "server"}, order)
 	})
+}
+
+// trapSeries collects the trap counters and keys each data point by its
+// metric name and attributes, so a withdrawn policy's absence is observable.
+func trapSeries(t *testing.T, reader sdkmetric.Reader) map[string]int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	got := map[string]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				continue
+			}
+			for _, dp := range sum.DataPoints {
+				key := m.Name
+				for _, kv := range dp.Attributes.ToSlice() {
+					key += "|" + string(kv.Key) + "=" + kv.Value.String()
+				}
+				got[key] = dp.Value
+			}
+		}
+	}
+	return got
+}
+
+// F6: a stopped policy must stop exporting its trap series, and that only
+// happens if the withdrawal reaches the tally. The registry on its own
+// satisfies policy.TrapRegistry, so passing it in bare compiles and runs and
+// leaves every count a stopped policy ever recorded exporting for the life of
+// the process, which is exactly the contract Runner.Stop documents.
+func TestTrapRegistration_WithdrawReachesTheRegistryAndTheTally(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+	metrics.SetMeterForTest(provider.Meter("test"))
+	t.Cleanup(metrics.ResetMeter)
+
+	registry := traps.NewRegistry()
+	tally := traps.NewTally(discardLogger())
+	tally.Register()
+	t.Cleanup(tally.Close)
+
+	// Through the interface the manager is given, so the test fails if the
+	// adapter stops satisfying it.
+	var reg policy.TrapRegistry = newTrapRegistration(registry, tally)
+	reg.Register("core", []traps.Device{{Policy: "core", Addr: netip.MustParseAddr("10.0.0.5")}}, nil)
+	reg.Register("edge", []traps.Device{{Policy: "edge", Addr: netip.MustParseAddr("10.0.0.6")}}, nil)
+	tally.Received("10.0.0.5", "core", "linkDown", traps.V2c)
+	tally.Received("10.0.0.6", "edge", "linkDown", traps.V2c)
+
+	const coreSeries = "snmp.traps_received|device_ip=10.0.0.5|policy=core|trap_name=linkDown|version=2c"
+	const edgeSeries = "snmp.traps_received|device_ip=10.0.0.6|policy=edge|trap_name=linkDown|version=2c"
+	require.Equal(t, 2, registry.Size())
+	require.Contains(t, trapSeries(t, reader), coreSeries)
+
+	reg.Withdraw("core")
+	assert.Equal(t, 1, registry.Size(), "the registry stops attributing the policy's addresses")
+	series := trapSeries(t, reader)
+	assert.NotContains(t, series, coreSeries, "the tally stops exporting the policy's counts")
+	assert.Contains(t, series, edgeSeries, "another policy's series is untouched")
 }

--- a/orb-telemetry/snmp-telemetry/cmd/main_test.go
+++ b/orb-telemetry/snmp-telemetry/cmd/main_test.go
@@ -48,7 +48,10 @@ func TestShutdownCancelsRootBetweenTheFlushAndTheServerStop(t *testing.T) {
 		errAtFlush error
 	)
 
-	shutdown(cancel, stopFunc(func() {
+	shutdown(cancel, closeFunc(func() {
+		order = append(order, "intake")
+		require.NoError(t, rootCtx.Err(), "trap intake closes before anything is cancelled")
+	}), stopFunc(func() {
 		order = append(order, "stop")
 		errAtStop = rootCtx.Err()
 	}), func() {
@@ -56,7 +59,8 @@ func TestShutdownCancelsRootBetweenTheFlushAndTheServerStop(t *testing.T) {
 		errAtFlush = rootCtx.Err()
 	})
 
-	require.Equal(t, []string{"flush", "stop"}, order)
+	require.Equal(t, []string{"intake", "flush", "stop"}, order,
+		"trap intake closes first so nothing is counted after the final export; the flush still precedes the cancel")
 	require.ErrorIs(t, errAtStop, context.Canceled, "the root context must be cancelled before the server is stopped")
 	require.NoError(t, errAtFlush, "the root context must still be live during the final flush")
 }
@@ -209,7 +213,7 @@ func TestShutdownFlushesObservationsBeforeTheServerStopDropsThem(t *testing.T) {
 		storeMu.Unlock()
 	})
 
-	shutdown(cancel, stop, func() { flushMetrics(logger, metricsFlushTimeout) })
+	shutdown(cancel, closeFunc(func() {}), stop, func() { flushMetrics(logger, metricsFlushTimeout) })
 
 	assert.Equal(t, []int64{42}, receiver.gaugeValues(metricName),
 		"the final export must carry the observations the server stop drops")
@@ -337,7 +341,7 @@ func TestShutdownFlushesBeforeACancelledCollectionForgetsTheDevice(t *testing.T)
 		<-forgotten
 	}
 
-	shutdown(cancelRoot, stopFunc(func() {}), func() { flushMetrics(logger, metricsFlushTimeout) })
+	shutdown(cancelRoot, closeFunc(func() {}), stopFunc(func() {}), func() { flushMetrics(logger, metricsFlushTimeout) })
 
 	assert.Equal(t, []int64{7}, receiver.gaugeValues(metricName),
 		"the final export must carry the observations a cancelled collection forgets")
@@ -348,19 +352,19 @@ type closeFunc func()
 
 func (f closeFunc) Close() { f() }
 
-// stopAll closes the trap pool, then the tally, then the server. shutdown's
+// stopAll closes the tally, then the server; the trap pool closes earlier, in
+// shutdown itself, ahead of the flush. shutdown's
 // own flush, cancel, stop order is a separate concern, already pinned by
 // TestShutdownCancelsRootBetweenTheFlushAndTheServerStop; this test is only
 // about the sequence stopAll.Stop itself encodes.
 func TestStopAllOrder(t *testing.T) {
 	var order []string
 	sa := stopAll{
-		pool:   closeFunc(func() { order = append(order, "pool") }),
 		tally:  closeFunc(func() { order = append(order, "tally") }),
 		server: stopFunc(func() { order = append(order, "server") }),
 	}
 	sa.Stop()
-	assert.Equal(t, []string{"pool", "tally", "server"}, order)
+	assert.Equal(t, []string{"tally", "server"}, order)
 }
 
 // The adapter is what the manager is given, so it must satisfy the interface

--- a/orb-telemetry/snmp-telemetry/cmd/main_test.go
+++ b/orb-telemetry/snmp-telemetry/cmd/main_test.go
@@ -377,25 +377,16 @@ func TestTrapPoolAdapter(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = blocker.Close() })
 
-	pool := traps.NewPool(traps.NewTally(discardLogger()), traps.BuildNames(nil), discardLogger())
+	pool := traps.NewPool(traps.NewTally(discardLogger()), discardLogger())
 	t.Cleanup(pool.Close)
 	var adapted policy.TrapPool = trapPool{pool: pool}
 
-	lease, err := adapted.Acquire(blocker.LocalAddr().String(), "core", nil)
+	lease, err := adapted.Acquire(blocker.LocalAddr().String(), "core", nil, nil)
 	require.Error(t, err)
 	assert.True(t, lease == nil, "an error must come with an untyped nil lease")
 
-	lease, err = adapted.Acquire("127.0.0.1:0", "core", nil)
+	lease, err = adapted.Acquire("127.0.0.1:0", "core", nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, lease)
 	lease.Release()
-}
-
-// loadTrapNames builds the closed name set from the bundled tree. It is what
-// every receiver labels with, so it must load without an override directory.
-func TestLoadTrapNamesFromTheBundledTree(t *testing.T) {
-	names, err := loadTrapNames("", discardLogger())
-	require.NoError(t, err)
-	assert.Greater(t, len(names), 150)
-	assert.Equal(t, "linkDown", names["1.3.6.1.6.3.1.1.5.3"])
 }

--- a/orb-telemetry/snmp-telemetry/cmd/main_test.go
+++ b/orb-telemetry/snmp-telemetry/cmd/main_test.go
@@ -48,13 +48,13 @@ func TestShutdownCancelsRootBetweenTheFlushAndTheServerStop(t *testing.T) {
 		errAtFlush error
 	)
 
-	shutdown(cancel, closeFunc(func() {
+	shutdown(shutdownBudget, cancel, closeFunc(func() {
 		order = append(order, "intake")
 		require.NoError(t, rootCtx.Err(), "trap intake closes before anything is cancelled")
 	}), stopFunc(func() {
 		order = append(order, "stop")
 		errAtStop = rootCtx.Err()
-	}), func() {
+	}), func(time.Duration) {
 		order = append(order, "flush")
 		errAtFlush = rootCtx.Err()
 	})
@@ -63,6 +63,22 @@ func TestShutdownCancelsRootBetweenTheFlushAndTheServerStop(t *testing.T) {
 		"trap intake closes first so nothing is counted after the final export; the flush still precedes the cancel")
 	require.ErrorIs(t, errAtStop, context.Canceled, "the root context must be cancelled before the server is stopped")
 	require.NoError(t, errAtFlush, "the root context must still be live during the final flush")
+}
+
+// The agent gives the process one stop grace. Closing trap intake spends part
+// of it, so the flush is handed what is left of the shared budget rather than
+// a budget of its own that, added to the intake close, could outlast the grace.
+func TestShutdownChargesTheIntakeCloseAgainstTheFlushBudget(t *testing.T) {
+	const budget = 500 * time.Millisecond
+	const intakeTook = 200 * time.Millisecond
+
+	var flushGot time.Duration
+	shutdown(budget, func() {}, closeFunc(func() { time.Sleep(intakeTook) }), stopFunc(func() {}), func(timeout time.Duration) {
+		flushGot = timeout
+	})
+
+	assert.Greater(t, flushGot, time.Duration(0), "the flush still runs when the intake close leaves budget")
+	assert.LessOrEqual(t, flushGot, budget-intakeTook, "the intake close is charged against the flush's budget")
 }
 
 // The flush runs on its own context, so a root context already cancelled when
@@ -213,7 +229,7 @@ func TestShutdownFlushesObservationsBeforeTheServerStopDropsThem(t *testing.T) {
 		storeMu.Unlock()
 	})
 
-	shutdown(cancel, closeFunc(func() {}), stop, func() { flushMetrics(logger, metricsFlushTimeout) })
+	shutdown(shutdownBudget, cancel, closeFunc(func() {}), stop, func(timeout time.Duration) { flushMetrics(logger, timeout) })
 
 	assert.Equal(t, []int64{42}, receiver.gaugeValues(metricName),
 		"the final export must carry the observations the server stop drops")
@@ -341,7 +357,7 @@ func TestShutdownFlushesBeforeACancelledCollectionForgetsTheDevice(t *testing.T)
 		<-forgotten
 	}
 
-	shutdown(cancelRoot, closeFunc(func() {}), stopFunc(func() {}), func() { flushMetrics(logger, metricsFlushTimeout) })
+	shutdown(shutdownBudget, cancelRoot, closeFunc(func() {}), stopFunc(func() {}), func(timeout time.Duration) { flushMetrics(logger, timeout) })
 
 	assert.Equal(t, []int64{7}, receiver.gaugeValues(metricName),
 		"the final export must carry the observations a cancelled collection forgets")

--- a/orb-telemetry/snmp-telemetry/cmd/main_test.go
+++ b/orb-telemetry/snmp-telemetry/cmd/main_test.go
@@ -379,7 +379,7 @@ func TestTrapPoolAdapter(t *testing.T) {
 
 	lease, err := adapted.Acquire(blocker.LocalAddr().String(), "core", nil, nil)
 	require.Error(t, err)
-	assert.Nil(t, lease, "an error must come with an untyped nil lease")
+	assert.True(t, lease == nil, "an error must come with an untyped nil lease")
 
 	lease, err = adapted.Acquire("127.0.0.1:0", "core", nil, nil)
 	require.NoError(t, err)

--- a/orb-telemetry/snmp-telemetry/cmd/main_test.go
+++ b/orb-telemetry/snmp-telemetry/cmd/main_test.go
@@ -381,11 +381,11 @@ func TestTrapPoolAdapter(t *testing.T) {
 	t.Cleanup(pool.Close)
 	var adapted policy.TrapPool = trapPool{pool: pool}
 
-	lease, err := adapted.Acquire(blocker.LocalAddr().String(), "core", nil, nil)
+	lease, err := adapted.Acquire(blocker.LocalAddr().String(), "core", nil)
 	require.Error(t, err)
 	assert.True(t, lease == nil, "an error must come with an untyped nil lease")
 
-	lease, err = adapted.Acquire("127.0.0.1:0", "core", nil, nil)
+	lease, err = adapted.Acquire("127.0.0.1:0", "core", nil)
 	require.NoError(t, err)
 	require.NotNil(t, lease)
 	lease.Release()

--- a/orb-telemetry/snmp-telemetry/cmd/main_test.go
+++ b/orb-telemetry/snmp-telemetry/cmd/main_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log/slog"
 	"net"
-	"net/netip"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -17,8 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/metric"
-	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	collectormetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	"google.golang.org/grpc"
 
@@ -346,111 +343,55 @@ func TestShutdownFlushesBeforeACancelledCollectionForgetsTheDevice(t *testing.T)
 		"the final export must carry the observations a cancelled collection forgets")
 }
 
-// With no --trap-listen, no socket is opened and nothing else changes.
-func TestTrapListenEmptyOpensNoSocket(t *testing.T) {
-	rcv, err := startTrapReceiver("", "", nil, nil, discardLogger())
-	require.NoError(t, err)
-	assert.Nil(t, rcv)
-}
-
-func TestTrapListenBindFailureIsAnError(t *testing.T) {
-	blocker, err := net.ListenPacket("udp", "127.0.0.1:0")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = blocker.Close() })
-	_, err = startTrapReceiver(blocker.LocalAddr().String(), "", traps.NewRegistry(), traps.NewTally(discardLogger()), discardLogger())
-	require.Error(t, err, "a bind failure is reported, not logged from a goroutine")
-}
-
 // closeFunc adapts a function to the closer stopAll's tally field takes.
 type closeFunc func()
 
 func (f closeFunc) Close() { f() }
 
-// stopAll stops the receiver, then closes the tally, then stops the server.
-// shutdown's own flush, cancel, stop order is a separate concern, already
-// pinned by TestShutdownCancelsRootBetweenTheFlushAndTheServerStop; this test
-// is only about the sequence stopAll.Stop itself encodes.
+// stopAll closes the trap pool, then the tally, then the server. shutdown's
+// own flush, cancel, stop order is a separate concern, already pinned by
+// TestShutdownCancelsRootBetweenTheFlushAndTheServerStop; this test is only
+// about the sequence stopAll.Stop itself encodes.
 func TestStopAllOrder(t *testing.T) {
-	t.Run("with a receiver", func(t *testing.T) {
-		var order []string
-		sa := stopAll{
-			receiver: stopFunc(func() { order = append(order, "receiver") }),
-			tally:    closeFunc(func() { order = append(order, "tally") }),
-			server:   stopFunc(func() { order = append(order, "server") }),
-		}
-		sa.Stop()
-		assert.Equal(t, []string{"receiver", "tally", "server"}, order)
-	})
-
-	t.Run("without a receiver", func(t *testing.T) {
-		var order []string
-		sa := stopAll{
-			tally:  closeFunc(func() { order = append(order, "tally") }),
-			server: stopFunc(func() { order = append(order, "server") }),
-		}
-		assert.NotPanics(t, sa.Stop)
-		assert.Equal(t, []string{"tally", "server"}, order)
-	})
-}
-
-// trapSeries collects the trap counters and keys each data point by its
-// metric name and attributes, so a withdrawn policy's absence is observable.
-func trapSeries(t *testing.T, reader sdkmetric.Reader) map[string]int64 {
-	t.Helper()
-	var rm metricdata.ResourceMetrics
-	require.NoError(t, reader.Collect(context.Background(), &rm))
-	got := map[string]int64{}
-	for _, sm := range rm.ScopeMetrics {
-		for _, m := range sm.Metrics {
-			sum, ok := m.Data.(metricdata.Sum[int64])
-			if !ok {
-				continue
-			}
-			for _, dp := range sum.DataPoints {
-				key := m.Name
-				for _, kv := range dp.Attributes.ToSlice() {
-					key += "|" + string(kv.Key) + "=" + kv.Value.String()
-				}
-				got[key] = dp.Value
-			}
-		}
+	var order []string
+	sa := stopAll{
+		pool:   closeFunc(func() { order = append(order, "pool") }),
+		tally:  closeFunc(func() { order = append(order, "tally") }),
+		server: stopFunc(func() { order = append(order, "server") }),
 	}
-	return got
+	sa.Stop()
+	assert.Equal(t, []string{"pool", "tally", "server"}, order)
 }
 
-// F6: a stopped policy must stop exporting its trap series, and that only
-// happens if the withdrawal reaches the tally. The registry on its own
-// satisfies policy.TrapRegistry, so passing it in bare compiles and runs and
-// leaves every count a stopped policy ever recorded exporting for the life of
-// the process, which is exactly the contract Runner.Stop documents.
-func TestTrapRegistration_WithdrawReachesTheRegistryAndTheTally(t *testing.T) {
-	reader := sdkmetric.NewManualReader()
-	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
-	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
-	metrics.SetMeterForTest(provider.Meter("test"))
-	t.Cleanup(metrics.ResetMeter)
+// The adapter is what the manager is given, so it must satisfy the interface
+// and must surface a bind failure as an error with a nil lease, not a typed
+// nil pointer inside a non-nil interface.
+func TestTrapPoolAdapter(t *testing.T) {
+	var _ policy.TrapPool = trapPool{}
 
-	registry := traps.NewRegistry()
-	tally := traps.NewTally(discardLogger())
-	tally.Register()
-	t.Cleanup(tally.Close)
+	blocker, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = blocker.Close() })
 
-	// Through the interface the manager is given, so the test fails if the
-	// adapter stops satisfying it.
-	var reg policy.TrapRegistry = newTrapRegistration(registry, tally)
-	reg.Register("core", []traps.Device{{Policy: "core", Addr: netip.MustParseAddr("10.0.0.5")}}, nil)
-	reg.Register("edge", []traps.Device{{Policy: "edge", Addr: netip.MustParseAddr("10.0.0.6")}}, nil)
-	tally.Received("10.0.0.5", "core", "linkDown", traps.V2c)
-	tally.Received("10.0.0.6", "edge", "linkDown", traps.V2c)
+	pool := traps.NewPool(traps.NewTally(discardLogger()), traps.BuildNames(nil), discardLogger())
+	t.Cleanup(pool.Close)
+	var adapted policy.TrapPool = trapPool{pool: pool}
 
-	const coreSeries = "snmp.traps_received|device_ip=10.0.0.5|policy=core|trap_name=linkDown|version=2c"
-	const edgeSeries = "snmp.traps_received|device_ip=10.0.0.6|policy=edge|trap_name=linkDown|version=2c"
-	require.Equal(t, 2, registry.Size())
-	require.Contains(t, trapSeries(t, reader), coreSeries)
+	lease, err := adapted.Acquire(blocker.LocalAddr().String(), "core", nil, nil)
+	require.Error(t, err)
+	assert.Nil(t, lease, "an error must come with an untyped nil lease")
 
-	reg.Withdraw("core")
-	assert.Equal(t, 1, registry.Size(), "the registry stops attributing the policy's addresses")
-	series := trapSeries(t, reader)
-	assert.NotContains(t, series, coreSeries, "the tally stops exporting the policy's counts")
-	assert.Contains(t, series, edgeSeries, "another policy's series is untouched")
+	lease, err = adapted.Acquire("127.0.0.1:0", "core", nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	lease.Release()
+}
+
+// loadTrapNames builds the closed name set from the bundled tree. It is what
+// every receiver labels with, so it must load without an override directory.
+func TestLoadTrapNamesFromTheBundledTree(t *testing.T) {
+	names, err := loadTrapNames("", discardLogger())
+	require.NoError(t, err)
+	assert.Greater(t, len(names), 150)
+	assert.Equal(t, "linkDown", names["1.3.6.1.6.3.1.1.5.3"])
 }

--- a/orb-telemetry/snmp-telemetry/cmd/main_test.go
+++ b/orb-telemetry/snmp-telemetry/cmd/main_test.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/metrics"
+	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/traps"
 )
 
 // stopFunc adapts a function to the stopper the shutdown sequence takes.
@@ -339,4 +340,28 @@ func TestShutdownFlushesBeforeACancelledCollectionForgetsTheDevice(t *testing.T)
 
 	assert.Equal(t, []int64{7}, receiver.gaugeValues(metricName),
 		"the final export must carry the observations a cancelled collection forgets")
+}
+
+// With no --trap-listen, no socket is opened and nothing else changes.
+func TestTrapListenEmptyOpensNoSocket(t *testing.T) {
+	rcv, err := startTrapReceiver("", "", false, nil, nil, discardLogger())
+	require.NoError(t, err)
+	assert.Nil(t, rcv)
+}
+
+func TestTrapListenBindFailureIsAnError(t *testing.T) {
+	blocker, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = blocker.Close() })
+	_, err = startTrapReceiver(blocker.LocalAddr().String(), "", false, traps.NewRegistry(), traps.NewTally(discardLogger()), discardLogger())
+	require.Error(t, err, "a bind failure is reported, not logged from a goroutine")
+}
+
+// The receiver stops with the server, after the flush, so the final export
+// still holds everything counted and the stop spends none of its budget.
+func TestShutdownStopsTheTrapReceiverAfterTheFlush(t *testing.T) {
+	var order []string
+	srv := stopFunc(func() { order = append(order, "stop") })
+	shutdown(func() { order = append(order, "cancel") }, srv, func() { order = append(order, "flush") })
+	assert.Equal(t, []string{"flush", "cancel", "stop"}, order)
 }

--- a/orb-telemetry/snmp-telemetry/cmd/main_test.go
+++ b/orb-telemetry/snmp-telemetry/cmd/main_test.go
@@ -357,11 +357,34 @@ func TestTrapListenBindFailureIsAnError(t *testing.T) {
 	require.Error(t, err, "a bind failure is reported, not logged from a goroutine")
 }
 
-// The receiver stops with the server, after the flush, so the final export
-// still holds everything counted and the stop spends none of its budget.
-func TestShutdownStopsTheTrapReceiverAfterTheFlush(t *testing.T) {
-	var order []string
-	srv := stopFunc(func() { order = append(order, "stop") })
-	shutdown(func() { order = append(order, "cancel") }, srv, func() { order = append(order, "flush") })
-	assert.Equal(t, []string{"flush", "cancel", "stop"}, order)
+// closeFunc adapts a function to the closer stopAll's tally field takes.
+type closeFunc func()
+
+func (f closeFunc) Close() { f() }
+
+// stopAll stops the receiver, then closes the tally, then stops the server.
+// shutdown's own flush, cancel, stop order is a separate concern, already
+// pinned by TestShutdownCancelsRootBetweenTheFlushAndTheServerStop; this test
+// is only about the sequence stopAll.Stop itself encodes.
+func TestStopAllOrder(t *testing.T) {
+	t.Run("with a receiver", func(t *testing.T) {
+		var order []string
+		sa := stopAll{
+			receiver: stopFunc(func() { order = append(order, "receiver") }),
+			tally:    closeFunc(func() { order = append(order, "tally") }),
+			server:   stopFunc(func() { order = append(order, "server") }),
+		}
+		sa.Stop()
+		assert.Equal(t, []string{"receiver", "tally", "server"}, order)
+	})
+
+	t.Run("without a receiver", func(t *testing.T) {
+		var order []string
+		sa := stopAll{
+			tally:  closeFunc(func() { order = append(order, "tally") }),
+			server: stopFunc(func() { order = append(order, "server") }),
+		}
+		assert.NotPanics(t, sa.Stop)
+		assert.Equal(t, []string{"tally", "server"}, order)
+	})
 }

--- a/orb-telemetry/snmp-telemetry/collector/collector.go
+++ b/orb-telemetry/snmp-telemetry/collector/collector.go
@@ -316,6 +316,11 @@ type MetricsCollector struct {
 	reviewedProfiles map[string]struct{}
 }
 
+// TrapNames is the trap definitions of the profile set this collector polls
+// with, keyed by normalised OID. A policy registers them with its trap claims
+// so the receiver names its traps by its own set.
+func (c *MetricsCollector) TrapNames() map[string]string { return c.matcher.TrapNames() }
+
 // NewMetricsCollector creates a MetricsCollector.
 func NewMetricsCollector(clientFactory snmp.ClientFactory, matcher *profiles.Matcher, logger *slog.Logger) *MetricsCollector {
 	return &MetricsCollector{

--- a/orb-telemetry/snmp-telemetry/config/config.go
+++ b/orb-telemetry/snmp-telemetry/config/config.go
@@ -30,6 +30,18 @@ type Policies struct {
 type Scope struct {
 	Targets        []Target       `yaml:"targets"`
 	Authentication Authentication `yaml:"authentication"`
+	// Traps, when present, has the policy receive SNMP traps and informs from
+	// the addresses its targets expand to. It lives under scope rather than
+	// config because it is a source the policy observes, beside the targets
+	// it polls and the credentials that verify a v3 trap.
+	Traps *Traps `yaml:"traps,omitempty"`
+}
+
+// Traps is a policy's trap reception. Listen is the host:port the socket
+// binds. Policies naming the same string share one socket; two spellings of
+// one port are two bind attempts and the second fails.
+type Traps struct {
+	Listen string `yaml:"listen"`
 }
 
 // Target represents a target host to collect metrics from
@@ -66,6 +78,9 @@ type PolicyConfig struct {
 	// context. Carrying the field without reading it made a policy asking to be
 	// polled at specific times poll continuously instead, and said nothing.
 	// Absent from this struct, it is reported as an unrecognised key.
+	//
+	// MetricsInterval is optional: a policy that omits it polls nothing, and
+	// must then declare scope.traps or it has nothing to do.
 	MetricsInterval *int   `yaml:"metrics_interval"`
 	ProfilesDir     string `yaml:"profiles_dir,omitempty"`
 	SNMPTimeout     int    `yaml:"snmp_timeout"`

--- a/orb-telemetry/snmp-telemetry/config/unknown_keys.go
+++ b/orb-telemetry/snmp-telemetry/config/unknown_keys.go
@@ -34,6 +34,7 @@ var narrowedTypes = map[string]bool{
 	"config.Scope":          true,
 	"config.Target":         true,
 	"config.Authentication": true,
+	"config.Traps":          true,
 }
 
 // credentialParents are the blocks that hold an authentication block one level

--- a/orb-telemetry/snmp-telemetry/config/unknown_keys_test.go
+++ b/orb-telemetry/snmp-telemetry/config/unknown_keys_test.go
@@ -186,3 +186,25 @@ func TestNilLoggerIsSafe(t *testing.T) {
 		WarnUnknownPolicyKeys([]byte("policies:\n  p1:\n    config:\n      bogus: 1\n"), nil)
 	})
 }
+
+// A misspelled key under scope.traps is dropped like any other unknown key,
+// so the block is one of the narrowed types the warning covers.
+func TestUnknownKeyInsideTrapsIsReported(t *testing.T) {
+	out := captureWarnings(t, `
+policies:
+  p1:
+    config:
+      metrics_interval: 60
+    scope:
+      authentication:
+        protocol_version: v2c
+        community: public
+      targets:
+        - host: 192.0.2.1
+      traps:
+        listen: "0.0.0.0:162"
+        accept_unknown: true
+`)
+	require.Contains(t, out, "accept_unknown")
+	assert.NotContains(t, out, "did_you_mean")
+}

--- a/orb-telemetry/snmp-telemetry/metrics/metrics.go
+++ b/orb-telemetry/snmp-telemetry/metrics/metrics.go
@@ -29,6 +29,17 @@ var (
 	logger             *slog.Logger
 )
 
+// cardinalityLimit bounds the attribute sets one instrument may hold before
+// the SDK folds new ones into a single overflow bucket. The default is 2000
+// and, once reached, every later series including a genuine device's first
+// trap lands in that bucket for the life of the process. Ten thousand
+// accommodates a few hundred trapping devices each sending a dozen kinds,
+// five times the default, and stays well below where one OTLP export payload
+// becomes a problem. Trap series are bounded above by registered addresses
+// times the closed trap name set times three versions; the README says that a
+// policy naming a whole /16 whose every host sends every kind is past this.
+const cardinalityLimit = 10000
+
 // endpointOptions returns the otlpmetricgrpc options for the configured
 // endpoint: where to connect, and whether that connection is plaintext.
 //
@@ -100,7 +111,10 @@ func SetupMetricsExport(ctx context.Context, logg *slog.Logger, endpoint string,
 	reader := sdkmetric.NewPeriodicReader(exporter,
 		sdkmetric.WithInterval(time.Duration(exportPeriodSeconds)*time.Second),
 	)
-	meterProvider = sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	meterProvider = sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(reader),
+		sdkmetric.WithCardinalityLimit(cardinalityLimit),
+	)
 	otel.SetMeterProvider(meterProvider)
 	meter = otel.Meter("snmp-telemetry")
 	logger = logg
@@ -196,6 +210,12 @@ func GetMeter() metric.Meter {
 // ResetMeter resets the meter to nil for testing purposes.
 func ResetMeter() {
 	meter = nil
+}
+
+// SetMeterForTest installs a meter without an exporter, for tests that read
+// instruments through a manual reader. ResetMeter undoes it.
+func SetMeterForTest(m metric.Meter) {
+	meter = m
 }
 
 // Shutdown gracefully shuts down the metrics exporter

--- a/orb-telemetry/snmp-telemetry/metrics/metrics.go
+++ b/orb-telemetry/snmp-telemetry/metrics/metrics.go
@@ -29,7 +29,7 @@ var (
 	logger             *slog.Logger
 )
 
-// cardinalityLimit bounds the attribute sets one instrument may hold before
+// CardinalityLimit bounds the attribute sets one instrument may hold before
 // the SDK folds new ones into a single overflow bucket. The default is 2000
 // and, once reached, every later series including a genuine device's first
 // trap lands in that bucket for the life of the process. Ten thousand
@@ -38,7 +38,9 @@ var (
 // becomes a problem. Trap series are bounded above by registered addresses
 // times the closed trap name set times three versions; the README says that a
 // policy naming a whole /16 whose every host sends every kind is past this.
-const cardinalityLimit = 10000
+// Exported so the trap tally can bound its own map at the same number and
+// never hand the SDK a series it would fold.
+const CardinalityLimit = 10000
 
 // providerOptions is everything the meter provider is configured with beside
 // its reader. It is a function rather than a literal in SetupMetricsExport so
@@ -47,7 +49,7 @@ const cardinalityLimit = 10000
 // to: the limit only matters for what it does to an instrument, and that is
 // only observable through a provider that has it.
 func providerOptions() []sdkmetric.Option {
-	return []sdkmetric.Option{sdkmetric.WithCardinalityLimit(cardinalityLimit)}
+	return []sdkmetric.Option{sdkmetric.WithCardinalityLimit(CardinalityLimit)}
 }
 
 // endpointOptions returns the otlpmetricgrpc options for the configured

--- a/orb-telemetry/snmp-telemetry/metrics/metrics.go
+++ b/orb-telemetry/snmp-telemetry/metrics/metrics.go
@@ -40,6 +40,16 @@ var (
 // policy naming a whole /16 whose every host sends every kind is past this.
 const cardinalityLimit = 10000
 
+// providerOptions is everything the meter provider is configured with beside
+// its reader. It is a function rather than a literal in SetupMetricsExport so
+// a test can build a provider configured exactly the way this process
+// configures its own, over a manual reader, with no OTLP endpoint to export
+// to: the limit only matters for what it does to an instrument, and that is
+// only observable through a provider that has it.
+func providerOptions() []sdkmetric.Option {
+	return []sdkmetric.Option{sdkmetric.WithCardinalityLimit(cardinalityLimit)}
+}
+
 // endpointOptions returns the otlpmetricgrpc options for the configured
 // endpoint: where to connect, and whether that connection is plaintext.
 //
@@ -111,10 +121,7 @@ func SetupMetricsExport(ctx context.Context, logg *slog.Logger, endpoint string,
 	reader := sdkmetric.NewPeriodicReader(exporter,
 		sdkmetric.WithInterval(time.Duration(exportPeriodSeconds)*time.Second),
 	)
-	meterProvider = sdkmetric.NewMeterProvider(
-		sdkmetric.WithReader(reader),
-		sdkmetric.WithCardinalityLimit(cardinalityLimit),
-	)
+	meterProvider = sdkmetric.NewMeterProvider(append(providerOptions(), sdkmetric.WithReader(reader))...)
 	otel.SetMeterProvider(meterProvider)
 	meter = otel.Meter("snmp-telemetry")
 	logger = logg

--- a/orb-telemetry/snmp-telemetry/metrics/metrics_test.go
+++ b/orb-telemetry/snmp-telemetry/metrics/metrics_test.go
@@ -320,17 +320,17 @@ func TestProviderOptions_ApplyTheCardinalityLimit(t *testing.T) {
 	counter, err := provider.Meter("test").Int64Counter("limit.probe")
 	require.NoError(t, err)
 	ctx := context.Background()
-	for i := range cardinalityLimit - 1 {
+	for i := range CardinalityLimit - 1 {
 		counter.Add(ctx, 1, otelmetric.WithAttributes(attribute.String("k", strconv.Itoa(i))))
 	}
 
 	points, overflow := collectProbe(t, reader)
-	require.Equal(t, cardinalityLimit-1, points, "every set below the limit keeps its own attributes")
+	require.Equal(t, CardinalityLimit-1, points, "every set below the limit keeps its own attributes")
 	require.False(t, overflow, "nothing has overflowed yet")
 
 	counter.Add(ctx, 1, otelmetric.WithAttributes(attribute.String("k", "one past the limit")))
 	points, overflow = collectProbe(t, reader)
-	assert.Equal(t, cardinalityLimit, points, "the overflow set is the limit's last slot")
+	assert.Equal(t, CardinalityLimit, points, "the overflow set is the limit's last slot")
 	assert.True(t, overflow, "past the limit the SDK folds, it does not drop")
 }
 

--- a/orb-telemetry/snmp-telemetry/metrics/metrics_test.go
+++ b/orb-telemetry/snmp-telemetry/metrics/metrics_test.go
@@ -296,3 +296,11 @@ func TestSetupMetricsExport_PeriodPastTheBoundIsInertWithNoEndpoint(t *testing.T
 	require.NoError(t, SetupMetricsExport(context.Background(), testLogger(), "", config.MaxDurationSeconds+1))
 	assert.Nil(t, GetMeter())
 }
+
+// F7: the SDK's default cardinality limit is 2000 per instrument, and past it
+// every new attribute set folds into one overflow bucket. The trap counters
+// are the first instruments here whose label values a sender influences, so
+// the limit is chosen rather than inherited.
+func TestSetupMetricsExport_SetsTheCardinalityLimit(t *testing.T) {
+	assert.Equal(t, 10000, cardinalityLimit, "the limit is a decision; the comment beside it says why")
+}

--- a/orb-telemetry/snmp-telemetry/metrics/metrics_test.go
+++ b/orb-telemetry/snmp-telemetry/metrics/metrics_test.go
@@ -13,7 +13,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
 	otlpmetric "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	otelmetric "go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/config"
@@ -298,9 +301,59 @@ func TestSetupMetricsExport_PeriodPastTheBoundIsInertWithNoEndpoint(t *testing.T
 }
 
 // F7: the SDK's default cardinality limit is 2000 per instrument, and past it
-// every new attribute set folds into one overflow bucket. The trap counters
-// are the first instruments here whose label values a sender influences, so
-// the limit is chosen rather than inherited.
-func TestSetupMetricsExport_SetsTheCardinalityLimit(t *testing.T) {
-	assert.Equal(t, 10000, cardinalityLimit, "the limit is a decision; the comment beside it says why")
+// every new attribute set folds into one bucket carrying nothing but
+// otel.metric.overflow, so the metric stops answering any question. The trap
+// counters are the first instruments here whose label values a sender
+// influences, so the limit is chosen rather than inherited.
+//
+// This drives a real instrument through a provider built from the same
+// options SetupMetricsExport builds its own from, because a limit that is
+// configured and not applied looks exactly like one that is not configured.
+// The SDK reserves one slot of the limit for the overflow set itself
+// (aggregate/limit.go: len(measurements) >= aggLimit-1), so the last
+// distinct set that keeps its own attributes is number aggLimit-1.
+func TestProviderOptions_ApplyTheCardinalityLimit(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(append(providerOptions(), sdkmetric.WithReader(reader))...)
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+	counter, err := provider.Meter("test").Int64Counter("limit.probe")
+	require.NoError(t, err)
+	ctx := context.Background()
+	for i := range cardinalityLimit - 1 {
+		counter.Add(ctx, 1, otelmetric.WithAttributes(attribute.String("k", strconv.Itoa(i))))
+	}
+
+	points, overflow := collectProbe(t, reader)
+	require.Equal(t, cardinalityLimit-1, points, "every set below the limit keeps its own attributes")
+	require.False(t, overflow, "nothing has overflowed yet")
+
+	counter.Add(ctx, 1, otelmetric.WithAttributes(attribute.String("k", "one past the limit")))
+	points, overflow = collectProbe(t, reader)
+	assert.Equal(t, cardinalityLimit, points, "the overflow set is the limit's last slot")
+	assert.True(t, overflow, "past the limit the SDK folds, it does not drop")
+}
+
+// collectProbe reports how many data points the probe instrument holds and
+// whether one of them is the SDK's overflow set.
+func collectProbe(t *testing.T, reader sdkmetric.Reader) (points int, overflow bool) {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "limit.probe" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok)
+			points = len(sum.DataPoints)
+			for _, dp := range sum.DataPoints {
+				if _, ok := dp.Attributes.Value("otel.metric.overflow"); ok {
+					overflow = true
+				}
+			}
+		}
+	}
+	return points, overflow
 }

--- a/orb-telemetry/snmp-telemetry/policy/docs_sample_test.go
+++ b/orb-telemetry/snmp-telemetry/policy/docs_sample_test.go
@@ -40,20 +40,20 @@ func TestTheDocumentedRetryRuleMatchesTheRunner(t *testing.T) {
 	}
 
 	// A single attempt that fills the interval can never produce a sample.
-	_, err = NewRunner(t.Context(), testLogger, "p1", policyWithDial(30, 30, 0), &spyCollector{})
+	_, err = NewRunner(t.Context(), testLogger, "p1", policyWithDial(30, 30, 0), &spyCollector{}, nil)
 	require.Error(t, err)
 	says("is rejected, because a single attempt filling the interval can never produce a sample")
 
 	// A retry sequence that reaches the interval starts anyway, and an
 	// unresponsive device gets a truncated sequence rather than a refusal.
-	_, err = NewRunner(t.Context(), testLogger, "p1", policyWithDial(10, 9, 10), &spyCollector{})
+	_, err = NewRunner(t.Context(), testLogger, "p1", policyWithDial(10, 9, 10), &spyCollector{}, nil)
 	require.NoError(t, err)
 	says("warned about rather than rejected")
 	says("the retry sequence is cut short when the interval runs out")
 
 	// A count past the ceiling is refused rather than warned about, because
 	// the client allocates on it.
-	_, err = NewRunner(t.Context(), testLogger, "p1", policyWithDial(10, 9, maxPolicyRetries+1), &spyCollector{})
+	_, err = NewRunner(t.Context(), testLogger, "p1", policyWithDial(10, 9, maxPolicyRetries+1), &spyCollector{}, nil)
 	require.Error(t, err)
 	says(fmt.Sprintf("`retries` is capped at %d", maxPolicyRetries))
 }

--- a/orb-telemetry/snmp-telemetry/policy/expansion_test.go
+++ b/orb-telemetry/snmp-telemetry/policy/expansion_test.go
@@ -155,7 +155,7 @@ func TestValidate_RejectsPolicyOverTheBudget(t *testing.T) {
 
 func TestNewRunner_RejectsOversizedTarget(t *testing.T) {
 	for _, host := range oversizedTargets {
-		_, err := NewRunner(t.Context(), testLogger, "p1", policyWithTarget(host), &spyCollector{})
+		_, err := NewRunner(t.Context(), testLogger, "p1", policyWithTarget(host), &spyCollector{}, nil)
 		require.Error(t, err, "target %s should be rejected", host)
 		assert.ErrorContains(t, err, "65536")
 	}
@@ -164,7 +164,7 @@ func TestNewRunner_RejectsOversizedTarget(t *testing.T) {
 // A direct NewRunner call does not pass through validatePolicy, so the budget
 // has to hold there too or the scheduler still gets the million jobs.
 func TestNewRunner_RejectsPolicyOverTheBudget(t *testing.T) {
-	_, err := NewRunner(t.Context(), testLogger, "p1", policyWithTargets(sixteenSixteens()...), &spyCollector{})
+	_, err := NewRunner(t.Context(), testLogger, "p1", policyWithTargets(sixteenSixteens()...), &spyCollector{}, nil)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "1048544")
 	assert.ErrorContains(t, err, "65536")

--- a/orb-telemetry/snmp-telemetry/policy/lifecycle_test.go
+++ b/orb-telemetry/snmp-telemetry/policy/lifecycle_test.go
@@ -499,7 +499,6 @@ type spyPool struct {
 	mu       sync.Mutex
 	listens  map[string]string // policy -> listen string
 	devices  map[string][]traps.Device
-	users    map[string][]traps.V3User
 	released []string
 	// calls is every Acquire and Release in the order they arrived, which
 	// is what a same-name replacement is judged on: the same two names in the
@@ -511,10 +510,10 @@ type spyPool struct {
 }
 
 func newSpyPool() *spyPool {
-	return &spyPool{listens: map[string]string{}, devices: map[string][]traps.Device{}, users: map[string][]traps.V3User{}}
+	return &spyPool{listens: map[string]string{}, devices: map[string][]traps.Device{}}
 }
 
-func (s *spyPool) Acquire(listen, policy string, devices []traps.Device, users []traps.V3User) (TrapLease, error) {
+func (s *spyPool) Acquire(listen, policy string, devices []traps.Device) (TrapLease, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.acquireErr != nil {
@@ -522,7 +521,6 @@ func (s *spyPool) Acquire(listen, policy string, devices []traps.Device, users [
 	}
 	s.listens[policy] = listen
 	s.devices[policy] = devices
-	s.users[policy] = users
 	s.calls = append(s.calls, "acquire:"+policy)
 	return &spyLease{pool: s, policy: policy}, nil
 }
@@ -567,8 +565,10 @@ func TestRunner_AcquiresExpandedTargetsAndReleasesOnStop(t *testing.T) {
 		assert.Equal(t, "p1", d.Policy)
 		assert.True(t, d.Addr.Is4())
 	}
-	require.Len(t, pool.users["p1"], 1)
-	assert.Equal(t, pol.Scope.Authentication.Username, pool.users["p1"][0].Username)
+	for _, d := range devices {
+		require.NotNil(t, d.User, "a v3 device carries the credential its target polls with")
+		assert.Equal(t, pol.Scope.Authentication.Username, d.User.Username)
+	}
 
 	require.NoError(t, r.Stop())
 	assert.Equal(t, []string{"p1"}, pool.released)
@@ -579,8 +579,8 @@ func TestRunner_V2cTargetsAcquireNoUsers(t *testing.T) {
 	r, err := NewRunner(t.Context(), testLogger, "p1", withTraps(policyWithTargets("10.0.0.1"), ":162"), &spyCollector{}, pool)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = r.Stop() })
-	assert.Empty(t, pool.users["p1"])
-	assert.Len(t, pool.devices["p1"], 1)
+	require.Len(t, pool.devices["p1"], 1)
+	assert.Nil(t, pool.devices["p1"][0].User, "a v2c device carries no v3 credential")
 }
 
 // A policy that declares no traps never reaches the pool, and a nil pool is
@@ -644,4 +644,26 @@ policies:
 	t.Cleanup(func() { _ = m.Stop() })
 	assert.Len(t, pool.devices["p1"], 1)
 	assert.Equal(t, "0.0.0.0:1162", pool.listens["p1"])
+}
+
+// A target with its own v3 authentication registers with that credential,
+// not the policy-level one, so the receiver tries the right secret for the
+// right device.
+func TestRunner_RegistersEachDevicesOwnCredential(t *testing.T) {
+	pool := newSpyPool()
+	pol := withTraps(policyWithTargets("10.0.0.1", "10.0.0.2"), ":162")
+	pol.Scope.Authentication = v3AuthAuth()
+	own := v3AuthAuth()
+	own.Username = "second-device"
+	pol.Scope.Targets[1].Authentication = &own
+	r, err := NewRunner(t.Context(), testLogger, "p1", pol, &spyCollector{}, pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Stop() })
+
+	byAddr := map[string]string{}
+	for _, d := range pool.devices["p1"] {
+		require.NotNil(t, d.User)
+		byAddr[d.Addr.String()] = d.User.Username
+	}
+	assert.Equal(t, map[string]string{"10.0.0.1": pol.Scope.Authentication.Username, "10.0.0.2": "second-device"}, byAddr)
 }

--- a/orb-telemetry/snmp-telemetry/policy/lifecycle_test.go
+++ b/orb-telemetry/snmp-telemetry/policy/lifecycle_test.go
@@ -486,87 +486,139 @@ func TestNewRunner_RejectsRetriesAboveTheCeiling(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Trap registry registration and withdrawal
+// Trap pool acquisition and release
 // ---------------------------------------------------------------------------
 
-type spyRegistry struct {
-	mu         sync.Mutex
-	registered map[string][]traps.Device
-	users      map[string][]traps.V3User
-	withdrawn  []string
-	// calls is every Register and Withdraw in the order they arrived, which
+type spyPool struct {
+	mu       sync.Mutex
+	listens  map[string]string // policy -> listen string
+	devices  map[string][]traps.Device
+	users    map[string][]traps.V3User
+	released []string
+	// calls is every Acquire and Release in the order they arrived, which
 	// is what a same-name replacement is judged on: the same two names in the
 	// wrong order leave the new policy unregistered.
 	calls []string
+	// acquireErr, when set, is what Acquire returns, standing in for a bind
+	// failure.
+	acquireErr error
 }
 
-func newSpyRegistry() *spyRegistry {
-	return &spyRegistry{registered: map[string][]traps.Device{}, users: map[string][]traps.V3User{}}
+func newSpyPool() *spyPool {
+	return &spyPool{listens: map[string]string{}, devices: map[string][]traps.Device{}, users: map[string][]traps.V3User{}}
 }
 
-func (s *spyRegistry) Register(policy string, devices []traps.Device, users []traps.V3User) {
+func (s *spyPool) Acquire(listen, policy string, devices []traps.Device, users []traps.V3User) (TrapLease, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.registered[policy] = devices
+	if s.acquireErr != nil {
+		return nil, s.acquireErr
+	}
+	s.listens[policy] = listen
+	s.devices[policy] = devices
 	s.users[policy] = users
-	s.calls = append(s.calls, "register:"+policy)
+	s.calls = append(s.calls, "acquire:"+policy)
+	return &spyLease{pool: s, policy: policy}, nil
 }
 
-func (s *spyRegistry) Withdraw(policy string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.withdrawn = append(s.withdrawn, policy)
-	s.calls = append(s.calls, "withdraw:"+policy)
-}
-
-// callSequence is every call so far, in order.
-func (s *spyRegistry) callSequence() []string {
+func (s *spyPool) callSequence() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return append([]string(nil), s.calls...)
 }
 
-// A runner registers the addresses its targets expand to, with the v3 users
-// those targets carry, and withdraws them when it stops.
-func TestRunner_RegistersExpandedTargetsAndWithdrawsOnStop(t *testing.T) {
-	reg := newSpyRegistry()
-	pol := policyWithTargets("10.0.0.0/30", "router.example.com")
+type spyLease struct {
+	pool   *spyPool
+	policy string
+}
+
+func (l *spyLease) Release() {
+	l.pool.mu.Lock()
+	defer l.pool.mu.Unlock()
+	l.pool.released = append(l.pool.released, l.policy)
+	l.pool.calls = append(l.pool.calls, "release:"+l.policy)
+}
+
+func withTraps(p config.Policy, listen string) config.Policy {
+	p.Scope.Traps = &config.Traps{Listen: listen}
+	return p
+}
+
+// A runner acquires the socket its policy names with the addresses its
+// targets expand to and the v3 users those targets carry, and releases it
+// when it stops.
+func TestRunner_AcquiresExpandedTargetsAndReleasesOnStop(t *testing.T) {
+	pool := newSpyPool()
+	pol := withTraps(policyWithTargets("10.0.0.0/30", "router.example.com"), "0.0.0.0:1162")
 	pol.Scope.Authentication = v3AuthAuth()
-	r, err := NewRunner(t.Context(), testLogger, "p1", pol, &spyCollector{}, reg)
+	r, err := NewRunner(t.Context(), testLogger, "p1", pol, &spyCollector{}, pool)
 	require.NoError(t, err)
 
-	devices := reg.registered["p1"]
+	assert.Equal(t, "0.0.0.0:1162", pool.listens["p1"])
+	devices := pool.devices["p1"]
 	assert.Len(t, devices, 2, "a /30 is two hosts; the hostname target has no address and is not registered")
 	for _, d := range devices {
 		assert.Equal(t, "p1", d.Policy)
 		assert.True(t, d.Addr.Is4())
 	}
-	require.Len(t, reg.users["p1"], 1)
-	assert.Equal(t, pol.Scope.Authentication.Username, reg.users["p1"][0].Username)
+	require.Len(t, pool.users["p1"], 1)
+	assert.Equal(t, pol.Scope.Authentication.Username, pool.users["p1"][0].Username)
 
 	require.NoError(t, r.Stop())
-	assert.Equal(t, []string{"p1"}, reg.withdrawn)
+	assert.Equal(t, []string{"p1"}, pool.released)
 }
 
-func TestRunner_V2cTargetsRegisterNoUsers(t *testing.T) {
-	reg := newSpyRegistry()
-	r, err := NewRunner(t.Context(), testLogger, "p1", policyWithTargets("10.0.0.1"), &spyCollector{}, reg)
+func TestRunner_V2cTargetsAcquireNoUsers(t *testing.T) {
+	pool := newSpyPool()
+	r, err := NewRunner(t.Context(), testLogger, "p1", withTraps(policyWithTargets("10.0.0.1"), ":162"), &spyCollector{}, pool)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = r.Stop() })
-	assert.Empty(t, reg.users["p1"])
-	assert.Len(t, reg.registered["p1"], 1)
+	assert.Empty(t, pool.users["p1"])
+	assert.Len(t, pool.devices["p1"], 1)
 }
 
-func TestRunner_NilRegistryIsTolerated(t *testing.T) {
-	r, err := NewRunner(t.Context(), testLogger, "p1", policyWithTargets("10.0.0.1"), &spyCollector{}, nil)
+// A policy that declares no traps never reaches the pool, and a nil pool is
+// tolerated by such a policy.
+func TestRunner_WithoutTrapsNeverTouchesThePool(t *testing.T) {
+	pool := newSpyPool()
+	r, err := NewRunner(t.Context(), testLogger, "p1", policyWithTargets("10.0.0.1"), &spyCollector{}, pool)
+	require.NoError(t, err)
+	require.NoError(t, r.Stop())
+	assert.Empty(t, pool.callSequence())
+
+	r, err = NewRunner(t.Context(), testLogger, "p2", policyWithTargets("10.0.0.1"), &spyCollector{}, nil)
 	require.NoError(t, err)
 	require.NoError(t, r.Stop())
 }
 
-// The manager threads the registry from its options to every runner it builds.
-func TestManager_PassesTheRegistryToRunners(t *testing.T) {
-	reg := newSpyRegistry()
-	m := NewManager(t.Context(), testLogger, Options{TrapRegistry: reg})
+// A bind failure is a start failure, with the pool's error in the message,
+// and it leaves nothing to release.
+func TestRunner_AcquireFailureFailsTheStart(t *testing.T) {
+	pool := newSpyPool()
+	pool.acquireErr = errors.New("binding trap socket 0.0.0.0:162: address already in use")
+	_, err := NewRunner(t.Context(), testLogger, "p1", withTraps(policyWithTargets("10.0.0.1"), "0.0.0.0:162"), &spyCollector{}, pool)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "binding trap socket 0.0.0.0:162: address already in use")
+	assert.Empty(t, pool.released)
+}
+
+// A policy that declares traps but whose targets expand to no address still
+// acquires, with no devices, so its v3 users can authenticate and so the
+// socket is held for it; every trap it receives is dropped, which the runner
+// warns about at start.
+func TestRunner_TrapsWithNoAddressTargetsAcquiresEmpty(t *testing.T) {
+	pool := newSpyPool()
+	r, err := NewRunner(t.Context(), testLogger, "p1", withTraps(policyWithTargets("router.example.com"), ":162"), &spyCollector{}, pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Stop() })
+	assert.Equal(t, []string{"acquire:p1"}, pool.callSequence())
+	assert.Empty(t, pool.devices["p1"])
+}
+
+// The manager threads the pool from its options to every runner it builds.
+func TestManager_PassesThePoolToRunners(t *testing.T) {
+	pool := newSpyPool()
+	m := NewManager(t.Context(), testLogger, Options{TrapPool: pool})
 	policies, err := m.ParsePolicies([]byte(`
 policies:
   p1:
@@ -578,9 +630,12 @@ policies:
         community: public
       targets:
         - host: 10.0.0.1
+      traps:
+        listen: "0.0.0.0:1162"
 `))
 	require.NoError(t, err)
 	require.NoError(t, m.StartPolicy("p1", policies["p1"]))
 	t.Cleanup(func() { _ = m.Stop() })
-	assert.Len(t, reg.registered["p1"], 1)
+	assert.Len(t, pool.devices["p1"], 1)
+	assert.Equal(t, "0.0.0.0:1162", pool.listens["p1"])
 }

--- a/orb-telemetry/snmp-telemetry/policy/lifecycle_test.go
+++ b/orb-telemetry/snmp-telemetry/policy/lifecycle_test.go
@@ -494,6 +494,10 @@ type spyRegistry struct {
 	registered map[string][]traps.Device
 	users      map[string][]traps.V3User
 	withdrawn  []string
+	// calls is every Register and Withdraw in the order they arrived, which
+	// is what a same-name replacement is judged on: the same two names in the
+	// wrong order leave the new policy unregistered.
+	calls []string
 }
 
 func newSpyRegistry() *spyRegistry {
@@ -505,12 +509,21 @@ func (s *spyRegistry) Register(policy string, devices []traps.Device, users []tr
 	defer s.mu.Unlock()
 	s.registered[policy] = devices
 	s.users[policy] = users
+	s.calls = append(s.calls, "register:"+policy)
 }
 
 func (s *spyRegistry) Withdraw(policy string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.withdrawn = append(s.withdrawn, policy)
+	s.calls = append(s.calls, "withdraw:"+policy)
+}
+
+// callSequence is every call so far, in order.
+func (s *spyRegistry) callSequence() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.calls...)
 }
 
 // A runner registers the addresses its targets expand to, with the v3 users
@@ -542,16 +555,6 @@ func TestRunner_V2cTargetsRegisterNoUsers(t *testing.T) {
 	t.Cleanup(func() { _ = r.Stop() })
 	assert.Empty(t, reg.users["p1"])
 	assert.Len(t, reg.registered["p1"], 1)
-}
-
-// A runner that fails after registering must not leave its claims behind.
-func TestRunner_FailedStartWithdraws(t *testing.T) {
-	reg := newSpyRegistry()
-	_, err := NewRunner(t.Context(), testLogger, "p1", policyWithTargets("10.0.0.1/99"), &spyCollector{}, reg)
-	require.Error(t, err)
-	if _, registered := reg.registered["p1"]; registered {
-		assert.Contains(t, reg.withdrawn, "p1", "whatever was registered before the failure is withdrawn")
-	}
 }
 
 func TestRunner_NilRegistryIsTolerated(t *testing.T) {

--- a/orb-telemetry/snmp-telemetry/policy/lifecycle_test.go
+++ b/orb-telemetry/snmp-telemetry/policy/lifecycle_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/collector"
 	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/config"
+	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/traps"
 )
 
 // spyCollector records the policy names it was told to forget.
@@ -45,7 +46,7 @@ func (s *spyCollector) forgotten() []string {
 
 func TestRunnerStop_ForgetsCollectorState(t *testing.T) {
 	spy := &spyCollector{}
-	r, err := NewRunner(context.Background(), testLogger, "p1", minimalPolicy(v2cAuth()), spy)
+	r, err := NewRunner(context.Background(), testLogger, "p1", minimalPolicy(v2cAuth()), spy, nil)
 	require.NoError(t, err)
 	require.NoError(t, r.Stop())
 	assert.Equal(t, []string{"p1"}, spy.forgotten())
@@ -54,7 +55,7 @@ func TestRunnerStop_ForgetsCollectorState(t *testing.T) {
 func TestStopPolicy_ForgetsCollectorState(t *testing.T) {
 	spy := &spyCollector{}
 	m := newTestManager()
-	r, err := NewRunner(m.ctx, testLogger, "p1", minimalPolicy(v2cAuth()), spy)
+	r, err := NewRunner(m.ctx, testLogger, "p1", minimalPolicy(v2cAuth()), spy, nil)
 	require.NoError(t, err)
 	m.policies["p1"] = r
 
@@ -67,7 +68,7 @@ func TestManagerStop_ForgetsEveryPolicy(t *testing.T) {
 	spy := &spyCollector{}
 	m := newTestManager()
 	for _, name := range []string{"p1", "p2"} {
-		r, err := NewRunner(m.ctx, testLogger, name, minimalPolicy(v2cAuth()), spy)
+		r, err := NewRunner(m.ctx, testLogger, name, minimalPolicy(v2cAuth()), spy, nil)
 		require.NoError(t, err)
 		m.policies[name] = r
 	}
@@ -89,14 +90,14 @@ func policyWithDial(intervalSec, timeoutSec, retries int) config.Policy {
 }
 
 func TestNewRunner_DerivesDialSettingsFromPolicy(t *testing.T) {
-	r, err := NewRunner(t.Context(), testLogger, "p1", policyWithDial(120, 12, 4), &spyCollector{})
+	r, err := NewRunner(t.Context(), testLogger, "p1", policyWithDial(120, 12, 4), &spyCollector{}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 12*time.Second, r.snmpTimeout)
 	assert.Equal(t, 4, r.retries)
 }
 
 func TestNewRunner_ZeroSNMPTimeoutFallsBackToDefault(t *testing.T) {
-	r, err := NewRunner(t.Context(), testLogger, "p1", policyWithDial(60, 0, 0), &spyCollector{})
+	r, err := NewRunner(t.Context(), testLogger, "p1", policyWithDial(60, 0, 0), &spyCollector{}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, defaultSNMPTimeout, r.snmpTimeout)
 	assert.Equal(t, 0, r.retries)
@@ -105,25 +106,25 @@ func TestNewRunner_ZeroSNMPTimeoutFallsBackToDefault(t *testing.T) {
 func TestNewRunner_RejectsTimeoutAtOrAboveInterval(t *testing.T) {
 	// The run context is bounded by metrics_interval, so a dial allowed to take
 	// the whole interval can never complete a collection.
-	_, err := NewRunner(t.Context(), testLogger, "p1", policyWithDial(30, 30, 0), &spyCollector{})
+	_, err := NewRunner(t.Context(), testLogger, "p1", policyWithDial(30, 30, 0), &spyCollector{}, nil)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "snmp_timeout")
 
-	_, err = NewRunner(t.Context(), testLogger, "p1", policyWithDial(30, 45, 0), &spyCollector{})
+	_, err = NewRunner(t.Context(), testLogger, "p1", policyWithDial(30, 45, 0), &spyCollector{}, nil)
 	assert.Error(t, err)
 
 	// The default applies before the comparison, so a short interval is caught
 	// even when the policy never named a timeout.
-	_, err = NewRunner(t.Context(), testLogger, "p1", policyWithDial(3, 0, 0), &spyCollector{})
+	_, err = NewRunner(t.Context(), testLogger, "p1", policyWithDial(3, 0, 0), &spyCollector{}, nil)
 	assert.Error(t, err)
 
-	_, err = NewRunner(t.Context(), testLogger, "p1", policyWithDial(30, 29, 0), &spyCollector{})
+	_, err = NewRunner(t.Context(), testLogger, "p1", policyWithDial(30, 29, 0), &spyCollector{}, nil)
 	assert.NoError(t, err)
 }
 
 func TestRunMetrics_PassesDialSettingsToCollector(t *testing.T) {
 	spy := &spyCollector{}
-	r, err := NewRunner(t.Context(), testLogger, "p1", policyWithDial(120, 12, 4), spy)
+	r, err := NewRunner(t.Context(), testLogger, "p1", policyWithDial(120, 12, 4), spy, nil)
 	require.NoError(t, err)
 
 	r.runMetrics(config.Target{Host: "192.168.1.1", Port: 161})
@@ -160,21 +161,21 @@ func TestValidate_RejectsSecondsThatCannotBeADuration(t *testing.T) {
 // NewRunner is where the multiply happens, and it is reachable without the
 // API, so it carries the bound too.
 func TestNewRunner_RejectsSecondsThatCannotBeADuration(t *testing.T) {
-	_, err := NewRunner(t.Context(), testLogger, "p1", policyWithDial(40423014371506394, 5, 0), &spyCollector{})
+	_, err := NewRunner(t.Context(), testLogger, "p1", policyWithDial(40423014371506394, 5, 0), &spyCollector{}, nil)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "metrics_interval")
 
-	_, err = NewRunner(t.Context(), testLogger, "p1", policyWithDial(maxPolicySeconds+1, 5, 0), &spyCollector{})
+	_, err = NewRunner(t.Context(), testLogger, "p1", policyWithDial(maxPolicySeconds+1, 5, 0), &spyCollector{}, nil)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "metrics_interval")
 
 	// The interval is sane, so only the timeout can be at fault, and it must be
 	// named rather than reported as a timeout below a tiny interval.
-	_, err = NewRunner(t.Context(), testLogger, "p1", policyWithDial(60, 20211507185753197, 0), &spyCollector{})
+	_, err = NewRunner(t.Context(), testLogger, "p1", policyWithDial(60, 20211507185753197, 0), &spyCollector{}, nil)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "snmp_timeout")
 
-	_, err = NewRunner(t.Context(), testLogger, "p1", policyWithDial(60, maxPolicySeconds+1, 0), &spyCollector{})
+	_, err = NewRunner(t.Context(), testLogger, "p1", policyWithDial(60, maxPolicySeconds+1, 0), &spyCollector{}, nil)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "snmp_timeout")
 }
@@ -183,7 +184,7 @@ func TestNewRunner_RejectsSecondsThatCannotBeADuration(t *testing.T) {
 // durations the runner keeps are the ones the policy asked for, not a wrapped
 // remainder.
 func TestNewRunner_KeepsTheDurationsAtTheBound(t *testing.T) {
-	r, err := NewRunner(t.Context(), testLogger, "p1", policyWithDial(maxPolicySeconds, maxPolicySeconds-1, 0), &spyCollector{})
+	r, err := NewRunner(t.Context(), testLogger, "p1", policyWithDial(maxPolicySeconds, maxPolicySeconds-1, 0), &spyCollector{}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, maxPolicySeconds*time.Second, r.metricsInterval)
 	assert.Equal(t, (maxPolicySeconds-1)*time.Second, r.snmpTimeout)
@@ -196,7 +197,7 @@ func TestNewRunner_KeepsTheDurationsAtTheBound(t *testing.T) {
 func TestNewRunner_RetryCeilingHoldsAtTheBound(t *testing.T) {
 	var buf bytes.Buffer
 	lg := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
-	_, err := NewRunner(t.Context(), lg, "p1", policyWithDial(maxPolicySeconds, maxPolicySeconds-1, maxPolicyRetries), &spyCollector{})
+	_, err := NewRunner(t.Context(), lg, "p1", policyWithDial(maxPolicySeconds, maxPolicySeconds-1, maxPolicyRetries), &spyCollector{}, nil)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "SNMP retries can exceed the collection interval")
 }
@@ -225,7 +226,7 @@ func (f *failingCollector) ForgetPolicy(string) {}
 // healthy while half its targets were unreachable.
 func TestRunMetrics_SameEndpointTwiceKeepsErrorsApart(t *testing.T) {
 	c := &failingCollector{failIDs: map[string]bool{"11": true}}
-	r, err := NewRunner(t.Context(), testLogger, "p1", policyWithDial(60, 5, 0), c)
+	r, err := NewRunner(t.Context(), testLogger, "p1", policyWithDial(60, 5, 0), c, nil)
 	require.NoError(t, err)
 
 	failing := config.Target{Host: "10.0.0.1", Port: 161, ID: "11"}
@@ -270,7 +271,7 @@ func TestNewRunner_WarnsWhenRetriesCanExceedTheInterval(t *testing.T) {
 	capture := func(pol config.Policy) (string, error) {
 		var buf bytes.Buffer
 		lg := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
-		_, err := NewRunner(t.Context(), lg, "p1", pol, &spyCollector{})
+		_, err := NewRunner(t.Context(), lg, "p1", pol, &spyCollector{}, nil)
 		return buf.String(), err
 	}
 
@@ -291,7 +292,7 @@ func TestNewRunner_WarnsWhenRetriesCanExceedTheInterval(t *testing.T) {
 	assert.NotContains(t, out, "SNMP retries can exceed the collection interval")
 
 	// A single attempt filling the interval is still an error, not a warning.
-	_, err = NewRunner(t.Context(), testLogger, "p1", policyWithDial(30, 30, 0), &spyCollector{})
+	_, err = NewRunner(t.Context(), testLogger, "p1", policyWithDial(30, 30, 0), &spyCollector{}, nil)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "snmp_timeout")
 	assert.NotContains(t, err.Error(), "retries")
@@ -381,7 +382,7 @@ func (s *stallingCollector) unblock() {
 // through to completion first.
 func TestRunnerStop_CancelsACollectionStillInFlight(t *testing.T) {
 	c := newStallingCollector()
-	r, err := NewRunner(context.Background(), testLogger, "p1", policyWithDial(60, 5, 0), c)
+	r, err := NewRunner(context.Background(), testLogger, "p1", policyWithDial(60, 5, 0), c, nil)
 	require.NoError(t, err)
 	c.runner = r
 	t.Cleanup(c.unblock)
@@ -406,7 +407,7 @@ func TestRunnerStop_CancelsACollectionStillInFlight(t *testing.T) {
 // then fails it. Cancelling before that wait is what lets the wait succeed.
 func TestRunnerStop_CancelsBeforeWaitingForTheScheduler(t *testing.T) {
 	c := newStallingCollector()
-	r, err := NewRunner(context.Background(), testLogger, "p1", policyWithDial(60, 5, 0), c)
+	r, err := NewRunner(context.Background(), testLogger, "p1", policyWithDial(60, 5, 0), c, nil)
 	require.NoError(t, err)
 	c.runner = r
 	t.Cleanup(c.unblock)
@@ -430,7 +431,7 @@ func TestRunnerStop_CancelsBeforeWaitingForTheScheduler(t *testing.T) {
 // joined into one string.
 func TestRunMetrics_CollidingIdentityFieldsKeepErrorsApart(t *testing.T) {
 	c := &failingCollector{failIDs: map[string]bool{"a context=b": true}}
-	r, err := NewRunner(t.Context(), testLogger, "p1", policyWithDial(60, 5, 0), c)
+	r, err := NewRunner(t.Context(), testLogger, "p1", policyWithDial(60, 5, 0), c, nil)
 	require.NoError(t, err)
 
 	failing := config.Target{Host: "10.0.0.1", Port: 161, ID: "a context=b"}
@@ -467,19 +468,116 @@ func TestValidate_RejectsRetriesAboveTheCeiling(t *testing.T) {
 // NewRunner builds the dial options the client is constructed from and is
 // reachable without the API, so it carries the bound too.
 func TestNewRunner_RejectsRetriesAboveTheCeiling(t *testing.T) {
-	_, err := NewRunner(t.Context(), testLogger, "p1", policyWithDial(60, 5, maxPolicyRetries+1), &spyCollector{})
+	_, err := NewRunner(t.Context(), testLogger, "p1", policyWithDial(60, 5, maxPolicyRetries+1), &spyCollector{}, nil)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "retries")
 
-	_, err = NewRunner(t.Context(), testLogger, "p1", policyWithDial(60, 5, math.MaxInt), &spyCollector{})
+	_, err = NewRunner(t.Context(), testLogger, "p1", policyWithDial(60, 5, math.MaxInt), &spyCollector{}, nil)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "retries")
 
 	// The ceiling itself is accepted, and reaches the collector unchanged.
 	spy := &spyCollector{}
-	r, err := NewRunner(t.Context(), testLogger, "p1", policyWithDial(60, 5, maxPolicyRetries), spy)
+	r, err := NewRunner(t.Context(), testLogger, "p1", policyWithDial(60, 5, maxPolicyRetries), spy, nil)
 	require.NoError(t, err)
 	r.runMetrics(config.Target{Host: "192.168.1.1", Port: 161})
 	require.Len(t, spy.dials, 1)
 	assert.Equal(t, maxPolicyRetries, spy.dials[0].Retries)
+}
+
+// ---------------------------------------------------------------------------
+// Trap registry registration and withdrawal
+// ---------------------------------------------------------------------------
+
+type spyRegistry struct {
+	mu         sync.Mutex
+	registered map[string][]traps.Device
+	users      map[string][]traps.V3User
+	withdrawn  []string
+}
+
+func newSpyRegistry() *spyRegistry {
+	return &spyRegistry{registered: map[string][]traps.Device{}, users: map[string][]traps.V3User{}}
+}
+
+func (s *spyRegistry) Register(policy string, devices []traps.Device, users []traps.V3User) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.registered[policy] = devices
+	s.users[policy] = users
+}
+
+func (s *spyRegistry) Withdraw(policy string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.withdrawn = append(s.withdrawn, policy)
+}
+
+// A runner registers the addresses its targets expand to, with the v3 users
+// those targets carry, and withdraws them when it stops.
+func TestRunner_RegistersExpandedTargetsAndWithdrawsOnStop(t *testing.T) {
+	reg := newSpyRegistry()
+	pol := policyWithTargets("10.0.0.0/30", "router.example.com")
+	pol.Scope.Authentication = v3AuthAuth()
+	r, err := NewRunner(t.Context(), testLogger, "p1", pol, &spyCollector{}, reg)
+	require.NoError(t, err)
+
+	devices := reg.registered["p1"]
+	assert.Len(t, devices, 2, "a /30 is two hosts; the hostname target has no address and is not registered")
+	for _, d := range devices {
+		assert.Equal(t, "p1", d.Policy)
+		assert.True(t, d.Addr.Is4())
+	}
+	require.Len(t, reg.users["p1"], 1)
+	assert.Equal(t, pol.Scope.Authentication.Username, reg.users["p1"][0].Username)
+
+	require.NoError(t, r.Stop())
+	assert.Equal(t, []string{"p1"}, reg.withdrawn)
+}
+
+func TestRunner_V2cTargetsRegisterNoUsers(t *testing.T) {
+	reg := newSpyRegistry()
+	r, err := NewRunner(t.Context(), testLogger, "p1", policyWithTargets("10.0.0.1"), &spyCollector{}, reg)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Stop() })
+	assert.Empty(t, reg.users["p1"])
+	assert.Len(t, reg.registered["p1"], 1)
+}
+
+// A runner that fails after registering must not leave its claims behind.
+func TestRunner_FailedStartWithdraws(t *testing.T) {
+	reg := newSpyRegistry()
+	_, err := NewRunner(t.Context(), testLogger, "p1", policyWithTargets("10.0.0.1/99"), &spyCollector{}, reg)
+	require.Error(t, err)
+	if _, registered := reg.registered["p1"]; registered {
+		assert.Contains(t, reg.withdrawn, "p1", "whatever was registered before the failure is withdrawn")
+	}
+}
+
+func TestRunner_NilRegistryIsTolerated(t *testing.T) {
+	r, err := NewRunner(t.Context(), testLogger, "p1", policyWithTargets("10.0.0.1"), &spyCollector{}, nil)
+	require.NoError(t, err)
+	require.NoError(t, r.Stop())
+}
+
+// The manager threads the registry from its options to every runner it builds.
+func TestManager_PassesTheRegistryToRunners(t *testing.T) {
+	reg := newSpyRegistry()
+	m := NewManager(t.Context(), testLogger, Options{TrapRegistry: reg})
+	policies, err := m.ParsePolicies([]byte(`
+policies:
+  p1:
+    config:
+      metrics_interval: 60
+    scope:
+      authentication:
+        protocol_version: v2c
+        community: public
+      targets:
+        - host: 10.0.0.1
+`))
+	require.NoError(t, err)
+	require.NoError(t, m.StartPolicy("p1", policies["p1"]))
+	t.Cleanup(func() { _ = m.Stop() })
+	assert.Len(t, reg.registered["p1"], 1)
 }

--- a/orb-telemetry/snmp-telemetry/policy/lifecycle_test.go
+++ b/orb-telemetry/snmp-telemetry/policy/lifecycle_test.go
@@ -38,6 +38,12 @@ func (s *spyCollector) ForgetPolicy(name string) {
 	s.forgot = append(s.forgot, name)
 }
 
+func (s *spyCollector) dialed() []collector.DialOptions {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]collector.DialOptions(nil), s.dials...)
+}
+
 func (s *spyCollector) forgotten() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/orb-telemetry/snmp-telemetry/policy/lifecycle_test.go
+++ b/orb-telemetry/snmp-telemetry/policy/lifecycle_test.go
@@ -20,9 +20,10 @@ import (
 
 // spyCollector records the policy names it was told to forget.
 type spyCollector struct {
-	mu     sync.Mutex
-	forgot []string
-	dials  []collector.DialOptions
+	mu        sync.Mutex
+	forgot    []string
+	dials     []collector.DialOptions
+	trapNames map[string]string
 }
 
 func (s *spyCollector) CollectTarget(_ context.Context, _ config.Target, _ *config.Authentication, _ string, dial collector.DialOptions) error {
@@ -31,6 +32,9 @@ func (s *spyCollector) CollectTarget(_ context.Context, _ config.Target, _ *conf
 	s.dials = append(s.dials, dial)
 	return nil
 }
+
+// trapNames is what TrapNames returns, standing in for a profile set.
+func (s *spyCollector) TrapNames() map[string]string { return s.trapNames }
 
 func (s *spyCollector) ForgetPolicy(name string) {
 	s.mu.Lock()
@@ -224,6 +228,8 @@ func (f *failingCollector) CollectTarget(_ context.Context, target config.Target
 	return nil
 }
 
+func (f *failingCollector) TrapNames() map[string]string { return nil }
+
 func (f *failingCollector) ForgetPolicy(string) {}
 
 // TestRunMetrics_SameEndpointTwiceKeepsErrorsApart covers a policy that names
@@ -358,6 +364,8 @@ func (s *stallingCollector) CollectTarget(ctx context.Context, target config.Tar
 	s.store[policyName] = append(s.store[policyName], target.Host)
 	return nil
 }
+
+func (s *stallingCollector) TrapNames() map[string]string { return nil }
 
 func (s *stallingCollector) ForgetPolicy(name string) {
 	s.mu.Lock()
@@ -499,6 +507,7 @@ type spyPool struct {
 	mu       sync.Mutex
 	listens  map[string]string // policy -> listen string
 	devices  map[string][]traps.Device
+	names    map[string]map[string]string
 	released []string
 	// calls is every Acquire and Release in the order they arrived, which
 	// is what a same-name replacement is judged on: the same two names in the
@@ -510,10 +519,10 @@ type spyPool struct {
 }
 
 func newSpyPool() *spyPool {
-	return &spyPool{listens: map[string]string{}, devices: map[string][]traps.Device{}}
+	return &spyPool{listens: map[string]string{}, devices: map[string][]traps.Device{}, names: map[string]map[string]string{}}
 }
 
-func (s *spyPool) Acquire(listen, policy string, devices []traps.Device) (TrapLease, error) {
+func (s *spyPool) Acquire(listen, policy string, devices []traps.Device, names map[string]string) (TrapLease, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.acquireErr != nil {
@@ -521,6 +530,7 @@ func (s *spyPool) Acquire(listen, policy string, devices []traps.Device) (TrapLe
 	}
 	s.listens[policy] = listen
 	s.devices[policy] = devices
+	s.names[policy] = names
 	s.calls = append(s.calls, "acquire:"+policy)
 	return &spyLease{pool: s, policy: policy}, nil
 }
@@ -666,4 +676,15 @@ func TestRunner_RegistersEachDevicesOwnCredential(t *testing.T) {
 		byAddr[d.Addr.String()] = d.User.Username
 	}
 	assert.Equal(t, map[string]string{"10.0.0.1": pol.Scope.Authentication.Username, "10.0.0.2": "second-device"}, byAddr)
+}
+
+// The runner hands the pool the trap names of the profile set its collector
+// was built from, so the receiver names this policy's traps by them.
+func TestRunner_HandsThePoolItsProfileSetsTrapNames(t *testing.T) {
+	pool := newSpyPool()
+	spy := &spyCollector{trapNames: map[string]string{"1.2.3": "custom"}}
+	r, err := NewRunner(t.Context(), testLogger, "p1", withTraps(policyWithTargets("10.0.0.1"), ":162"), spy, pool)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = r.Stop() })
+	assert.Equal(t, map[string]string{"1.2.3": "custom"}, pool.names["p1"])
 }

--- a/orb-telemetry/snmp-telemetry/policy/manager.go
+++ b/orb-telemetry/snmp-telemetry/policy/manager.go
@@ -729,15 +729,30 @@ func (m *Manager) validatePolicy(policy config.Policy) error {
 		return err
 	}
 
-	if policy.Config.MetricsInterval == nil || *policy.Config.MetricsInterval <= 0 {
-		return fmt.Errorf("metrics_interval must be a positive integer")
+	if policy.Scope.Traps != nil {
+		if err := validateTrapListen(policy.Scope.Traps.Listen); err != nil {
+			return err
+		}
 	}
-	// Both are turned into a Duration by multiplying by time.Second, which
-	// wraps to a small value past this bound. Rejected here so the request is
-	// refused with the field named, and again in NewRunner where the multiply
-	// happens.
-	if *policy.Config.MetricsInterval > maxPolicySeconds {
-		return fmt.Errorf("metrics_interval must be at most %d seconds", maxPolicySeconds)
+
+	// A policy with no interval polls nothing. That is a valid policy only
+	// when it receives traps; otherwise the API would report as running a
+	// policy that can never produce anything.
+	if policy.Config.MetricsInterval == nil {
+		if policy.Scope.Traps == nil {
+			return errors.New("policy has neither metrics_interval nor scope.traps: nothing to do")
+		}
+	} else {
+		if *policy.Config.MetricsInterval <= 0 {
+			return fmt.Errorf("metrics_interval must be a positive integer")
+		}
+		// Turned into a Duration by multiplying by time.Second, which wraps to
+		// a small value past this bound. Rejected here so the request is
+		// refused with the field named, and again in NewRunner where the
+		// multiply happens.
+		if *policy.Config.MetricsInterval > maxPolicySeconds {
+			return fmt.Errorf("metrics_interval must be at most %d seconds", maxPolicySeconds)
+		}
 	}
 
 	if policy.Config.SNMPTimeout < 0 {

--- a/orb-telemetry/snmp-telemetry/policy/manager.go
+++ b/orb-telemetry/snmp-telemetry/policy/manager.go
@@ -64,6 +64,10 @@ type Manager struct {
 	// allowedEnvVars is the set of environment variables a policy may read
 	// through a ${NAME} credential reference. Empty reads none.
 	allowedEnvVars map[string]struct{}
+	// trapRegistry receives each policy's expanded addresses and v3 users as
+	// its runner starts, and loses them as it stops. Nil disables trap
+	// registration entirely.
+	trapRegistry TrapRegistry
 
 	collectorsMu    sync.Mutex
 	collectorsByDir map[string]*cachedCollector
@@ -103,6 +107,10 @@ type Options struct {
 	// inherits the agent's environment, so an unrestricted resolver hands any
 	// process secret to whatever host the policy targets.
 	AllowedEnvVars []string
+	// TrapRegistry receives each policy's expanded addresses and v3 users as
+	// its runner starts, and loses them as it stops. Nil disables trap
+	// registration entirely.
+	TrapRegistry TrapRegistry
 }
 
 // NewManager returns a new policy manager
@@ -123,6 +131,7 @@ func NewManager(ctx context.Context, logger *slog.Logger, opts Options) *Manager
 		profilesRoot:       opts.ProfilesRoot,
 		allowedEnvVars:     allowed,
 		collectorsByDir:    make(map[string]*cachedCollector),
+		trapRegistry:       opts.TrapRegistry,
 	}
 }
 
@@ -439,7 +448,7 @@ func (m *Manager) StartPolicyHandle(name string, policy config.Policy) (Handle, 
 	}
 	defer m.mu.Unlock()
 
-	r, err := NewRunner(m.ctx, m.logger, name, policy, sharedCollector)
+	r, err := NewRunner(m.ctx, m.logger, name, policy, sharedCollector, m.trapRegistry)
 	if err != nil {
 		return Handle{}, err
 	}

--- a/orb-telemetry/snmp-telemetry/policy/manager.go
+++ b/orb-telemetry/snmp-telemetry/policy/manager.go
@@ -64,10 +64,10 @@ type Manager struct {
 	// allowedEnvVars is the set of environment variables a policy may read
 	// through a ${NAME} credential reference. Empty reads none.
 	allowedEnvVars map[string]struct{}
-	// trapRegistry receives each policy's expanded addresses and v3 users as
-	// its runner starts, and loses them as it stops. Nil disables trap
-	// registration entirely.
-	trapRegistry TrapRegistry
+	// trapPool hands each policy that declares scope.traps the socket it
+	// names, as its runner starts, and takes it back as the runner stops. Nil
+	// makes such a policy fail to start.
+	trapPool TrapPool
 
 	collectorsMu    sync.Mutex
 	collectorsByDir map[string]*cachedCollector
@@ -107,10 +107,10 @@ type Options struct {
 	// inherits the agent's environment, so an unrestricted resolver hands any
 	// process secret to whatever host the policy targets.
 	AllowedEnvVars []string
-	// TrapRegistry receives each policy's expanded addresses and v3 users as
-	// its runner starts, and loses them as it stops. Nil disables trap
-	// registration entirely.
-	TrapRegistry TrapRegistry
+	// TrapPool hands each policy that declares scope.traps the socket it
+	// names, as its runner starts, and takes it back as the runner stops. Nil
+	// makes such a policy fail to start.
+	TrapPool TrapPool
 }
 
 // NewManager returns a new policy manager
@@ -131,7 +131,7 @@ func NewManager(ctx context.Context, logger *slog.Logger, opts Options) *Manager
 		profilesRoot:       opts.ProfilesRoot,
 		allowedEnvVars:     allowed,
 		collectorsByDir:    make(map[string]*cachedCollector),
-		trapRegistry:       opts.TrapRegistry,
+		trapPool:           opts.TrapPool,
 	}
 }
 
@@ -448,7 +448,7 @@ func (m *Manager) StartPolicyHandle(name string, policy config.Policy) (Handle, 
 	}
 	defer m.mu.Unlock()
 
-	r, err := NewRunner(m.ctx, m.logger, name, policy, sharedCollector, m.trapRegistry)
+	r, err := NewRunner(m.ctx, m.logger, name, policy, sharedCollector, m.trapPool)
 	if err != nil {
 		return Handle{}, err
 	}

--- a/orb-telemetry/snmp-telemetry/policy/manager_concurrency_test.go
+++ b/orb-telemetry/snmp-telemetry/policy/manager_concurrency_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/collector"
@@ -261,4 +262,43 @@ func TestStopPolicyHandle_AHandleWithNoRunnerStopsNothing(t *testing.T) {
 		require.True(t, m.HasPolicy("p1"))
 		require.NoError(t, m.Stop())
 	}
+}
+
+// The sibling of the test above, on the mark a replacement leaves in the trap
+// registry rather than on the name it takes. The withdrawal is the last thing
+// Runner.Stop does and the manager holds the stopping reservation until Stop
+// returns, so the two calls can only arrive in one order: the replacement's
+// registration is the registry's last word for the name, not a withdrawal
+// arriving late and erasing it.
+func TestStopPolicy_SameNameReplacementEndsRegistered(t *testing.T) {
+	reg := newSpyRegistry()
+	m := NewManager(context.Background(), testLogger, Options{TrapRegistry: reg})
+	_, err := m.acquireCollector("")
+	require.NoError(t, err)
+	t.Cleanup(func() { m.releaseCollector("") })
+
+	gate := newGatedCollector()
+	t.Cleanup(gate.unblock)
+
+	r, err := NewRunner(m.ctx, testLogger, "p1", minimalPolicy(v2cAuth()), gate, reg)
+	require.NoError(t, err)
+	r.Start()
+	m.policies["p1"] = r
+	require.Equal(t, []string{"register:p1"}, reg.callSequence())
+
+	stopped := make(chan error, 1)
+	go func() { stopped <- m.StopPolicy("p1") }()
+	<-gate.entered
+
+	started := make(chan error, 1)
+	go func() { started <- m.StartPolicy("p1", minimalPolicy(v2cAuth())) }()
+
+	gate.unblock()
+	require.NoError(t, <-stopped)
+	require.NoError(t, <-started)
+	require.True(t, m.HasPolicy("p1"))
+
+	assert.Equal(t, []string{"register:p1", "withdraw:p1", "register:p1"}, reg.callSequence(),
+		"the replacement registers after the withdrawal, and exactly once")
+	require.NoError(t, m.Stop())
 }

--- a/orb-telemetry/snmp-telemetry/policy/manager_concurrency_test.go
+++ b/orb-telemetry/snmp-telemetry/policy/manager_concurrency_test.go
@@ -107,7 +107,7 @@ func TestStopPolicy_HoldsTheNameUntilTheRunnerHasStopped(t *testing.T) {
 	gate := newGatedCollector()
 	t.Cleanup(gate.unblock)
 
-	r, err := NewRunner(m.ctx, testLogger, "p1", minimalPolicy(v2cAuth()), gate)
+	r, err := NewRunner(m.ctx, testLogger, "p1", minimalPolicy(v2cAuth()), gate, nil)
 	require.NoError(t, err)
 	r.Start()
 	m.policies["p1"] = r
@@ -185,7 +185,7 @@ func TestStopPolicy_DoesNotBlockOtherNames(t *testing.T) {
 
 	gate := newGatedCollector()
 	t.Cleanup(gate.unblock)
-	r, err := NewRunner(m.ctx, testLogger, "slow", minimalPolicy(v2cAuth()), gate)
+	r, err := NewRunner(m.ctx, testLogger, "slow", minimalPolicy(v2cAuth()), gate, nil)
 	require.NoError(t, err)
 	r.Start()
 	m.policies["slow"] = r

--- a/orb-telemetry/snmp-telemetry/policy/manager_concurrency_test.go
+++ b/orb-telemetry/snmp-telemetry/policy/manager_concurrency_test.go
@@ -265,14 +265,14 @@ func TestStopPolicyHandle_AHandleWithNoRunnerStopsNothing(t *testing.T) {
 }
 
 // The sibling of the test above, on the mark a replacement leaves in the trap
-// registry rather than on the name it takes. The withdrawal is the last thing
+// pool rather than on the name it takes. The release is the last thing
 // Runner.Stop does and the manager holds the stopping reservation until Stop
 // returns, so the two calls can only arrive in one order: the replacement's
-// registration is the registry's last word for the name, not a withdrawal
-// arriving late and erasing it.
+// acquire is the pool's last word for the name, not a release arriving late
+// and erasing it.
 func TestStopPolicy_SameNameReplacementEndsRegistered(t *testing.T) {
-	reg := newSpyRegistry()
-	m := NewManager(context.Background(), testLogger, Options{TrapRegistry: reg})
+	reg := newSpyPool()
+	m := NewManager(context.Background(), testLogger, Options{TrapPool: reg})
 	_, err := m.acquireCollector("")
 	require.NoError(t, err)
 	t.Cleanup(func() { m.releaseCollector("") })
@@ -280,25 +280,25 @@ func TestStopPolicy_SameNameReplacementEndsRegistered(t *testing.T) {
 	gate := newGatedCollector()
 	t.Cleanup(gate.unblock)
 
-	r, err := NewRunner(m.ctx, testLogger, "p1", minimalPolicy(v2cAuth()), gate, reg)
+	r, err := NewRunner(m.ctx, testLogger, "p1", withTraps(minimalPolicy(v2cAuth()), ":162"), gate, reg)
 	require.NoError(t, err)
 	r.Start()
 	m.policies["p1"] = r
-	require.Equal(t, []string{"register:p1"}, reg.callSequence())
+	require.Equal(t, []string{"acquire:p1"}, reg.callSequence())
 
 	stopped := make(chan error, 1)
 	go func() { stopped <- m.StopPolicy("p1") }()
 	<-gate.entered
 
 	started := make(chan error, 1)
-	go func() { started <- m.StartPolicy("p1", minimalPolicy(v2cAuth())) }()
+	go func() { started <- m.StartPolicy("p1", withTraps(minimalPolicy(v2cAuth()), ":162")) }()
 
 	gate.unblock()
 	require.NoError(t, <-stopped)
 	require.NoError(t, <-started)
 	require.True(t, m.HasPolicy("p1"))
 
-	assert.Equal(t, []string{"register:p1", "withdraw:p1", "register:p1"}, reg.callSequence(),
-		"the replacement registers after the withdrawal, and exactly once")
+	assert.Equal(t, []string{"acquire:p1", "release:p1", "acquire:p1"}, reg.callSequence(),
+		"the replacement acquires after the release, and exactly once")
 	require.NoError(t, m.Stop())
 }

--- a/orb-telemetry/snmp-telemetry/policy/manager_concurrency_test.go
+++ b/orb-telemetry/snmp-telemetry/policy/manager_concurrency_test.go
@@ -84,6 +84,8 @@ func (g *gatedCollector) CollectTarget(_ context.Context, _ config.Target, _ *co
 	return nil
 }
 
+func (g *gatedCollector) TrapNames() map[string]string { return nil }
+
 func (g *gatedCollector) ForgetPolicy(string) {
 	close(g.entered)
 	<-g.release

--- a/orb-telemetry/snmp-telemetry/policy/runner.go
+++ b/orb-telemetry/snmp-telemetry/policy/runner.go
@@ -212,6 +212,12 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 	}
 
 	if policy.Scope.Traps != nil {
+		// Guarded here as well as in validatePolicy so a direct NewRunner call
+		// cannot slip past, the same way the interval, the timeout and the
+		// retry count are.
+		if err := validateTrapListen(policy.Scope.Traps.Listen); err != nil {
+			return nil, err
+		}
 		if pool == nil {
 			return nil, errors.New("policy declares scope.traps but this backend has no trap pool")
 		}

--- a/orb-telemetry/snmp-telemetry/policy/runner.go
+++ b/orb-telemetry/snmp-telemetry/policy/runner.go
@@ -86,9 +86,20 @@ type Runner struct {
 // metricsCollector is the shared collector for this policy's profiles directory —
 // created once by the Manager and reused across all policies using the same dir.
 func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy config.Policy, metricsCollector Collector, pool TrapPool) (*Runner, error) {
-	s, err := gocron.NewScheduler()
-	if err != nil {
-		return nil, err
+	polls := policy.Config.MetricsInterval != nil
+	if !polls && policy.Scope.Traps == nil {
+		return nil, errors.New("policy has neither metrics_interval nor scope.traps: nothing to do")
+	}
+	// A trap-only policy has no scheduler at all. Every use of it below and in
+	// Start and Stop is guarded on nil rather than on a second flag, so the
+	// field is the one source of truth.
+	var s gocron.Scheduler
+	if polls {
+		var err error
+		s, err = gocron.NewScheduler()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	runCtx, cancel := context.WithCancel(context.WithValue(ctx, policyKey, name))
@@ -119,17 +130,19 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 		targetErrs:       make(map[targetKey]error),
 	}
 
-	if policy.Config.MetricsInterval == nil || *policy.Config.MetricsInterval <= 0 {
-		return nil, fmt.Errorf("metrics_interval must be a positive integer")
+	if polls {
+		if *policy.Config.MetricsInterval <= 0 {
+			return nil, fmt.Errorf("metrics_interval must be a positive integer")
+		}
+		// Bounded before the multiply rather than after it: seconds past the
+		// bound wrap to a small duration, and every check below would then
+		// compare the wrapped values and pass. Guarded here as well as in
+		// validatePolicy so a direct NewRunner call cannot slip past.
+		if *policy.Config.MetricsInterval > maxPolicySeconds {
+			return nil, fmt.Errorf("metrics_interval must be at most %d seconds", maxPolicySeconds)
+		}
+		runner.metricsInterval = time.Duration(*policy.Config.MetricsInterval) * time.Second
 	}
-	// Bounded before the multiply rather than after it: seconds past the bound
-	// wrap to a small duration, and every check below would then compare the
-	// wrapped values and pass. Guarded here as well as in validatePolicy so a
-	// direct NewRunner call cannot slip past.
-	if *policy.Config.MetricsInterval > maxPolicySeconds {
-		return nil, fmt.Errorf("metrics_interval must be at most %d seconds", maxPolicySeconds)
-	}
-	runner.metricsInterval = time.Duration(*policy.Config.MetricsInterval) * time.Second
 
 	if policy.Config.SNMPTimeout > maxPolicySeconds {
 		return nil, fmt.Errorf("snmp_timeout must be at most %d seconds", maxPolicySeconds)
@@ -148,27 +161,29 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 	if runner.retries < 0 {
 		runner.retries = 0
 	}
-	// A single attempt that fills the interval can never produce a sample: the
-	// run's deadline expires at or before the first request returns. That is
-	// rejected, matching snmp-discovery.
-	if runner.snmpTimeout >= runner.metricsInterval {
-		return nil, fmt.Errorf("snmp_timeout (%s) must be less than metrics_interval (%s)", runner.snmpTimeout, runner.metricsInterval)
-	}
-	// Retries raise the ceiling for one request to snmp_timeout times
-	// retries+1, but that ceiling is only reached against a device that never
-	// answers. Warning rather than rejecting keeps a policy that collects
-	// normally from being refused for its worst case.
-	//
-	// Attempts are capped at what the interval holds, which is a different
-	// bound from maxPolicyRetries: that one refuses a count the client would
-	// allocate on, this one reports the ceiling the run's deadline actually
-	// permits rather than the one the policy asked for.
-	attempts := min(int64(runner.retries)+1, int64(runner.metricsInterval/runner.snmpTimeout)+1)
-	if ceiling := time.Duration(attempts) * runner.snmpTimeout; ceiling >= runner.metricsInterval {
-		logger.Warn("SNMP retries can exceed the collection interval, a run against an unresponsive device will be cut short",
-			"policy", config.SanitizeLogValue(name),
-			"snmp_timeout", runner.snmpTimeout, "retries", runner.retries,
-			"request_ceiling", ceiling, "metrics_interval", runner.metricsInterval)
+	if polls {
+		// A single attempt that fills the interval can never produce a
+		// sample: the run's deadline expires at or before the first request
+		// returns. That is rejected, matching snmp-discovery.
+		if runner.snmpTimeout >= runner.metricsInterval {
+			return nil, fmt.Errorf("snmp_timeout (%s) must be less than metrics_interval (%s)", runner.snmpTimeout, runner.metricsInterval)
+		}
+		// Retries raise the ceiling for one request to snmp_timeout times
+		// retries+1, but that ceiling is only reached against a device that
+		// never answers. Warning rather than rejecting keeps a policy that
+		// collects normally from being refused for its worst case.
+		//
+		// Attempts are capped at what the interval holds, which is a
+		// different bound from maxPolicyRetries: that one refuses a count the
+		// client would allocate on, this one reports the ceiling the run's
+		// deadline actually permits rather than the one the policy asked for.
+		attempts := min(int64(runner.retries)+1, int64(runner.metricsInterval/runner.snmpTimeout)+1)
+		if ceiling := time.Duration(attempts) * runner.snmpTimeout; ceiling >= runner.metricsInterval {
+			logger.Warn("SNMP retries can exceed the collection interval, a run against an unresponsive device will be cut short",
+				"policy", config.SanitizeLogValue(name),
+				"snmp_timeout", runner.snmpTimeout, "retries", runner.retries,
+				"request_ceiling", ceiling, "metrics_interval", runner.metricsInterval)
+		}
 	}
 
 	// Charged over the whole policy before any target is expanded, since
@@ -209,11 +224,13 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 	}
 
 	// Schedule a metrics job for each expanded target
-	for _, t := range expanded {
-		metricsTask := gocron.NewTask(runner.runMetrics, t)
-		if _, err := s.NewJob(gocron.DurationJob(runner.metricsInterval), metricsTask,
-			gocron.WithSingletonMode(gocron.LimitModeReschedule)); err != nil {
-			return nil, fmt.Errorf("scheduling metrics job for %s: %w", t.Host, err)
+	if polls {
+		for _, t := range expanded {
+			metricsTask := gocron.NewTask(runner.runMetrics, t)
+			if _, err := s.NewJob(gocron.DurationJob(runner.metricsInterval), metricsTask,
+				gocron.WithSingletonMode(gocron.LimitModeReschedule)); err != nil {
+				return nil, fmt.Errorf("scheduling metrics job for %s: %w", t.Host, err)
+			}
 		}
 	}
 
@@ -403,8 +420,10 @@ func (r *Runner) buildCombinedError() error {
 
 // Start starts the policy runner
 func (r *Runner) Start() {
-	r.logger.Info("Starting policy runner", "policy", config.SanitizeLogValue(r.name))
-	r.scheduler.Start()
+	r.logger.Info("Starting policy runner", "policy", config.SanitizeLogValue(r.name), "polls", r.scheduler != nil)
+	if r.scheduler != nil {
+		r.scheduler.Start()
+	}
 }
 
 // Stop stops the policy runner and drops the collector state it owns, so a
@@ -426,12 +445,18 @@ func (r *Runner) Start() {
 // therefore cannot start and acquire until the release has already
 // happened, so it cannot have its own lease erased by the outgoing
 // runner's.
+//
+// A trap-only runner has no scheduler and no collector state, so only the
+// release runs.
 func (r *Runner) Stop() error {
 	r.cancel()
-	err := r.scheduler.StopJobs()
-	err = errors.Join(err, r.scheduler.Shutdown())
-	if r.metricsCollector != nil {
-		r.metricsCollector.ForgetPolicy(r.name)
+	var err error
+	if r.scheduler != nil {
+		err = r.scheduler.StopJobs()
+		err = errors.Join(err, r.scheduler.Shutdown())
+		if r.metricsCollector != nil {
+			r.metricsCollector.ForgetPolicy(r.name)
+		}
 	}
 	if r.trapLease != nil {
 		r.trapLease.Release()

--- a/orb-telemetry/snmp-telemetry/policy/runner.go
+++ b/orb-telemetry/snmp-telemetry/policy/runner.go
@@ -68,7 +68,6 @@ type Runner struct {
 	cancel           context.CancelFunc
 	name             string
 	metricsCollector Collector
-	trapPool         TrapPool
 	trapLease        TrapLease
 	metricsInterval  time.Duration
 	snmpTimeout      time.Duration
@@ -129,7 +128,6 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 		logger:           logger,
 		name:             name,
 		metricsCollector: metricsCollector,
-		trapPool:         pool,
 		config:           policy.Config,
 		scope:            policy.Scope,
 		ctx:              runCtx,
@@ -448,9 +446,9 @@ func (r *Runner) Start() {
 // not cut it short. StopJobs then has a wait it can finish, and it comes before
 // the state is dropped so a run is not still writing when the drop happens.
 // Shutdown runs whatever StopJobs reported, rather than leaving the scheduler
-// behind when a job overran. ForgetPolicy and the trap release come last
-// and unconditionally, so the policy stops exporting either kind of series
-// even if the scheduler did not unwind cleanly.
+// behind when a job overran. ForgetPolicy and the trap release come last and
+// outside the scheduler guard, so the policy stops exporting either kind of
+// series even if the scheduler did not unwind cleanly.
 //
 // The release lives here, at the end of Stop, rather than in the manager
 // after Stop returns, because the manager holds the stopping policy's name
@@ -459,17 +457,19 @@ func (r *Runner) Start() {
 // happened, so it cannot have its own lease erased by the outgoing
 // runner's.
 //
-// A trap-only runner has no scheduler and no collector state, so only the
-// release runs.
+// A trap-only runner has no scheduler, so the shutdown is skipped. It has no
+// collector state either, and ForgetPolicy still runs against it: dropping
+// nothing is cheaper than a second flag saying whether there is anything to
+// drop.
 func (r *Runner) Stop() error {
 	r.cancel()
 	var err error
 	if r.scheduler != nil {
 		err = r.scheduler.StopJobs()
 		err = errors.Join(err, r.scheduler.Shutdown())
-		if r.metricsCollector != nil {
-			r.metricsCollector.ForgetPolicy(r.name)
-		}
+	}
+	if r.metricsCollector != nil {
+		r.metricsCollector.ForgetPolicy(r.name)
 	}
 	if r.trapLease != nil {
 		r.trapLease.Release()

--- a/orb-telemetry/snmp-telemetry/policy/runner.go
+++ b/orb-telemetry/snmp-telemetry/policy/runner.go
@@ -113,6 +113,13 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 			if lease != nil {
 				lease.Release()
 			}
+			// gocron starts a goroutine in NewScheduler, before any job is
+			// added and before Start is called, so a rejected policy that
+			// only cancelled its context would strand one for the life of
+			// the process.
+			if s != nil {
+				_ = s.Shutdown()
+			}
 			cancel()
 		}
 	}()

--- a/orb-telemetry/snmp-telemetry/policy/runner.go
+++ b/orb-telemetry/snmp-telemetry/policy/runner.go
@@ -408,8 +408,16 @@ func (r *Runner) Start() {
 // not cut it short. StopJobs then has a wait it can finish, and it comes before
 // the state is dropped so a run is not still writing when the drop happens.
 // Shutdown runs whatever StopJobs reported, rather than leaving the scheduler
-// behind when a job overran. ForgetPolicy comes last and unconditionally, so
-// the policy stops exporting even if the scheduler did not unwind cleanly.
+// behind when a job overran. ForgetPolicy and the trap withdrawal come last
+// and unconditionally, so the policy stops exporting either kind of series
+// even if the scheduler did not unwind cleanly.
+//
+// The withdrawal lives here, at the end of Stop, rather than in the manager
+// after Stop returns, because the manager holds the stopping policy's name
+// reservation for exactly as long as Stop runs. A same-name replacement
+// therefore cannot start and register until the withdrawal has already
+// happened, so it cannot have its own registration erased by the outgoing
+// runner's.
 func (r *Runner) Stop() error {
 	r.cancel()
 	err := r.scheduler.StopJobs()

--- a/orb-telemetry/snmp-telemetry/policy/runner.go
+++ b/orb-telemetry/snmp-telemetry/policy/runner.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/netip"
 	"strings"
 	"sync"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/collector"
 	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/config"
 	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/targets"
+	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/traps"
 )
 
 // Define a custom type for the context key
@@ -55,6 +57,15 @@ type Collector interface {
 	ForgetPolicy(policyName string)
 }
 
+// TrapRegistry is the trap receiver's view of a policy: the addresses it
+// polls and the v3 users it carries, claimed as the runner starts and
+// withdrawn as it stops. It is a second narrow interface rather than a
+// back-reference to the manager, for the same reason Collector is.
+type TrapRegistry interface {
+	Register(policy string, devices []traps.Device, users []traps.V3User)
+	Withdraw(policy string)
+}
+
 // Runner represents the policy runner for SNMP metrics collection
 type Runner struct {
 	scheduler gocron.Scheduler
@@ -66,6 +77,7 @@ type Runner struct {
 	cancel           context.CancelFunc
 	name             string
 	metricsCollector Collector
+	trapRegistry     TrapRegistry
 	metricsInterval  time.Duration
 	snmpTimeout      time.Duration
 	retries          int
@@ -81,7 +93,7 @@ type Runner struct {
 // NewRunner returns a new policy runner.
 // metricsCollector is the shared collector for this policy's profiles directory —
 // created once by the Manager and reused across all policies using the same dir.
-func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy config.Policy, metricsCollector Collector) (*Runner, error) {
+func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy config.Policy, metricsCollector Collector, registry TrapRegistry) (*Runner, error) {
 	s, err := gocron.NewScheduler()
 	if err != nil {
 		return nil, err
@@ -94,6 +106,9 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 	built := false
 	defer func() {
 		if !built {
+			if registry != nil {
+				registry.Withdraw(name)
+			}
 			cancel()
 		}
 	}()
@@ -103,6 +118,7 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 		logger:           logger,
 		name:             name,
 		metricsCollector: metricsCollector,
+		trapRegistry:     registry,
 		config:           policy.Config,
 		scope:            policy.Scope,
 		ctx:              runCtx,
@@ -178,6 +194,10 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 	if collapsed > 0 {
 		logger.Info("Policy names the same device more than once, collapsing the repeats",
 			"policy", config.SanitizeLogValue(name), "collapsed", collapsed, "devices", len(expanded))
+	}
+
+	if registry != nil {
+		registry.Register(name, trapDevices(name, expanded), trapUsers(runner, expanded))
 	}
 
 	// Schedule a metrics job for each expanded target
@@ -397,5 +417,50 @@ func (r *Runner) Stop() error {
 	if r.metricsCollector != nil {
 		r.metricsCollector.ForgetPolicy(r.name)
 	}
+	if r.trapRegistry != nil {
+		r.trapRegistry.Withdraw(r.name)
+	}
 	return err
+}
+
+// trapDevices is the address each expanded target names. A target that is a
+// hostname rather than an address has none and is skipped; the README says
+// such a target does not receive traps in this phase.
+func trapDevices(policy string, targets []config.Target) []traps.Device {
+	out := make([]traps.Device, 0, len(targets))
+	for _, t := range targets {
+		addr, err := netip.ParseAddr(t.Host)
+		if err != nil {
+			continue
+		}
+		out = append(out, traps.Device{Policy: policy, Addr: addr})
+	}
+	return out
+}
+
+// trapUsers is the v3 credential each expanded target polls with, deduplicated
+// on every field, so the receiver can authenticate a trap from that device
+// with the same user the poller uses.
+func trapUsers(r *Runner, targets []config.Target) []traps.V3User {
+	seen := make(map[traps.V3User]struct{})
+	var out []traps.V3User
+	for _, t := range targets {
+		auth := r.resolveTargetAuthentication(t)
+		if auth == nil || normalizeProtocolVersion(auth.ProtocolVersion) != "SNMPv3" {
+			continue
+		}
+		u := traps.V3User{
+			Username:       auth.Username,
+			AuthProtocol:   auth.AuthProtocol,
+			AuthPassphrase: auth.AuthPassphrase,
+			PrivProtocol:   auth.PrivProtocol,
+			PrivPassphrase: auth.PrivPassphrase,
+		}
+		if _, dup := seen[u]; dup {
+			continue
+		}
+		seen[u] = struct{}{}
+		out = append(out, u)
+	}
+	return out
 }

--- a/orb-telemetry/snmp-telemetry/policy/runner.go
+++ b/orb-telemetry/snmp-telemetry/policy/runner.go
@@ -199,7 +199,7 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 			// so a policy made only of them holds the socket and receives
 			// nothing it can attribute.
 			logger.Warn("Policy receives traps but none of its targets is an address, every trap it receives will be dropped as unknown_source",
-				"policy", config.SanitizeLogValue(name), "listen", policy.Scope.Traps.Listen)
+				"policy", config.SanitizeLogValue(name), "listen", config.SanitizeLogValue(policy.Scope.Traps.Listen))
 		}
 		lease, err = pool.Acquire(policy.Scope.Traps.Listen, name, devices, trapUsers(runner, expanded))
 		if err != nil {

--- a/orb-telemetry/snmp-telemetry/policy/runner.go
+++ b/orb-telemetry/snmp-telemetry/policy/runner.go
@@ -55,6 +55,9 @@ const (
 type Collector interface {
 	CollectTarget(ctx context.Context, target config.Target, auth *config.Authentication, policyName string, dial collector.DialOptions) error
 	ForgetPolicy(policyName string)
+	// TrapNames is the trap definitions of the profile set the collector
+	// polls with, which the runner registers with its trap claims.
+	TrapNames() map[string]string
 }
 
 // Runner represents the policy runner for SNMP metrics collection
@@ -227,7 +230,11 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 			logger.Warn("Policy receives traps but none of its targets is an address, every trap it receives will be dropped as unknown_source",
 				"policy", config.SanitizeLogValue(name), "listen", config.SanitizeLogValue(policy.Scope.Traps.Listen))
 		}
-		lease, err = pool.Acquire(policy.Scope.Traps.Listen, name, devices)
+		var names map[string]string
+		if metricsCollector != nil {
+			names = metricsCollector.TrapNames()
+		}
+		lease, err = pool.Acquire(policy.Scope.Traps.Listen, name, devices, names)
 		if err != nil {
 			return nil, err
 		}

--- a/orb-telemetry/snmp-telemetry/policy/runner.go
+++ b/orb-telemetry/snmp-telemetry/policy/runner.go
@@ -219,7 +219,7 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 		if pool == nil {
 			return nil, errors.New("policy declares scope.traps but this backend has no trap pool")
 		}
-		devices := trapDevices(name, expanded)
+		devices := trapDevices(runner, expanded)
 		if len(devices) == 0 {
 			// Hostname targets carry no address to match a source against,
 			// so a policy made only of them holds the socket and receives
@@ -227,7 +227,7 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 			logger.Warn("Policy receives traps but none of its targets is an address, every trap it receives will be dropped as unknown_source",
 				"policy", config.SanitizeLogValue(name), "listen", config.SanitizeLogValue(policy.Scope.Traps.Listen))
 		}
-		lease, err = pool.Acquire(policy.Scope.Traps.Listen, name, devices, trapUsers(runner, expanded))
+		lease, err = pool.Acquire(policy.Scope.Traps.Listen, name, devices)
 		if err != nil {
 			return nil, err
 		}
@@ -477,44 +477,29 @@ func (r *Runner) Stop() error {
 	return err
 }
 
-// trapDevices is the address each expanded target names. A target that is a
-// hostname rather than an address has none and is skipped; the README says
-// such a target does not receive traps in this phase.
-func trapDevices(policy string, targets []config.Target) []traps.Device {
+// trapDevices is the address each expanded target names, with the v3 user the
+// target is polled with, so the receiver authenticates a trap from that
+// device with that credential and no other. A target that is a hostname
+// rather than an address has none and is skipped; the README says such a
+// target does not receive traps in this phase.
+func trapDevices(r *Runner, targets []config.Target) []traps.Device {
 	out := make([]traps.Device, 0, len(targets))
 	for _, t := range targets {
 		addr, err := netip.ParseAddr(t.Host)
 		if err != nil {
 			continue
 		}
-		out = append(out, traps.Device{Policy: policy, Addr: addr})
-	}
-	return out
-}
-
-// trapUsers is the v3 credential each expanded target polls with, deduplicated
-// on every field, so the receiver can authenticate a trap from that device
-// with the same user the poller uses.
-func trapUsers(r *Runner, targets []config.Target) []traps.V3User {
-	seen := make(map[traps.V3User]struct{})
-	var out []traps.V3User
-	for _, t := range targets {
-		auth := r.resolveTargetAuthentication(t)
-		if auth == nil || normalizeProtocolVersion(auth.ProtocolVersion) != "SNMPv3" {
-			continue
+		d := traps.Device{Policy: r.name, Addr: addr}
+		if auth := r.resolveTargetAuthentication(t); auth != nil && normalizeProtocolVersion(auth.ProtocolVersion) == "SNMPv3" {
+			d.User = &traps.V3User{
+				Username:       auth.Username,
+				AuthProtocol:   auth.AuthProtocol,
+				AuthPassphrase: auth.AuthPassphrase,
+				PrivProtocol:   auth.PrivProtocol,
+				PrivPassphrase: auth.PrivPassphrase,
+			}
 		}
-		u := traps.V3User{
-			Username:       auth.Username,
-			AuthProtocol:   auth.AuthProtocol,
-			AuthPassphrase: auth.AuthPassphrase,
-			PrivProtocol:   auth.PrivProtocol,
-			PrivPassphrase: auth.PrivPassphrase,
-		}
-		if _, dup := seen[u]; dup {
-			continue
-		}
-		seen[u] = struct{}{}
-		out = append(out, u)
+		out = append(out, d)
 	}
 	return out
 }

--- a/orb-telemetry/snmp-telemetry/policy/runner.go
+++ b/orb-telemetry/snmp-telemetry/policy/runner.go
@@ -57,15 +57,6 @@ type Collector interface {
 	ForgetPolicy(policyName string)
 }
 
-// TrapRegistry is the trap receiver's view of a policy: the addresses it
-// polls and the v3 users it carries, claimed as the runner starts and
-// withdrawn as it stops. It is a second narrow interface rather than a
-// back-reference to the manager, for the same reason Collector is.
-type TrapRegistry interface {
-	Register(policy string, devices []traps.Device, users []traps.V3User)
-	Withdraw(policy string)
-}
-
 // Runner represents the policy runner for SNMP metrics collection
 type Runner struct {
 	scheduler gocron.Scheduler
@@ -77,7 +68,8 @@ type Runner struct {
 	cancel           context.CancelFunc
 	name             string
 	metricsCollector Collector
-	trapRegistry     TrapRegistry
+	trapPool         TrapPool
+	trapLease        TrapLease
 	metricsInterval  time.Duration
 	snmpTimeout      time.Duration
 	retries          int
@@ -93,7 +85,7 @@ type Runner struct {
 // NewRunner returns a new policy runner.
 // metricsCollector is the shared collector for this policy's profiles directory —
 // created once by the Manager and reused across all policies using the same dir.
-func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy config.Policy, metricsCollector Collector, registry TrapRegistry) (*Runner, error) {
+func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy config.Policy, metricsCollector Collector, pool TrapPool) (*Runner, error) {
 	s, err := gocron.NewScheduler()
 	if err != nil {
 		return nil, err
@@ -104,10 +96,11 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 	// would otherwise stay attached to the manager's for the life of the
 	// process.
 	built := false
+	var lease TrapLease
 	defer func() {
 		if !built {
-			if registry != nil {
-				registry.Withdraw(name)
+			if lease != nil {
+				lease.Release()
 			}
 			cancel()
 		}
@@ -118,7 +111,7 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 		logger:           logger,
 		name:             name,
 		metricsCollector: metricsCollector,
-		trapRegistry:     registry,
+		trapPool:         pool,
 		config:           policy.Config,
 		scope:            policy.Scope,
 		ctx:              runCtx,
@@ -196,8 +189,23 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 			"policy", config.SanitizeLogValue(name), "collapsed", collapsed, "devices", len(expanded))
 	}
 
-	if registry != nil {
-		registry.Register(name, trapDevices(name, expanded), trapUsers(runner, expanded))
+	if policy.Scope.Traps != nil {
+		if pool == nil {
+			return nil, errors.New("policy declares scope.traps but this backend has no trap pool")
+		}
+		devices := trapDevices(name, expanded)
+		if len(devices) == 0 {
+			// Hostname targets carry no address to match a source against,
+			// so a policy made only of them holds the socket and receives
+			// nothing it can attribute.
+			logger.Warn("Policy receives traps but none of its targets is an address, every trap it receives will be dropped as unknown_source",
+				"policy", config.SanitizeLogValue(name), "listen", policy.Scope.Traps.Listen)
+		}
+		lease, err = pool.Acquire(policy.Scope.Traps.Listen, name, devices, trapUsers(runner, expanded))
+		if err != nil {
+			return nil, err
+		}
+		runner.trapLease = lease
 	}
 
 	// Schedule a metrics job for each expanded target
@@ -408,15 +416,15 @@ func (r *Runner) Start() {
 // not cut it short. StopJobs then has a wait it can finish, and it comes before
 // the state is dropped so a run is not still writing when the drop happens.
 // Shutdown runs whatever StopJobs reported, rather than leaving the scheduler
-// behind when a job overran. ForgetPolicy and the trap withdrawal come last
+// behind when a job overran. ForgetPolicy and the trap release come last
 // and unconditionally, so the policy stops exporting either kind of series
 // even if the scheduler did not unwind cleanly.
 //
-// The withdrawal lives here, at the end of Stop, rather than in the manager
+// The release lives here, at the end of Stop, rather than in the manager
 // after Stop returns, because the manager holds the stopping policy's name
 // reservation for exactly as long as Stop runs. A same-name replacement
-// therefore cannot start and register until the withdrawal has already
-// happened, so it cannot have its own registration erased by the outgoing
+// therefore cannot start and acquire until the release has already
+// happened, so it cannot have its own lease erased by the outgoing
 // runner's.
 func (r *Runner) Stop() error {
 	r.cancel()
@@ -425,8 +433,8 @@ func (r *Runner) Stop() error {
 	if r.metricsCollector != nil {
 		r.metricsCollector.ForgetPolicy(r.name)
 	}
-	if r.trapRegistry != nil {
-		r.trapRegistry.Withdraw(r.name)
+	if r.trapLease != nil {
+		r.trapLease.Release()
 	}
 	return err
 }

--- a/orb-telemetry/snmp-telemetry/policy/runner_test.go
+++ b/orb-telemetry/snmp-telemetry/policy/runner_test.go
@@ -32,7 +32,7 @@ func TestNewRunner_RejectsUnexpandableTarget(t *testing.T) {
 		"inverted range":          "10.0.0.100-10.0.0.1",
 	} {
 		t.Run(name, func(t *testing.T) {
-			_, err := NewRunner(context.Background(), testLogger, "p1", policyWithTargets(host), &spyCollector{})
+			_, err := NewRunner(context.Background(), testLogger, "p1", policyWithTargets(host), &spyCollector{}, nil)
 			require.Error(t, err, "an unexpandable target must fail the runner, not be skipped")
 			assert.Contains(t, err.Error(), host, "the error must name the offending target")
 		})
@@ -44,7 +44,7 @@ func TestNewRunner_RejectsUnexpandableTarget(t *testing.T) {
 // operator who asked for two subnets and got one is not told which.
 func TestNewRunner_RejectsUnexpandableTargetAmongValidOnes(t *testing.T) {
 	_, err := NewRunner(context.Background(), testLogger, "p1",
-		policyWithTargets("192.168.1.1", "10.0.0.1/99"), &spyCollector{})
+		policyWithTargets("192.168.1.1", "10.0.0.1/99"), &spyCollector{}, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "10.0.0.1/99")
 }
@@ -60,7 +60,7 @@ func TestNewRunner_AcceptsExpandableTargets(t *testing.T) {
 		"snmp.example.com", "edge-router-1.example.com", "10.0.0.256", "192.168.1.1", "10.0.0.0/30",
 	} {
 		t.Run(host, func(t *testing.T) {
-			r, err := NewRunner(context.Background(), testLogger, "p1", policyWithTargets(host), &spyCollector{})
+			r, err := NewRunner(context.Background(), testLogger, "p1", policyWithTargets(host), &spyCollector{}, nil)
 			require.NoError(t, err)
 			t.Cleanup(func() { _ = r.Stop() })
 			assert.NotEmpty(t, r.scheduler.Jobs(), "an accepted target must schedule at least one job")
@@ -181,7 +181,7 @@ func TestExpandTargets_ReportsAnUnexpandableTarget(t *testing.T) {
 // defeats.
 func TestNewRunner_SchedulesOneJobPerIdentity(t *testing.T) {
 	r, err := NewRunner(context.Background(), testLogger, "p1",
-		policyWithTargets("10.0.0.0/30", "10.0.0.1"), &spyCollector{})
+		policyWithTargets("10.0.0.0/30", "10.0.0.1"), &spyCollector{}, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = r.Stop() })
 	assert.Len(t, r.scheduler.Jobs(), 2, "the repeated address must not get a second job")
@@ -193,7 +193,7 @@ func TestNewRunner_SchedulesOneJobPerIdentity(t *testing.T) {
 // counts the raw notation and refuses.
 func TestNewRunner_ChargesTheBudgetBeforeCollapsing(t *testing.T) {
 	_, err := NewRunner(context.Background(), testLogger, "p1",
-		policyWithTargets("10.0.0.0/16", "10.0.0.0/16"), &spyCollector{})
+		policyWithTargets("10.0.0.0/16", "10.0.0.0/16"), &spyCollector{}, nil)
 	require.Error(t, err, "a policy may not name a prefix twice to pay for it once")
 	assert.Contains(t, err.Error(), "more than the limit")
 }
@@ -240,7 +240,7 @@ func TestNewRunner_SchedulesBothTargetsACollidingKeyWouldMerge(t *testing.T) {
 		config.Target{Host: "10.0.0.1", Port: 161, ID: "a context=b"},
 		config.Target{Host: "10.0.0.1", Port: 161, ID: "a", Authentication: v3ContextAuth("b")},
 	)
-	r, err := NewRunner(context.Background(), testLogger, "p1", pol, &spyCollector{})
+	r, err := NewRunner(context.Background(), testLogger, "p1", pol, &spyCollector{}, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = r.Stop() })
 	assert.Len(t, r.scheduler.Jobs(), 2, "a target was collapsed into another and is never polled")

--- a/orb-telemetry/snmp-telemetry/policy/traps.go
+++ b/orb-telemetry/snmp-telemetry/policy/traps.go
@@ -1,0 +1,34 @@
+package policy
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"strconv"
+	"strings"
+)
+
+// validateTrapListen accepts host:port where host is empty, meaning every
+// interface, or an IP literal. A hostname is rejected rather than resolved,
+// for the same reason targets are not resolved: nothing here does DNS, and a
+// name that resolved differently at each start would bind a different socket.
+func validateTrapListen(listen string) error {
+	if strings.TrimSpace(listen) == "" {
+		return errors.New(`scope.traps.listen: required, for example "0.0.0.0:162"`)
+	}
+	host, port, err := net.SplitHostPort(listen)
+	if err != nil {
+		return fmt.Errorf("scope.traps.listen: %w", err)
+	}
+	if host != "" {
+		if _, err := netip.ParseAddr(host); err != nil {
+			return fmt.Errorf("scope.traps.listen: host must be an IP address or empty, not %q", host)
+		}
+	}
+	p, err := strconv.Atoi(port)
+	if err != nil || p < 1 || p > 65535 {
+		return fmt.Errorf("scope.traps.listen: port must be 1 to 65535, not %q", port)
+	}
+	return nil
+}

--- a/orb-telemetry/snmp-telemetry/policy/traps.go
+++ b/orb-telemetry/snmp-telemetry/policy/traps.go
@@ -36,11 +36,11 @@ func validateTrapListen(listen string) error {
 }
 
 // TrapPool hands a policy the socket its traps arrive on. A runner acquires
-// as it starts, with the addresses its targets expand to and the v3 users it
-// carries, and releases as it stops. It is a narrow interface rather than a
+// as it starts, with the addresses its targets expand to and the v3 user
+// each is polled with, and releases as it stops. It is a narrow interface rather than a
 // back-reference to the pool, for the same reason Collector is.
 type TrapPool interface {
-	Acquire(listen, policy string, devices []traps.Device, users []traps.V3User) (TrapLease, error)
+	Acquire(listen, policy string, devices []traps.Device) (TrapLease, error)
 }
 
 // TrapLease is one runner's hold on one socket.

--- a/orb-telemetry/snmp-telemetry/policy/traps.go
+++ b/orb-telemetry/snmp-telemetry/policy/traps.go
@@ -7,6 +7,8 @@ import (
 	"net/netip"
 	"strconv"
 	"strings"
+
+	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/traps"
 )
 
 // validateTrapListen accepts host:port where host is empty, meaning every
@@ -31,4 +33,17 @@ func validateTrapListen(listen string) error {
 		return fmt.Errorf("scope.traps.listen: port must be 1 to 65535, not %q", port)
 	}
 	return nil
+}
+
+// TrapPool hands a policy the socket its traps arrive on. A runner acquires
+// as it starts, with the addresses its targets expand to and the v3 users it
+// carries, and releases as it stops. It is a narrow interface rather than a
+// back-reference to the pool, for the same reason Collector is.
+type TrapPool interface {
+	Acquire(listen, policy string, devices []traps.Device, users []traps.V3User) (TrapLease, error)
+}
+
+// TrapLease is one runner's hold on one socket.
+type TrapLease interface {
+	Release()
 }

--- a/orb-telemetry/snmp-telemetry/policy/traps.go
+++ b/orb-telemetry/snmp-telemetry/policy/traps.go
@@ -36,11 +36,12 @@ func validateTrapListen(listen string) error {
 }
 
 // TrapPool hands a policy the socket its traps arrive on. A runner acquires
-// as it starts, with the addresses its targets expand to and the v3 user
-// each is polled with, and releases as it stops. It is a narrow interface rather than a
+// as it starts, with the addresses its targets expand to, the v3 user each
+// is polled with and the trap names of its profile set, and releases as it
+// stops. It is a narrow interface rather than a
 // back-reference to the pool, for the same reason Collector is.
 type TrapPool interface {
-	Acquire(listen, policy string, devices []traps.Device) (TrapLease, error)
+	Acquire(listen, policy string, devices []traps.Device, names map[string]string) (TrapLease, error)
 }
 
 // TrapLease is one runner's hold on one socket.

--- a/orb-telemetry/snmp-telemetry/policy/traps_test.go
+++ b/orb-telemetry/snmp-telemetry/policy/traps_test.go
@@ -198,3 +198,14 @@ func schedulerGoroutines(t *testing.T) int {
 		buf = make([]byte, 2*len(buf))
 	}
 }
+
+// The listen string is re-checked in NewRunner as well as in validatePolicy,
+// so a direct call cannot hand the pool a string the API would have refused.
+func TestRunner_ValidatesTheListenString(t *testing.T) {
+	pool := newSpyPool()
+	_, err := NewRunner(t.Context(), testLogger, "p1", trapPolicy(nil, "trap.example:162"), &spyCollector{}, pool)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "scope.traps.listen")
+	assert.Contains(t, err.Error(), "host must be an IP address")
+	assert.Empty(t, pool.callSequence(), "and nothing was acquired")
+}

--- a/orb-telemetry/snmp-telemetry/policy/traps_test.go
+++ b/orb-telemetry/snmp-telemetry/policy/traps_test.go
@@ -2,6 +2,8 @@ package policy
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -208,4 +210,24 @@ func TestRunner_ValidatesTheListenString(t *testing.T) {
 	assert.Contains(t, err.Error(), "scope.traps.listen")
 	assert.Contains(t, err.Error(), "host must be an IP address")
 	assert.Empty(t, pool.callSequence(), "and nothing was acquired")
+}
+
+// The collector the manager builds for a profiles directory carries that
+// directory's trap names, override files included, which is what a policy
+// with its own profiles_dir registers.
+func TestManager_CollectorCarriesItsProfilesDirsTrapNames(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "custom"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "custom", "traps.yml"), []byte(`
+traps:
+  - trap_oid: 1.3.6.1.4.1.99999.0.1
+    trap_name: customWidgetFailed
+`), 0o644))
+	m := NewManager(t.Context(), testLogger, Options{})
+	c, err := m.acquireCollector(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { m.releaseCollector(dir) })
+	names := c.TrapNames()
+	assert.Equal(t, "customWidgetFailed", names["1.3.6.1.4.1.99999.0.1"])
+	assert.Equal(t, "bigipTrafficGroupStandby", names["1.3.6.1.4.1.3375.2.4.0.141"])
 }

--- a/orb-telemetry/snmp-telemetry/policy/traps_test.go
+++ b/orb-telemetry/snmp-telemetry/policy/traps_test.go
@@ -1,0 +1,96 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/config"
+)
+
+func TestValidateTrapListen(t *testing.T) {
+	accepted := []string{"0.0.0.0:162", ":162", "127.0.0.1:1162", "[::]:162", "[fe80::1%en0]:162", "10.0.0.5:65535"}
+	for _, listen := range accepted {
+		assert.NoError(t, validateTrapListen(listen), listen)
+	}
+	rejected := map[string]string{
+		"":                  "required",
+		"   ":               "required",
+		"162":               "missing port",
+		"0.0.0.0":           "missing port",
+		"0.0.0.0:0":         "port must be 1 to 65535",
+		"0.0.0.0:65536":     "port must be 1 to 65535",
+		"0.0.0.0:snmptrap":  "port must be 1 to 65535",
+		"trap.example:162":  "host must be an IP address",
+		"localhost:162":     "host must be an IP address",
+		"0.0.0.0:162:extra": "too many colons",
+	}
+	for listen, want := range rejected {
+		err := validateTrapListen(listen)
+		require.Error(t, err, listen)
+		assert.Contains(t, err.Error(), "scope.traps.listen", listen)
+		assert.Contains(t, err.Error(), want, listen)
+	}
+}
+
+func trapPolicy(interval *int, listen string) config.Policy {
+	p := config.Policy{
+		Config: config.PolicyConfig{MetricsInterval: interval},
+		Scope: config.Scope{
+			Authentication: config.Authentication{ProtocolVersion: "SNMPv2c", Community: "public"},
+			Targets:        []config.Target{{Host: "10.0.0.1"}},
+		},
+	}
+	if listen != "" {
+		p.Scope.Traps = &config.Traps{Listen: listen}
+	}
+	return p
+}
+
+func TestValidatePolicy_TrapsAndInterval(t *testing.T) {
+	m := NewManager(t.Context(), testLogger, Options{})
+	sixty := 60
+
+	assert.NoError(t, m.validatePolicy(trapPolicy(&sixty, "")), "polling only is unchanged")
+	assert.NoError(t, m.validatePolicy(trapPolicy(&sixty, "0.0.0.0:162")), "polling and traps")
+	assert.NoError(t, m.validatePolicy(trapPolicy(nil, "0.0.0.0:162")), "traps only: no interval needed")
+
+	err := m.validatePolicy(trapPolicy(nil, ""))
+	require.Error(t, err)
+	assert.Equal(t, "policy has neither metrics_interval nor scope.traps: nothing to do", err.Error())
+
+	err = m.validatePolicy(trapPolicy(&sixty, "0.0.0.0"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "scope.traps.listen")
+
+	zero := 0
+	err = m.validatePolicy(trapPolicy(&zero, "0.0.0.0:162"))
+	require.Error(t, err, "a present interval is still range-checked")
+	assert.Contains(t, err.Error(), "metrics_interval must be a positive integer")
+
+	huge := maxPolicySeconds + 1
+	err = m.validatePolicy(trapPolicy(&huge, ""))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "metrics_interval must be at most")
+}
+
+func TestParsePolicies_ReadsTheTrapsBlock(t *testing.T) {
+	m := NewManager(t.Context(), testLogger, Options{})
+	policies, err := m.ParsePolicies([]byte(`
+policies:
+  edge:
+    scope:
+      authentication:
+        protocol_version: v2c
+        community: public
+      targets:
+        - host: 10.1.0.0/30
+      traps:
+        listen: "0.0.0.0:162"
+`))
+	require.NoError(t, err)
+	require.NotNil(t, policies["edge"].Scope.Traps)
+	assert.Equal(t, "0.0.0.0:162", policies["edge"].Scope.Traps.Listen)
+	assert.Nil(t, policies["edge"].Config.MetricsInterval)
+}

--- a/orb-telemetry/snmp-telemetry/policy/traps_test.go
+++ b/orb-telemetry/snmp-telemetry/policy/traps_test.go
@@ -79,9 +79,9 @@ func TestValidatePolicy_TrapsAndInterval(t *testing.T) {
 	assert.Contains(t, err.Error(), "metrics_interval must be at most")
 }
 
-// A policy with no metrics_interval polls nothing: no scheduler, no job, no
-// collector call, no ForgetPolicy on stop. It still expands its targets and
-// acquires the socket with them.
+// A policy with no metrics_interval polls nothing: no scheduler, no job and no
+// collector call. It still expands its targets and acquires the socket with
+// them, and its stop still forgets a policy the collector never heard of.
 func TestRunner_TrapOnlySchedulesNothing(t *testing.T) {
 	pool := newSpyPool()
 	spy := &spyCollector{}
@@ -94,11 +94,11 @@ func TestRunner_TrapOnlySchedulesNothing(t *testing.T) {
 
 	assert.NotPanics(t, r.Start)
 	time.Sleep(50 * time.Millisecond)
-	assert.Empty(t, spy.dials, "nothing was polled")
+	assert.Empty(t, spy.dialed(), "nothing was polled")
 
 	require.NoError(t, r.Stop())
 	assert.Equal(t, []string{"edge"}, pool.released)
-	assert.Empty(t, spy.forgotten(), "there is no collector state to forget")
+	assert.Equal(t, []string{"edge"}, spy.forgotten(), "the forget runs whatever the runner scheduled, and finds no state")
 }
 
 // The guard in NewRunner mirrors validatePolicy so a direct call cannot slip

--- a/orb-telemetry/snmp-telemetry/policy/traps_test.go
+++ b/orb-telemetry/snmp-telemetry/policy/traps_test.go
@@ -1,6 +1,9 @@
 package policy
 
 import (
+	"errors"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -153,4 +156,45 @@ policies:
 	require.NotNil(t, policies["edge"].Scope.Traps)
 	assert.Equal(t, "0.0.0.0:162", policies["edge"].Scope.Traps.Listen)
 	assert.Nil(t, policies["edge"].Config.MetricsInterval)
+}
+
+// A start that fails after the scheduler exists shuts it down. gocron starts a
+// goroutine in NewScheduler, so a rejected policy that only cancelled its
+// context would strand one for the life of the process, and a trap socket
+// collision is a rejection that happens after the scheduler is built.
+func TestRunner_FailedStartShutsDownTheScheduler(t *testing.T) {
+	pool := newSpyPool()
+	pool.acquireErr = errors.New("binding trap socket 0.0.0.0:1162: address already in use")
+	sixty := 60
+
+	baseline := schedulerGoroutines(t)
+	const rejected = 20
+	for range rejected {
+		_, err := NewRunner(t.Context(), testLogger, "p1", trapPolicy(&sixty, "0.0.0.0:1162"), &spyCollector{}, pool)
+		require.Error(t, err)
+	}
+
+	// Shutdown returns before the goroutine it stopped has finished unwinding,
+	// so the count is polled rather than read once.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) && schedulerGoroutines(t) > baseline {
+		time.Sleep(10 * time.Millisecond)
+	}
+	assert.LessOrEqual(t, schedulerGoroutines(t), baseline,
+		"every rejected policy's scheduler goroutine is gone, not %d of them left running", rejected)
+}
+
+// schedulerGoroutines counts the live goroutines gocron.NewScheduler started.
+// The dump names the creator of every goroutine, which is what tells a
+// scheduler's own goroutine apart from the rest of the test binary's.
+func schedulerGoroutines(t *testing.T) int {
+	t.Helper()
+	buf := make([]byte, 1<<20)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return strings.Count(string(buf[:n]), "gocron/v2.NewScheduler")
+		}
+		buf = make([]byte, 2*len(buf))
+	}
 }

--- a/orb-telemetry/snmp-telemetry/policy/traps_test.go
+++ b/orb-telemetry/snmp-telemetry/policy/traps_test.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -73,6 +74,65 @@ func TestValidatePolicy_TrapsAndInterval(t *testing.T) {
 	err = m.validatePolicy(trapPolicy(&huge, ""))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "metrics_interval must be at most")
+}
+
+// A policy with no metrics_interval polls nothing: no scheduler, no job, no
+// collector call, no ForgetPolicy on stop. It still expands its targets and
+// acquires the socket with them.
+func TestRunner_TrapOnlySchedulesNothing(t *testing.T) {
+	pool := newSpyPool()
+	spy := &spyCollector{}
+	pol := trapPolicy(nil, "0.0.0.0:1162")
+	pol.Scope.Targets = []config.Target{{Host: "10.0.0.0/30"}}
+	r, err := NewRunner(t.Context(), testLogger, "edge", pol, spy, pool)
+	require.NoError(t, err)
+	assert.Nil(t, r.scheduler, "a trap-only runner has no scheduler")
+	assert.Len(t, pool.devices["edge"], 2)
+
+	assert.NotPanics(t, r.Start)
+	time.Sleep(50 * time.Millisecond)
+	assert.Empty(t, spy.dials, "nothing was polled")
+
+	require.NoError(t, r.Stop())
+	assert.Equal(t, []string{"edge"}, pool.released)
+	assert.Empty(t, spy.forgotten(), "there is no collector state to forget")
+}
+
+// The guard in NewRunner mirrors validatePolicy so a direct call cannot slip
+// past.
+func TestRunner_NeitherIntervalNorTrapsIsRejected(t *testing.T) {
+	_, err := NewRunner(t.Context(), testLogger, "p1", trapPolicy(nil, ""), &spyCollector{}, newSpyPool())
+	require.Error(t, err)
+	assert.Equal(t, "policy has neither metrics_interval nor scope.traps: nothing to do", err.Error())
+}
+
+// Through the manager, so the whole start and stop path is exercised with
+// the real lifecycle and none of it dereferences the absent scheduler.
+func TestManager_TrapOnlyPolicyStartsAndStops(t *testing.T) {
+	pool := newSpyPool()
+	m := NewManager(t.Context(), testLogger, Options{TrapPool: pool})
+	policies, err := m.ParsePolicies([]byte(`
+policies:
+  edge:
+    scope:
+      authentication:
+        protocol_version: v2c
+        community: public
+      targets:
+        - host: 10.0.0.1
+      traps:
+        listen: "0.0.0.0:1162"
+`))
+	require.NoError(t, err)
+	require.NoError(t, m.StartPolicy("edge", policies["edge"]))
+	require.True(t, m.HasPolicy("edge"))
+	statuses := m.GetPolicyStatuses()
+	require.Len(t, statuses, 1)
+	assert.Equal(t, "running", statuses[0].Status)
+
+	require.NoError(t, m.StopPolicy("edge"))
+	assert.Equal(t, []string{"acquire:edge", "release:edge"}, pool.callSequence())
+	require.NoError(t, m.Stop())
 }
 
 func TestParsePolicies_ReadsTheTrapsBlock(t *testing.T) {

--- a/orb-telemetry/snmp-telemetry/profiles/loader.go
+++ b/orb-telemetry/snmp-telemetry/profiles/loader.go
@@ -296,6 +296,7 @@ func (l *Loader) resolvePath(key string) (*Profile, error) {
 		// and there is no parent list for a child's to interleave with.
 		Matches:          p.Matches,
 		MatchesList:      p.MatchesList,
+		Traps:            p.Traps,
 		NoUseBulkWalkAll: p.NoUseBulkWalkAll,
 	}
 

--- a/orb-telemetry/snmp-telemetry/profiles/matcher.go
+++ b/orb-telemetry/snmp-telemetry/profiles/matcher.go
@@ -23,6 +23,10 @@ type matchRedirect struct {
 
 // Matcher matches a device sysObjectID (and optionally sysDescr) to a Profile.
 type Matcher struct {
+	// trapNames is the trap definitions of the profile set this matcher was
+	// built from, keyed by normalised OID, built once. A policy registers
+	// them with its trap claims so its traps are named by its own set.
+	trapNames     map[string]string
 	exactIndex    map[string]*Profile          // normalized OID -> profile (exact matches)
 	wildcardIndex []wildcardEntry              // sorted longest-prefix-first for wildcard matches
 	profileByFile map[string]*Profile          // filename -> profile (for sysDescr redirects)
@@ -111,6 +115,7 @@ func NewMatcher(profiles []*Profile, logger *slog.Logger) *Matcher {
 	reportShadowed(byWildcard, logger, "sysobjectid", keyClaims.bundled)
 
 	m := &Matcher{
+		trapNames:     TrapNames(profiles),
 		exactIndex:    make(map[string]*Profile, len(byExact)),
 		profileByFile: make(map[string]*Profile, len(byBase)),
 		wildcardIndex: make([]wildcardEntry, 0, len(byWildcard)),
@@ -356,3 +361,7 @@ func normalizeOID(raw string) string {
 	oid = strings.TrimPrefix(oid, "iso.")
 	return oid
 }
+
+// TrapNames is the trap definitions of the profile set this matcher was built
+// from, keyed by normalised OID. The same map is returned every time.
+func (m *Matcher) TrapNames() map[string]string { return m.trapNames }

--- a/orb-telemetry/snmp-telemetry/profiles/profile.go
+++ b/orb-telemetry/snmp-telemetry/profiles/profile.go
@@ -51,6 +51,14 @@ type Match struct {
 	Target string `yaml:"target"`
 }
 
+// TrapDef names one trap a definition file describes. Phase 1 of the trap
+// receiver reads only the OID and the name; the events and attributes upstream
+// carries belong to the payload work and are not decoded here.
+type TrapDef struct {
+	OID  string `yaml:"trap_oid"`
+	Name string `yaml:"trap_name"`
+}
+
 // Profile is the top-level representation of a ktranslate-compatible SNMP profile file.
 type Profile struct {
 	// FileName is the base filename, populated by the Loader (not from YAML).
@@ -83,6 +91,11 @@ type Profile struct {
 
 	Metrics    []MetricEntry `yaml:"metrics"`
 	MetricTags []MetricTag   `yaml:"metric_tags"`
+	// Traps are the trap definitions a file declares. The bundled tree ships
+	// ten such files, which carry no sysobjectid and no metrics and so match
+	// no device; they exist to name traps. Like the two redirect forms, they
+	// are the declaring file's own and are not merged through extends.
+	Traps []TrapDef `yaml:"traps"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler for Profile.

--- a/orb-telemetry/snmp-telemetry/profiles/traps.go
+++ b/orb-telemetry/snmp-telemetry/profiles/traps.go
@@ -17,7 +17,7 @@ import "strings"
 func TrapNames(all []*Profile) map[string]string {
 	names := make(map[string]string)
 	add := func(oid, name string) {
-		oid = strings.TrimPrefix(strings.TrimSpace(oid), ".")
+		oid = normalizeOID(oid)
 		if oid == "" || name == "" {
 			return
 		}

--- a/orb-telemetry/snmp-telemetry/profiles/traps.go
+++ b/orb-telemetry/snmp-telemetry/profiles/traps.go
@@ -7,18 +7,30 @@ import "strings"
 // dot, and gosnmp reports every parsed OID with one, so the key is the form
 // with none, matching how the collector normalises.
 //
+// A definition is either an entry under `traps:` or a flat metric entry whose
+// `type` is trap. The loader leaves the latter unfolded, since nothing polls
+// a trap, and one bundled file declares all of its traps that way.
+//
 // A later profile's name for an OID replaces an earlier one's. The bundled set
 // has one such collision, in cisco/traps.yml, and this reports the file as
 // written; the trap receiver applies the RFC 1215 names on top.
 func TrapNames(all []*Profile) map[string]string {
 	names := make(map[string]string)
+	add := func(oid, name string) {
+		oid = strings.TrimPrefix(strings.TrimSpace(oid), ".")
+		if oid == "" || name == "" {
+			return
+		}
+		names[oid] = name
+	}
 	for _, p := range all {
 		for _, def := range p.Traps {
-			oid := strings.TrimPrefix(strings.TrimSpace(def.OID), ".")
-			if oid == "" || def.Name == "" {
-				continue
+			add(def.OID, def.Name)
+		}
+		for _, m := range p.Metrics {
+			if strings.EqualFold(strings.TrimSpace(m.Type), "trap") {
+				add(m.OID, m.Name)
 			}
-			names[oid] = def.Name
 		}
 	}
 	return names

--- a/orb-telemetry/snmp-telemetry/profiles/traps.go
+++ b/orb-telemetry/snmp-telemetry/profiles/traps.go
@@ -1,0 +1,25 @@
+package profiles
+
+import "strings"
+
+// TrapNames collects every trap definition in a resolved set into one map from
+// normalised OID to name. Definitions are written with and without a leading
+// dot, and gosnmp reports every parsed OID with one, so the key is the form
+// with none, matching how the collector normalises.
+//
+// A later profile's name for an OID replaces an earlier one's. The bundled set
+// has one such collision, in cisco/traps.yml, and this reports the file as
+// written; the trap receiver applies the RFC 1215 names on top.
+func TrapNames(all []*Profile) map[string]string {
+	names := make(map[string]string)
+	for _, p := range all {
+		for _, def := range p.Traps {
+			oid := strings.TrimPrefix(strings.TrimSpace(def.OID), ".")
+			if oid == "" || def.Name == "" {
+				continue
+			}
+			names[oid] = def.Name
+		}
+	}
+	return names
+}

--- a/orb-telemetry/snmp-telemetry/profiles/traps_test.go
+++ b/orb-telemetry/snmp-telemetry/profiles/traps_test.go
@@ -119,3 +119,22 @@ traps:
 	assert.Equal(t, "bigipTrafficGroupStandby", names["1.3.6.1.4.1.3375.2.4.0.141"], "the bundled ones still are")
 	assert.Equal(t, reflect.ValueOf(names).Pointer(), reflect.ValueOf(m.TrapNames()).Pointer(), "built once, not per call")
 }
+
+// An override file may write a trap OID in the iso. form the repository
+// supports, iso. before the full numeric OID; it is normalised the same way a
+// metric OID is, dropping the iso. label, so the numeric wire OID finds it.
+func TestTrapNames_NormalisesTheIsoPrefix(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "custom"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "custom", "traps.yml"), []byte(`
+traps:
+  - trap_oid: iso.1.3.6.1.4.1.99999.0.7
+    trap_name: isoSpelledTrap
+`), 0o644))
+	l, err := LoadProfiles(dir, silentLogger)
+	require.NoError(t, err)
+	all, err := l.AllResolved()
+	require.NoError(t, err)
+	names := TrapNames(all)
+	assert.Equal(t, "isoSpelledTrap", names["1.3.6.1.4.1.99999.0.7"], "the iso. label is stripped like a metric OID's")
+}

--- a/orb-telemetry/snmp-telemetry/profiles/traps_test.go
+++ b/orb-telemetry/snmp-telemetry/profiles/traps_test.go
@@ -1,0 +1,79 @@
+package profiles
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The bundled tree carries ten trap definition files. They are loaded as
+// profiles today with their traps: key dropped by the permissive decode, so
+// the first thing to pin is that the field is read at all.
+func TestTrapNames_BundledDefinitionsAreRead(t *testing.T) {
+	l, err := LoadProfiles("", silentLogger)
+	require.NoError(t, err)
+	all, err := l.AllResolved()
+	require.NoError(t, err)
+
+	names := TrapNames(all)
+	assert.GreaterOrEqual(t, len(names), 185, "ten bundled files carry about 190 definitions")
+	assert.Equal(t, "linkDown", names["1.3.6.1.6.3.1.1.5.3"])
+	assert.Equal(t, "bigipTrafficGroupStandby", names["1.3.6.1.4.1.3375.2.4.0.141"],
+		"f5 carries the bulk of the definitions")
+}
+
+// The bundled cisco file maps both .5.5 and .5.6 to authenticationFailure.
+// TrapNames reports what the files say; the RFC 1215 override lives in the
+// traps package, so this pins that the loader does not silently correct it.
+func TestTrapNames_ReportsTheBundledFilesAsWritten(t *testing.T) {
+	l, err := LoadProfiles("", silentLogger)
+	require.NoError(t, err)
+	all, err := l.AllResolved()
+	require.NoError(t, err)
+
+	names := TrapNames(all)
+	assert.Equal(t, "authenticationFailure", names["1.3.6.1.6.3.1.1.5.6"],
+		"the vendored cisco file is wrong here and must stay byte identical")
+}
+
+// A trap OID written with a leading dot in a definition file must land on the
+// same key as one written without, or a lookup misses depending on spelling.
+func TestTrapNames_NormalisesTheLeadingDot(t *testing.T) {
+	names := TrapNames([]*Profile{{
+		FileName: "x.yml",
+		Traps:    []TrapDef{{OID: ".1.3.6.1.4.1.9.9.41.2.0.1", Name: "clogMessageGenerated"}},
+	}})
+	assert.Equal(t, "clogMessageGenerated", names["1.3.6.1.4.1.9.9.41.2.0.1"])
+}
+
+// When two profiles declare the same OID under different names, the profile
+// resolved later wins. TrapNames reports what the files say rather than
+// picking a winner itself, so this pins the iteration order rather than some
+// preference for one profile over another.
+func TestTrapNames_LaterProfileWinsOnACollidingOID(t *testing.T) {
+	names := TrapNames([]*Profile{
+		{FileName: "a.yml", Traps: []TrapDef{{OID: "1.2.3", Name: "firstName"}}},
+		{FileName: "b.yml", Traps: []TrapDef{{OID: "1.2.3", Name: "secondName"}}},
+	})
+	assert.Equal(t, "secondName", names["1.2.3"])
+}
+
+// Traps follow matches and matches_list: the declaring file's own, never
+// merged through extends.
+func TestResolve_TrapsAreNotInheritedThroughExtends(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, dir, "parent.yml", "traps:\n  - trap_oid: 1.2.3\n    trap_name: parentTrap\n")
+	writeYAML(t, dir, "child.yml", "extends:\n  - parent.yml\nsysobjectid: 1.3.6.1.4.1.9.1.1\nmetrics: []\n")
+
+	l, err := NewLoader(dir, silentLogger)
+	require.NoError(t, err)
+	child, err := l.Resolve("child.yml")
+	require.NoError(t, err)
+	assert.Empty(t, child.Traps, "a child does not inherit its parent's trap definitions")
+
+	parent, err := l.Resolve("parent.yml")
+	require.NoError(t, err)
+	require.Len(t, parent.Traps, 1)
+	assert.Equal(t, "parentTrap", parent.Traps[0].Name)
+}

--- a/orb-telemetry/snmp-telemetry/profiles/traps_test.go
+++ b/orb-telemetry/snmp-telemetry/profiles/traps_test.go
@@ -1,6 +1,9 @@
 package profiles
 
 import (
+	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -93,4 +96,26 @@ func TestTrapNames_ReadsFlatTrapEntries(t *testing.T) {
 	assert.Equal(t, "ruckusSCGAPRebootTrap", names["1.3.6.1.4.1.25053.2.10.1.25"], "written with a leading dot in the file")
 	assert.Equal(t, "ruckusSCGAPLostHeartbeatTrap", names["1.3.6.1.4.1.25053.2.10.1.24"])
 	assert.NotContains(t, names, "1.3.6.1.4.1.25053.1.8.1.1.1.1.2.1.11", "a flat gauge entry is not a trap")
+}
+
+// A matcher carries the trap names of the profile set it was built from, so a
+// policy's own profiles directory names its traps, override files included.
+func TestMatcher_TrapNamesComeFromItsProfileSet(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "custom"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "custom", "traps.yml"), []byte(`
+traps:
+  - trap_oid: 1.3.6.1.4.1.99999.0.1
+    trap_name: customWidgetFailed
+`), 0o644))
+	l, err := LoadProfiles(dir, silentLogger)
+	require.NoError(t, err)
+	all, err := l.AllResolved()
+	require.NoError(t, err)
+	m := NewMatcher(all, silentLogger)
+
+	names := m.TrapNames()
+	assert.Equal(t, "customWidgetFailed", names["1.3.6.1.4.1.99999.0.1"], "the override file's trap is named")
+	assert.Equal(t, "bigipTrafficGroupStandby", names["1.3.6.1.4.1.3375.2.4.0.141"], "the bundled ones still are")
+	assert.Equal(t, reflect.ValueOf(names).Pointer(), reflect.ValueOf(m.TrapNames()).Pointer(), "built once, not per call")
 }

--- a/orb-telemetry/snmp-telemetry/profiles/traps_test.go
+++ b/orb-telemetry/snmp-telemetry/profiles/traps_test.go
@@ -77,3 +77,20 @@ func TestResolve_TrapsAreNotInheritedThroughExtends(t *testing.T) {
 	require.Len(t, parent.Traps, 1)
 	assert.Equal(t, "parentTrap", parent.Traps[0].Name)
 }
+
+// One bundled file, ruckus/Ruckus_Contoller_SNMP.yml, declares its three
+// traps as flat metric entries with `type: trap` rather than under `traps:`.
+// The loader keeps such entries unfolded, since nothing polls them, and the
+// name map reads them so those traps are named rather than labelled other.
+func TestTrapNames_ReadsFlatTrapEntries(t *testing.T) {
+	l, err := LoadProfiles("", silentLogger)
+	require.NoError(t, err)
+	all, err := l.AllResolved()
+	require.NoError(t, err)
+
+	names := TrapNames(all)
+	assert.Equal(t, "ruckusSCGAPDisconnectedTrap", names["1.3.6.1.4.1.25053.2.10.1.23"])
+	assert.Equal(t, "ruckusSCGAPRebootTrap", names["1.3.6.1.4.1.25053.2.10.1.25"], "written with a leading dot in the file")
+	assert.Equal(t, "ruckusSCGAPLostHeartbeatTrap", names["1.3.6.1.4.1.25053.2.10.1.24"])
+	assert.NotContains(t, names, "1.3.6.1.4.1.25053.1.8.1.1.1.1.2.1.11", "a flat gauge entry is not a trap")
+}

--- a/orb-telemetry/snmp-telemetry/snmp/snmp.go
+++ b/orb-telemetry/snmp-telemetry/snmp/snmp.go
@@ -323,6 +323,14 @@ func ValidateV3SecurityParameters(auth *config.Authentication) error {
 	return nil
 }
 
+// AuthProtocol maps a policy's auth_protocol spelling to gosnmp's constant.
+// Exported for the trap receiver, which builds USM parameters from the same
+// policy fields the poller uses.
+func AuthProtocol(name string) (gosnmp.SnmpV3AuthProtocol, error) { return getAuthProtocol(name) }
+
+// PrivProtocol maps a policy's priv_protocol spelling to gosnmp's constant.
+func PrivProtocol(name string) (gosnmp.SnmpV3PrivProtocol, error) { return getPrivProtocol(name) }
+
 func getAuthProtocol(authProtocol string) (gosnmp.SnmpV3AuthProtocol, error) {
 	switch authProtocol {
 	case "", "NoAuth":

--- a/orb-telemetry/snmp-telemetry/traps/decode.go
+++ b/orb-telemetry/snmp-telemetry/traps/decode.go
@@ -80,6 +80,17 @@ func Decode(p *gosnmp.SnmpPacket) (Trap, DropReason) {
 		if !ok || sp.UserName == "" || sp.AuthoritativeEngineID == "" {
 			return Trap{}, DropV3Unauthenticated
 		}
+		// The residual of the same finding: gosnmp authenticates only a packet
+		// that asks to be. It verifies the digest when the wire message flags
+		// carry the auth bit and skips the check entirely when they do not. A
+		// username is in the policy and in any captured traffic, so an identity
+		// check alone leaves a sender free to name a known user, clear the bit,
+		// and be believed. Such a trap is exactly as unauthenticated as a v2c
+		// one and must not be counted as v3. authNoPriv and authPriv both carry
+		// the bit; noAuthNoPriv does not.
+		if p.MsgFlags&gosnmp.AuthNoPriv == 0 {
+			return Trap{}, DropV3Unauthenticated
+		}
 		return decodeV2(p, V3)
 	default:
 		return decodeV2(p, V2c)

--- a/orb-telemetry/snmp-telemetry/traps/decode.go
+++ b/orb-telemetry/snmp-telemetry/traps/decode.go
@@ -72,8 +72,18 @@ func normalizeOID(oid string) string {
 // Decode turns a parsed packet into a trap identity, or says why it cannot.
 // It is a pure function over the packet and never touches the network.
 func Decode(p *gosnmp.SnmpPacket) (Trap, DropReason) {
+	// Each version carries its own PDU types. gosnmp parses the other
+	// combinations into a packet with the wrong fields zeroed, so a v2 trap
+	// under version 1 would read as a coldStart; they are unsupported here.
 	switch p.PDUType {
-	case gosnmp.Trap, gosnmp.SNMPv2Trap, gosnmp.InformRequest:
+	case gosnmp.Trap:
+		if p.Version != gosnmp.Version1 {
+			return Trap{}, DropUnsupportedPDU
+		}
+	case gosnmp.SNMPv2Trap, gosnmp.InformRequest:
+		if p.Version == gosnmp.Version1 {
+			return Trap{}, DropUnsupportedPDU
+		}
 	default:
 		return Trap{}, DropUnsupportedPDU
 	}

--- a/orb-telemetry/snmp-telemetry/traps/decode.go
+++ b/orb-telemetry/snmp-telemetry/traps/decode.go
@@ -1,0 +1,145 @@
+package traps
+
+import (
+	"net/netip"
+	"strconv"
+	"strings"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// Version is the SNMP version a trap arrived with, as a metric label value.
+type Version string
+
+// The three SNMP protocol versions Decode recognises.
+const (
+	V1  Version = "1"
+	V2c Version = "2c"
+	V3  Version = "3"
+)
+
+// Trap is what Decode extracts from a packet: enough to name and count it.
+type Trap struct {
+	// OID is the trap's identity, normalised with no leading dot. For v1 it is
+	// synthesised per RFC 3584 section 3.1 so that one OID space serves every
+	// version.
+	OID     string
+	Version Version
+	// Inform is set for an InformRequest, which the sender expects acknowledged.
+	Inform bool
+	// AgentAddr is the v1 agent-addr field when it names an address, and
+	// invalid otherwise. v2c and v3 carry no such field.
+	AgentAddr netip.Addr
+}
+
+// DropReason says why a datagram produced no count. It is a metric label
+// value, so the set is closed.
+type DropReason string
+
+// The closed set of reasons Decode can drop a datagram for.
+const (
+	DropUnknownSource     DropReason = "unknown_source"
+	DropOversized         DropReason = "oversized"
+	DropMalformed         DropReason = "malformed"
+	DropUnsupportedPDU    DropReason = "unsupported_pdu"
+	DropV3Unauthenticated DropReason = "v3_unauthenticated"
+	DropNoTrapOID         DropReason = "no_trap_oid"
+)
+
+const (
+	snmpTrapOIDInstance = "1.3.6.1.6.3.1.1.4.1.0"
+	snmpTrapOIDBare     = "1.3.6.1.6.3.1.1.4.1"
+	genericTrapBase     = "1.3.6.1.6.3.1.1.5."
+)
+
+// normalizeOID strips the leading dot gosnmp puts on every OID it parses, so
+// what Decode emits matches the bundled definitions and the collector's own
+// spelling.
+func normalizeOID(oid string) string {
+	return strings.TrimPrefix(strings.TrimSpace(oid), ".")
+}
+
+// Decode turns a parsed packet into a trap identity, or says why it cannot.
+// It is a pure function over the packet and never touches the network.
+func Decode(p *gosnmp.SnmpPacket) (Trap, DropReason) {
+	switch p.PDUType {
+	case gosnmp.Trap, gosnmp.SNMPv2Trap, gosnmp.InformRequest:
+	default:
+		return Trap{}, DropUnsupportedPDU
+	}
+
+	switch p.Version {
+	case gosnmp.Version1:
+		return decodeV1(p)
+	case gosnmp.Version3:
+		// F1: gosnmp skips authentication for a packet whose USM username and
+		// authoritative engine ID are both empty, the RFC 3414 engine discovery
+		// shape. No legitimate trap has it, and a trap that reached here with
+		// it was not authenticated whatever gosnmp returned.
+		sp, ok := p.SecurityParameters.(*gosnmp.UsmSecurityParameters)
+		if !ok || sp.UserName == "" || sp.AuthoritativeEngineID == "" {
+			return Trap{}, DropV3Unauthenticated
+		}
+		return decodeV2(p, V3)
+	default:
+		return decodeV2(p, V2c)
+	}
+}
+
+// decodeV2 reads snmpTrapOID.0 from the varbinds. RFC 3416 section 4.2.6 puts
+// it in position two, but the search itself is a plain forward scan: the
+// first varbind named by either spelling wins, whatever position it is at.
+// The name is matched by equality against both forms, never by prefix,
+// because 1.3.6.1.6.3.1.1.4.10 has the bare form as a prefix.
+func decodeV2(p *gosnmp.SnmpPacket, v Version) (Trap, DropReason) {
+	tr := Trap{Version: v, Inform: p.PDUType == gosnmp.InformRequest}
+	for _, vb := range p.Variables {
+		if oid, ok := trapOIDValue(vb); ok {
+			tr.OID = oid
+			return tr, ""
+		}
+	}
+	return Trap{}, DropNoTrapOID
+}
+
+// trapOIDValue reports the trap OID a varbind carries, if the varbind is
+// snmpTrapOID.0 in either spelling and its value is an OID.
+func trapOIDValue(vb gosnmp.SnmpPDU) (string, bool) {
+	name := normalizeOID(vb.Name)
+	if name != snmpTrapOIDInstance && name != snmpTrapOIDBare {
+		return "", false
+	}
+	if vb.Type != gosnmp.ObjectIdentifier {
+		return "", false
+	}
+	value, ok := vb.Value.(string)
+	if !ok || value == "" {
+		return "", false
+	}
+	return normalizeOID(value), true
+}
+
+// decodeV1 synthesises the v2 trap OID from the v1 fields per RFC 3584
+// section 3.1: generic-trap 0 to 5 become 1.3.6.1.6.3.1.1.5.<generic+1>, and
+// generic-trap 6 becomes <enterprise>.0.<specific>. gosnmp parses both fields
+// as unchecked signed integers, and the RFC defines nothing outside that
+// range, so anything else is malformed rather than a manufactured label.
+func decodeV1(p *gosnmp.SnmpPacket) (Trap, DropReason) {
+	tr := Trap{Version: V1}
+	if addr, err := netip.ParseAddr(p.AgentAddress); err == nil && !addr.IsUnspecified() {
+		tr.AgentAddr = addr.Unmap()
+	}
+	switch {
+	case p.GenericTrap >= 0 && p.GenericTrap <= 5:
+		tr.OID = genericTrapBase + strconv.Itoa(p.GenericTrap+1)
+	case p.GenericTrap == 6:
+		enterprise := normalizeOID(p.Enterprise)
+		if enterprise == "" || p.SpecificTrap < 0 {
+			return Trap{}, DropMalformed
+		}
+		tr.OID = enterprise + ".0." + strconv.Itoa(p.SpecificTrap)
+	default:
+		return Trap{}, DropMalformed
+	}
+	return tr, ""
+}

--- a/orb-telemetry/snmp-telemetry/traps/decode.go
+++ b/orb-telemetry/snmp-telemetry/traps/decode.go
@@ -45,9 +45,9 @@ const (
 	// DropUnsupportedVersion is a wire version this backend does not speak:
 	// anything but v1, v2c and v3. gosnmp keeps the integer as written.
 	DropUnsupportedVersion DropReason = "unsupported_version"
-	// DropSeriesLimit is a trap the tally could not count because its series
-	// does not exist yet and there is no room for one, not even for its
-	// policy's overflow series.
+	// DropSeriesLimit is a datagram no claiming policy could count because
+	// the trap's series does not exist yet and there is no room for one, not
+	// even for the policy's overflow series. Recorded once per datagram.
 	DropSeriesLimit       DropReason = "series_limit"
 	DropV3Unauthenticated DropReason = "v3_unauthenticated"
 	// DropV3NotInTimeWindow is an authenticated v3 trap whose engine boots

--- a/orb-telemetry/snmp-telemetry/traps/decode.go
+++ b/orb-telemetry/snmp-telemetry/traps/decode.go
@@ -45,7 +45,11 @@ const (
 	// DropUnsupportedVersion is a wire version this backend does not speak:
 	// anything but v1, v2c and v3. gosnmp keeps the integer as written.
 	DropUnsupportedVersion DropReason = "unsupported_version"
-	DropV3Unauthenticated  DropReason = "v3_unauthenticated"
+	// DropSeriesLimit is a trap the tally could not count because its series
+	// does not exist yet and there is no room for one, not even for its
+	// policy's overflow series.
+	DropSeriesLimit       DropReason = "series_limit"
+	DropV3Unauthenticated DropReason = "v3_unauthenticated"
 	// DropV3NotInTimeWindow is an authenticated v3 trap whose engine boots
 	// or time fall outside RFC 3414's window for its engine: a replay.
 	DropV3NotInTimeWindow DropReason = "v3_not_in_time_window"

--- a/orb-telemetry/snmp-telemetry/traps/decode.go
+++ b/orb-telemetry/snmp-telemetry/traps/decode.go
@@ -38,11 +38,14 @@ type DropReason string
 
 // The closed set of reasons Decode can drop a datagram for.
 const (
-	DropUnknownSource     DropReason = "unknown_source"
-	DropOversized         DropReason = "oversized"
-	DropMalformed         DropReason = "malformed"
-	DropUnsupportedPDU    DropReason = "unsupported_pdu"
-	DropV3Unauthenticated DropReason = "v3_unauthenticated"
+	DropUnknownSource  DropReason = "unknown_source"
+	DropOversized      DropReason = "oversized"
+	DropMalformed      DropReason = "malformed"
+	DropUnsupportedPDU DropReason = "unsupported_pdu"
+	// DropUnsupportedVersion is a wire version this backend does not speak:
+	// anything but v1, v2c and v3. gosnmp keeps the integer as written.
+	DropUnsupportedVersion DropReason = "unsupported_version"
+	DropV3Unauthenticated  DropReason = "v3_unauthenticated"
 	// DropV3NotInTimeWindow is an authenticated v3 trap whose engine boots
 	// or time fall outside RFC 3414's window for its engine: a replay.
 	DropV3NotInTimeWindow DropReason = "v3_not_in_time_window"
@@ -106,8 +109,13 @@ func Decode(p *gosnmp.SnmpPacket) (Trap, DropReason) {
 			return Trap{}, DropV3Unauthenticated
 		}
 		return decodeV2(p, V3)
-	default:
+	case gosnmp.Version2c:
 		return decodeV2(p, V2c)
+	default:
+		// SNMPv2u and SNMPv2p are version 2 on the wire, and a sender can
+		// write any integer. None of them is a version this backend speaks,
+		// and counting one as 2c would misreport the version breakdown.
+		return Trap{}, DropUnsupportedVersion
 	}
 }
 

--- a/orb-telemetry/snmp-telemetry/traps/decode.go
+++ b/orb-telemetry/snmp-telemetry/traps/decode.go
@@ -76,6 +76,17 @@ func Decode(p *gosnmp.SnmpPacket) (Trap, DropReason) {
 		// authoritative engine ID are both empty, the RFC 3414 engine discovery
 		// shape. No legitimate trap has it, and a trap that reached here with
 		// it was not authenticated whatever gosnmp returned.
+		// F15: gosnmp runs testAuthentication only for a packet whose
+		// msgSecurityModel is the user security model (trap.go:529-535), and
+		// that field is read straight off the wire (v3.go:423). Under any
+		// other model the packet is parsed with no authentication at all,
+		// while its security parameters still carry the wire username and
+		// engine ID, so every guard below would pass. The USM is the only
+		// security model this backend has credentials for, so it is the only
+		// one a trap can be authenticated under.
+		if p.SecurityModel != gosnmp.UserSecurityModel {
+			return Trap{}, DropV3Unauthenticated
+		}
 		sp, ok := p.SecurityParameters.(*gosnmp.UsmSecurityParameters)
 		if !ok || sp.UserName == "" || sp.AuthoritativeEngineID == "" {
 			return Trap{}, DropV3Unauthenticated

--- a/orb-telemetry/snmp-telemetry/traps/decode.go
+++ b/orb-telemetry/snmp-telemetry/traps/decode.go
@@ -43,6 +43,9 @@ const (
 	DropMalformed         DropReason = "malformed"
 	DropUnsupportedPDU    DropReason = "unsupported_pdu"
 	DropV3Unauthenticated DropReason = "v3_unauthenticated"
+	// DropV3NotInTimeWindow is an authenticated v3 trap whose engine boots
+	// or time fall outside RFC 3414's window for its engine: a replay.
+	DropV3NotInTimeWindow DropReason = "v3_not_in_time_window"
 	DropNoTrapOID         DropReason = "no_trap_oid"
 )
 

--- a/orb-telemetry/snmp-telemetry/traps/decode_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/decode_test.go
@@ -175,6 +175,7 @@ func TestDecode_V3EmptyIdentityIsUnauthenticated(t *testing.T) {
 		// AuthPriv so the identity check is what rejects these, not the flags.
 		p := &gosnmp.SnmpPacket{
 			Version: gosnmp.Version3, PDUType: gosnmp.SNMPv2Trap, MsgFlags: gosnmp.AuthPriv,
+			SecurityModel:      gosnmp.UserSecurityModel,
 			SecurityParameters: &gosnmp.UsmSecurityParameters{UserName: tc.user, AuthoritativeEngineID: tc.engine},
 			Variables:          []gosnmp.SnmpPDU{oidVar(trapOIDInstanceDotted, linkDownDotted)},
 		}
@@ -186,6 +187,7 @@ func TestDecode_V3EmptyIdentityIsUnauthenticated(t *testing.T) {
 func TestDecode_V3WithIdentityDecodes(t *testing.T) {
 	p := &gosnmp.SnmpPacket{
 		Version: gosnmp.Version3, PDUType: gosnmp.SNMPv2Trap, MsgFlags: gosnmp.AuthPriv,
+		SecurityModel:      gosnmp.UserSecurityModel,
 		SecurityParameters: &gosnmp.UsmSecurityParameters{UserName: "u", AuthoritativeEngineID: "\x80\x00\x00\x00\x01"},
 		Variables:          []gosnmp.SnmpPDU{oidVar(trapOIDInstanceDotted, linkDownDotted)},
 	}
@@ -212,6 +214,7 @@ func TestDecode_V3NoAuthFlagIsUnauthenticated(t *testing.T) {
 	} {
 		p := &gosnmp.SnmpPacket{
 			Version: gosnmp.Version3, PDUType: gosnmp.SNMPv2Trap, MsgFlags: tc.flags,
+			SecurityModel:      gosnmp.UserSecurityModel,
 			SecurityParameters: &gosnmp.UsmSecurityParameters{UserName: "u", AuthoritativeEngineID: "\x80\x00\x00\x00\x01"},
 			Variables:          []gosnmp.SnmpPDU{oidVar(trapOIDInstanceDotted, linkDownDotted)},
 		}
@@ -224,4 +227,23 @@ func TestDecode_V3WithoutUSMParamsIsUnauthenticated(t *testing.T) {
 	p := &gosnmp.SnmpPacket{Version: gosnmp.Version3, PDUType: gosnmp.SNMPv2Trap, Variables: []gosnmp.SnmpPDU{oidVar(trapOIDInstanceDotted, linkDownDotted)}}
 	_, reason := Decode(p)
 	assert.Equal(t, DropV3Unauthenticated, reason)
+}
+
+// F15: gosnmp runs testAuthentication only when the packet's msgSecurityModel
+// is the user security model (trap.go:529-535), and that field is read
+// straight off the wire (v3.go:423). A sender that names any other model has
+// its packet parsed with no authentication at all while its security
+// parameters still carry a wire username and engine ID, so every other guard
+// here passes. Only the USM is authenticated, so only the USM is counted.
+func TestDecode_V3NonUSMSecurityModelIsUnauthenticated(t *testing.T) {
+	for _, model := range []gosnmp.SnmpV3SecurityModel{1, 2, 4} {
+		p := &gosnmp.SnmpPacket{
+			Version: gosnmp.Version3, PDUType: gosnmp.SNMPv2Trap, MsgFlags: gosnmp.AuthPriv,
+			SecurityModel:      model,
+			SecurityParameters: &gosnmp.UsmSecurityParameters{UserName: "u", AuthoritativeEngineID: "\x80\x00\x00\x00\x01"},
+			Variables:          []gosnmp.SnmpPDU{oidVar(trapOIDInstanceDotted, linkDownDotted)},
+		}
+		_, reason := Decode(p)
+		assert.Equal(t, DropV3Unauthenticated, reason, "security model %d", model)
+	}
 }

--- a/orb-telemetry/snmp-telemetry/traps/decode_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/decode_test.go
@@ -172,8 +172,9 @@ func TestDecode_V1CarriesAgentAddrWhenSet(t *testing.T) {
 // shape, so it is rejected here regardless of what gosnmp did.
 func TestDecode_V3EmptyIdentityIsUnauthenticated(t *testing.T) {
 	for _, tc := range []struct{ user, engine string }{{"", ""}, {"", "engine"}, {"user", ""}} {
+		// AuthPriv so the identity check is what rejects these, not the flags.
 		p := &gosnmp.SnmpPacket{
-			Version: gosnmp.Version3, PDUType: gosnmp.SNMPv2Trap,
+			Version: gosnmp.Version3, PDUType: gosnmp.SNMPv2Trap, MsgFlags: gosnmp.AuthPriv,
 			SecurityParameters: &gosnmp.UsmSecurityParameters{UserName: tc.user, AuthoritativeEngineID: tc.engine},
 			Variables:          []gosnmp.SnmpPDU{oidVar(trapOIDInstanceDotted, linkDownDotted)},
 		}
@@ -184,7 +185,7 @@ func TestDecode_V3EmptyIdentityIsUnauthenticated(t *testing.T) {
 
 func TestDecode_V3WithIdentityDecodes(t *testing.T) {
 	p := &gosnmp.SnmpPacket{
-		Version: gosnmp.Version3, PDUType: gosnmp.SNMPv2Trap,
+		Version: gosnmp.Version3, PDUType: gosnmp.SNMPv2Trap, MsgFlags: gosnmp.AuthPriv,
 		SecurityParameters: &gosnmp.UsmSecurityParameters{UserName: "u", AuthoritativeEngineID: "\x80\x00\x00\x00\x01"},
 		Variables:          []gosnmp.SnmpPDU{oidVar(trapOIDInstanceDotted, linkDownDotted)},
 	}
@@ -192,6 +193,31 @@ func TestDecode_V3WithIdentityDecodes(t *testing.T) {
 	require.Empty(t, reason)
 	assert.Equal(t, V3, tr.Version)
 	assert.Equal(t, "1.3.6.1.6.3.1.1.5.3", tr.OID)
+}
+
+// F1's residual: gosnmp verifies a digest only when the wire message flags
+// carry the auth bit, and skips the check entirely when they do not. A
+// username is in the policy and in any captured traffic, so an identity check
+// alone lets a sender clear the bit and be believed. Both authenticated levels
+// are accepted; noAuthNoPriv is not.
+func TestDecode_V3NoAuthFlagIsUnauthenticated(t *testing.T) {
+	for _, tc := range []struct {
+		flags gosnmp.SnmpV3MsgFlags
+		want  DropReason
+	}{
+		{gosnmp.NoAuthNoPriv, DropV3Unauthenticated},
+		{gosnmp.NoAuthNoPriv | gosnmp.Reportable, DropV3Unauthenticated},
+		{gosnmp.AuthNoPriv, ""},
+		{gosnmp.AuthPriv, ""},
+	} {
+		p := &gosnmp.SnmpPacket{
+			Version: gosnmp.Version3, PDUType: gosnmp.SNMPv2Trap, MsgFlags: tc.flags,
+			SecurityParameters: &gosnmp.UsmSecurityParameters{UserName: "u", AuthoritativeEngineID: "\x80\x00\x00\x00\x01"},
+			Variables:          []gosnmp.SnmpPDU{oidVar(trapOIDInstanceDotted, linkDownDotted)},
+		}
+		_, reason := Decode(p)
+		assert.Equal(t, tc.want, reason, "flags=%s", tc.flags)
+	}
 }
 
 func TestDecode_V3WithoutUSMParamsIsUnauthenticated(t *testing.T) {

--- a/orb-telemetry/snmp-telemetry/traps/decode_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/decode_test.go
@@ -1,0 +1,187 @@
+package traps
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These carry the wire-format leading dot and are named apart from decode.go's
+// unexported snmpTrapOIDInstance/snmpTrapOIDBare, which hold the normalised
+// (undotted) form used for internal matching; the two sets share a package
+// and would otherwise collide.
+const (
+	trapOIDInstanceDotted = ".1.3.6.1.6.3.1.1.4.1.0"
+	trapOIDBareDotted     = ".1.3.6.1.6.3.1.1.4.1"
+	linkDownDotted        = ".1.3.6.1.6.3.1.1.5.3"
+)
+
+func v2cPacket(vars ...gosnmp.SnmpPDU) *gosnmp.SnmpPacket {
+	return &gosnmp.SnmpPacket{Version: gosnmp.Version2c, PDUType: gosnmp.SNMPv2Trap, Variables: vars}
+}
+
+func oidVar(name, value string) gosnmp.SnmpPDU {
+	return gosnmp.SnmpPDU{Name: name, Type: gosnmp.ObjectIdentifier, Value: value}
+}
+
+func TestDecode_V2cTakesTheTrapOIDFromPositionTwo(t *testing.T) {
+	p := v2cPacket(
+		gosnmp.SnmpPDU{Name: ".1.3.6.1.2.1.1.3.0", Type: gosnmp.TimeTicks, Value: uint32(5)},
+		oidVar(trapOIDInstanceDotted, linkDownDotted),
+	)
+	tr, reason := Decode(p)
+	require.Empty(t, reason)
+	assert.Equal(t, "1.3.6.1.6.3.1.1.5.3", tr.OID, "normalised, no leading dot")
+	assert.Equal(t, V2c, tr.Version)
+	assert.False(t, tr.Inform)
+}
+
+// Both spellings of snmpTrapOID appear in the wild; ktranslate checks both.
+func TestDecode_V2cAcceptsTheBareObjectForm(t *testing.T) {
+	tr, reason := Decode(v2cPacket(oidVar(trapOIDBareDotted, linkDownDotted)))
+	require.Empty(t, reason)
+	assert.Equal(t, "1.3.6.1.6.3.1.1.5.3", tr.OID)
+}
+
+// .1.3.6.1.6.3.1.1.4.10 has the bare form as a prefix. Matching is by
+// equality, never by prefix.
+func TestDecode_DoesNotPrefixMatchTheTrapOIDName(t *testing.T) {
+	_, reason := Decode(v2cPacket(oidVar(".1.3.6.1.6.3.1.1.4.10", linkDownDotted)))
+	assert.Equal(t, DropNoTrapOID, reason)
+}
+
+func TestDecode_V2cWithNoTrapOIDVarbind(t *testing.T) {
+	_, reason := Decode(v2cPacket(gosnmp.SnmpPDU{Name: ".1.3.6.1.2.1.1.3.0", Type: gosnmp.TimeTicks, Value: uint32(5)}))
+	assert.Equal(t, DropNoTrapOID, reason)
+}
+
+// Present but the wrong type counts the same as absent: there is no OID to
+// name, and a string here is a sender that is confused or hostile.
+func TestDecode_V2cTrapOIDOfWrongTypeIsNoTrapOID(t *testing.T) {
+	p := v2cPacket(gosnmp.SnmpPDU{Name: trapOIDInstanceDotted, Type: gosnmp.OctetString, Value: []byte("linkDown")})
+	_, reason := Decode(p)
+	assert.Equal(t, DropNoTrapOID, reason)
+}
+
+func TestDecode_FirstMatchingTrapOIDWins(t *testing.T) {
+	p := v2cPacket(
+		oidVar(trapOIDInstanceDotted, linkDownDotted),
+		oidVar(trapOIDInstanceDotted, ".1.3.6.1.6.3.1.1.5.4"),
+	)
+	tr, reason := Decode(p)
+	require.Empty(t, reason)
+	assert.Equal(t, "1.3.6.1.6.3.1.1.5.3", tr.OID)
+}
+
+func TestDecode_InformIsATrapThatWantsAnAck(t *testing.T) {
+	p := v2cPacket(oidVar(trapOIDInstanceDotted, linkDownDotted))
+	p.PDUType = gosnmp.InformRequest
+	tr, reason := Decode(p)
+	require.Empty(t, reason)
+	assert.True(t, tr.Inform)
+}
+
+// gosnmp delivers GetRequest, GetResponse and the rest to a trap handler.
+func TestDecode_RejectsNonTrapPDUs(t *testing.T) {
+	for _, pdu := range []gosnmp.PDUType{gosnmp.GetRequest, gosnmp.GetResponse, gosnmp.GetNextRequest, gosnmp.SetRequest, gosnmp.Report} {
+		p := v2cPacket(oidVar(trapOIDInstanceDotted, linkDownDotted))
+		p.PDUType = pdu
+		_, reason := Decode(p)
+		assert.Equal(t, DropUnsupportedPDU, reason, "pdu %#x", pdu)
+	}
+}
+
+// RFC 3584 section 3.1(3): generic-trap 0 to 5 map onto 1.3.6.1.6.3.1.1.5.<g+1>.
+func TestDecode_V1GenericTrapsMapPerRFC3584(t *testing.T) {
+	for generic, want := range map[int]string{
+		0: "1.3.6.1.6.3.1.1.5.1", 1: "1.3.6.1.6.3.1.1.5.2", 2: "1.3.6.1.6.3.1.1.5.3",
+		3: "1.3.6.1.6.3.1.1.5.4", 4: "1.3.6.1.6.3.1.1.5.5", 5: "1.3.6.1.6.3.1.1.5.6",
+	} {
+		p := &gosnmp.SnmpPacket{Version: gosnmp.Version1, PDUType: gosnmp.Trap, SnmpTrap: gosnmp.SnmpTrap{Enterprise: ".1.3.6.1.4.1.9", GenericTrap: generic, SpecificTrap: 0}}
+		tr, reason := Decode(p)
+		require.Empty(t, reason, "generic %d", generic)
+		assert.Equal(t, want, tr.OID, "generic %d", generic)
+		assert.Equal(t, V1, tr.Version)
+	}
+}
+
+// RFC 3584 section 3.1(2): generic-trap 6 becomes <enterprise>.0.<specific>,
+// unconditionally, including when the enterprise already ends in a zero arc.
+func TestDecode_V1EnterpriseSpecificPerRFC3584(t *testing.T) {
+	p := &gosnmp.SnmpPacket{Version: gosnmp.Version1, PDUType: gosnmp.Trap, SnmpTrap: gosnmp.SnmpTrap{Enterprise: ".1.3.6.1.4.1.9", GenericTrap: 6, SpecificTrap: 5}}
+	tr, reason := Decode(p)
+	require.Empty(t, reason)
+	assert.Equal(t, "1.3.6.1.4.1.9.0.5", tr.OID)
+
+	p.Enterprise = ".1.3.6.1.4.1.9.0"
+	tr, reason = Decode(p)
+	require.Empty(t, reason)
+	assert.Equal(t, "1.3.6.1.4.1.9.0.0.5", tr.OID, "the zero arc is kept; section 3.2 reverses it cleanly")
+}
+
+// gosnmp parses generic-trap and specific-trap as unchecked signed ints. RFC
+// 3584 defines nothing outside 0 to 6, so those are malformed rather than a
+// manufactured label.
+func TestDecode_V1OutOfRangeFieldsAreMalformed(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		generic, specific int
+		enterprise        string
+	}{
+		{"generic 7", 7, 0, ".1.3.6.1.4.1.9"},
+		{"generic negative", -1, 0, ".1.3.6.1.4.1.9"},
+		{"specific negative", 6, -1, ".1.3.6.1.4.1.9"},
+		{"enterprise empty", 6, 1, ""},
+	} {
+		p := &gosnmp.SnmpPacket{Version: gosnmp.Version1, PDUType: gosnmp.Trap, SnmpTrap: gosnmp.SnmpTrap{Enterprise: tc.enterprise, GenericTrap: tc.generic, SpecificTrap: tc.specific}}
+		_, reason := Decode(p)
+		assert.Equal(t, DropMalformed, reason, tc.name)
+	}
+}
+
+func TestDecode_V1CarriesAgentAddrWhenSet(t *testing.T) {
+	p := &gosnmp.SnmpPacket{Version: gosnmp.Version1, PDUType: gosnmp.Trap, SnmpTrap: gosnmp.SnmpTrap{Enterprise: ".1.3.6.1.4.1.9", GenericTrap: 2, AgentAddress: "10.0.0.7"}}
+	tr, reason := Decode(p)
+	require.Empty(t, reason)
+	assert.Equal(t, netip.MustParseAddr("10.0.0.7"), tr.AgentAddr)
+
+	p.AgentAddress = "0.0.0.0"
+	tr, _ = Decode(p)
+	assert.False(t, tr.AgentAddr.IsValid(), "an unspecified agent-addr is no address")
+}
+
+// F1: gosnmp's engine-discovery exemption lets a v3 packet with an empty
+// username and engine ID through unauthenticated. No legitimate trap has that
+// shape, so it is rejected here regardless of what gosnmp did.
+func TestDecode_V3EmptyIdentityIsUnauthenticated(t *testing.T) {
+	for _, tc := range []struct{ user, engine string }{{"", ""}, {"", "engine"}, {"user", ""}} {
+		p := &gosnmp.SnmpPacket{
+			Version: gosnmp.Version3, PDUType: gosnmp.SNMPv2Trap,
+			SecurityParameters: &gosnmp.UsmSecurityParameters{UserName: tc.user, AuthoritativeEngineID: tc.engine},
+			Variables:          []gosnmp.SnmpPDU{oidVar(trapOIDInstanceDotted, linkDownDotted)},
+		}
+		_, reason := Decode(p)
+		assert.Equal(t, DropV3Unauthenticated, reason, "user=%q engine=%q", tc.user, tc.engine)
+	}
+}
+
+func TestDecode_V3WithIdentityDecodes(t *testing.T) {
+	p := &gosnmp.SnmpPacket{
+		Version: gosnmp.Version3, PDUType: gosnmp.SNMPv2Trap,
+		SecurityParameters: &gosnmp.UsmSecurityParameters{UserName: "u", AuthoritativeEngineID: "\x80\x00\x00\x00\x01"},
+		Variables:          []gosnmp.SnmpPDU{oidVar(trapOIDInstanceDotted, linkDownDotted)},
+	}
+	tr, reason := Decode(p)
+	require.Empty(t, reason)
+	assert.Equal(t, V3, tr.Version)
+	assert.Equal(t, "1.3.6.1.6.3.1.1.5.3", tr.OID)
+}
+
+func TestDecode_V3WithoutUSMParamsIsUnauthenticated(t *testing.T) {
+	p := &gosnmp.SnmpPacket{Version: gosnmp.Version3, PDUType: gosnmp.SNMPv2Trap, Variables: []gosnmp.SnmpPDU{oidVar(trapOIDInstanceDotted, linkDownDotted)}}
+	_, reason := Decode(p)
+	assert.Equal(t, DropV3Unauthenticated, reason)
+}

--- a/orb-telemetry/snmp-telemetry/traps/decode_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/decode_test.go
@@ -59,11 +59,25 @@ func TestDecode_V2cWithNoTrapOIDVarbind(t *testing.T) {
 }
 
 // Present but the wrong type counts the same as absent: there is no OID to
-// name, and a string here is a sender that is confused or hostile.
+// name, and a value of the wrong type is a sender that is confused or
+// hostile. OctetString stores its value as []byte, so it fails the
+// vb.Value.(string) assertion on its own; IPAddress stores its value as a
+// string, so only the explicit Type check stops it, and a trap OID varbind
+// typed IPAddress with a value like "10.0.0.1" must not be accepted as if it
+// were an object identifier.
 func TestDecode_V2cTrapOIDOfWrongTypeIsNoTrapOID(t *testing.T) {
-	p := v2cPacket(gosnmp.SnmpPDU{Name: trapOIDInstanceDotted, Type: gosnmp.OctetString, Value: []byte("linkDown")})
-	_, reason := Decode(p)
-	assert.Equal(t, DropNoTrapOID, reason)
+	for _, tc := range []struct {
+		name  string
+		typ   gosnmp.Asn1BER
+		value any
+	}{
+		{"OctetString", gosnmp.OctetString, []byte("linkDown")},
+		{"IPAddress", gosnmp.IPAddress, "10.0.0.1"},
+	} {
+		p := v2cPacket(gosnmp.SnmpPDU{Name: trapOIDInstanceDotted, Type: tc.typ, Value: tc.value})
+		_, reason := Decode(p)
+		assert.Equal(t, DropNoTrapOID, reason, tc.name)
+	}
 }
 
 func TestDecode_FirstMatchingTrapOIDWins(t *testing.T) {

--- a/orb-telemetry/snmp-telemetry/traps/decode_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/decode_test.go
@@ -247,3 +247,19 @@ func TestDecode_V3NonUSMSecurityModelIsUnauthenticated(t *testing.T) {
 		assert.Equal(t, DropV3Unauthenticated, reason, "security model %d", model)
 	}
 }
+
+// gosnmp keeps whatever version integer the wire carried, and the decoder
+// used to let every value that was not v1 or v3 through as v2c. SNMPv2u and
+// SNMPv2p are version 2, and a sender can write any number; none of them is
+// a version this backend speaks, so they are dropped rather than counted
+// under a label that says 2c.
+func TestDecode_RejectsVersionsThisBackendDoesNotSpeak(t *testing.T) {
+	for _, v := range []gosnmp.SnmpVersion{2, 4, 7, 127} {
+		p := &gosnmp.SnmpPacket{Version: v, PDUType: gosnmp.SNMPv2Trap, Variables: v2cPacket(oidVar(trapOIDBareDotted, linkDownDotted)).Variables}
+		_, reason := Decode(p)
+		assert.Equal(t, DropUnsupportedVersion, reason, "version %d", v)
+	}
+	tr, reason := Decode(&gosnmp.SnmpPacket{Version: gosnmp.Version2c, PDUType: gosnmp.SNMPv2Trap, Variables: v2cPacket(oidVar(trapOIDBareDotted, linkDownDotted)).Variables})
+	require.Empty(t, reason)
+	assert.Equal(t, V2c, tr.Version)
+}

--- a/orb-telemetry/snmp-telemetry/traps/decode_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/decode_test.go
@@ -263,3 +263,24 @@ func TestDecode_RejectsVersionsThisBackendDoesNotSpeak(t *testing.T) {
 	require.Empty(t, reason)
 	assert.Equal(t, V2c, tr.Version)
 }
+
+// Each wire version carries its own PDU types: a v1 Trap-PDU under version 1,
+// an SNMPv2-Trap-PDU or InformRequest-PDU under 2c and 3. gosnmp parses the
+// other combinations into a packet with the wrong fields zeroed, so a v2 trap
+// under version 1 would read as coldStart; they are unsupported_pdu instead.
+func TestDecode_RejectsAPDUForeignToItsVersion(t *testing.T) {
+	v1Trap := gosnmp.SnmpTrap{Enterprise: ".1.3.6.1.4.1.9", GenericTrap: 0}
+	cases := []struct {
+		name string
+		p    *gosnmp.SnmpPacket
+	}{
+		{"v2 trap under version 1", &gosnmp.SnmpPacket{Version: gosnmp.Version1, PDUType: gosnmp.SNMPv2Trap, Variables: v2cPacket(oidVar(trapOIDBareDotted, linkDownDotted)).Variables, SnmpTrap: v1Trap}},
+		{"inform under version 1", &gosnmp.SnmpPacket{Version: gosnmp.Version1, PDUType: gosnmp.InformRequest, Variables: v2cPacket(oidVar(trapOIDBareDotted, linkDownDotted)).Variables, SnmpTrap: v1Trap}},
+		{"v1 trap under version 2c", &gosnmp.SnmpPacket{Version: gosnmp.Version2c, PDUType: gosnmp.Trap, Variables: v2cPacket(oidVar(trapOIDBareDotted, linkDownDotted)).Variables, SnmpTrap: v1Trap}},
+		{"v1 trap under version 3", &gosnmp.SnmpPacket{Version: gosnmp.Version3, PDUType: gosnmp.Trap, SecurityModel: gosnmp.UserSecurityModel, MsgFlags: gosnmp.AuthPriv, SecurityParameters: &gosnmp.UsmSecurityParameters{UserName: "u", AuthoritativeEngineID: "e"}, Variables: v2cPacket(oidVar(trapOIDBareDotted, linkDownDotted)).Variables, SnmpTrap: v1Trap}},
+	}
+	for _, tc := range cases {
+		_, reason := Decode(tc.p)
+		assert.Equal(t, DropUnsupportedPDU, reason, tc.name)
+	}
+}

--- a/orb-telemetry/snmp-telemetry/traps/doc.go
+++ b/orb-telemetry/snmp-telemetry/traps/doc.go
@@ -1,0 +1,11 @@
+// Package traps receives SNMP traps on a UDP socket the package owns, identifies
+// the sender against the addresses running policies name, and counts what it
+// received and what it dropped.
+//
+// Invariant: this package never imports policy or collector, and nothing a
+// trap says may trigger a poll. A trap is one-way UDP with a source address
+// anyone on the path can choose. The obvious later enhancement, a linkDown
+// trap prompting an immediate re-poll, would turn a spoofable packet into a
+// credentialed outbound SNMP request, which the README promises the backend
+// never sends to an address a policy did not name.
+package traps

--- a/orb-telemetry/snmp-telemetry/traps/export.go
+++ b/orb-telemetry/snmp-telemetry/traps/export.go
@@ -73,6 +73,11 @@ type Tally struct {
 	received  map[receivedKey]*series
 	dropped   map[DropReason]int64
 	datagrams int64
+	// withdrawn is every policy whose lease was released and not acquired
+	// again. A count for one of them is kept but stays dormant: a datagram
+	// past its registry lookup when the release happened must not bring
+	// the policy's series back to life.
+	withdrawn map[string]struct{}
 
 	regMu        sync.Mutex
 	registration metric.Registration
@@ -81,9 +86,10 @@ type Tally struct {
 // NewTally returns an empty tally. Register attaches it to the meter.
 func NewTally(logger *slog.Logger) *Tally {
 	return &Tally{
-		logger:   logger,
-		received: make(map[receivedKey]*series),
-		dropped:  make(map[DropReason]int64),
+		logger:    logger,
+		received:  make(map[receivedKey]*series),
+		dropped:   make(map[DropReason]int64),
+		withdrawn: make(map[string]struct{}),
 	}
 }
 
@@ -107,7 +113,17 @@ func (t *Tally) Received(deviceIP, policy, trapName string, v Version) {
 		t.received[k] = sr
 	}
 	sr.n++
-	sr.live = true
+	if _, withdrawn := t.withdrawn[policy]; !withdrawn {
+		sr.live = true
+	}
+}
+
+// Activate marks a policy acquired, so its counts are exported again. The
+// pool calls it as a policy's lease is granted.
+func (t *Tally) Activate(policy string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.withdrawn, policy)
 }
 
 // evictDormant removes one dormant series to make room for a live one and
@@ -146,6 +162,7 @@ func (t *Tally) Datagram() {
 func (t *Tally) Withdraw(policy string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	t.withdrawn[policy] = struct{}{}
 	for k, sr := range t.received {
 		if k.policy == policy {
 			sr.live = false

--- a/orb-telemetry/snmp-telemetry/traps/export.go
+++ b/orb-telemetry/snmp-telemetry/traps/export.go
@@ -77,6 +77,10 @@ type Tally struct {
 	// past its registry lookup when the release happened must not bring
 	// the policy's series back to life.
 	withdrawn map[string]struct{}
+	// dormant is the set of series not currently exported, kept beside the
+	// map so the overflow path never scans it: with nothing dormant the
+	// check is a length, and an eviction is one pop.
+	dormant map[receivedKey]struct{}
 
 	regMu        sync.Mutex
 	registration metric.Registration
@@ -89,6 +93,7 @@ func NewTally(logger *slog.Logger) *Tally {
 		received:  make(map[receivedKey]*series),
 		dropped:   make(map[DropReason]int64),
 		withdrawn: make(map[string]struct{}),
+		dormant:   make(map[receivedKey]struct{}),
 	}
 }
 
@@ -113,9 +118,14 @@ func (t *Tally) Received(deviceIP, policy, trapName string, v Version) {
 		t.received[k] = sr
 	}
 	sr.n++
-	if _, withdrawn := t.withdrawn[policy]; !withdrawn {
-		sr.live = true
+	if _, withdrawn := t.withdrawn[policy]; withdrawn {
+		if !sr.live {
+			t.dormant[k] = struct{}{}
+		}
+		return
 	}
+	sr.live = true
+	delete(t.dormant, k)
 }
 
 // Activate marks a policy acquired, so its counts are exported again. The
@@ -128,13 +138,14 @@ func (t *Tally) Activate(policy string) {
 
 // evictDormant removes one dormant series to make room for a live one and
 // reports whether it found one. A retained total is worth less than a live
-// series, so it goes before a live series is folded.
+// series, so it goes before a live series is folded. The set makes this a
+// pop rather than a scan, so a sender past the limit cannot turn every
+// datagram into a walk of the map.
 func (t *Tally) evictDormant() bool {
-	for k, sr := range t.received {
-		if !sr.live {
-			delete(t.received, k)
-			return true
-		}
+	for k := range t.dormant {
+		delete(t.dormant, k)
+		delete(t.received, k)
+		return true
 	}
 	return false
 }
@@ -166,6 +177,7 @@ func (t *Tally) Withdraw(policy string) {
 	for k, sr := range t.received {
 		if k.policy == policy {
 			sr.live = false
+			t.dormant[k] = struct{}{}
 		}
 	}
 }
@@ -255,6 +267,12 @@ func (t *Tally) droppedCount(r DropReason) int64 {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.dropped[r]
+}
+
+func (t *Tally) dormantCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.dormant)
 }
 
 func (t *Tally) seriesCount() int {

--- a/orb-telemetry/snmp-telemetry/traps/export.go
+++ b/orb-telemetry/snmp-telemetry/traps/export.go
@@ -17,6 +17,18 @@ const (
 	datagramsName = "snmp.traps_datagrams"
 )
 
+// maxSeries bounds the distinct received series the tally holds. A v1 or v2c
+// sender able to spoof a registered address can vary the source across a
+// registered prefix and the trap name across the closed set, and every
+// combination is a map entry that lives until its policy is withdrawn; a /16
+// times two hundred names times three versions is tens of millions of them.
+// The SDK's cardinality limit folds series only as the callback observes
+// them, so it bounds the export and not this map. The cap is the same number,
+// so nothing the tally exports is ever folded by the SDK either. Past it, a
+// series that does not exist yet is counted under its policy's overflow
+// series, device_ip and trap_name both OtherName, and the count survives.
+const maxSeries = metrics.CardinalityLimit
+
 type receivedKey struct {
 	deviceIP, policy, trapName string
 	version                    Version
@@ -51,11 +63,16 @@ func NewTally(logger *slog.Logger) *Tally {
 
 // Received counts one trap for one policy's device. The address set is
 // bounded by the policies an operator wrote, since the receiver drops every
-// source no policy names before it counts anything.
+// source no policy names before it counts anything, and the series set is
+// bounded by maxSeries against a sender who can spoof inside that set.
 func (t *Tally) Received(deviceIP, policy, trapName string, v Version) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.received[receivedKey{deviceIP, policy, trapName, v}]++
+	k := receivedKey{deviceIP, policy, trapName, v}
+	if _, exists := t.received[k]; !exists && len(t.received) >= maxSeries {
+		k = receivedKey{OtherName, policy, OtherName, v}
+	}
+	t.received[k]++
 }
 
 // Dropped counts one datagram that produced no trap, by reason.
@@ -163,6 +180,12 @@ func (t *Tally) droppedCount(r DropReason) int64 {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.dropped[r]
+}
+
+func (t *Tally) seriesCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.received)
 }
 
 func (t *Tally) datagramCount() int64 {

--- a/orb-telemetry/snmp-telemetry/traps/export.go
+++ b/orb-telemetry/snmp-telemetry/traps/export.go
@@ -27,7 +27,21 @@ const (
 // so nothing the tally exports is ever folded by the SDK either. Past it, a
 // series that does not exist yet is counted under its policy's overflow
 // series, device_ip and trap_name both OtherName, and the count survives.
-const maxSeries = metrics.CardinalityLimit
+//
+// The overflow series need room of their own, or the first of them would be
+// the entry past the limit and the SDK would fold an arbitrary series
+// instead. So real series stop at seriesLimit, a reserve below maxSeries
+// holds one overflow series per overflowing policy and version, and the last
+// versionCount slots of the reserve are kept for one process-wide overflow
+// series per version, where a policy whose own overflow series would not fit
+// is counted. Nothing can push the map past maxSeries.
+const (
+	maxSeries       = metrics.CardinalityLimit
+	overflowReserve = 100
+	seriesLimit     = maxSeries - overflowReserve
+	// versionCount is how many Version values exist: V1, V2c and V3.
+	versionCount = 3
+)
 
 type receivedKey struct {
 	deviceIP, policy, trapName string
@@ -69,8 +83,11 @@ func (t *Tally) Received(deviceIP, policy, trapName string, v Version) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	k := receivedKey{deviceIP, policy, trapName, v}
-	if _, exists := t.received[k]; !exists && len(t.received) >= maxSeries {
+	if _, exists := t.received[k]; !exists && len(t.received) >= seriesLimit {
 		k = receivedKey{OtherName, policy, OtherName, v}
+		if _, exists := t.received[k]; !exists && len(t.received) >= maxSeries-versionCount {
+			k = receivedKey{OtherName, OtherName, OtherName, v}
+		}
 	}
 	t.received[k]++
 }

--- a/orb-telemetry/snmp-telemetry/traps/export.go
+++ b/orb-telemetry/snmp-telemetry/traps/export.go
@@ -1,6 +1,7 @@
 package traps
 
 import (
+	"container/list"
 	"context"
 	"log/slog"
 	"sync"
@@ -81,6 +82,13 @@ type Tally struct {
 	// map so the overflow path never scans it: with nothing dormant the
 	// check is a length, and an eviction is one pop.
 	dormant map[receivedKey]struct{}
+	// baselines is the total of every series evicted while dormant, keyed
+	// like the series and kept in eviction order, so a series that comes
+	// back resumes from it and the counter never reads lower. It is bounded
+	// at maxBaselines, dropping its oldest, so the tally's memory is bounded
+	// at twice the cap.
+	baselines     map[receivedKey]*list.Element
+	baselineOrder *list.List
 
 	regMu        sync.Mutex
 	registration metric.Registration
@@ -89,11 +97,13 @@ type Tally struct {
 // NewTally returns an empty tally. Register attaches it to the meter.
 func NewTally(logger *slog.Logger) *Tally {
 	return &Tally{
-		logger:    logger,
-		received:  make(map[receivedKey]*series),
-		dropped:   make(map[DropReason]int64),
-		withdrawn: make(map[string]struct{}),
-		dormant:   make(map[receivedKey]struct{}),
+		logger:        logger,
+		received:      make(map[receivedKey]*series),
+		dropped:       make(map[DropReason]int64),
+		withdrawn:     make(map[string]struct{}),
+		dormant:       make(map[receivedKey]struct{}),
+		baselines:     make(map[receivedKey]*list.Element),
+		baselineOrder: list.New(),
 	}
 }
 
@@ -114,7 +124,7 @@ func (t *Tally) Received(deviceIP, policy, trapName string, v Version) {
 	}
 	sr := t.received[k]
 	if sr == nil {
-		sr = &series{}
+		sr = &series{n: t.takeBaseline(k)}
 		t.received[k] = sr
 	}
 	sr.n++
@@ -143,11 +153,48 @@ func (t *Tally) Activate(policy string) {
 // datagram into a walk of the map.
 func (t *Tally) evictDormant() bool {
 	for k := range t.dormant {
+		t.keepBaseline(k, t.received[k].n)
 		delete(t.dormant, k)
 		delete(t.received, k)
 		return true
 	}
 	return false
+}
+
+// baseline is one evicted series' total, kept in eviction order.
+type baseline struct {
+	key receivedKey
+	n   int64
+}
+
+// maxBaselines bounds the baseline tier at the series limit.
+const maxBaselines = maxSeries
+
+// keepBaseline records an evicted series' total, dropping the oldest baseline
+// when the tier is full.
+func (t *Tally) keepBaseline(k receivedKey, n int64) {
+	if el, ok := t.baselines[k]; ok {
+		el.Value.(*baseline).n = n
+		t.baselineOrder.MoveToFront(el)
+		return
+	}
+	if t.baselineOrder.Len() >= maxBaselines {
+		oldest := t.baselineOrder.Back()
+		delete(t.baselines, oldest.Value.(*baseline).key)
+		t.baselineOrder.Remove(oldest)
+	}
+	t.baselines[k] = t.baselineOrder.PushFront(&baseline{key: k, n: n})
+}
+
+// takeBaseline returns and forgets the baseline for a series, or zero.
+func (t *Tally) takeBaseline(k receivedKey) int64 {
+	el, ok := t.baselines[k]
+	if !ok {
+		return 0
+	}
+	delete(t.baselines, k)
+	t.baselineOrder.Remove(el)
+	return el.Value.(*baseline).n
 }
 
 // Dropped counts one datagram that produced no trap, by reason.
@@ -267,6 +314,22 @@ func (t *Tally) droppedCount(r DropReason) int64 {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.dropped[r]
+}
+
+func (t *Tally) baselineCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.baselines)
+}
+
+// retainedCount is a series' total whether or not it is exported.
+func (t *Tally) retainedCount(deviceIP, policy, trapName string, v Version) int64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if sr := t.received[receivedKey{deviceIP, policy, trapName, v}]; sr != nil {
+		return sr.n
+	}
+	return 0
 }
 
 func (t *Tally) dormantCount() int {

--- a/orb-telemetry/snmp-telemetry/traps/export.go
+++ b/orb-telemetry/snmp-telemetry/traps/export.go
@@ -48,6 +48,18 @@ type receivedKey struct {
 	version                    Version
 }
 
+// series is one received series' total and whether it is exported. A
+// withdrawn policy's series go dormant rather than away: the counter is
+// monotonic and the SDK reports a series from the provider's start time, so
+// a series that reappeared at one after a policy was deleted and recreated
+// under the same name would read as a decrease. A dormant series is not
+// observed, keeps its total, resumes from it when its key is counted again,
+// and is the first thing evicted when the map is at its cap.
+type series struct {
+	n    int64
+	live bool
+}
+
 // Tally holds the counts the receiver produces and exports them through
 // observable counters, the way the collector exports gauges. A map the
 // package owns is what makes Withdraw possible: a synchronous counter keeps
@@ -58,7 +70,7 @@ type Tally struct {
 	logger *slog.Logger
 
 	mu        sync.Mutex
-	received  map[receivedKey]int64
+	received  map[receivedKey]*series
 	dropped   map[DropReason]int64
 	datagrams int64
 
@@ -70,7 +82,7 @@ type Tally struct {
 func NewTally(logger *slog.Logger) *Tally {
 	return &Tally{
 		logger:   logger,
-		received: make(map[receivedKey]int64),
+		received: make(map[receivedKey]*series),
 		dropped:  make(map[DropReason]int64),
 	}
 }
@@ -83,13 +95,32 @@ func (t *Tally) Received(deviceIP, policy, trapName string, v Version) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	k := receivedKey{deviceIP, policy, trapName, v}
-	if _, exists := t.received[k]; !exists && len(t.received) >= seriesLimit {
+	if _, exists := t.received[k]; !exists && len(t.received) >= seriesLimit && !t.evictDormant() {
 		k = receivedKey{OtherName, policy, OtherName, v}
-		if _, exists := t.received[k]; !exists && len(t.received) >= maxSeries-versionCount {
+		if _, exists := t.received[k]; !exists && len(t.received) >= maxSeries-versionCount && !t.evictDormant() {
 			k = receivedKey{OtherName, OtherName, OtherName, v}
 		}
 	}
-	t.received[k]++
+	sr := t.received[k]
+	if sr == nil {
+		sr = &series{}
+		t.received[k] = sr
+	}
+	sr.n++
+	sr.live = true
+}
+
+// evictDormant removes one dormant series to make room for a live one and
+// reports whether it found one. A retained total is worth less than a live
+// series, so it goes before a live series is folded.
+func (t *Tally) evictDormant() bool {
+	for k, sr := range t.received {
+		if !sr.live {
+			delete(t.received, k)
+			return true
+		}
+	}
+	return false
 }
 
 // Dropped counts one datagram that produced no trap, by reason.
@@ -108,14 +139,16 @@ func (t *Tally) Datagram() {
 	t.datagrams++
 }
 
-// Withdraw drops every received series the policy owns, so a stopped policy
-// stops exporting. Drops and datagrams are process-level and are kept.
+// Withdraw makes every received series the policy owns dormant, so a stopped
+// policy stops exporting; the totals are kept so a series that reappears
+// resumes rather than restarts. Drops and datagrams are process-level and
+// are kept.
 func (t *Tally) Withdraw(policy string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	for k := range t.received {
+	for k, sr := range t.received {
 		if k.policy == policy {
-			delete(t.received, k)
+			sr.live = false
 		}
 	}
 }
@@ -151,8 +184,11 @@ func (t *Tally) Register() {
 	reg, err := m.RegisterCallback(func(_ context.Context, o metric.Observer) error {
 		t.mu.Lock()
 		defer t.mu.Unlock()
-		for k, n := range t.received {
-			o.ObserveInt64(received, n, metric.WithAttributes(
+		for k, sr := range t.received {
+			if !sr.live {
+				continue
+			}
+			o.ObserveInt64(received, sr.n, metric.WithAttributes(
 				attribute.String("device_ip", k.deviceIP),
 				attribute.String("policy", k.policy),
 				attribute.String("trap_name", k.trapName),
@@ -187,10 +223,15 @@ func (t *Tally) Close() {
 
 // Test accessors. Exported through _test.go only by convention: they are
 // unexported and read under the lock.
+// receivedCount is what the series exports: its total while live, zero
+// while dormant.
 func (t *Tally) receivedCount(deviceIP, policy, trapName string, v Version) int64 {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	return t.received[receivedKey{deviceIP, policy, trapName, v}]
+	if sr := t.received[receivedKey{deviceIP, policy, trapName, v}]; sr != nil && sr.live {
+		return sr.n
+	}
+	return 0
 }
 
 func (t *Tally) droppedCount(r DropReason) int64 {

--- a/orb-telemetry/snmp-telemetry/traps/export.go
+++ b/orb-telemetry/snmp-telemetry/traps/export.go
@@ -123,6 +123,38 @@ func NewTally(logger *slog.Logger) *Tally {
 func (t *Tally) Received(deviceIP, policy, trapName string, v Version) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	return t.receivedLocked(deviceIP, policy, trapName, v)
+}
+
+// Account runs fn with the tally locked, so everything fn records lands in
+// one transaction: a datagram and its outcome are seen together by an
+// export, never the datagram alone. The registry's read lock nests inside
+// this one when the receiver visits the claims; nothing takes the two in
+// the other order.
+func (t *Tally) Account(fn func(a *Account)) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	fn(&Account{t: t})
+}
+
+// Account is the tally as seen from inside one transaction.
+type Account struct {
+	t *Tally
+}
+
+// Datagram counts one datagram in the transaction.
+func (a *Account) Datagram() { a.t.datagrams++ }
+
+// Dropped counts one drop in the transaction.
+func (a *Account) Dropped(r DropReason) { a.t.dropped[r]++ }
+
+// Received counts one trap in the transaction and reports whether it was
+// counted, as Tally.Received does.
+func (a *Account) Received(deviceIP, policy, trapName string, v Version) bool {
+	return a.t.receivedLocked(deviceIP, policy, trapName, v)
+}
+
+func (t *Tally) receivedLocked(deviceIP, policy, trapName string, v Version) bool {
 	k := receivedKey{deviceIP, policy, trapName, v}
 	if _, exists := t.received[k]; !exists && len(t.received) >= seriesLimit && !t.evictDormant() {
 		k = receivedKey{OtherName, policy, OtherName, v}

--- a/orb-telemetry/snmp-telemetry/traps/export.go
+++ b/orb-telemetry/snmp-telemetry/traps/export.go
@@ -30,17 +30,16 @@ const (
 //
 // The overflow series need room of their own, or the first of them would be
 // the entry past the limit and the SDK would fold an arbitrary series
-// instead. So real series stop at seriesLimit, a reserve below maxSeries
-// holds one overflow series per overflowing policy and version, and the last
-// versionCount slots of the reserve are kept for one process-wide overflow
-// series per version, where a policy whose own overflow series would not fit
-// is counted. Nothing can push the map past maxSeries.
+// instead. So real series stop at seriesLimit, and a reserve below maxSeries
+// holds one overflow series per overflowing policy and version. When the
+// reserve is used up too, a trap whose policy has no overflow series yet is
+// counted as a series_limit drop rather than under a series no policy owns:
+// every series in the map carries the policy that can withdraw it. Nothing
+// can push the map past maxSeries.
 const (
 	maxSeries       = metrics.CardinalityLimit
 	overflowReserve = 100
 	seriesLimit     = maxSeries - overflowReserve
-	// versionCount is how many Version values exist: V1, V2c and V3.
-	versionCount = 3
 )
 
 type receivedKey struct {
@@ -103,8 +102,9 @@ func (t *Tally) Received(deviceIP, policy, trapName string, v Version) {
 	k := receivedKey{deviceIP, policy, trapName, v}
 	if _, exists := t.received[k]; !exists && len(t.received) >= seriesLimit && !t.evictDormant() {
 		k = receivedKey{OtherName, policy, OtherName, v}
-		if _, exists := t.received[k]; !exists && len(t.received) >= maxSeries-versionCount && !t.evictDormant() {
-			k = receivedKey{OtherName, OtherName, OtherName, v}
+		if _, exists := t.received[k]; !exists && len(t.received) >= maxSeries && !t.evictDormant() {
+			t.dropped[DropSeriesLimit]++
+			return
 		}
 	}
 	sr := t.received[k]

--- a/orb-telemetry/snmp-telemetry/traps/export.go
+++ b/orb-telemetry/snmp-telemetry/traps/export.go
@@ -17,21 +17,6 @@ const (
 	datagramsName = "snmp.traps_datagrams"
 )
 
-// maxUnknownSources bounds the distinct device_ip values the tally will hold
-// for sources no policy names. With --trap-accept-unknown on, every distinct
-// address that sends a datagram makes a new series, and a source address is
-// spoofable, so without a cap the map grows from the network without bound.
-// A thousand is far more unregistered senders than an operator closing a
-// registration gap needs to see, and a tenth of the SDK cardinality ceiling
-// this backend sets, so the fold happens here where the count survives it
-// rather than in the SDK where the metric stops answering anything.
-const maxUnknownSources = 1000
-
-// unknownSourceOverflow is the device_ip every unknown source past the cap is
-// counted under, mirroring the closed sink NameFor folds unrecognised trap
-// OIDs into: the traps are still counted, they just stop naming their sender.
-const unknownSourceOverflow = "other"
-
 type receivedKey struct {
 	deviceIP, policy, trapName string
 	version                    Version
@@ -50,10 +35,6 @@ type Tally struct {
 	received  map[receivedKey]int64
 	dropped   map[DropReason]int64
 	datagrams int64
-	// unknownSources is the set of addresses that have already been given a
-	// device_ip of their own with no policy behind them, so the cap counts
-	// distinct senders rather than datagrams.
-	unknownSources map[string]struct{}
 
 	regMu        sync.Mutex
 	registration metric.Registration
@@ -62,32 +43,18 @@ type Tally struct {
 // NewTally returns an empty tally. Register attaches it to the meter.
 func NewTally(logger *slog.Logger) *Tally {
 	return &Tally{
-		logger:         logger,
-		received:       make(map[receivedKey]int64),
-		dropped:        make(map[DropReason]int64),
-		unknownSources: make(map[string]struct{}),
+		logger:   logger,
+		received: make(map[receivedKey]int64),
+		dropped:  make(map[DropReason]int64),
 	}
 }
 
-// Received counts one trap for one policy's device.
-//
-// A claim with no policy came from an address no policy names, which only
-// --trap-accept-unknown produces. Those addresses are the ones a stranger
-// chooses, so they are capped: past maxUnknownSources distinct ones the count
-// still lands, under the overflow device_ip. A registered device is bounded by
-// the policies an operator wrote and is never folded.
+// Received counts one trap for one policy's device. The address set is
+// bounded by the policies an operator wrote, since the receiver drops every
+// source no policy names before it counts anything.
 func (t *Tally) Received(deviceIP, policy, trapName string, v Version) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	if policy == "" {
-		if _, seen := t.unknownSources[deviceIP]; !seen {
-			if len(t.unknownSources) >= maxUnknownSources {
-				deviceIP = unknownSourceOverflow
-			} else {
-				t.unknownSources[deviceIP] = struct{}{}
-			}
-		}
-	}
 	t.received[receivedKey{deviceIP, policy, trapName, v}]++
 }
 

--- a/orb-telemetry/snmp-telemetry/traps/export.go
+++ b/orb-telemetry/snmp-telemetry/traps/export.go
@@ -1,0 +1,170 @@
+package traps
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/metrics"
+)
+
+const (
+	receivedName  = "snmp.traps_received"
+	droppedName   = "snmp.traps_dropped"
+	datagramsName = "snmp.traps_datagrams"
+)
+
+type receivedKey struct {
+	deviceIP, policy, trapName string
+	version                    Version
+}
+
+// Tally holds the counts the receiver produces and exports them through
+// observable counters, the way the collector exports gauges. A map the
+// package owns is what makes Withdraw possible: a synchronous counter keeps
+// every attribute set it ever saw for the life of the process, and a deleted
+// policy would keep exporting its devices' trap series after every other
+// series of theirs was gone.
+type Tally struct {
+	logger *slog.Logger
+
+	mu        sync.Mutex
+	received  map[receivedKey]int64
+	dropped   map[DropReason]int64
+	datagrams int64
+
+	regMu        sync.Mutex
+	registration metric.Registration
+}
+
+// NewTally returns an empty tally. Register attaches it to the meter.
+func NewTally(logger *slog.Logger) *Tally {
+	return &Tally{
+		logger:   logger,
+		received: make(map[receivedKey]int64),
+		dropped:  make(map[DropReason]int64),
+	}
+}
+
+// Received counts one trap for one policy's device.
+func (t *Tally) Received(deviceIP, policy, trapName string, v Version) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.received[receivedKey{deviceIP, policy, trapName, v}]++
+}
+
+// Dropped counts one datagram that produced no trap, by reason.
+func (t *Tally) Dropped(r DropReason) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.dropped[r]++
+}
+
+// Datagram counts one datagram read from the socket, before any decision, so
+// the gap against received plus dropped is the loss an operator cannot
+// otherwise see.
+func (t *Tally) Datagram() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.datagrams++
+}
+
+// Withdraw drops every received series the policy owns, so a stopped policy
+// stops exporting. Drops and datagrams are process-level and are kept.
+func (t *Tally) Withdraw(policy string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for k := range t.received {
+		if k.policy == policy {
+			delete(t.received, k)
+		}
+	}
+}
+
+// Register attaches the observable counters. With no meter, which is the case
+// whenever no OTLP endpoint is configured, it does nothing, and every count
+// still lands in the maps so a later Register would export them.
+func (t *Tally) Register() {
+	t.regMu.Lock()
+	defer t.regMu.Unlock()
+	if t.registration != nil {
+		return
+	}
+	m := metrics.GetMeter()
+	if m == nil {
+		return
+	}
+	received, err := m.Int64ObservableCounter(receivedName, metric.WithDescription("SNMP traps received, by device, policy, trap name and version"))
+	if err != nil {
+		t.logger.Error("Failed to create trap counter", "name", receivedName, "error", err)
+		return
+	}
+	dropped, err := m.Int64ObservableCounter(droppedName, metric.WithDescription("SNMP trap datagrams that produced no count, by reason"))
+	if err != nil {
+		t.logger.Error("Failed to create trap counter", "name", droppedName, "error", err)
+		return
+	}
+	datagrams, err := m.Int64ObservableCounter(datagramsName, metric.WithDescription("SNMP trap datagrams read from the socket before any decision"))
+	if err != nil {
+		t.logger.Error("Failed to create trap counter", "name", datagramsName, "error", err)
+		return
+	}
+	reg, err := m.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		for k, n := range t.received {
+			o.ObserveInt64(received, n, metric.WithAttributes(
+				attribute.String("device_ip", k.deviceIP),
+				attribute.String("policy", k.policy),
+				attribute.String("trap_name", k.trapName),
+				attribute.String("version", string(k.version)),
+			))
+		}
+		for r, n := range t.dropped {
+			o.ObserveInt64(dropped, n, metric.WithAttributes(attribute.String("reason", string(r))))
+		}
+		o.ObserveInt64(datagrams, t.datagrams)
+		return nil
+	}, received, dropped, datagrams)
+	if err != nil {
+		t.logger.Error("Failed to register trap counter callback", "error", err)
+		return
+	}
+	t.registration = reg
+}
+
+// Close unregisters the callback. Safe to call without Register.
+func (t *Tally) Close() {
+	t.regMu.Lock()
+	defer t.regMu.Unlock()
+	if t.registration == nil {
+		return
+	}
+	if err := t.registration.Unregister(); err != nil {
+		t.logger.Warn("Failed to unregister trap counter callback", "error", err)
+	}
+	t.registration = nil
+}
+
+// Test accessors. Exported through _test.go only by convention: they are
+// unexported and read under the lock.
+func (t *Tally) receivedCount(deviceIP, policy, trapName string, v Version) int64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.received[receivedKey{deviceIP, policy, trapName, v}]
+}
+
+func (t *Tally) droppedCount(r DropReason) int64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.dropped[r]
+}
+
+func (t *Tally) datagramCount() int64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.datagrams
+}

--- a/orb-telemetry/snmp-telemetry/traps/export.go
+++ b/orb-telemetry/snmp-telemetry/traps/export.go
@@ -111,15 +111,19 @@ func NewTally(logger *slog.Logger) *Tally {
 // bounded by the policies an operator wrote, since the receiver drops every
 // source no policy names before it counts anything, and the series set is
 // bounded by maxSeries against a sender who can spoof inside that set.
-func (t *Tally) Received(deviceIP, policy, trapName string, v Version) {
+//
+// It reports whether the trap was counted. It is not when the series does
+// not exist and there is no room for it, not even for the policy's overflow
+// series; the receiver, which counts once per claiming policy, decides from
+// the outcomes whether the datagram as a whole is a series_limit drop.
+func (t *Tally) Received(deviceIP, policy, trapName string, v Version) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	k := receivedKey{deviceIP, policy, trapName, v}
 	if _, exists := t.received[k]; !exists && len(t.received) >= seriesLimit && !t.evictDormant() {
 		k = receivedKey{OtherName, policy, OtherName, v}
 		if _, exists := t.received[k]; !exists && len(t.received) >= maxSeries && !t.evictDormant() {
-			t.dropped[DropSeriesLimit]++
-			return
+			return false
 		}
 	}
 	sr := t.received[k]
@@ -132,10 +136,11 @@ func (t *Tally) Received(deviceIP, policy, trapName string, v Version) {
 		if !sr.live {
 			t.dormant[k] = struct{}{}
 		}
-		return
+		return true
 	}
 	sr.live = true
 	delete(t.dormant, k)
+	return true
 }
 
 // Activate marks a policy acquired, so its counts are exported again. The

--- a/orb-telemetry/snmp-telemetry/traps/export.go
+++ b/orb-telemetry/snmp-telemetry/traps/export.go
@@ -17,6 +17,21 @@ const (
 	datagramsName = "snmp.traps_datagrams"
 )
 
+// maxUnknownSources bounds the distinct device_ip values the tally will hold
+// for sources no policy names. With --trap-accept-unknown on, every distinct
+// address that sends a datagram makes a new series, and a source address is
+// spoofable, so without a cap the map grows from the network without bound.
+// A thousand is far more unregistered senders than an operator closing a
+// registration gap needs to see, and a tenth of the SDK cardinality ceiling
+// this backend sets, so the fold happens here where the count survives it
+// rather than in the SDK where the metric stops answering anything.
+const maxUnknownSources = 1000
+
+// unknownSourceOverflow is the device_ip every unknown source past the cap is
+// counted under, mirroring the closed sink NameFor folds unrecognised trap
+// OIDs into: the traps are still counted, they just stop naming their sender.
+const unknownSourceOverflow = "other"
+
 type receivedKey struct {
 	deviceIP, policy, trapName string
 	version                    Version
@@ -35,6 +50,10 @@ type Tally struct {
 	received  map[receivedKey]int64
 	dropped   map[DropReason]int64
 	datagrams int64
+	// unknownSources is the set of addresses that have already been given a
+	// device_ip of their own with no policy behind them, so the cap counts
+	// distinct senders rather than datagrams.
+	unknownSources map[string]struct{}
 
 	regMu        sync.Mutex
 	registration metric.Registration
@@ -43,16 +62,32 @@ type Tally struct {
 // NewTally returns an empty tally. Register attaches it to the meter.
 func NewTally(logger *slog.Logger) *Tally {
 	return &Tally{
-		logger:   logger,
-		received: make(map[receivedKey]int64),
-		dropped:  make(map[DropReason]int64),
+		logger:         logger,
+		received:       make(map[receivedKey]int64),
+		dropped:        make(map[DropReason]int64),
+		unknownSources: make(map[string]struct{}),
 	}
 }
 
 // Received counts one trap for one policy's device.
+//
+// A claim with no policy came from an address no policy names, which only
+// --trap-accept-unknown produces. Those addresses are the ones a stranger
+// chooses, so they are capped: past maxUnknownSources distinct ones the count
+// still lands, under the overflow device_ip. A registered device is bounded by
+// the policies an operator wrote and is never folded.
 func (t *Tally) Received(deviceIP, policy, trapName string, v Version) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	if policy == "" {
+		if _, seen := t.unknownSources[deviceIP]; !seen {
+			if len(t.unknownSources) >= maxUnknownSources {
+				deviceIP = unknownSourceOverflow
+			} else {
+				t.unknownSources[deviceIP] = struct{}{}
+			}
+		}
+	}
 	t.received[receivedKey{deviceIP, policy, trapName, v}]++
 }
 

--- a/orb-telemetry/snmp-telemetry/traps/export.go
+++ b/orb-telemetry/snmp-telemetry/traps/export.go
@@ -82,6 +82,11 @@ type Tally struct {
 	// past its registry lookup when the release happened must not bring
 	// the policy's series back to life.
 	withdrawn map[string]struct{}
+	// polSeries counts the received entries and baselines each policy has,
+	// its retained state; a withdrawn marker is kept only while this is
+	// positive, so the withdrawn set is bounded by retained state rather
+	// than by how many policies were ever deleted.
+	polSeries map[string]int
 	// dormant is the set of series not currently exported, kept beside the
 	// map so the overflow path never scans it: with nothing dormant the
 	// check is a length, and an eviction is one pop.
@@ -105,6 +110,7 @@ func NewTally(logger *slog.Logger) *Tally {
 		received:      make(map[receivedKey]*series),
 		dropped:       make(map[DropReason]int64),
 		withdrawn:     make(map[string]struct{}),
+		polSeries:     make(map[string]int),
 		dormant:       make(map[receivedKey]struct{}),
 		baselines:     make(map[receivedKey]*list.Element),
 		baselineOrder: list.New(),
@@ -166,6 +172,13 @@ func (t *Tally) receivedLocked(deviceIP, policy, trapName string, v Version) boo
 	if sr == nil {
 		sr = &series{n: t.takeBaseline(k)}
 		t.received[k] = sr
+		// A brand-new key, not one taken back from a baseline, is a new
+		// piece of retained state for its policy. takeBaseline returns a
+		// positive total for a real baseline, since a series is at least
+		// one before it can be evicted.
+		if sr.n == 0 {
+			t.polSeries[k.policy]++
+		}
 	}
 	sr.n++
 	if _, withdrawn := t.withdrawn[policy]; withdrawn {
@@ -221,10 +234,23 @@ func (t *Tally) keepBaseline(k receivedKey, n int64) {
 	}
 	if t.baselineOrder.Len() >= maxBaselines {
 		oldest := t.baselineOrder.Back()
-		delete(t.baselines, oldest.Value.(*baseline).key)
+		dropped := oldest.Value.(*baseline).key
+		delete(t.baselines, dropped)
 		t.baselineOrder.Remove(oldest)
+		t.releaseSeries(dropped.policy)
 	}
 	t.baselines[k] = t.baselineOrder.PushFront(&baseline{key: k, n: n})
+}
+
+// releaseSeries records that a policy lost one retained entry and prunes its
+// withdrawn marker once it has none left, so the marker cannot outlive the
+// state it protects.
+func (t *Tally) releaseSeries(policy string) {
+	t.polSeries[policy]--
+	if t.polSeries[policy] <= 0 {
+		delete(t.polSeries, policy)
+		delete(t.withdrawn, policy)
+	}
 }
 
 // takeBaseline returns and forgets the baseline for a series, or zero.
@@ -262,12 +288,17 @@ func (t *Tally) Datagram() {
 func (t *Tally) Withdraw(policy string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.withdrawn[policy] = struct{}{}
 	for k, sr := range t.received {
 		if k.policy == policy {
 			sr.live = false
 			t.dormant[k] = struct{}{}
 		}
+	}
+	// The marker only protects retained series from an in-flight count
+	// reviving them; a policy with none needs none, which is what keeps
+	// deleting uniquely named policies from accumulating markers.
+	if t.polSeries[policy] > 0 {
+		t.withdrawn[policy] = struct{}{}
 	}
 }
 
@@ -372,6 +403,12 @@ func (t *Tally) retainedCount(deviceIP, policy, trapName string, v Version) int6
 		return sr.n
 	}
 	return 0
+}
+
+func (t *Tally) withdrawnCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.withdrawn)
 }
 
 func (t *Tally) dormantCount() int {

--- a/orb-telemetry/snmp-telemetry/traps/export.go
+++ b/orb-telemetry/snmp-telemetry/traps/export.go
@@ -37,8 +37,12 @@ const (
 // counted as a series_limit drop rather than under a series no policy owns:
 // every series in the map carries the policy that can withdraw it. Nothing
 // can push the map past maxSeries.
+//
+// maxSeries is one short of the SDK's limit: the SDK keeps its last slot for
+// its own overflow point, so a tally offering exactly the limit would have
+// one arbitrary series folded.
 const (
-	maxSeries       = metrics.CardinalityLimit
+	maxSeries       = metrics.CardinalityLimit - 1
 	overflowReserve = 100
 	seriesLimit     = maxSeries - overflowReserve
 )
@@ -209,9 +213,10 @@ func (t *Tally) Dropped(r DropReason) {
 	t.dropped[r]++
 }
 
-// Datagram counts one datagram read from the socket, before any decision, so
-// the gap against received plus dropped is the loss an operator cannot
-// otherwise see.
+// Datagram counts one datagram. The receiver records it together with the
+// datagram's outcome, a drop or a count, so the two sides of the accounting
+// agree in every export, including a final one taken while a datagram is in
+// flight.
 func (t *Tally) Datagram() {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/orb-telemetry/snmp-telemetry/traps/export_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/export_test.go
@@ -118,24 +118,29 @@ func TestTally_FoldsNewSeriesPastTheCap(t *testing.T) {
 }
 
 // The overflow series live in the reserve, and the reserve is bounded too:
-// once it is down to the slots kept for the process-wide overflow series,
-// one per version, a policy whose overflow series does not exist yet is
-// counted there. So the map never holds more than the SDK's limit and the
-// SDK never folds a series the tally chose to keep.
+// once it is used up, a policy whose overflow series does not exist yet has
+// its trap counted as a drop under series_limit rather than under a series
+// no policy owns. So the map never holds more than the SDK's limit, the SDK
+// never folds a series the tally chose to keep, and every series carries the
+// policy that can withdraw it.
 func TestTally_NeverExceedsTheCardinalityLimit(t *testing.T) {
 	tally := NewTally(testLogger)
 	for i := range seriesLimit {
 		tally.Received(fmt.Sprintf("10.%d.%d.%d", i>>16&255, i>>8&255, i&255), "core", "linkDown", V2c)
 	}
-	perPolicyRoom := maxSeries - versionCount - seriesLimit
+	perPolicyRoom := maxSeries - seriesLimit
 	extra := 10
 	for i := range perPolicyRoom + extra {
 		tally.Received("198.51.100.1", fmt.Sprintf("p%d", i), "linkUp", V2c)
 	}
-	assert.LessOrEqual(t, tally.seriesCount(), maxSeries)
+	assert.Equal(t, maxSeries, tally.seriesCount())
 	assert.Equal(t, int64(1), tally.receivedCount(OtherName, "p0", OtherName, V2c), "the first overflowing policy got its own series")
 	assert.Equal(t, int64(0), tally.receivedCount(OtherName, fmt.Sprintf("p%d", perPolicyRoom), OtherName, V2c), "the first past the reserve did not")
-	assert.Equal(t, int64(extra), tally.receivedCount(OtherName, OtherName, OtherName, V2c), "and every one past the reserve counted process-wide")
+	assert.Equal(t, int64(extra), tally.droppedCount(DropSeriesLimit), "and every one past the reserve is a series_limit drop")
+	assert.Equal(t, int64(0), tally.receivedCount(OtherName, OtherName, OtherName, V2c), "no series without a policy")
+
+	tally.Withdraw("p0")
+	assert.Equal(t, int64(0), tally.receivedCount(OtherName, "p0", OtherName, V2c), "an overflow series is withdrawn with its policy")
 }
 
 // The counters are monotonic and the SDK reports a series from the provider's

--- a/orb-telemetry/snmp-telemetry/traps/export_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/export_test.go
@@ -2,7 +2,6 @@ package traps
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 	"testing"
@@ -88,34 +87,4 @@ func TestTally_ExportsThroughObservableCounters(t *testing.T) {
 	assert.Equal(t, int64(2), got["snmp.traps_received|device_ip=10.0.0.5|policy=core|trap_name=linkDown|version=2c"])
 	assert.Equal(t, int64(1), got["snmp.traps_dropped|reason=unknown_source"])
 	assert.Equal(t, int64(1), got["snmp.traps_datagrams"])
-}
-
-// I4: with --trap-accept-unknown on, every distinct source address makes a new
-// series, and a source address is spoofable, so the map would grow from the
-// network without bound. Past the cap the addresses fold into one sentinel,
-// which keeps the total count right while the cardinality stops.
-func TestTally_CapsTheDeviceIPsUnknownSourcesCanCreate(t *testing.T) {
-	ta := NewTally(testLogger)
-	for i := range maxUnknownSources + 1 {
-		ta.Received(fmt.Sprintf("10.0.%d.%d", i/256, i%256), "", "linkDown", V2c)
-	}
-
-	distinct := map[string]struct{}{}
-	ta.mu.Lock()
-	for k := range ta.received {
-		distinct[k.deviceIP] = struct{}{}
-	}
-	ta.mu.Unlock()
-
-	assert.Len(t, distinct, maxUnknownSources+1, "the cap plus the one sentinel")
-	assert.Contains(t, distinct, unknownSourceOverflow)
-	assert.Equal(t, int64(1), ta.receivedCount(unknownSourceOverflow, "", "linkDown", V2c),
-		"the source past the cap is counted, under the sentinel")
-	assert.Equal(t, int64(1), ta.receivedCount("10.0.0.0", "", "linkDown", V2c),
-		"a source seen before the cap keeps its own address")
-
-	// A registered device is bounded by the policies an operator wrote, not by
-	// what the network sends, so the cap must not reach it.
-	ta.Received("10.9.9.9", "core", "linkDown", V2c)
-	assert.Equal(t, int64(1), ta.receivedCount("10.9.9.9", "core", "linkDown", V2c))
 }

--- a/orb-telemetry/snmp-telemetry/traps/export_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/export_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -358,4 +359,28 @@ func TestTally_LiveSeriesNeverReachTheSDKFold(t *testing.T) {
 		}
 	}
 	assert.Equal(t, maxSeries, points, "every live series exported with its attributes")
+}
+
+// A datagram and its outcome land under one tally lock, so an export taken
+// while a datagram is being accounted sees both or neither.
+func TestTally_AccountLandsADatagramAndItsOutcomeTogether(t *testing.T) {
+	ta := NewTally(testLogger)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	go ta.Account(func(a *Account) {
+		a.Datagram()
+		close(entered)
+		<-release
+		a.Dropped(DropMalformed)
+	})
+	<-entered
+	seen := make(chan [2]int64, 1)
+	go func() { seen <- [2]int64{ta.datagramCount(), ta.droppedCount(DropMalformed)} }()
+	select {
+	case got := <-seen:
+		t.Fatalf("an export read the tally mid-transaction: %v", got)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	assert.Equal(t, [2]int64{1, 1}, <-seen, "both landed before anything could read")
 }

--- a/orb-telemetry/snmp-telemetry/traps/export_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/export_test.go
@@ -2,6 +2,7 @@ package traps
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"testing"
@@ -87,4 +88,31 @@ func TestTally_ExportsThroughObservableCounters(t *testing.T) {
 	assert.Equal(t, int64(2), got["snmp.traps_received|device_ip=10.0.0.5|policy=core|trap_name=linkDown|version=2c"])
 	assert.Equal(t, int64(1), got["snmp.traps_dropped|reason=unknown_source"])
 	assert.Equal(t, int64(1), got["snmp.traps_datagrams"])
+}
+
+// The map is bounded from the network side. Past the cap, a series that does
+// not exist yet is counted under its policy's overflow series rather than
+// inserted, an existing series still counts, and a withdrawal frees room. The
+// cap is the SDK's cardinality limit, so nothing this tally exports is ever
+// folded by the SDK either.
+func TestTally_FoldsNewSeriesPastTheCap(t *testing.T) {
+	tally := NewTally(testLogger)
+	for i := range maxSeries {
+		tally.Received(fmt.Sprintf("10.%d.%d.%d", i>>16&255, i>>8&255, i&255), "core", "linkDown", V2c)
+	}
+	require.Equal(t, maxSeries, tally.seriesCount())
+
+	tally.Received("192.0.2.1", "core", "linkUp", V2c)
+	assert.Equal(t, int64(0), tally.receivedCount("192.0.2.1", "core", "linkUp", V2c), "a new series past the cap is not inserted")
+	assert.Equal(t, int64(1), tally.receivedCount(OtherName, "core", OtherName, V2c), "it is counted under the policy's overflow series")
+
+	tally.Received("10.0.0.1", "core", "linkDown", V2c)
+	assert.Equal(t, int64(2), tally.receivedCount("10.0.0.1", "core", "linkDown", V2c), "an existing series still counts")
+
+	tally.Received("192.0.2.2", "edge", "linkUp", V3)
+	assert.Equal(t, int64(1), tally.receivedCount(OtherName, "edge", OtherName, V3), "the overflow series is per policy and version")
+
+	tally.Withdraw("core")
+	tally.Received("192.0.2.1", "core", "linkUp", V2c)
+	assert.Equal(t, int64(1), tally.receivedCount("192.0.2.1", "core", "linkUp", V2c), "withdrawal frees room")
 }

--- a/orb-telemetry/snmp-telemetry/traps/export_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/export_test.go
@@ -1,0 +1,90 @@
+package traps
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/metrics"
+)
+
+var testLogger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+// F6: a synchronous counter cannot be forgotten. The tally is a map the
+// package owns, so a withdrawn policy's series disappears, which is the
+// contract every other metric in this backend honours.
+func TestTally_WithdrawDropsAPolicysSeries(t *testing.T) {
+	ta := NewTally(testLogger)
+	ta.Received("10.0.0.5", "core", "linkDown", V2c)
+	ta.Received("10.0.0.5", "edge", "linkDown", V2c)
+	ta.Received("10.0.0.5", "core", "linkDown", V2c)
+
+	assert.Equal(t, int64(2), ta.receivedCount("10.0.0.5", "core", "linkDown", V2c))
+	ta.Withdraw("core")
+	assert.Equal(t, int64(0), ta.receivedCount("10.0.0.5", "core", "linkDown", V2c))
+	assert.Equal(t, int64(1), ta.receivedCount("10.0.0.5", "edge", "linkDown", V2c), "edge is untouched")
+}
+
+func TestTally_CountsDropsAndDatagrams(t *testing.T) {
+	ta := NewTally(testLogger)
+	ta.Datagram()
+	ta.Datagram()
+	ta.Dropped(DropUnknownSource)
+	assert.Equal(t, int64(2), ta.datagramCount())
+	assert.Equal(t, int64(1), ta.droppedCount(DropUnknownSource))
+	assert.Equal(t, int64(0), ta.droppedCount(DropMalformed))
+}
+
+// F8: with no OTLP endpoint there is no meter. Registering must be a no-op,
+// not a nil dereference in the receive goroutine.
+func TestTally_RegisterWithoutAMeterIsSafe(t *testing.T) {
+	metrics.ResetMeter()
+	ta := NewTally(testLogger)
+	assert.NotPanics(t, func() { ta.Register(); ta.Received("10.0.0.5", "p", "linkDown", V2c); ta.Close() })
+}
+
+// The observable counters report what the map holds, with the attribute names
+// the polled series already use, so trap counts join to poll metrics.
+func TestTally_ExportsThroughObservableCounters(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+	metrics.SetMeterForTest(provider.Meter("test"))
+	t.Cleanup(metrics.ResetMeter)
+
+	ta := NewTally(testLogger)
+	ta.Register()
+	t.Cleanup(ta.Close)
+	ta.Datagram()
+	ta.Received("10.0.0.5", "core", "linkDown", V2c)
+	ta.Received("10.0.0.5", "core", "linkDown", V2c)
+	ta.Dropped(DropUnknownSource)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	got := map[string]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "%s must be a sum", m.Name)
+			assert.True(t, sum.IsMonotonic, "%s must be monotonic", m.Name)
+			for _, dp := range sum.DataPoints {
+				key := m.Name
+				for _, kv := range dp.Attributes.ToSlice() {
+					key += "|" + string(kv.Key) + "=" + kv.Value.String()
+				}
+				got[key] = dp.Value
+			}
+		}
+	}
+	assert.Equal(t, int64(2), got["snmp.traps_received|device_ip=10.0.0.5|policy=core|trap_name=linkDown|version=2c"])
+	assert.Equal(t, int64(1), got["snmp.traps_dropped|reason=unknown_source"])
+	assert.Equal(t, int64(1), got["snmp.traps_datagrams"])
+}

--- a/orb-telemetry/snmp-telemetry/traps/export_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/export_test.go
@@ -245,3 +245,29 @@ func TestTally_DormantSeriesAreNotExportedAndResumeOnReturn(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, int64(4), v, "the series resumes from its total")
 }
+
+// Dormant series are tracked in a set of their own, so the overflow path
+// with nothing dormant costs a length check and an eviction costs one pop,
+// never a scan of the map. The set follows every transition: withdrawal
+// fills it, a revived series leaves it, an eviction takes from it, and a
+// count for a still-withdrawn policy leaves it in place.
+func TestTally_TracksDormantSeriesInASet(t *testing.T) {
+	ta := NewTally(testLogger)
+	for i := range seriesLimit {
+		ta.Received(fmt.Sprintf("10.%d.%d.%d", i>>16&255, i>>8&255, i&255), "core", "linkDown", V2c)
+	}
+	assert.Equal(t, 0, ta.dormantCount())
+	ta.Withdraw("core")
+	assert.Equal(t, seriesLimit, ta.dormantCount(), "withdrawal makes every series dormant")
+
+	ta.Received("10.0.0.1", "core", "linkDown", V2c)
+	assert.Equal(t, seriesLimit, ta.dormantCount(), "a count for a still-withdrawn policy stays dormant")
+	ta.Activate("core")
+	ta.Received("10.0.0.1", "core", "linkDown", V2c)
+	assert.Equal(t, seriesLimit-1, ta.dormantCount(), "a revived series leaves the set")
+
+	ta.Received("192.0.2.1", "edge", "linkUp", V2c)
+	assert.Equal(t, seriesLimit-2, ta.dormantCount(), "an eviction takes one from the set")
+	assert.Equal(t, seriesLimit, ta.seriesCount())
+	assert.Equal(t, int64(1), ta.receivedCount("192.0.2.1", "edge", "linkUp", V2c))
+}

--- a/orb-telemetry/snmp-telemetry/traps/export_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/export_test.go
@@ -136,3 +136,87 @@ func TestTally_NeverExceedsTheCardinalityLimit(t *testing.T) {
 	assert.Equal(t, int64(0), tally.receivedCount(OtherName, fmt.Sprintf("p%d", perPolicyRoom), OtherName, V2c), "the first past the reserve did not")
 	assert.Equal(t, int64(extra), tally.receivedCount(OtherName, OtherName, OtherName, V2c), "and every one past the reserve counted process-wide")
 }
+
+// The counters are monotonic and the SDK reports a series from the provider's
+// start time, so a withdrawn series that reappears under the same attributes
+// must not start again at one. A withdrawn series stops being exported, keeps
+// its total, and resumes from it.
+func TestTally_ResumesATotalWhenAWithdrawnSeriesReappears(t *testing.T) {
+	ta := NewTally(testLogger)
+	for range 3 {
+		ta.Received("10.0.0.5", "core", "linkDown", V2c)
+	}
+	ta.Withdraw("core")
+	assert.Equal(t, int64(0), ta.receivedCount("10.0.0.5", "core", "linkDown", V2c), "not exported while withdrawn")
+	ta.Received("10.0.0.5", "core", "linkDown", V2c)
+	assert.Equal(t, int64(4), ta.receivedCount("10.0.0.5", "core", "linkDown", V2c), "the counter never goes backwards")
+}
+
+// A retained total is worth less than a live series: at the cap, a dormant
+// entry is evicted to make room for a new live one rather than the new one
+// being folded.
+func TestTally_EvictsDormantSeriesBeforeFolding(t *testing.T) {
+	ta := NewTally(testLogger)
+	for i := range seriesLimit {
+		ta.Received(fmt.Sprintf("10.%d.%d.%d", i>>16&255, i>>8&255, i&255), "core", "linkDown", V2c)
+	}
+	ta.Withdraw("core")
+	ta.Received("192.0.2.1", "edge", "linkUp", V2c)
+	assert.Equal(t, int64(1), ta.receivedCount("192.0.2.1", "edge", "linkUp", V2c), "inserted, not folded")
+	assert.Equal(t, int64(0), ta.receivedCount(OtherName, "edge", OtherName, V2c))
+	assert.Equal(t, seriesLimit, ta.seriesCount(), "one dormant entry made way")
+}
+
+// What the export sees: a withdrawn series is absent from the next
+// collection, and when it reappears the exported value is the resumed total,
+// never a smaller number than the SDK already reported for that series.
+func TestTally_DormantSeriesAreNotExportedAndResumeOnReturn(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+	metrics.SetMeterForTest(provider.Meter("test"))
+	t.Cleanup(metrics.ResetMeter)
+
+	ta := NewTally(testLogger)
+	ta.Register()
+	t.Cleanup(ta.Close)
+	const key = "snmp.traps_received|device_ip=10.0.0.5|policy=core|trap_name=linkDown|version=2c"
+	export := func() (int64, bool) {
+		var rm metricdata.ResourceMetrics
+		require.NoError(t, reader.Collect(context.Background(), &rm))
+		for _, sm := range rm.ScopeMetrics {
+			for _, m := range sm.Metrics {
+				sum, ok := m.Data.(metricdata.Sum[int64])
+				if !ok {
+					continue
+				}
+				for _, dp := range sum.DataPoints {
+					k := m.Name
+					for _, kv := range dp.Attributes.ToSlice() {
+						k += "|" + string(kv.Key) + "=" + kv.Value.String()
+					}
+					if k == key {
+						return dp.Value, true
+					}
+				}
+			}
+		}
+		return 0, false
+	}
+
+	for range 3 {
+		ta.Received("10.0.0.5", "core", "linkDown", V2c)
+	}
+	v, ok := export()
+	require.True(t, ok)
+	assert.Equal(t, int64(3), v)
+
+	ta.Withdraw("core")
+	_, ok = export()
+	assert.False(t, ok, "a withdrawn series is not exported")
+
+	ta.Received("10.0.0.5", "core", "linkDown", V2c)
+	v, ok = export()
+	require.True(t, ok)
+	assert.Equal(t, int64(4), v, "the series resumes from its total")
+}

--- a/orb-telemetry/snmp-telemetry/traps/export_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/export_test.go
@@ -384,3 +384,36 @@ func TestTally_AccountLandsADatagramAndItsOutcomeTogether(t *testing.T) {
 	close(release)
 	assert.Equal(t, [2]int64{1, 1}, <-seen, "both landed before anything could read")
 }
+
+// The withdrawn set is bounded by retained state, not by history. A policy
+// that received nothing leaves no marker when withdrawn, and a policy whose
+// series were all evicted and whose baselines were all dropped loses its
+// marker too, so a long-running agent creating and deleting uniquely named
+// trap policies does not accumulate markers.
+func TestTally_WithdrawnSetIsBoundedByRetainedState(t *testing.T) {
+	ta := NewTally(testLogger)
+	for i := range 1000 {
+		ta.Withdraw(fmt.Sprintf("never-received-%d", i))
+	}
+	assert.Equal(t, 0, ta.withdrawnCount(), "a policy that received nothing leaves no marker")
+
+	ta.Received("10.0.0.1", "had-one", "linkDown", V2c)
+	ta.Withdraw("had-one")
+	assert.Equal(t, 1, ta.withdrawnCount(), "a policy with a retained series keeps its marker")
+	ta.Activate("had-one")
+	assert.Equal(t, 0, ta.withdrawnCount(), "acquiring it again clears the marker")
+	ta.Withdraw("had-one")
+
+	// Every one of these received one trap and was withdrawn under a unique
+	// name, far more than the retained tiers can hold. The withdrawn set is
+	// bounded by that retained state, not by how many were ever deleted.
+	const churn = 5 * maxSeries
+	for i := range churn {
+		name := fmt.Sprintf("churn-%d", i)
+		ta.Received(fmt.Sprintf("198.%d.%d.%d", i>>16&255, i>>8&255, i&255), name, "linkUp", V2c)
+		ta.Withdraw(name)
+	}
+	assert.GreaterOrEqual(t, ta.withdrawnCount(), 1, "policies with retained series keep their markers")
+	assert.LessOrEqual(t, ta.withdrawnCount(), maxSeries+maxBaselines, "markers are bounded by retained state")
+	assert.Less(t, ta.withdrawnCount(), churn/2, "and far below the number of policies deleted")
+}

--- a/orb-telemetry/snmp-telemetry/traps/export_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/export_test.go
@@ -112,6 +112,7 @@ func TestTally_FoldsNewSeriesPastTheCap(t *testing.T) {
 	assert.Equal(t, int64(1), tally.receivedCount(OtherName, "edge", OtherName, V3), "the overflow series is per policy and version")
 
 	tally.Withdraw("core")
+	tally.Activate("core")
 	tally.Received("192.0.2.1", "core", "linkUp", V2c)
 	assert.Equal(t, int64(1), tally.receivedCount("192.0.2.1", "core", "linkUp", V2c), "withdrawal frees room")
 }
@@ -148,8 +149,26 @@ func TestTally_ResumesATotalWhenAWithdrawnSeriesReappears(t *testing.T) {
 	}
 	ta.Withdraw("core")
 	assert.Equal(t, int64(0), ta.receivedCount("10.0.0.5", "core", "linkDown", V2c), "not exported while withdrawn")
+	ta.Activate("core")
 	ta.Received("10.0.0.5", "core", "linkDown", V2c)
 	assert.Equal(t, int64(4), ta.receivedCount("10.0.0.5", "core", "linkDown", V2c), "the counter never goes backwards")
+}
+
+// A datagram that was past its registry lookup when its policy was withdrawn
+// still reaches the tally. It must not bring the series back: a count for a
+// withdrawn policy stays dormant, total kept, until the policy is acquired
+// again.
+func TestTally_CountsForAWithdrawnPolicyStayDormantUntilActivated(t *testing.T) {
+	ta := NewTally(testLogger)
+	ta.Received("10.0.0.5", "core", "linkDown", V2c)
+	ta.Withdraw("core")
+	ta.Received("10.0.0.5", "core", "linkDown", V2c)
+	assert.Equal(t, int64(0), ta.receivedCount("10.0.0.5", "core", "linkDown", V2c), "an in-flight count does not revive the series")
+	ta.Received("10.0.0.6", "core", "linkUp", V2c)
+	assert.Equal(t, int64(0), ta.receivedCount("10.0.0.6", "core", "linkUp", V2c), "nor create a live one")
+	ta.Activate("core")
+	ta.Received("10.0.0.5", "core", "linkDown", V2c)
+	assert.Equal(t, int64(3), ta.receivedCount("10.0.0.5", "core", "linkDown", V2c), "every count was kept")
 }
 
 // A retained total is worth less than a live series: at the cap, a dormant
@@ -215,6 +234,7 @@ func TestTally_DormantSeriesAreNotExportedAndResumeOnReturn(t *testing.T) {
 	_, ok = export()
 	assert.False(t, ok, "a withdrawn series is not exported")
 
+	ta.Activate("core")
 	ta.Received("10.0.0.5", "core", "linkDown", V2c)
 	v, ok = export()
 	require.True(t, ok)

--- a/orb-telemetry/snmp-telemetry/traps/export_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/export_test.go
@@ -2,6 +2,7 @@ package traps
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"testing"
@@ -87,4 +88,34 @@ func TestTally_ExportsThroughObservableCounters(t *testing.T) {
 	assert.Equal(t, int64(2), got["snmp.traps_received|device_ip=10.0.0.5|policy=core|trap_name=linkDown|version=2c"])
 	assert.Equal(t, int64(1), got["snmp.traps_dropped|reason=unknown_source"])
 	assert.Equal(t, int64(1), got["snmp.traps_datagrams"])
+}
+
+// I4: with --trap-accept-unknown on, every distinct source address makes a new
+// series, and a source address is spoofable, so the map would grow from the
+// network without bound. Past the cap the addresses fold into one sentinel,
+// which keeps the total count right while the cardinality stops.
+func TestTally_CapsTheDeviceIPsUnknownSourcesCanCreate(t *testing.T) {
+	ta := NewTally(testLogger)
+	for i := range maxUnknownSources + 1 {
+		ta.Received(fmt.Sprintf("10.0.%d.%d", i/256, i%256), "", "linkDown", V2c)
+	}
+
+	distinct := map[string]struct{}{}
+	ta.mu.Lock()
+	for k := range ta.received {
+		distinct[k.deviceIP] = struct{}{}
+	}
+	ta.mu.Unlock()
+
+	assert.Len(t, distinct, maxUnknownSources+1, "the cap plus the one sentinel")
+	assert.Contains(t, distinct, unknownSourceOverflow)
+	assert.Equal(t, int64(1), ta.receivedCount(unknownSourceOverflow, "", "linkDown", V2c),
+		"the source past the cap is counted, under the sentinel")
+	assert.Equal(t, int64(1), ta.receivedCount("10.0.0.0", "", "linkDown", V2c),
+		"a source seen before the cap keeps its own address")
+
+	// A registered device is bounded by the policies an operator wrote, not by
+	// what the network sends, so the cap must not reach it.
+	ta.Received("10.9.9.9", "core", "linkDown", V2c)
+	assert.Equal(t, int64(1), ta.receivedCount("10.9.9.9", "core", "linkDown", V2c))
 }

--- a/orb-telemetry/snmp-telemetry/traps/export_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/export_test.go
@@ -271,3 +271,47 @@ func TestTally_TracksDormantSeriesInASet(t *testing.T) {
 	assert.Equal(t, seriesLimit, ta.seriesCount())
 	assert.Equal(t, int64(1), ta.receivedCount("192.0.2.1", "edge", "linkUp", V2c))
 }
+
+// An evicted dormant series keeps its total in a baseline tier, so a series
+// that comes back after eviction resumes rather than restarts, and the
+// monotonic counter never reads lower than it did.
+func TestTally_EvictedSeriesResumeFromTheirBaseline(t *testing.T) {
+	ta := NewTally(testLogger)
+	for i := range seriesLimit {
+		ta.Received(fmt.Sprintf("10.%d.%d.%d", i>>16&255, i>>8&255, i&255), "core", "linkDown", V2c)
+	}
+	ta.Received("10.0.0.1", "core", "linkDown", V2c)
+	require.Equal(t, int64(2), ta.receivedCount("10.0.0.1", "core", "linkDown", V2c))
+	ta.Withdraw("core")
+	for i := range seriesLimit {
+		ta.Received(fmt.Sprintf("192.%d.%d.%d", i>>16&255, i>>8&255, i&255), "edge", "linkUp", V2c)
+	}
+	require.Equal(t, seriesLimit, ta.seriesCount(), "every dormant core series was evicted for a live edge one")
+	assert.Equal(t, seriesLimit, ta.baselineCount(), "and each left its total behind")
+
+	ta.Withdraw("edge")
+	ta.Activate("core")
+	ta.Received("10.0.0.1", "core", "linkDown", V2c)
+	assert.Equal(t, int64(3), ta.receivedCount("10.0.0.1", "core", "linkDown", V2c), "resumed from the evicted total")
+	assert.Equal(t, seriesLimit, ta.baselineCount(), "core's baseline was consumed and the edge series evicted for it left one")
+	ta.Received("10.0.0.1", "core", "linkDown", V2c)
+	assert.Equal(t, int64(4), ta.receivedCount("10.0.0.1", "core", "linkDown", V2c))
+}
+
+// The baseline tier is bounded at the series limit, evicting its oldest
+// entry, so the tally's memory is bounded at twice the cap whatever a sender
+// or an operator's policy churn does.
+func TestTally_BaselinesAreBounded(t *testing.T) {
+	ta := NewTally(testLogger)
+	fill := func(prefix, policy string) {
+		for i := range seriesLimit {
+			ta.Received(fmt.Sprintf("%s.%d.%d.%d", prefix, i>>16&255, i>>8&255, i&255), policy, "linkDown", V2c)
+		}
+		ta.Withdraw(policy)
+	}
+	fill("10", "a")
+	fill("172", "b")
+	fill("192", "c")
+	assert.Equal(t, maxBaselines, ta.baselineCount())
+	assert.LessOrEqual(t, ta.seriesCount()+ta.baselineCount(), 2*maxSeries)
+}

--- a/orb-telemetry/snmp-telemetry/traps/export_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/export_test.go
@@ -90,17 +90,16 @@ func TestTally_ExportsThroughObservableCounters(t *testing.T) {
 	assert.Equal(t, int64(1), got["snmp.traps_datagrams"])
 }
 
-// The map is bounded from the network side. Past the cap, a series that does
-// not exist yet is counted under its policy's overflow series rather than
-// inserted, an existing series still counts, and a withdrawal frees room. The
-// cap is the SDK's cardinality limit, so nothing this tally exports is ever
-// folded by the SDK either.
+// The map is bounded from the network side. Real series stop at seriesLimit,
+// below the SDK's cardinality limit by a reserve; past it, a series that does
+// not exist yet is counted under its policy's overflow series, an existing
+// series still counts, and a withdrawal frees room.
 func TestTally_FoldsNewSeriesPastTheCap(t *testing.T) {
 	tally := NewTally(testLogger)
-	for i := range maxSeries {
+	for i := range seriesLimit {
 		tally.Received(fmt.Sprintf("10.%d.%d.%d", i>>16&255, i>>8&255, i&255), "core", "linkDown", V2c)
 	}
-	require.Equal(t, maxSeries, tally.seriesCount())
+	require.Equal(t, seriesLimit, tally.seriesCount())
 
 	tally.Received("192.0.2.1", "core", "linkUp", V2c)
 	assert.Equal(t, int64(0), tally.receivedCount("192.0.2.1", "core", "linkUp", V2c), "a new series past the cap is not inserted")
@@ -115,4 +114,25 @@ func TestTally_FoldsNewSeriesPastTheCap(t *testing.T) {
 	tally.Withdraw("core")
 	tally.Received("192.0.2.1", "core", "linkUp", V2c)
 	assert.Equal(t, int64(1), tally.receivedCount("192.0.2.1", "core", "linkUp", V2c), "withdrawal frees room")
+}
+
+// The overflow series live in the reserve, and the reserve is bounded too:
+// once it is down to the slots kept for the process-wide overflow series,
+// one per version, a policy whose overflow series does not exist yet is
+// counted there. So the map never holds more than the SDK's limit and the
+// SDK never folds a series the tally chose to keep.
+func TestTally_NeverExceedsTheCardinalityLimit(t *testing.T) {
+	tally := NewTally(testLogger)
+	for i := range seriesLimit {
+		tally.Received(fmt.Sprintf("10.%d.%d.%d", i>>16&255, i>>8&255, i&255), "core", "linkDown", V2c)
+	}
+	perPolicyRoom := maxSeries - versionCount - seriesLimit
+	extra := 10
+	for i := range perPolicyRoom + extra {
+		tally.Received("198.51.100.1", fmt.Sprintf("p%d", i), "linkUp", V2c)
+	}
+	assert.LessOrEqual(t, tally.seriesCount(), maxSeries)
+	assert.Equal(t, int64(1), tally.receivedCount(OtherName, "p0", OtherName, V2c), "the first overflowing policy got its own series")
+	assert.Equal(t, int64(0), tally.receivedCount(OtherName, fmt.Sprintf("p%d", perPolicyRoom), OtherName, V2c), "the first past the reserve did not")
+	assert.Equal(t, int64(extra), tally.receivedCount(OtherName, OtherName, OtherName, V2c), "and every one past the reserve counted process-wide")
 }

--- a/orb-telemetry/snmp-telemetry/traps/export_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/export_test.go
@@ -136,7 +136,9 @@ func TestTally_NeverExceedsTheCardinalityLimit(t *testing.T) {
 	assert.Equal(t, maxSeries, tally.seriesCount())
 	assert.Equal(t, int64(1), tally.receivedCount(OtherName, "p0", OtherName, V2c), "the first overflowing policy got its own series")
 	assert.Equal(t, int64(0), tally.receivedCount(OtherName, fmt.Sprintf("p%d", perPolicyRoom), OtherName, V2c), "the first past the reserve did not")
-	assert.Equal(t, int64(extra), tally.droppedCount(DropSeriesLimit), "and every one past the reserve is a series_limit drop")
+	assert.Equal(t, int64(0), tally.droppedCount(DropSeriesLimit), "the tally reports a refused count, the receiver decides whether the datagram is a drop")
+	assert.False(t, tally.Received("198.51.100.1", "p-late", "linkUp", V2c), "refused: no room for the policy's overflow series")
+	assert.True(t, tally.Received("198.51.100.1", "p0", "linkUp", V2c), "counted: this policy's overflow series exists")
 	assert.Equal(t, int64(0), tally.receivedCount(OtherName, OtherName, OtherName, V2c), "no series without a policy")
 
 	tally.Withdraw("p0")

--- a/orb-telemetry/snmp-telemetry/traps/export_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/export_test.go
@@ -317,3 +317,45 @@ func TestTally_BaselinesAreBounded(t *testing.T) {
 	assert.Equal(t, maxBaselines, ta.baselineCount())
 	assert.LessOrEqual(t, ta.seriesCount()+ta.baselineCount(), 2*maxSeries)
 }
+
+// The SDK keeps the last of its cardinality-limit slots for its own overflow
+// point, so a tally holding as many live series as the limit would have one
+// of them folded, losing its policy and device. The cap is one short of the
+// limit, and a provider configured exactly as this process configures its
+// own exports every live series with its attributes intact.
+func TestTally_LiveSeriesNeverReachTheSDKFold(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader), sdkmetric.WithCardinalityLimit(metrics.CardinalityLimit))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+	metrics.SetMeterForTest(provider.Meter("test"))
+	t.Cleanup(metrics.ResetMeter)
+
+	ta := NewTally(testLogger)
+	ta.Register()
+	t.Cleanup(ta.Close)
+	for i := range seriesLimit {
+		ta.Received(fmt.Sprintf("10.%d.%d.%d", i>>16&255, i>>8&255, i&255), "core", "linkDown", V2c)
+	}
+	for i := range maxSeries - seriesLimit {
+		ta.Received("198.51.100.1", fmt.Sprintf("p%d", i), "linkUp", V2c)
+	}
+	require.Equal(t, maxSeries, ta.seriesCount())
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	points := 0
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != receivedName {
+				continue
+			}
+			for _, dp := range m.Data.(metricdata.Sum[int64]).DataPoints {
+				points++
+				for _, kv := range dp.Attributes.ToSlice() {
+					assert.NotEqual(t, "otel.metric.overflow", string(kv.Key), "no live series was folded")
+				}
+			}
+		}
+	}
+	assert.Equal(t, maxSeries, points, "every live series exported with its attributes")
+}

--- a/orb-telemetry/snmp-telemetry/traps/names.go
+++ b/orb-telemetry/snmp-telemetry/traps/names.go
@@ -1,0 +1,40 @@
+package traps
+
+import "maps"
+
+// OtherName labels a trap whose OID is in neither the RFC 1215 table nor the
+// bundled definitions. It is the only label a sender cannot choose, which is
+// the point: a raw OID in a metric label is attacker-controlled and
+// unbounded, and the SDK folds everything past its cardinality limit into one
+// overflow bucket that answers no question at all.
+const OtherName = "other"
+
+// rfc1215 names the six generic traps by the OIDs RFC 3584 section 3.1(3)
+// assigns them. It takes precedence over the bundled definitions, one of which
+// maps 1.3.6.1.6.3.1.1.5.6 to authenticationFailure.
+var rfc1215 = map[string]string{
+	"1.3.6.1.6.3.1.1.5.1": "coldStart",
+	"1.3.6.1.6.3.1.1.5.2": "warmStart",
+	"1.3.6.1.6.3.1.1.5.3": "linkDown",
+	"1.3.6.1.6.3.1.1.5.4": "linkUp",
+	"1.3.6.1.6.3.1.1.5.5": "authenticationFailure",
+	"1.3.6.1.6.3.1.1.5.6": "egpNeighborLoss",
+}
+
+// BuildNames returns the closed set of trap names: the bundled definitions with
+// the RFC 1215 names laid over them. Keys are normalised OIDs with no leading
+// dot, which is what profiles.TrapNames produces and what Decode emits.
+func BuildNames(bundled map[string]string) map[string]string {
+	names := make(map[string]string, len(bundled)+len(rfc1215))
+	maps.Copy(names, bundled)
+	maps.Copy(names, rfc1215)
+	return names
+}
+
+// NameFor returns the closed-set name for an OID, or OtherName.
+func NameFor(names map[string]string, oid string) string {
+	if name, ok := names[oid]; ok {
+		return name
+	}
+	return OtherName
+}

--- a/orb-telemetry/snmp-telemetry/traps/names.go
+++ b/orb-telemetry/snmp-telemetry/traps/names.go
@@ -31,8 +31,13 @@ func BuildNames(bundled map[string]string) map[string]string {
 	return names
 }
 
-// NameFor returns the closed-set name for an OID, or OtherName.
+// NameFor returns the closed-set name for an OID, or OtherName. The RFC 1215
+// names take precedence over whatever a profile set calls the same OID, so a
+// per-policy name set does not have to carry them.
 func NameFor(names map[string]string, oid string) string {
+	if name, ok := rfc1215[oid]; ok {
+		return name
+	}
 	if name, ok := names[oid]; ok {
 		return name
 	}

--- a/orb-telemetry/snmp-telemetry/traps/names_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/names_test.go
@@ -1,0 +1,42 @@
+package traps
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The RFC 1215 table wins over the bundled definitions. The bundled cisco file
+// maps 1.3.6.1.6.3.1.1.5.6 to authenticationFailure; per RFC 3584 section
+// 3.1(3) it is egpNeighborLoss, and the vendored tree cannot be edited.
+func TestBuildNames_RFC1215WinsOverTheBundledFiles(t *testing.T) {
+	names := BuildNames(map[string]string{
+		"1.3.6.1.6.3.1.1.5.6":        "authenticationFailure",
+		"1.3.6.1.4.1.3375.2.4.0.144": "bigipTrafficGroupStandby",
+	})
+	assert.Equal(t, "egpNeighborLoss", names["1.3.6.1.6.3.1.1.5.6"])
+	assert.Equal(t, "bigipTrafficGroupStandby", names["1.3.6.1.4.1.3375.2.4.0.144"],
+		"a bundled name with no RFC counterpart is kept")
+}
+
+func TestBuildNames_CarriesAllSixGenericTraps(t *testing.T) {
+	names := BuildNames(nil)
+	want := map[string]string{
+		"1.3.6.1.6.3.1.1.5.1": "coldStart",
+		"1.3.6.1.6.3.1.1.5.2": "warmStart",
+		"1.3.6.1.6.3.1.1.5.3": "linkDown",
+		"1.3.6.1.6.3.1.1.5.4": "linkUp",
+		"1.3.6.1.6.3.1.1.5.5": "authenticationFailure",
+		"1.3.6.1.6.3.1.1.5.6": "egpNeighborLoss",
+	}
+	for oid, name := range want {
+		assert.Equal(t, name, names[oid], oid)
+	}
+}
+
+// A raw OID never becomes a label. Anything outside the closed set is "other".
+func TestNameFor_UnknownIsOther(t *testing.T) {
+	names := BuildNames(nil)
+	assert.Equal(t, OtherName, NameFor(names, "1.3.6.1.4.1.99999.0.7"))
+	assert.Equal(t, "linkDown", NameFor(names, "1.3.6.1.6.3.1.1.5.3"))
+}

--- a/orb-telemetry/snmp-telemetry/traps/packets_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/packets_test.go
@@ -55,6 +55,14 @@ func v2cTrap(community string) []byte {
 	return tlv(0x30, cat(berInt(1), berOctets(community), pdu))
 }
 
+// trapWithVersion is v2cTrap with the version integer chosen by the test:
+// 0 is v1, 1 is v2c, 3 is v3, and anything else is a version this backend
+// does not speak.
+func trapWithVersion(version int, community string) []byte {
+	pdu := tlv(0xa7, cat(berInt(1), berInt(0), berInt(0), linkDownVarbinds()))
+	return tlv(0x30, cat(berInt(version), berOctets(community), pdu))
+}
+
 // v2cInform is the same payload as an InformRequest-PDU (0xa6).
 func v2cInform(community string) []byte {
 	pdu := tlv(0xa6, cat(berInt(1), berInt(0), berInt(0), linkDownVarbinds()))

--- a/orb-telemetry/snmp-telemetry/traps/packets_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/packets_test.go
@@ -72,15 +72,17 @@ func v1Trap(community string, agentAddr [4]byte, generic, specific int) []byte {
 	return tlv(0x30, cat(berInt(0), berOctets(community), pdu))
 }
 
-// v3Unauthenticated is the engine discovery shape: version 3, an empty
-// authoritative engine ID, noAuthNoPriv flags, no authentication parameters,
-// and a plaintext scoped PDU carrying a trap. The username is a parameter
-// because gosnmp looks the datagram's username up in its credential table
-// before it parses anything else, so only a name the registry knows reaches
-// the parser at all. F1: gosnmp then accepts the packet without
-// authenticating it.
-func v3Unauthenticated(username string) []byte {
-	usm := tlv(0x30, cat(berOctets(""), berInt(0), berInt(0), berOctets(username), berOctets(""), berOctets("")))
+// v3Unauthenticated builds a version 3 packet with noAuthNoPriv message
+// flags, no authentication parameters, and a plaintext scoped PDU carrying a
+// trap. The username is a parameter because gosnmp looks the datagram's
+// username up in its credential table before it parses anything else, so only
+// a name the registry knows reaches the parser at all; the engine ID is a
+// parameter because F1 has two shapes. Empty gives the RFC 3414 engine
+// discovery shape. Non-empty gives the residual: gosnmp verifies no digest
+// when the flags do not ask it to, so a sender naming a known user is not
+// authenticated either way.
+func v3Unauthenticated(username, engineID string) []byte {
+	usm := tlv(0x30, cat(berOctets(engineID), berInt(0), berInt(0), berOctets(username), berOctets(""), berOctets("")))
 	globalData := tlv(0x30, cat(berInt(1), tlv(0x02, []byte{0x7f}), tlv(0x04, []byte{0x00}), berInt(3)))
 	pdu := tlv(0xa7, cat(berInt(1), berInt(0), berInt(0), linkDownVarbinds()))
 	scoped := tlv(0x30, cat(berOctets(""), berOctets(""), pdu))

--- a/orb-telemetry/snmp-telemetry/traps/packets_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/packets_test.go
@@ -134,6 +134,13 @@ func v3Unauthenticated(username, engineID string) []byte {
 // assembled by hand here.
 func v3AuthPrivTrap(t *testing.T, u V3User, engineID string) []byte {
 	t.Helper()
+	return v3AuthPrivTrapAt(t, u, engineID, 1, 1)
+}
+
+// v3AuthPrivTrapAt is v3AuthPrivTrap with the sending engine's boots and time
+// chosen by the test, which is what the receiver's time window judges.
+func v3AuthPrivTrapAt(t *testing.T, u V3User, engineID string, boots, engineTime uint32) []byte {
+	t.Helper()
 	authProto, err := snmp.AuthProtocol(u.AuthProtocol)
 	require.NoError(t, err)
 	privProto, err := snmp.PrivProtocol(u.PrivProtocol)
@@ -147,8 +154,8 @@ func v3AuthPrivTrap(t *testing.T, u V3User, engineID string) []byte {
 		PrivacyProtocol:          privProto,
 		PrivacyPassphrase:        u.PrivPassphrase,
 		AuthoritativeEngineID:    engineID,
-		AuthoritativeEngineBoots: 1,
-		AuthoritativeEngineTime:  1,
+		AuthoritativeEngineBoots: boots,
+		AuthoritativeEngineTime:  engineTime,
 		Logger:                   logger,
 	}
 	require.NoError(t, sp.InitSecurityKeys())

--- a/orb-telemetry/snmp-telemetry/traps/packets_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/packets_test.go
@@ -72,19 +72,48 @@ func v1Trap(community string, agentAddr [4]byte, generic, specific int) []byte {
 	return tlv(0x30, cat(berInt(0), berOctets(community), pdu))
 }
 
-// v3Unauthenticated builds a version 3 packet with noAuthNoPriv message
-// flags, no authentication parameters, and a plaintext scoped PDU carrying a
-// trap. The username is a parameter because gosnmp looks the datagram's
-// username up in its credential table before it parses anything else, so only
-// a name the registry knows reaches the parser at all; the engine ID is a
-// parameter because F1 has two shapes. Empty gives the RFC 3414 engine
-// discovery shape. Non-empty gives the residual: gosnmp verifies no digest
-// when the flags do not ask it to, so a sender naming a known user is not
-// authenticated either way.
+// v3Options describes a version 3 datagram to build. Every field is on the
+// wire rather than derived, because the receiver's v3 guards are all about
+// what a sender can choose to write there.
+type v3Options struct {
+	// username is a parameter because gosnmp looks the datagram's username up
+	// in its credential table before it parses anything else, so only a name
+	// the registry knows reaches the parser at all.
+	username string
+	// engineID is a parameter because F1 has two shapes. Empty gives the RFC
+	// 3414 engine discovery shape; non-empty gives its residual.
+	engineID string
+	// secModel is msgSecurityModel. 3 is the user security model, the only one
+	// gosnmp authenticates (F15).
+	secModel int
+	// flags is msgFlags. 0x01 is the auth bit, 0x03 authPriv.
+	flags byte
+	// authParamLen sizes msgAuthenticationParameters. SHA wants 12 bytes, and
+	// gosnmp writes that many back into the buffer when the auth bit is set.
+	authParamLen int
+	// truncateAfterUSM cuts the datagram off right after the USM parameter
+	// block, leaving no scoped PDU (F16).
+	truncateAfterUSM bool
+}
+
+// v3Packet builds a version 3 datagram with a plaintext scoped PDU carrying a
+// linkDown trap, unless it is truncated.
+func v3Packet(o v3Options) []byte {
+	authParams := make([]byte, o.authParamLen)
+	usm := tlv(0x30, cat(berOctets(o.engineID), berInt(0), berInt(0), berOctets(o.username), tlv(0x04, authParams), berOctets("")))
+	globalData := tlv(0x30, cat(berInt(1), tlv(0x02, []byte{0x7f}), tlv(0x04, []byte{o.flags}), berInt(o.secModel)))
+	body := cat(berInt(3), globalData, tlv(0x04, usm))
+	if !o.truncateAfterUSM {
+		pdu := tlv(0xa7, cat(berInt(1), berInt(0), berInt(0), linkDownVarbinds()))
+		body = cat(body, tlv(0x30, cat(berOctets(""), berOctets(""), pdu)))
+	}
+	return tlv(0x30, body)
+}
+
+// v3Unauthenticated is the noAuthNoPriv shape under the user security model:
+// no authentication parameters, and gosnmp verifies no digest when the flags
+// do not ask it to, so a sender naming a known user is not authenticated
+// either way.
 func v3Unauthenticated(username, engineID string) []byte {
-	usm := tlv(0x30, cat(berOctets(engineID), berInt(0), berInt(0), berOctets(username), berOctets(""), berOctets("")))
-	globalData := tlv(0x30, cat(berInt(1), tlv(0x02, []byte{0x7f}), tlv(0x04, []byte{0x00}), berInt(3)))
-	pdu := tlv(0xa7, cat(berInt(1), berInt(0), berInt(0), linkDownVarbinds()))
-	scoped := tlv(0x30, cat(berOctets(""), berOctets(""), pdu))
-	return tlv(0x30, cat(berInt(3), globalData, tlv(0x04, usm), scoped))
+	return v3Packet(v3Options{username: username, engineID: engineID, secModel: 3})
 }

--- a/orb-telemetry/snmp-telemetry/traps/packets_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/packets_test.go
@@ -45,6 +45,16 @@ var (
 	oidEnterprise = []byte{0x2b, 0x06, 0x01, 0x04, 0x01, 0x09}
 )
 
+// oidEnterpriseWidget is 1.3.6.1.4.1.9.9.999.0.1, an OID no bundled profile names.
+var oidEnterpriseWidget = []byte{0x2b, 0x06, 0x01, 0x04, 0x01, 0x09, 0x09, 0x87, 0x67, 0x00, 0x01}
+
+// v2cTrapWithOID is v2cTrap with the trap OID chosen by the test.
+func v2cTrapWithOID(community string, trapOID []byte) []byte {
+	varbinds := tlv(0x30, tlv(0x30, cat(tlv(0x06, oidSnmpTrapOID0), tlv(0x06, trapOID))))
+	pdu := tlv(0xa7, cat(berInt(1), berInt(0), berInt(0), varbinds))
+	return tlv(0x30, cat(berInt(1), berOctets(community), pdu))
+}
+
 func linkDownVarbinds() []byte {
 	return tlv(0x30, tlv(0x30, cat(tlv(0x06, oidSnmpTrapOID0), tlv(0x06, oidLinkDown))))
 }

--- a/orb-telemetry/snmp-telemetry/traps/packets_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/packets_test.go
@@ -1,5 +1,14 @@
 package traps
 
+import (
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/snmp"
+)
+
 // BER helpers for hand-built SNMP datagrams. Short-form lengths only, which
 // keeps every packet under 128 bytes and the encoder trivial.
 
@@ -116,4 +125,50 @@ func v3Packet(o v3Options) []byte {
 // either way.
 func v3Unauthenticated(username, engineID string) []byte {
 	return v3Packet(v3Options{username: username, engineID: engineID, secModel: 3})
+}
+
+// v3AuthPrivTrap marshals a genuinely authenticated and encrypted version 3
+// trap through gosnmp's own marshaller, so the acceptance path is exercised
+// against a packet built the way a device builds one, with a real digest over
+// the wire bytes and a real encrypted scoped PDU, rather than against a shape
+// assembled by hand here.
+func v3AuthPrivTrap(t *testing.T, u V3User, engineID string) []byte {
+	t.Helper()
+	authProto, err := snmp.AuthProtocol(u.AuthProtocol)
+	require.NoError(t, err)
+	privProto, err := snmp.PrivProtocol(u.PrivProtocol)
+	require.NoError(t, err)
+
+	logger := gosnmp.NewLogger(nil)
+	sp := &gosnmp.UsmSecurityParameters{
+		UserName:                 u.Username,
+		AuthenticationProtocol:   authProto,
+		AuthenticationPassphrase: u.AuthPassphrase,
+		PrivacyProtocol:          privProto,
+		PrivacyPassphrase:        u.PrivPassphrase,
+		AuthoritativeEngineID:    engineID,
+		AuthoritativeEngineBoots: 1,
+		AuthoritativeEngineTime:  1,
+		Logger:                   logger,
+	}
+	require.NoError(t, sp.InitSecurityKeys())
+
+	pkt := &gosnmp.SnmpPacket{
+		Version:            gosnmp.Version3,
+		MsgFlags:           gosnmp.AuthPriv,
+		SecurityModel:      gosnmp.UserSecurityModel,
+		SecurityParameters: sp,
+		MsgID:              1,
+		ContextEngineID:    engineID,
+		PDUType:            gosnmp.SNMPv2Trap,
+		RequestID:          1,
+		Logger:             logger,
+		Variables: []gosnmp.SnmpPDU{
+			{Name: ".1.3.6.1.2.1.1.3.0", Type: gosnmp.TimeTicks, Value: uint32(0)},
+			{Name: ".1.3.6.1.6.3.1.1.4.1.0", Type: gosnmp.ObjectIdentifier, Value: ".1.3.6.1.6.3.1.1.5.3"},
+		},
+	}
+	out, err := pkt.MarshalMsg()
+	require.NoError(t, err)
+	return out
 }

--- a/orb-telemetry/snmp-telemetry/traps/packets_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/packets_test.go
@@ -159,6 +159,18 @@ func v3AuthPrivTrap(t *testing.T, u V3User, engineID string) []byte {
 // chosen by the test, which is what the receiver's time window judges.
 func v3AuthPrivTrapAt(t *testing.T, u V3User, engineID string, boots, engineTime uint32) []byte {
 	t.Helper()
+	return v3TrapAt(t, u, engineID, boots, engineTime, gosnmp.AuthPriv)
+}
+
+// v3AuthNoPrivTrap is v3AuthPrivTrap at the authNoPriv level: a real digest
+// over the wire bytes and a plaintext scoped PDU.
+func v3AuthNoPrivTrap(t *testing.T, u V3User, engineID string) []byte {
+	t.Helper()
+	return v3TrapAt(t, u, engineID, 1, 1, gosnmp.AuthNoPriv)
+}
+
+func v3TrapAt(t *testing.T, u V3User, engineID string, boots, engineTime uint32, flags gosnmp.SnmpV3MsgFlags) []byte {
+	t.Helper()
 	authProto, err := snmp.AuthProtocol(u.AuthProtocol)
 	require.NoError(t, err)
 	privProto, err := snmp.PrivProtocol(u.PrivProtocol)
@@ -178,9 +190,13 @@ func v3AuthPrivTrapAt(t *testing.T, u V3User, engineID string, boots, engineTime
 	}
 	require.NoError(t, sp.InitSecurityKeys())
 
+	if flags&gosnmp.AuthPriv != gosnmp.AuthPriv {
+		sp.PrivacyProtocol = gosnmp.NoPriv
+		sp.PrivacyPassphrase = ""
+	}
 	pkt := &gosnmp.SnmpPacket{
 		Version:            gosnmp.Version3,
-		MsgFlags:           gosnmp.AuthPriv,
+		MsgFlags:           flags,
 		SecurityModel:      gosnmp.UserSecurityModel,
 		SecurityParameters: sp,
 		MsgID:              1,

--- a/orb-telemetry/snmp-telemetry/traps/packets_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/packets_test.go
@@ -1,0 +1,88 @@
+package traps
+
+// BER helpers for hand-built SNMP datagrams. Short-form lengths only, which
+// keeps every packet under 128 bytes and the encoder trivial.
+
+func tlv(tag byte, content []byte) []byte {
+	if len(content) > 127 {
+		panic("short form only")
+	}
+	return append([]byte{tag, byte(len(content))}, content...)
+}
+
+func berInt(n int) []byte {
+	if n < 0 || n > 127 {
+		panic("small non-negative ints only")
+	}
+	return tlv(0x02, []byte{byte(n)})
+}
+
+func berOctets(s string) []byte { return tlv(0x04, []byte(s)) }
+
+func cat(parts ...[]byte) []byte {
+	var out []byte
+	for _, p := range parts {
+		out = append(out, p...)
+	}
+	return out
+}
+
+var (
+	// 1.3.6.1.6.3.1.1.4.1.0, snmpTrapOID.0
+	oidSnmpTrapOID0 = []byte{0x2b, 0x06, 0x01, 0x06, 0x03, 0x01, 0x01, 0x04, 0x01, 0x00}
+	// 1.3.6.1.6.3.1.1.5.3, linkDown
+	oidLinkDown = []byte{0x2b, 0x06, 0x01, 0x06, 0x03, 0x01, 0x01, 0x05, 0x03}
+	// 1.3.6.1.4.1.9, an enterprise arc
+	oidEnterprise = []byte{0x2b, 0x06, 0x01, 0x04, 0x01, 0x09}
+)
+
+func linkDownVarbinds() []byte {
+	return tlv(0x30, tlv(0x30, cat(tlv(0x06, oidSnmpTrapOID0), tlv(0x06, oidLinkDown))))
+}
+
+// v2cTrap is an SNMPv2-Trap-PDU (0xa7) under version 1 (which is v2c on the wire).
+func v2cTrap(community string) []byte {
+	pdu := tlv(0xa7, cat(berInt(1), berInt(0), berInt(0), linkDownVarbinds()))
+	return tlv(0x30, cat(berInt(1), berOctets(community), pdu))
+}
+
+// v2cInform is the same payload as an InformRequest-PDU (0xa6).
+func v2cInform(community string) []byte {
+	pdu := tlv(0xa6, cat(berInt(1), berInt(0), berInt(0), linkDownVarbinds()))
+	return tlv(0x30, cat(berInt(1), berOctets(community), pdu))
+}
+
+// v2cGet is a GetRequest-PDU (0xa0), which is not a trap at all.
+func v2cGet(community string) []byte {
+	pdu := tlv(0xa0, cat(berInt(1), berInt(0), berInt(0), linkDownVarbinds()))
+	return tlv(0x30, cat(berInt(1), berOctets(community), pdu))
+}
+
+// v1Trap is a Trap-PDU (0xa4) under version 0: enterprise, agent-addr,
+// generic-trap, specific-trap, time-stamp, varbinds.
+func v1Trap(community string, agentAddr [4]byte, generic, specific int) []byte {
+	pdu := tlv(0xa4, cat(
+		tlv(0x06, oidEnterprise),
+		tlv(0x40, agentAddr[:]),
+		berInt(generic),
+		berInt(specific),
+		tlv(0x43, []byte{0x00}),
+		tlv(0x30, nil),
+	))
+	return tlv(0x30, cat(berInt(0), berOctets(community), pdu))
+}
+
+// v3Unauthenticated is the engine discovery shape: version 3, an empty
+// authoritative engine ID, noAuthNoPriv flags, no authentication parameters,
+// and a plaintext scoped PDU carrying a trap. The username is a parameter
+// because gosnmp looks the datagram's username up in its credential table
+// before it parses anything else, so only a name the registry knows reaches
+// the parser at all. F1: gosnmp then accepts the packet without
+// authenticating it.
+func v3Unauthenticated(username string) []byte {
+	usm := tlv(0x30, cat(berOctets(""), berInt(0), berInt(0), berOctets(username), berOctets(""), berOctets("")))
+	globalData := tlv(0x30, cat(berInt(1), tlv(0x02, []byte{0x7f}), tlv(0x04, []byte{0x00}), berInt(3)))
+	pdu := tlv(0xa7, cat(berInt(1), berInt(0), berInt(0), linkDownVarbinds()))
+	scoped := tlv(0x30, cat(berOctets(""), berOctets(""), pdu))
+	return tlv(0x30, cat(berInt(3), globalData, tlv(0x04, usm), scoped))
+}

--- a/orb-telemetry/snmp-telemetry/traps/pool.go
+++ b/orb-telemetry/snmp-telemetry/traps/pool.go
@@ -4,6 +4,8 @@ import (
 	"log/slog"
 	"net/netip"
 	"sync"
+
+	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/config"
 )
 
 // Pool opens one receiver per listen address and shares it between the
@@ -64,9 +66,9 @@ func (p *Pool) Acquire(listen, policy string, devices []Device, users []V3User) 
 		}
 		e = &poolEntry{receiver: rcv, registry: reg}
 		p.entries[listen] = e
-		p.logger.Info("Trap receiver listening", "address", rcv.Addr().String(), "policy", policy, "trap_names", len(p.names))
+		p.logger.Info("Trap receiver listening", "address", rcv.Addr().String(), "policy", config.SanitizeLogValue(policy), "trap_names", len(p.names))
 	} else {
-		p.logger.Debug("Policy joined an open trap socket", "address", listen, "policy", policy, "holders", e.refs+1)
+		p.logger.Debug("Policy joined an open trap socket", "address", config.SanitizeLogValue(listen), "policy", config.SanitizeLogValue(policy), "holders", e.refs+1)
 	}
 	e.registry.Register(policy, devices, users)
 	e.refs++
@@ -95,7 +97,7 @@ func (l *Lease) Release() {
 		// is spent outside the lock so another policy can acquire meanwhile.
 		if closing != nil {
 			closing.Stop()
-			p.logger.Info("Trap receiver closed", "address", l.listen)
+			p.logger.Info("Trap receiver closed", "address", config.SanitizeLogValue(l.listen))
 		}
 	})
 }

--- a/orb-telemetry/snmp-telemetry/traps/pool.go
+++ b/orb-telemetry/snmp-telemetry/traps/pool.go
@@ -118,12 +118,17 @@ func (l *Lease) Release() {
 		if e.refs == 0 {
 			delete(p.entries, l.listen)
 			closing = e.receiver
+			// Closed under the lock, because the entry is already out of the
+			// map: a policy acquiring the same string in the gap would bind
+			// while this socket was still open and fail with the operating
+			// system's address-in-use error.
+			closing.close()
 		}
 		p.mu.Unlock()
-		// Stopping waits for the read goroutine, up to its bound; that wait
-		// is spent outside the lock so another policy can acquire meanwhile.
+		// The wait for the read goroutine is spent outside the lock, so
+		// another policy can acquire meanwhile.
 		if closing != nil {
-			closing.Stop()
+			closing.wait()
 			p.logger.Info("Trap receiver closed", "address", config.SanitizeLogValue(l.listen))
 		}
 	})
@@ -136,9 +141,14 @@ func (p *Pool) Close() {
 	entries := p.entries
 	p.entries = make(map[string]*poolEntry)
 	p.closed = true
+	// Closed under the lock and waited for outside it, the same split Release
+	// makes, so no socket is left open once the map no longer names it.
+	for _, e := range entries {
+		e.receiver.close()
+	}
 	p.mu.Unlock()
 	for _, e := range entries {
-		e.receiver.Stop()
+		e.receiver.wait()
 	}
 }
 

--- a/orb-telemetry/snmp-telemetry/traps/pool.go
+++ b/orb-telemetry/snmp-telemetry/traps/pool.go
@@ -81,8 +81,12 @@ func (p *Pool) Acquire(listen, policy string, devices []Device, names map[string
 	} else {
 		p.logger.Debug("Policy joined an open trap socket", "address", config.SanitizeLogValue(listen), "policy", config.SanitizeLogValue(policy), "holders", e.refs+1)
 	}
-	e.registry.Register(policy, devices, names)
+	// Activated before the claims are published: a receiver already
+	// waiting on the registry lock counts the moment the claims land, and a
+	// count for a policy the tally still holds withdrawn would sit dormant
+	// until the same series key arrived again.
 	p.tally.Activate(policy)
+	e.registry.Register(policy, devices, names)
 	e.refs++
 	return &Lease{pool: p, entry: e, listen: listen, policy: policy}, nil
 }

--- a/orb-telemetry/snmp-telemetry/traps/pool.go
+++ b/orb-telemetry/snmp-telemetry/traps/pool.go
@@ -23,7 +23,6 @@ import (
 // traps arriving on another. The tally is shared: its series carry the policy.
 type Pool struct {
 	tally  *Tally
-	names  map[string]string
 	logger *slog.Logger
 
 	mu      sync.Mutex
@@ -48,10 +47,10 @@ type Lease struct {
 	once   sync.Once
 }
 
-// NewPool returns an empty pool. names is the closed trap-name set every
-// receiver labels with; tally is where every receiver counts.
-func NewPool(tally *Tally, names map[string]string, logger *slog.Logger) *Pool {
-	return &Pool{tally: tally, names: names, logger: logger, entries: make(map[string]*poolEntry)}
+// NewPool returns an empty pool. tally is where every receiver counts; trap
+// names come with each policy's claims.
+func NewPool(tally *Tally, logger *slog.Logger) *Pool {
+	return &Pool{tally: tally, logger: logger, entries: make(map[string]*poolEntry)}
 }
 
 // Acquire registers the policy's devices, each with its own v3 user, on the socket for listen,
@@ -63,7 +62,7 @@ func NewPool(tally *Tally, names map[string]string, logger *slog.Logger) *Pool {
 // replaces a policy's claims rather than accumulating them, so a second
 // acquire for the same pair would leave the policy holding the entry twice
 // while naming its devices once.
-func (p *Pool) Acquire(listen, policy string, devices []Device) (*Lease, error) {
+func (p *Pool) Acquire(listen, policy string, devices []Device, names map[string]string) (*Lease, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.closed {
@@ -72,17 +71,18 @@ func (p *Pool) Acquire(listen, policy string, devices []Device) (*Lease, error) 
 	e, ok := p.entries[listen]
 	if !ok {
 		reg := NewRegistry()
-		rcv, err := Listen(listen, reg, p.tally, p.names, p.logger)
+		rcv, err := Listen(listen, reg, p.tally, BuildNames(nil), p.logger)
 		if err != nil {
 			return nil, err
 		}
 		e = &poolEntry{receiver: rcv, registry: reg}
 		p.entries[listen] = e
-		p.logger.Info("Trap receiver listening", "address", rcv.Addr().String(), "policy", config.SanitizeLogValue(policy), "trap_names", len(p.names))
+		p.logger.Info("Trap receiver listening", "address", rcv.Addr().String(), "policy", config.SanitizeLogValue(policy))
 	} else {
 		p.logger.Debug("Policy joined an open trap socket", "address", config.SanitizeLogValue(listen), "policy", config.SanitizeLogValue(policy), "holders", e.refs+1)
 	}
-	e.registry.Register(policy, devices)
+	e.registry.Register(policy, devices, names)
+	p.tally.Activate(policy)
 	e.refs++
 	return &Lease{pool: p, entry: e, listen: listen, policy: policy}, nil
 }
@@ -186,13 +186,13 @@ func (p *Pool) lookup(listen string, a netip.Addr) []string {
 	return nil
 }
 
-func (p *Pool) register(listen, policy string, devices []Device) bool {
+func (p *Pool) register(listen, policy string, devices []Device, names map[string]string) bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	e, ok := p.entries[listen]
 	if !ok {
 		return false
 	}
-	e.registry.Register(policy, devices)
+	e.registry.Register(policy, devices, names)
 	return true
 }

--- a/orb-telemetry/snmp-telemetry/traps/pool.go
+++ b/orb-telemetry/snmp-telemetry/traps/pool.go
@@ -54,7 +54,7 @@ func NewPool(tally *Tally, names map[string]string, logger *slog.Logger) *Pool {
 	return &Pool{tally: tally, names: names, logger: logger, entries: make(map[string]*poolEntry)}
 }
 
-// Acquire registers the policy's devices and users on the socket for listen,
+// Acquire registers the policy's devices, each with its own v3 user, on the socket for listen,
 // binding it first when no policy holds it yet. A bind failure is returned as
 // Listen reports it and leaves the pool unchanged. A closed pool binds
 // nothing: the socket would have no one left to stop it.
@@ -63,7 +63,7 @@ func NewPool(tally *Tally, names map[string]string, logger *slog.Logger) *Pool {
 // replaces a policy's claims rather than accumulating them, so a second
 // acquire for the same pair would leave the policy holding the entry twice
 // while naming its devices once.
-func (p *Pool) Acquire(listen, policy string, devices []Device, users []V3User) (*Lease, error) {
+func (p *Pool) Acquire(listen, policy string, devices []Device) (*Lease, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if p.closed {
@@ -82,7 +82,7 @@ func (p *Pool) Acquire(listen, policy string, devices []Device, users []V3User) 
 	} else {
 		p.logger.Debug("Policy joined an open trap socket", "address", config.SanitizeLogValue(listen), "policy", config.SanitizeLogValue(policy), "holders", e.refs+1)
 	}
-	e.registry.Register(policy, devices, users)
+	e.registry.Register(policy, devices)
 	e.refs++
 	return &Lease{pool: p, entry: e, listen: listen, policy: policy}, nil
 }
@@ -186,13 +186,13 @@ func (p *Pool) lookup(listen string, a netip.Addr) []string {
 	return nil
 }
 
-func (p *Pool) register(listen, policy string, devices []Device, users []V3User) bool {
+func (p *Pool) register(listen, policy string, devices []Device) bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	e, ok := p.entries[listen]
 	if !ok {
 		return false
 	}
-	e.registry.Register(policy, devices, users)
+	e.registry.Register(policy, devices)
 	return true
 }

--- a/orb-telemetry/snmp-telemetry/traps/pool.go
+++ b/orb-telemetry/snmp-telemetry/traps/pool.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/netip"
 	"sync"
+	"time"
 
 	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/config"
 )
@@ -139,7 +140,9 @@ func (l *Lease) Release() {
 }
 
 // Close stops every receiver and refuses every later Acquire. Called once at
-// shutdown.
+// shutdown. The loops are waited for under one shared deadline rather than
+// one bound each in turn, so however many sockets the process holds, Close
+// spends at most the stop bound before the final flush that follows it.
 func (p *Pool) Close() {
 	p.mu.Lock()
 	entries := p.entries
@@ -151,9 +154,24 @@ func (p *Pool) Close() {
 		e.receiver.close()
 	}
 	p.mu.Unlock()
+	// A closed channel, not a time.After: that delivers once, and the first
+	// stalled receiver would drain it and leave the rest waiting forever.
+	expired := make(chan struct{})
+	timer := time.AfterFunc(stopTimeout, func() { close(expired) })
+	defer timer.Stop()
 	for _, e := range entries {
-		e.receiver.wait()
+		e.receiver.waitUntil(expired)
 	}
+}
+
+// receiver is a test accessor.
+func (p *Pool) receiver(listen string) *Receiver {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if e, ok := p.entries[listen]; ok {
+		return e.receiver
+	}
+	return nil
 }
 
 // Test accessors. Unexported and read under the lock.

--- a/orb-telemetry/snmp-telemetry/traps/pool.go
+++ b/orb-telemetry/snmp-telemetry/traps/pool.go
@@ -1,6 +1,7 @@
 package traps
 
 import (
+	"errors"
 	"log/slog"
 	"net/netip"
 	"sync"
@@ -27,6 +28,7 @@ type Pool struct {
 
 	mu      sync.Mutex
 	entries map[string]*poolEntry
+	closed  bool
 }
 
 type poolEntry struct {
@@ -40,6 +42,7 @@ type poolEntry struct {
 // the pool was closed, does nothing.
 type Lease struct {
 	pool   *Pool
+	entry  *poolEntry
 	listen string
 	policy string
 	once   sync.Once
@@ -53,10 +56,19 @@ func NewPool(tally *Tally, names map[string]string, logger *slog.Logger) *Pool {
 
 // Acquire registers the policy's devices and users on the socket for listen,
 // binding it first when no policy holds it yet. A bind failure is returned as
-// Listen reports it and leaves the pool unchanged.
+// Listen reports it and leaves the pool unchanged. A closed pool binds
+// nothing: the socket would have no one left to stop it.
+//
+// One lease per (listen, policy) pair is what the pool expects. The registry
+// replaces a policy's claims rather than accumulating them, so a second
+// acquire for the same pair would leave the policy holding the entry twice
+// while naming its devices once.
 func (p *Pool) Acquire(listen, policy string, devices []Device, users []V3User) (*Lease, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	if p.closed {
+		return nil, errors.New("trap pool is closed")
+	}
 	e, ok := p.entries[listen]
 	if !ok {
 		reg := NewRegistry()
@@ -72,25 +84,40 @@ func (p *Pool) Acquire(listen, policy string, devices []Device, users []V3User) 
 	}
 	e.registry.Register(policy, devices, users)
 	e.refs++
-	return &Lease{pool: p, listen: listen, policy: policy}, nil
+	return &Lease{pool: p, entry: e, listen: listen, policy: policy}, nil
 }
 
-// Release withdraws the policy. The tally is withdrawn even when the entry is
-// gone, so a policy released after Close still stops exporting.
+// Release withdraws the policy. The tally is withdrawn even when the entry
+// this lease held is gone, so a policy released after Close still stops
+// exporting.
+//
+// The entry is matched by identity, not by listen string alone. A pool that
+// was closed and then reopened, or any other path that replaces the entry
+// under a live lease, would otherwise have this release decrement a holder
+// count it never incremented and close a socket another policy is reading.
 func (l *Lease) Release() {
 	l.once.Do(func() {
 		p := l.pool
 		p.mu.Lock()
-		p.tally.Withdraw(l.policy)
 		e, ok := p.entries[l.listen]
+		if !ok || e != l.entry {
+			p.tally.Withdraw(l.policy)
+			p.mu.Unlock()
+			return
+		}
+		// The registry first, then the tally, so nothing is counted for a
+		// policy whose addresses the registry still answers for. The reverse
+		// window stays open: a datagram already past its lookup when the
+		// withdrawal runs can still count once for the released policy. That
+		// residual count is accepted, since closing it would mean holding a
+		// lock across the whole receive path.
+		e.registry.Withdraw(l.policy)
+		p.tally.Withdraw(l.policy)
+		e.refs--
 		var closing *Receiver
-		if ok {
-			e.registry.Withdraw(l.policy)
-			e.refs--
-			if e.refs == 0 {
-				delete(p.entries, l.listen)
-				closing = e.receiver
-			}
+		if e.refs == 0 {
+			delete(p.entries, l.listen)
+			closing = e.receiver
 		}
 		p.mu.Unlock()
 		// Stopping waits for the read goroutine, up to its bound; that wait
@@ -102,11 +129,13 @@ func (l *Lease) Release() {
 	})
 }
 
-// Close stops every receiver. Called once at shutdown.
+// Close stops every receiver and refuses every later Acquire. Called once at
+// shutdown.
 func (p *Pool) Close() {
 	p.mu.Lock()
 	entries := p.entries
 	p.entries = make(map[string]*poolEntry)
+	p.closed = true
 	p.mu.Unlock()
 	for _, e := range entries {
 		e.receiver.Stop()

--- a/orb-telemetry/snmp-telemetry/traps/pool.go
+++ b/orb-telemetry/snmp-telemetry/traps/pool.go
@@ -149,10 +149,19 @@ func (p *Pool) Close() {
 	p.entries = make(map[string]*poolEntry)
 	p.closed = true
 	// Closed under the lock and waited for outside it, the same split Release
-	// makes, so no socket is left open once the map no longer names it.
+	// makes, so no socket is left open once the map no longer names it. The
+	// closes run concurrently: each waits for its receiver's intake section,
+	// up to an acknowledgement write, and fifty busy sockets must cost the
+	// slowest one's wait, not the sum.
+	var closing sync.WaitGroup
 	for _, e := range entries {
-		e.receiver.close()
+		closing.Add(1)
+		go func(r *Receiver) {
+			defer closing.Done()
+			r.close()
+		}(e.receiver)
 	}
+	closing.Wait()
 	p.mu.Unlock()
 	// A closed channel, not a time.After: that delivers once, and the first
 	// stalled receiver would drain it and leave the rest waiting forever.

--- a/orb-telemetry/snmp-telemetry/traps/pool.go
+++ b/orb-telemetry/snmp-telemetry/traps/pool.go
@@ -1,0 +1,157 @@
+package traps
+
+import (
+	"log/slog"
+	"net/netip"
+	"sync"
+)
+
+// Pool opens one receiver per listen address and shares it between the
+// policies that name that address, the way pktvisor shares one input stream
+// between the policies that name one tap with one configuration.
+//
+// The listen string is the identity, verbatim. "0.0.0.0:162" twice is one
+// socket; "0.0.0.0:162" and ":162" are two bind attempts at one port and the
+// second fails with the operating system's error. The strings are not
+// normalised, because normalising would make sharing depend on a rule an
+// operator cannot see in their own YAML.
+//
+// Each entry has its own registry, so a policy on one socket never attributes
+// traps arriving on another. The tally is shared: its series carry the policy.
+type Pool struct {
+	tally  *Tally
+	names  map[string]string
+	logger *slog.Logger
+
+	mu      sync.Mutex
+	entries map[string]*poolEntry
+}
+
+type poolEntry struct {
+	receiver *Receiver
+	registry *Registry
+	refs     int
+}
+
+// Lease is one policy's hold on one socket. Release withdraws the policy and
+// closes the socket when it was the last holder. Releasing twice, or after
+// the pool was closed, does nothing.
+type Lease struct {
+	pool   *Pool
+	listen string
+	policy string
+	once   sync.Once
+}
+
+// NewPool returns an empty pool. names is the closed trap-name set every
+// receiver labels with; tally is where every receiver counts.
+func NewPool(tally *Tally, names map[string]string, logger *slog.Logger) *Pool {
+	return &Pool{tally: tally, names: names, logger: logger, entries: make(map[string]*poolEntry)}
+}
+
+// Acquire registers the policy's devices and users on the socket for listen,
+// binding it first when no policy holds it yet. A bind failure is returned as
+// Listen reports it and leaves the pool unchanged.
+func (p *Pool) Acquire(listen, policy string, devices []Device, users []V3User) (*Lease, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	e, ok := p.entries[listen]
+	if !ok {
+		reg := NewRegistry()
+		rcv, err := Listen(listen, reg, p.tally, p.names, p.logger)
+		if err != nil {
+			return nil, err
+		}
+		e = &poolEntry{receiver: rcv, registry: reg}
+		p.entries[listen] = e
+		p.logger.Info("Trap receiver listening", "address", rcv.Addr().String(), "policy", policy, "trap_names", len(p.names))
+	} else {
+		p.logger.Debug("Policy joined an open trap socket", "address", listen, "policy", policy, "holders", e.refs+1)
+	}
+	e.registry.Register(policy, devices, users)
+	e.refs++
+	return &Lease{pool: p, listen: listen, policy: policy}, nil
+}
+
+// Release withdraws the policy. The tally is withdrawn even when the entry is
+// gone, so a policy released after Close still stops exporting.
+func (l *Lease) Release() {
+	l.once.Do(func() {
+		p := l.pool
+		p.mu.Lock()
+		p.tally.Withdraw(l.policy)
+		e, ok := p.entries[l.listen]
+		var closing *Receiver
+		if ok {
+			e.registry.Withdraw(l.policy)
+			e.refs--
+			if e.refs == 0 {
+				delete(p.entries, l.listen)
+				closing = e.receiver
+			}
+		}
+		p.mu.Unlock()
+		// Stopping waits for the read goroutine, up to its bound; that wait
+		// is spent outside the lock so another policy can acquire meanwhile.
+		if closing != nil {
+			closing.Stop()
+			p.logger.Info("Trap receiver closed", "address", l.listen)
+		}
+	})
+}
+
+// Close stops every receiver. Called once at shutdown.
+func (p *Pool) Close() {
+	p.mu.Lock()
+	entries := p.entries
+	p.entries = make(map[string]*poolEntry)
+	p.mu.Unlock()
+	for _, e := range entries {
+		e.receiver.Stop()
+	}
+}
+
+// Test accessors. Unexported and read under the lock.
+func (p *Pool) size() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.entries)
+}
+
+func (p *Pool) refs(listen string) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if e, ok := p.entries[listen]; ok {
+		return e.refs
+	}
+	return 0
+}
+
+func (p *Pool) addr(listen string) (netip.AddrPort, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if e, ok := p.entries[listen]; ok {
+		return e.receiver.Addr(), true
+	}
+	return netip.AddrPort{}, false
+}
+
+func (p *Pool) lookup(listen string, a netip.Addr) []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if e, ok := p.entries[listen]; ok {
+		return e.registry.Lookup(a)
+	}
+	return nil
+}
+
+func (p *Pool) register(listen, policy string, devices []Device, users []V3User) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	e, ok := p.entries[listen]
+	if !ok {
+		return false
+	}
+	e.registry.Register(policy, devices, users)
+	return true
+}

--- a/orb-telemetry/snmp-telemetry/traps/pool_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/pool_test.go
@@ -25,7 +25,7 @@ func TestPool_FirstAcquireBindsAndCountsATrapForThePolicy(t *testing.T) {
 	p := NewPool(tally, BuildNames(nil), testLogger)
 	t.Cleanup(p.Close)
 
-	lease, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
+	lease, err := p.Acquire("127.0.0.1:0", "core", nil)
 	require.NoError(t, err)
 	t.Cleanup(lease.Release)
 	require.Equal(t, 1, p.size())
@@ -34,7 +34,7 @@ func TestPool_FirstAcquireBindsAndCountsATrapForThePolicy(t *testing.T) {
 
 	src, conn := senderAddr(t, addr)
 	// Register the sender's address under the policy so the trap is known.
-	require.True(t, p.register("127.0.0.1:0", "core", []Device{{Policy: "core", Addr: src}}, nil))
+	require.True(t, p.register("127.0.0.1:0", "core", []Device{{Policy: "core", Addr: src}}))
 	_, err = conn.Write(v2cTrap("public"))
 	require.NoError(t, err)
 	waitFor(t, 1, func() int64 { return tally.receivedCount(src.String(), "core", "linkDown", V2c) })
@@ -44,10 +44,10 @@ func TestPool_SameStringSharesOneSocket(t *testing.T) {
 	p := NewPool(NewTally(testLogger), BuildNames(nil), testLogger)
 	t.Cleanup(p.Close)
 
-	a, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
+	a, err := p.Acquire("127.0.0.1:0", "core", nil)
 	require.NoError(t, err)
 	addrA, _ := p.addr("127.0.0.1:0")
-	b, err := p.Acquire("127.0.0.1:0", "edge", nil, nil)
+	b, err := p.Acquire("127.0.0.1:0", "edge", nil)
 	require.NoError(t, err)
 	addrB, _ := p.addr("127.0.0.1:0")
 
@@ -67,9 +67,9 @@ func TestPool_ReleaseWithdrawsThePolicyFromRegistryAndTally(t *testing.T) {
 	p := NewPool(tally, BuildNames(nil), testLogger)
 	t.Cleanup(p.Close)
 
-	core, err := p.Acquire("127.0.0.1:0", "core", []Device{{Policy: "core", Addr: netip.MustParseAddr("10.0.0.5")}}, nil)
+	core, err := p.Acquire("127.0.0.1:0", "core", []Device{{Policy: "core", Addr: netip.MustParseAddr("10.0.0.5")}})
 	require.NoError(t, err)
-	edge, err := p.Acquire("127.0.0.1:0", "edge", []Device{{Policy: "edge", Addr: netip.MustParseAddr("10.0.0.6")}}, nil)
+	edge, err := p.Acquire("127.0.0.1:0", "edge", []Device{{Policy: "edge", Addr: netip.MustParseAddr("10.0.0.6")}})
 	require.NoError(t, err)
 	t.Cleanup(edge.Release)
 	tally.Received("10.0.0.5", "core", "linkDown", V2c)
@@ -90,11 +90,11 @@ func TestPool_CollisionFailsTheSecondAndKeepsTheFirst(t *testing.T) {
 
 	p := NewPool(NewTally(testLogger), BuildNames(nil), testLogger)
 	t.Cleanup(p.Close)
-	first, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
+	first, err := p.Acquire("127.0.0.1:0", "core", nil)
 	require.NoError(t, err)
 	t.Cleanup(first.Release)
 
-	_, err = p.Acquire(taken, "edge", nil, nil)
+	_, err = p.Acquire(taken, "edge", nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "binding trap socket "+taken)
 	assert.Equal(t, 1, p.size(), "the failed acquire left no entry")
@@ -105,14 +105,14 @@ func TestPool_LastReleaseClosesAndAcquireBindsAgain(t *testing.T) {
 	p := NewPool(NewTally(testLogger), BuildNames(nil), testLogger)
 	t.Cleanup(p.Close)
 
-	lease, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
+	lease, err := p.Acquire("127.0.0.1:0", "core", nil)
 	require.NoError(t, err)
 	before, _ := p.addr("127.0.0.1:0")
 	lease.Release()
 	lease.Release() // idempotent
 	require.Equal(t, 0, p.size())
 
-	again, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
+	again, err := p.Acquire("127.0.0.1:0", "core", nil)
 	require.NoError(t, err)
 	t.Cleanup(again.Release)
 	after, ok := p.addr("127.0.0.1:0")
@@ -125,9 +125,9 @@ func TestPool_LastReleaseClosesAndAcquireBindsAgain(t *testing.T) {
 
 func TestPool_CloseStopsEverythingAndLaterReleaseIsHarmless(t *testing.T) {
 	p := NewPool(NewTally(testLogger), BuildNames(nil), testLogger)
-	a, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
+	a, err := p.Acquire("127.0.0.1:0", "core", nil)
 	require.NoError(t, err)
-	b, err := p.Acquire("[::1]:0", "edge", nil, nil)
+	b, err := p.Acquire("[::1]:0", "edge", nil)
 	require.NoError(t, err)
 	require.Equal(t, 2, p.size())
 
@@ -146,7 +146,7 @@ func TestPool_StaleLeaseDoesNotTouchAFreshEntry(t *testing.T) {
 	p := NewPool(tally, BuildNames(nil), testLogger)
 	t.Cleanup(p.Close)
 
-	stale, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
+	stale, err := p.Acquire("127.0.0.1:0", "core", nil)
 	require.NoError(t, err)
 	p.Close()
 	// Close refuses every later Acquire, which is what keeps this sequence out
@@ -157,7 +157,7 @@ func TestPool_StaleLeaseDoesNotTouchAFreshEntry(t *testing.T) {
 	p.closed = false
 	p.mu.Unlock()
 
-	fresh, err := p.Acquire("127.0.0.1:0", "edge", nil, nil)
+	fresh, err := p.Acquire("127.0.0.1:0", "edge", nil)
 	require.NoError(t, err)
 	t.Cleanup(fresh.Release)
 	addr, ok := p.addr("127.0.0.1:0")
@@ -168,7 +168,7 @@ func TestPool_StaleLeaseDoesNotTouchAFreshEntry(t *testing.T) {
 	assert.Equal(t, 1, p.size(), "the fresh entry is still in the pool")
 	assert.Equal(t, 1, p.refs("127.0.0.1:0"), "with the holder it counted for itself")
 	src, conn := senderAddr(t, addr)
-	require.True(t, p.register("127.0.0.1:0", "edge", []Device{{Policy: "edge", Addr: src}}, nil))
+	require.True(t, p.register("127.0.0.1:0", "edge", []Device{{Policy: "edge", Addr: src}}))
 	_, err = conn.Write(v2cTrap("public"))
 	require.NoError(t, err)
 	waitFor(t, 1, func() int64 { return tally.receivedCount(src.String(), "edge", "linkDown", V2c) })
@@ -180,7 +180,7 @@ func TestPool_AcquireAfterCloseFails(t *testing.T) {
 	p := NewPool(NewTally(testLogger), BuildNames(nil), testLogger)
 	p.Close()
 
-	lease, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
+	lease, err := p.Acquire("127.0.0.1:0", "core", nil)
 	require.Error(t, err)
 	assert.Nil(t, lease)
 	assert.Contains(t, err.Error(), "trap pool is closed")
@@ -202,11 +202,11 @@ func TestPool_ReacquireAfterLastReleaseNeverSeesAddressInUse(t *testing.T) {
 	p := NewPool(NewTally(testLogger), BuildNames(nil), testLogger)
 	t.Cleanup(p.Close)
 	for i := range 50 {
-		lease, err := p.Acquire(listen, "core", nil, nil)
+		lease, err := p.Acquire(listen, "core", nil)
 		require.NoErrorf(t, err, "acquire %d of %s", i, listen)
 		lease.Release()
 	}
-	final, err := p.Acquire(listen, "core", nil, nil)
+	final, err := p.Acquire(listen, "core", nil)
 	require.NoError(t, err)
 	t.Cleanup(final.Release)
 	assert.Equal(t, 1, p.refs(listen))
@@ -231,7 +231,7 @@ func TestPool_ConcurrentReacquireNeverSeesAddressInUse(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for range 500 {
-				lease, err := p.Acquire(listen, "core", nil, nil)
+				lease, err := p.Acquire(listen, "core", nil)
 				if err != nil {
 					failures.Add(1)
 					continue
@@ -256,17 +256,17 @@ func TestPool_SocketsAreIsolated(t *testing.T) {
 	p := NewPool(tally, BuildNames(nil), testLogger)
 	t.Cleanup(p.Close)
 
-	core, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
+	core, err := p.Acquire("127.0.0.1:0", "core", nil)
 	require.NoError(t, err)
 	t.Cleanup(core.Release)
-	edge, err := p.Acquire("[::1]:0", "edge", nil, nil)
+	edge, err := p.Acquire("[::1]:0", "edge", nil)
 	require.NoError(t, err)
 	t.Cleanup(edge.Release)
 
 	coreAddr, ok := p.addr("127.0.0.1:0")
 	require.True(t, ok)
 	src, conn := senderAddr(t, coreAddr)
-	require.True(t, p.register("[::1]:0", "edge", []Device{{Policy: "edge", Addr: src}}, nil))
+	require.True(t, p.register("[::1]:0", "edge", []Device{{Policy: "edge", Addr: src}}))
 	require.Empty(t, p.lookup("127.0.0.1:0", src), "the other socket's entry never learned the address")
 
 	_, err = conn.Write(v2cTrap("public"))

--- a/orb-telemetry/snmp-telemetry/traps/pool_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/pool_test.go
@@ -336,3 +336,42 @@ func TestPool_CloseWaitsUnderOneSharedDeadline(t *testing.T) {
 	assert.Less(t, elapsed, 2*stopTimeout, "five stalled receivers cost one bound, not five")
 	assert.GreaterOrEqual(t, elapsed, stopTimeout, "and the bound was actually waited")
 }
+
+// Close closes every receiver concurrently, so the time it spends waiting
+// on receivers busy inside an intake section is the slowest one's, not the
+// sum: fifty busy sockets must not spend the agent's grace period.
+func TestPool_ClosesReceiversConcurrently(t *testing.T) {
+	tally := NewTally(testLogger)
+	p := NewPool(tally, testLogger)
+	const sockets = 5
+	const park = 200 * time.Millisecond
+	listens := make([]string, sockets)
+	for i := range sockets {
+		listens[i] = fmt.Sprintf("127.0.0.1:0#%d", i)
+	}
+	// Each socket needs its own listen string to be its own entry; the
+	// kernel-chosen port makes "127.0.0.1:0" the same entry every time, so
+	// the entries are bound one at a time on real ports.
+	for i := range sockets {
+		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+		require.NoError(t, err)
+		listens[i] = conn.LocalAddr().String()
+		_ = conn.Close()
+		lease, err := p.Acquire(listens[i], fmt.Sprintf("p%d", i), nil, nil)
+		require.NoError(t, err)
+		t.Cleanup(lease.Release)
+		addr, ok := p.addr(listens[i])
+		require.True(t, ok)
+		src, sender := senderAddr(t, addr)
+		require.True(t, p.register(listens[i], fmt.Sprintf("p%d", i), []Device{{Policy: fmt.Sprintf("p%d", i), Addr: src}}, nil))
+		p.receiver(listens[i]).setDuringCount(func() { time.Sleep(park) })
+		_, err = sender.Write(v2cTrap("public"))
+		require.NoError(t, err)
+	}
+	time.Sleep(20 * time.Millisecond)
+	started := time.Now()
+	p.Close()
+	elapsed := time.Since(started)
+	assert.Less(t, elapsed, park+stopTimeout+150*time.Millisecond, "closed concurrently: %s", elapsed)
+	assert.Equal(t, 0, p.size())
+}

--- a/orb-telemetry/snmp-telemetry/traps/pool_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/pool_test.go
@@ -135,3 +135,52 @@ func TestPool_CloseStopsEverythingAndLaterReleaseIsHarmless(t *testing.T) {
 	assert.NotPanics(t, b.Release)
 	assert.NotPanics(t, p.Close)
 }
+
+// A lease whose entry was replaced under it must not touch the replacement.
+// Releasing it decrements nothing and closes nothing: the socket it names now
+// belongs to another policy.
+func TestPool_StaleLeaseDoesNotTouchAFreshEntry(t *testing.T) {
+	tally := NewTally(testLogger)
+	p := NewPool(tally, BuildNames(nil), testLogger)
+	t.Cleanup(p.Close)
+
+	stale, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
+	require.NoError(t, err)
+	p.Close()
+	// Close refuses every later Acquire, which is what keeps this sequence out
+	// of the running agent. The flag is cleared here to reach the case the
+	// flag does not cover: an entry replaced under a lease still naming the
+	// old one.
+	p.mu.Lock()
+	p.closed = false
+	p.mu.Unlock()
+
+	fresh, err := p.Acquire("127.0.0.1:0", "edge", nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(fresh.Release)
+	addr, ok := p.addr("127.0.0.1:0")
+	require.True(t, ok)
+
+	stale.Release()
+
+	assert.Equal(t, 1, p.size(), "the fresh entry is still in the pool")
+	assert.Equal(t, 1, p.refs("127.0.0.1:0"), "with the holder it counted for itself")
+	src, conn := senderAddr(t, addr)
+	require.True(t, p.register("127.0.0.1:0", "edge", []Device{{Policy: "edge", Addr: src}}, nil))
+	_, err = conn.Write(v2cTrap("public"))
+	require.NoError(t, err)
+	waitFor(t, 1, func() int64 { return tally.receivedCount(src.String(), "edge", "linkDown", V2c) })
+}
+
+// Acquiring after Close binds nothing. The socket would have no one left to
+// stop it, since Close is what stops them and it has already run.
+func TestPool_AcquireAfterCloseFails(t *testing.T) {
+	p := NewPool(NewTally(testLogger), BuildNames(nil), testLogger)
+	p.Close()
+
+	lease, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
+	require.Error(t, err)
+	assert.Nil(t, lease)
+	assert.Contains(t, err.Error(), "trap pool is closed")
+	assert.Equal(t, 0, p.size(), "and left no entry behind")
+}

--- a/orb-telemetry/snmp-telemetry/traps/pool_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/pool_test.go
@@ -243,3 +243,35 @@ func TestPool_ConcurrentReacquireNeverSeesAddressInUse(t *testing.T) {
 	wg.Wait()
 	assert.Equal(t, int64(0), failures.Load(), "a bind failed while another holder's socket was still closing")
 }
+
+// Each entry has its own registry, which is what keeps a policy on one socket
+// from attributing traps that arrived on another. An address registered only
+// on the second socket's entry is unknown to the first, so a trap from it is
+// dropped there rather than counted for the policy that named it elsewhere.
+//
+// The second address is the IPv6 loopback rather than another 127/8 address,
+// because macOS has only 127.0.0.1 on lo0 and a bind of 127.0.0.2 fails.
+func TestPool_SocketsAreIsolated(t *testing.T) {
+	tally := NewTally(testLogger)
+	p := NewPool(tally, BuildNames(nil), testLogger)
+	t.Cleanup(p.Close)
+
+	core, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(core.Release)
+	edge, err := p.Acquire("[::1]:0", "edge", nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(edge.Release)
+
+	coreAddr, ok := p.addr("127.0.0.1:0")
+	require.True(t, ok)
+	src, conn := senderAddr(t, coreAddr)
+	require.True(t, p.register("[::1]:0", "edge", []Device{{Policy: "edge", Addr: src}}, nil))
+	require.Empty(t, p.lookup("127.0.0.1:0", src), "the other socket's entry never learned the address")
+
+	_, err = conn.Write(v2cTrap("public"))
+	require.NoError(t, err)
+	waitFor(t, 1, func() int64 { return tally.droppedCount(DropUnknownSource) })
+	assert.Equal(t, int64(0), tally.receivedCount(src.String(), "edge", "linkDown", V2c),
+		"a trap on one socket is never attributed to a policy registered on another")
+}

--- a/orb-telemetry/snmp-telemetry/traps/pool_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/pool_test.go
@@ -1,11 +1,13 @@
 package traps
 
 import (
+	"fmt"
 	"net"
 	"net/netip"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -295,4 +297,42 @@ func TestPool_ReacquireActivatesThePolicysSeries(t *testing.T) {
 	t.Cleanup(again.Release)
 	tally.Received("10.0.0.5", "core", "linkDown", V2c)
 	assert.Equal(t, int64(3), tally.receivedCount("10.0.0.5", "core", "linkDown", V2c), "live again with every count kept")
+}
+
+// Close waits for every receiver under one shared deadline, not one bound
+// per receiver in turn, so however many sockets a process holds, shutdown
+// spends at most the stop bound before the final flush.
+func TestPool_CloseWaitsUnderOneSharedDeadline(t *testing.T) {
+	p := NewPool(NewTally(testLogger), testLogger)
+	const sockets = 5
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	for i := range sockets {
+		// A distinct free port per socket, so each is its own entry.
+		probe, err := net.ListenPacket("udp", "127.0.0.1:0")
+		require.NoError(t, err)
+		listen := probe.LocalAddr().String()
+		require.NoError(t, probe.Close())
+		lease, err := p.Acquire(listen, fmt.Sprintf("p%d", i), nil, nil)
+		require.NoError(t, err)
+		t.Cleanup(lease.Release)
+		addr, ok := p.addr(listen)
+		require.True(t, ok)
+		// Park each receiver's goroutine after a parse, so none can exit
+		// within the bound.
+		entered := make(chan struct{})
+		rcv := p.receiver(listen)
+		rcv.setBeforeCount(func() { close(entered); <-release })
+		src, conn := senderAddr(t, addr)
+		require.True(t, p.register(listen, fmt.Sprintf("p%d", i), []Device{{Policy: fmt.Sprintf("p%d", i), Addr: src}}, nil))
+		_, err = conn.Write(v2cTrap("public"))
+		require.NoError(t, err)
+		<-entered
+	}
+
+	started := time.Now()
+	p.Close()
+	elapsed := time.Since(started)
+	assert.Less(t, elapsed, 2*stopTimeout, "five stalled receivers cost one bound, not five")
+	assert.GreaterOrEqual(t, elapsed, stopTimeout, "and the bound was actually waited")
 }

--- a/orb-telemetry/snmp-telemetry/traps/pool_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/pool_test.go
@@ -337,41 +337,63 @@ func TestPool_CloseWaitsUnderOneSharedDeadline(t *testing.T) {
 	assert.GreaterOrEqual(t, elapsed, stopTimeout, "and the bound was actually waited")
 }
 
-// Close closes every receiver concurrently, so the time it spends waiting
-// on receivers busy inside an intake section is the slowest one's, not the
-// sum: fifty busy sockets must not spend the agent's grace period.
+// Close asks every receiver to close at once rather than one after another,
+// so a shutdown waits for the slowest busy socket, not the sum. Each
+// receiver here is parked inside its intake section; a close asked of it
+// begins, and is visible as begun, before it can take the intake lock. With
+// concurrent closes every receiver is asked while all of them are parked;
+// sequential closes would ask the second only after the first was released.
 func TestPool_ClosesReceiversConcurrently(t *testing.T) {
 	tally := NewTally(testLogger)
 	p := NewPool(tally, testLogger)
 	const sockets = 5
-	const park = 200 * time.Millisecond
-	listens := make([]string, sockets)
-	for i := range sockets {
-		listens[i] = fmt.Sprintf("127.0.0.1:0#%d", i)
-	}
-	// Each socket needs its own listen string to be its own entry; the
-	// kernel-chosen port makes "127.0.0.1:0" the same entry every time, so
-	// the entries are bound one at a time on real ports.
+	release := make(chan struct{})
+	var parked atomic.Int32
+	receivers := make([]*Receiver, 0, sockets)
 	for i := range sockets {
 		conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
 		require.NoError(t, err)
-		listens[i] = conn.LocalAddr().String()
+		listen := conn.LocalAddr().String()
 		_ = conn.Close()
-		lease, err := p.Acquire(listens[i], fmt.Sprintf("p%d", i), nil, nil)
+		policy := fmt.Sprintf("p%d", i)
+		lease, err := p.Acquire(listen, policy, nil, nil)
 		require.NoError(t, err)
 		t.Cleanup(lease.Release)
-		addr, ok := p.addr(listens[i])
+		addr, ok := p.addr(listen)
 		require.True(t, ok)
 		src, sender := senderAddr(t, addr)
-		require.True(t, p.register(listens[i], fmt.Sprintf("p%d", i), []Device{{Policy: fmt.Sprintf("p%d", i), Addr: src}}, nil))
-		p.receiver(listens[i]).setDuringCount(func() { time.Sleep(park) })
+		require.True(t, p.register(listen, policy, []Device{{Policy: policy, Addr: src}}, nil))
+		r := p.receiver(listen)
+		r.setBeforeAccount(func() {
+			parked.Add(1)
+			<-release
+		})
+		receivers = append(receivers, r)
 		_, err = sender.Write(v2cTrap("public"))
 		require.NoError(t, err)
 	}
-	time.Sleep(20 * time.Millisecond)
-	started := time.Now()
-	p.Close()
-	elapsed := time.Since(started)
-	assert.Less(t, elapsed, park+stopTimeout+150*time.Millisecond, "closed concurrently: %s", elapsed)
+	waitFor(t, sockets, func() int64 { return int64(parked.Load()) })
+
+	closed := make(chan struct{})
+	go func() {
+		defer close(closed)
+		p.Close()
+	}()
+	// Every receiver is asked to close while all of them are still parked.
+	waitFor(t, sockets, func() int64 {
+		n := int64(0)
+		for _, r := range receivers {
+			if r.closeRequested() {
+				n++
+			}
+		}
+		return n
+	})
+	close(release)
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not return once the receivers were released")
+	}
 	assert.Equal(t, 0, p.size())
 }

--- a/orb-telemetry/snmp-telemetry/traps/pool_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/pool_test.go
@@ -1,0 +1,137 @@
+package traps
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// senderAddr is the address a loopback sender will have, without sending.
+func senderAddr(t *testing.T, addr netip.AddrPort) (netip.Addr, *net.UDPConn) {
+	t.Helper()
+	conn, err := net.DialUDP("udp", nil, net.UDPAddrFromAddrPort(addr))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return canonical(conn.LocalAddr().(*net.UDPAddr).AddrPort().Addr()), conn
+}
+
+func TestPool_FirstAcquireBindsAndCountsATrapForThePolicy(t *testing.T) {
+	tally := NewTally(testLogger)
+	p := NewPool(tally, BuildNames(nil), testLogger)
+	t.Cleanup(p.Close)
+
+	lease, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(lease.Release)
+	require.Equal(t, 1, p.size())
+	addr, ok := p.addr("127.0.0.1:0")
+	require.True(t, ok)
+
+	src, conn := senderAddr(t, addr)
+	// Register the sender's address under the policy so the trap is known.
+	require.True(t, p.register("127.0.0.1:0", "core", []Device{{Policy: "core", Addr: src}}, nil))
+	_, err = conn.Write(v2cTrap("public"))
+	require.NoError(t, err)
+	waitFor(t, 1, func() int64 { return tally.receivedCount(src.String(), "core", "linkDown", V2c) })
+}
+
+func TestPool_SameStringSharesOneSocket(t *testing.T) {
+	p := NewPool(NewTally(testLogger), BuildNames(nil), testLogger)
+	t.Cleanup(p.Close)
+
+	a, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
+	require.NoError(t, err)
+	addrA, _ := p.addr("127.0.0.1:0")
+	b, err := p.Acquire("127.0.0.1:0", "edge", nil, nil)
+	require.NoError(t, err)
+	addrB, _ := p.addr("127.0.0.1:0")
+
+	assert.Equal(t, 1, p.size(), "one entry for one string")
+	assert.Equal(t, addrA, addrB, "the second acquire bound nothing")
+	assert.Equal(t, 2, p.refs("127.0.0.1:0"))
+
+	a.Release()
+	assert.Equal(t, 1, p.size(), "the socket stays up for the other holder")
+	assert.Equal(t, 1, p.refs("127.0.0.1:0"))
+	b.Release()
+	assert.Equal(t, 0, p.size(), "the last release closes it")
+}
+
+func TestPool_ReleaseWithdrawsThePolicyFromRegistryAndTally(t *testing.T) {
+	tally := NewTally(testLogger)
+	p := NewPool(tally, BuildNames(nil), testLogger)
+	t.Cleanup(p.Close)
+
+	core, err := p.Acquire("127.0.0.1:0", "core", []Device{{Policy: "core", Addr: netip.MustParseAddr("10.0.0.5")}}, nil)
+	require.NoError(t, err)
+	edge, err := p.Acquire("127.0.0.1:0", "edge", []Device{{Policy: "edge", Addr: netip.MustParseAddr("10.0.0.6")}}, nil)
+	require.NoError(t, err)
+	t.Cleanup(edge.Release)
+	tally.Received("10.0.0.5", "core", "linkDown", V2c)
+	tally.Received("10.0.0.6", "edge", "linkDown", V2c)
+
+	core.Release()
+	assert.Equal(t, int64(0), tally.receivedCount("10.0.0.5", "core", "linkDown", V2c), "the released policy's series are gone")
+	assert.Equal(t, int64(1), tally.receivedCount("10.0.0.6", "edge", "linkDown", V2c), "the other policy's are kept")
+	assert.Empty(t, p.lookup("127.0.0.1:0", netip.MustParseAddr("10.0.0.5")), "the released policy's address is unknown")
+	assert.Equal(t, []string{"edge"}, p.lookup("127.0.0.1:0", netip.MustParseAddr("10.0.0.6")))
+}
+
+func TestPool_CollisionFailsTheSecondAndKeepsTheFirst(t *testing.T) {
+	blocker, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = blocker.Close() })
+	taken := blocker.LocalAddr().String()
+
+	p := NewPool(NewTally(testLogger), BuildNames(nil), testLogger)
+	t.Cleanup(p.Close)
+	first, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(first.Release)
+
+	_, err = p.Acquire(taken, "edge", nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "binding trap socket "+taken)
+	assert.Equal(t, 1, p.size(), "the failed acquire left no entry")
+	assert.Equal(t, 1, p.refs("127.0.0.1:0"), "and touched no other")
+}
+
+func TestPool_LastReleaseClosesAndAcquireBindsAgain(t *testing.T) {
+	p := NewPool(NewTally(testLogger), BuildNames(nil), testLogger)
+	t.Cleanup(p.Close)
+
+	lease, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
+	require.NoError(t, err)
+	before, _ := p.addr("127.0.0.1:0")
+	lease.Release()
+	lease.Release() // idempotent
+	require.Equal(t, 0, p.size())
+
+	again, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(again.Release)
+	after, ok := p.addr("127.0.0.1:0")
+	require.True(t, ok)
+	// Port 0 is kernel-chosen, so a different port proves a fresh bind. Equal
+	// ports are possible but rare; the size assertion above is the load-bearing one.
+	t.Logf("before %s after %s", before, after)
+	assert.Equal(t, 1, p.refs("127.0.0.1:0"))
+}
+
+func TestPool_CloseStopsEverythingAndLaterReleaseIsHarmless(t *testing.T) {
+	p := NewPool(NewTally(testLogger), BuildNames(nil), testLogger)
+	a, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
+	require.NoError(t, err)
+	b, err := p.Acquire("[::1]:0", "edge", nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, p.size())
+
+	p.Close()
+	assert.Equal(t, 0, p.size())
+	assert.NotPanics(t, a.Release)
+	assert.NotPanics(t, b.Release)
+	assert.NotPanics(t, p.Close)
+}

--- a/orb-telemetry/snmp-telemetry/traps/pool_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/pool_test.go
@@ -3,6 +3,8 @@ package traps
 import (
 	"net"
 	"net/netip"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -183,4 +185,61 @@ func TestPool_AcquireAfterCloseFails(t *testing.T) {
 	assert.Nil(t, lease)
 	assert.Contains(t, err.Error(), "trap pool is closed")
 	assert.Equal(t, 0, p.size(), "and left no entry behind")
+}
+
+// The last release closes the socket under the pool lock, so a policy
+// acquiring the same string cannot find the address still in use. Closing
+// after the unlock leaves a window where the entry is gone but the socket is
+// open, and a bind in that window fails.
+func TestPool_ReacquireAfterLastReleaseNeverSeesAddressInUse(t *testing.T) {
+	// A port the kernel just handed out and nothing holds, so the loop below
+	// binds a fixed string rather than a fresh one each time.
+	probe, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	listen := probe.LocalAddr().String()
+	require.NoError(t, probe.Close())
+
+	p := NewPool(NewTally(testLogger), BuildNames(nil), testLogger)
+	t.Cleanup(p.Close)
+	for i := range 50 {
+		lease, err := p.Acquire(listen, "core", nil, nil)
+		require.NoErrorf(t, err, "acquire %d of %s", i, listen)
+		lease.Release()
+	}
+	final, err := p.Acquire(listen, "core", nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(final.Release)
+	assert.Equal(t, 1, p.refs(listen))
+}
+
+// The same guarantee under contention, which is where the window was
+// reachable: four goroutines taking and dropping the last lease on one string
+// see the socket closed before the entry can be replaced, so no bind of it
+// ever finds the address in use.
+func TestPool_ConcurrentReacquireNeverSeesAddressInUse(t *testing.T) {
+	probe, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	require.NoError(t, err)
+	listen := probe.LocalAddr().String()
+	require.NoError(t, probe.Close())
+
+	p := NewPool(NewTally(testLogger), BuildNames(nil), testLogger)
+	t.Cleanup(p.Close)
+	var failures atomic.Int64
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 500 {
+				lease, err := p.Acquire(listen, "core", nil, nil)
+				if err != nil {
+					failures.Add(1)
+					continue
+				}
+				lease.Release()
+			}
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, int64(0), failures.Load(), "a bind failed while another holder's socket was still closing")
 }

--- a/orb-telemetry/snmp-telemetry/traps/pool_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/pool_test.go
@@ -22,10 +22,10 @@ func senderAddr(t *testing.T, addr netip.AddrPort) (netip.Addr, *net.UDPConn) {
 
 func TestPool_FirstAcquireBindsAndCountsATrapForThePolicy(t *testing.T) {
 	tally := NewTally(testLogger)
-	p := NewPool(tally, BuildNames(nil), testLogger)
+	p := NewPool(tally, testLogger)
 	t.Cleanup(p.Close)
 
-	lease, err := p.Acquire("127.0.0.1:0", "core", nil)
+	lease, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(lease.Release)
 	require.Equal(t, 1, p.size())
@@ -34,20 +34,20 @@ func TestPool_FirstAcquireBindsAndCountsATrapForThePolicy(t *testing.T) {
 
 	src, conn := senderAddr(t, addr)
 	// Register the sender's address under the policy so the trap is known.
-	require.True(t, p.register("127.0.0.1:0", "core", []Device{{Policy: "core", Addr: src}}))
+	require.True(t, p.register("127.0.0.1:0", "core", []Device{{Policy: "core", Addr: src}}, nil))
 	_, err = conn.Write(v2cTrap("public"))
 	require.NoError(t, err)
 	waitFor(t, 1, func() int64 { return tally.receivedCount(src.String(), "core", "linkDown", V2c) })
 }
 
 func TestPool_SameStringSharesOneSocket(t *testing.T) {
-	p := NewPool(NewTally(testLogger), BuildNames(nil), testLogger)
+	p := NewPool(NewTally(testLogger), testLogger)
 	t.Cleanup(p.Close)
 
-	a, err := p.Acquire("127.0.0.1:0", "core", nil)
+	a, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
 	require.NoError(t, err)
 	addrA, _ := p.addr("127.0.0.1:0")
-	b, err := p.Acquire("127.0.0.1:0", "edge", nil)
+	b, err := p.Acquire("127.0.0.1:0", "edge", nil, nil)
 	require.NoError(t, err)
 	addrB, _ := p.addr("127.0.0.1:0")
 
@@ -64,12 +64,12 @@ func TestPool_SameStringSharesOneSocket(t *testing.T) {
 
 func TestPool_ReleaseWithdrawsThePolicyFromRegistryAndTally(t *testing.T) {
 	tally := NewTally(testLogger)
-	p := NewPool(tally, BuildNames(nil), testLogger)
+	p := NewPool(tally, testLogger)
 	t.Cleanup(p.Close)
 
-	core, err := p.Acquire("127.0.0.1:0", "core", []Device{{Policy: "core", Addr: netip.MustParseAddr("10.0.0.5")}})
+	core, err := p.Acquire("127.0.0.1:0", "core", []Device{{Policy: "core", Addr: netip.MustParseAddr("10.0.0.5")}}, nil)
 	require.NoError(t, err)
-	edge, err := p.Acquire("127.0.0.1:0", "edge", []Device{{Policy: "edge", Addr: netip.MustParseAddr("10.0.0.6")}})
+	edge, err := p.Acquire("127.0.0.1:0", "edge", []Device{{Policy: "edge", Addr: netip.MustParseAddr("10.0.0.6")}}, nil)
 	require.NoError(t, err)
 	t.Cleanup(edge.Release)
 	tally.Received("10.0.0.5", "core", "linkDown", V2c)
@@ -88,13 +88,13 @@ func TestPool_CollisionFailsTheSecondAndKeepsTheFirst(t *testing.T) {
 	t.Cleanup(func() { _ = blocker.Close() })
 	taken := blocker.LocalAddr().String()
 
-	p := NewPool(NewTally(testLogger), BuildNames(nil), testLogger)
+	p := NewPool(NewTally(testLogger), testLogger)
 	t.Cleanup(p.Close)
-	first, err := p.Acquire("127.0.0.1:0", "core", nil)
+	first, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(first.Release)
 
-	_, err = p.Acquire(taken, "edge", nil)
+	_, err = p.Acquire(taken, "edge", nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "binding trap socket "+taken)
 	assert.Equal(t, 1, p.size(), "the failed acquire left no entry")
@@ -102,17 +102,17 @@ func TestPool_CollisionFailsTheSecondAndKeepsTheFirst(t *testing.T) {
 }
 
 func TestPool_LastReleaseClosesAndAcquireBindsAgain(t *testing.T) {
-	p := NewPool(NewTally(testLogger), BuildNames(nil), testLogger)
+	p := NewPool(NewTally(testLogger), testLogger)
 	t.Cleanup(p.Close)
 
-	lease, err := p.Acquire("127.0.0.1:0", "core", nil)
+	lease, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
 	require.NoError(t, err)
 	before, _ := p.addr("127.0.0.1:0")
 	lease.Release()
 	lease.Release() // idempotent
 	require.Equal(t, 0, p.size())
 
-	again, err := p.Acquire("127.0.0.1:0", "core", nil)
+	again, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(again.Release)
 	after, ok := p.addr("127.0.0.1:0")
@@ -124,10 +124,10 @@ func TestPool_LastReleaseClosesAndAcquireBindsAgain(t *testing.T) {
 }
 
 func TestPool_CloseStopsEverythingAndLaterReleaseIsHarmless(t *testing.T) {
-	p := NewPool(NewTally(testLogger), BuildNames(nil), testLogger)
-	a, err := p.Acquire("127.0.0.1:0", "core", nil)
+	p := NewPool(NewTally(testLogger), testLogger)
+	a, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
 	require.NoError(t, err)
-	b, err := p.Acquire("[::1]:0", "edge", nil)
+	b, err := p.Acquire("[::1]:0", "edge", nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, 2, p.size())
 
@@ -143,10 +143,10 @@ func TestPool_CloseStopsEverythingAndLaterReleaseIsHarmless(t *testing.T) {
 // belongs to another policy.
 func TestPool_StaleLeaseDoesNotTouchAFreshEntry(t *testing.T) {
 	tally := NewTally(testLogger)
-	p := NewPool(tally, BuildNames(nil), testLogger)
+	p := NewPool(tally, testLogger)
 	t.Cleanup(p.Close)
 
-	stale, err := p.Acquire("127.0.0.1:0", "core", nil)
+	stale, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
 	require.NoError(t, err)
 	p.Close()
 	// Close refuses every later Acquire, which is what keeps this sequence out
@@ -157,7 +157,7 @@ func TestPool_StaleLeaseDoesNotTouchAFreshEntry(t *testing.T) {
 	p.closed = false
 	p.mu.Unlock()
 
-	fresh, err := p.Acquire("127.0.0.1:0", "edge", nil)
+	fresh, err := p.Acquire("127.0.0.1:0", "edge", nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(fresh.Release)
 	addr, ok := p.addr("127.0.0.1:0")
@@ -168,7 +168,7 @@ func TestPool_StaleLeaseDoesNotTouchAFreshEntry(t *testing.T) {
 	assert.Equal(t, 1, p.size(), "the fresh entry is still in the pool")
 	assert.Equal(t, 1, p.refs("127.0.0.1:0"), "with the holder it counted for itself")
 	src, conn := senderAddr(t, addr)
-	require.True(t, p.register("127.0.0.1:0", "edge", []Device{{Policy: "edge", Addr: src}}))
+	require.True(t, p.register("127.0.0.1:0", "edge", []Device{{Policy: "edge", Addr: src}}, nil))
 	_, err = conn.Write(v2cTrap("public"))
 	require.NoError(t, err)
 	waitFor(t, 1, func() int64 { return tally.receivedCount(src.String(), "edge", "linkDown", V2c) })
@@ -177,10 +177,10 @@ func TestPool_StaleLeaseDoesNotTouchAFreshEntry(t *testing.T) {
 // Acquiring after Close binds nothing. The socket would have no one left to
 // stop it, since Close is what stops them and it has already run.
 func TestPool_AcquireAfterCloseFails(t *testing.T) {
-	p := NewPool(NewTally(testLogger), BuildNames(nil), testLogger)
+	p := NewPool(NewTally(testLogger), testLogger)
 	p.Close()
 
-	lease, err := p.Acquire("127.0.0.1:0", "core", nil)
+	lease, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
 	require.Error(t, err)
 	assert.Nil(t, lease)
 	assert.Contains(t, err.Error(), "trap pool is closed")
@@ -199,14 +199,14 @@ func TestPool_ReacquireAfterLastReleaseNeverSeesAddressInUse(t *testing.T) {
 	listen := probe.LocalAddr().String()
 	require.NoError(t, probe.Close())
 
-	p := NewPool(NewTally(testLogger), BuildNames(nil), testLogger)
+	p := NewPool(NewTally(testLogger), testLogger)
 	t.Cleanup(p.Close)
 	for i := range 50 {
-		lease, err := p.Acquire(listen, "core", nil)
+		lease, err := p.Acquire(listen, "core", nil, nil)
 		require.NoErrorf(t, err, "acquire %d of %s", i, listen)
 		lease.Release()
 	}
-	final, err := p.Acquire(listen, "core", nil)
+	final, err := p.Acquire(listen, "core", nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(final.Release)
 	assert.Equal(t, 1, p.refs(listen))
@@ -222,7 +222,7 @@ func TestPool_ConcurrentReacquireNeverSeesAddressInUse(t *testing.T) {
 	listen := probe.LocalAddr().String()
 	require.NoError(t, probe.Close())
 
-	p := NewPool(NewTally(testLogger), BuildNames(nil), testLogger)
+	p := NewPool(NewTally(testLogger), testLogger)
 	t.Cleanup(p.Close)
 	var failures atomic.Int64
 	var wg sync.WaitGroup
@@ -231,7 +231,7 @@ func TestPool_ConcurrentReacquireNeverSeesAddressInUse(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for range 500 {
-				lease, err := p.Acquire(listen, "core", nil)
+				lease, err := p.Acquire(listen, "core", nil, nil)
 				if err != nil {
 					failures.Add(1)
 					continue
@@ -253,20 +253,20 @@ func TestPool_ConcurrentReacquireNeverSeesAddressInUse(t *testing.T) {
 // because macOS has only 127.0.0.1 on lo0 and a bind of 127.0.0.2 fails.
 func TestPool_SocketsAreIsolated(t *testing.T) {
 	tally := NewTally(testLogger)
-	p := NewPool(tally, BuildNames(nil), testLogger)
+	p := NewPool(tally, testLogger)
 	t.Cleanup(p.Close)
 
-	core, err := p.Acquire("127.0.0.1:0", "core", nil)
+	core, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(core.Release)
-	edge, err := p.Acquire("[::1]:0", "edge", nil)
+	edge, err := p.Acquire("[::1]:0", "edge", nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(edge.Release)
 
 	coreAddr, ok := p.addr("127.0.0.1:0")
 	require.True(t, ok)
 	src, conn := senderAddr(t, coreAddr)
-	require.True(t, p.register("[::1]:0", "edge", []Device{{Policy: "edge", Addr: src}}))
+	require.True(t, p.register("[::1]:0", "edge", []Device{{Policy: "edge", Addr: src}}, nil))
 	require.Empty(t, p.lookup("127.0.0.1:0", src), "the other socket's entry never learned the address")
 
 	_, err = conn.Write(v2cTrap("public"))
@@ -274,4 +274,25 @@ func TestPool_SocketsAreIsolated(t *testing.T) {
 	waitFor(t, 1, func() int64 { return tally.droppedCount(DropUnknownSource) })
 	assert.Equal(t, int64(0), tally.receivedCount(src.String(), "edge", "linkDown", V2c),
 		"a trap on one socket is never attributed to a policy registered on another")
+}
+
+// Acquiring a policy activates its series in the tally, so a count that
+// arrived after the previous lease's release, and went dormant, resumes when
+// the policy comes back.
+func TestPool_ReacquireActivatesThePolicysSeries(t *testing.T) {
+	tally := NewTally(testLogger)
+	p := NewPool(tally, testLogger)
+	t.Cleanup(p.Close)
+	lease, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
+	require.NoError(t, err)
+	tally.Received("10.0.0.5", "core", "linkDown", V2c)
+	lease.Release()
+	tally.Received("10.0.0.5", "core", "linkDown", V2c)
+	assert.Equal(t, int64(0), tally.receivedCount("10.0.0.5", "core", "linkDown", V2c), "dormant after release")
+
+	again, err := p.Acquire("127.0.0.1:0", "core", nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(again.Release)
+	tally.Received("10.0.0.5", "core", "linkDown", V2c)
+	assert.Equal(t, int64(3), tally.receivedCount("10.0.0.5", "core", "linkDown", V2c), "live again with every count kept")
 }

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -264,12 +264,13 @@ func (r *Receiver) loop() {
 		// Decode has established that a v3 trap carries USM parameters and a
 		// verified digest, so the boots and time in them are the engine's
 		// own word; what remains is whether that word is current. The clock
-		// is kept per sender as well as per engine ID: a device writing
-		// another device's engine ID with higher boots, authenticated with
-		// its own credential, poisons only its own clock.
+		// is kept per sender, per credential and per engine ID: a device
+		// writing another device's engine ID with higher boots, authenticated
+		// with its own credential, poisons only the clock that credential is
+		// judged by, and two credentials at one address are two principals.
 		if tr.Version == V3 {
 			sp := pkt.SecurityParameters.(*gosnmp.UsmSecurityParameters)
-			if !r.clocks.check(src.String()+"|"+sp.AuthoritativeEngineID, sp.AuthoritativeEngineBoots, sp.AuthoritativeEngineTime) {
+			if !r.clocks.check(clockKey(src, sp), sp.AuthoritativeEngineBoots, sp.AuthoritativeEngineTime) {
 				r.drop(DropV3NotInTimeWindow, src, "")
 				continue
 			}
@@ -383,6 +384,15 @@ func (r *Receiver) parse(b []byte) (pkt *gosnmp.SnmpPacket, err error) {
 		}
 	}()
 	return r.params.UnmarshalTrap(b, false)
+}
+
+// clockKey names the clock a v3 message is judged by: the sender's address,
+// the credential that verified it, and the engine ID it carries. The
+// credential is identified by everything a registered user is compared on,
+// so two users sharing a name with different passphrases are two clocks.
+func clockKey(src netip.Addr, sp *gosnmp.UsmSecurityParameters) string {
+	return src.String() + "|" + sp.UserName + "|" + sp.AuthenticationPassphrase + "|" + sp.PrivacyPassphrase + "|" +
+		sp.AuthenticationProtocol.String() + "|" + sp.PrivacyProtocol.String() + "|" + sp.AuthoritativeEngineID
 }
 
 // credentialMatcher reports whether a registered user is the credential the

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -248,9 +248,15 @@ func (r *Receiver) loop() {
 			}
 		}
 
-		name := NameFor(r.names, tr.OID)
+		// Each policy names the trap from its own profile set, so two
+		// policies on one socket can count one OID under two names; a policy
+		// that registered no names uses the socket's.
 		for _, policy := range policies {
-			r.tally.Received(deviceIP.String(), policy, name, tr.Version)
+			names := r.reg.NamesFor(policy)
+			if names == nil {
+				names = r.names
+			}
+			r.tally.Received(deviceIP.String(), policy, NameFor(names, tr.OID), tr.Version)
 		}
 
 		if tr.Inform {

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net"
 	"net/netip"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -180,11 +181,8 @@ func (r *Receiver) tableFor(src netip.Addr) *gosnmp.SnmpV3SecurityParametersTabl
 		r.usersGen = gen
 	}
 	users := r.reg.UsersAt(src)
-	var key strings.Builder
-	for _, u := range users {
-		key.WriteString(u.Username + "\x00" + u.AuthProtocol + "\x00" + u.AuthPassphrase + "\x00" + u.PrivProtocol + "\x00" + u.PrivPassphrase + "\x01")
-	}
-	if table, ok := r.tables[key.String()]; ok {
+	key := userSetKey(users)
+	if table, ok := r.tables[key]; ok {
 		return table
 	}
 	table := gosnmp.NewSnmpV3SecurityParametersTable(r.params.Logger)
@@ -211,7 +209,7 @@ func (r *Receiver) tableFor(src netip.Addr) *gosnmp.SnmpV3SecurityParametersTabl
 			r.logger.Warn("Could not add a trap v3 user", "username", u.Username, "error", err)
 		}
 	}
-	r.tables[key.String()] = table
+	r.tables[key] = table
 	return table
 }
 
@@ -390,9 +388,32 @@ func (r *Receiver) parse(b []byte) (pkt *gosnmp.SnmpPacket, err error) {
 // the credential that verified it, and the engine ID it carries. The
 // credential is identified by everything a registered user is compared on,
 // so two users sharing a name with different passphrases are two clocks.
-func clockKey(src netip.Addr, sp *gosnmp.UsmSecurityParameters) string {
-	return src.String() + "|" + sp.UserName + "|" + sp.AuthenticationPassphrase + "|" + sp.PrivacyPassphrase + "|" +
-		sp.AuthenticationProtocol.String() + "|" + sp.PrivacyProtocol.String() + "|" + sp.AuthoritativeEngineID
+func clockKey(src netip.Addr, sp *gosnmp.UsmSecurityParameters) clockID {
+	return clockID{
+		src:       src,
+		user:      sp.UserName,
+		authPass:  sp.AuthenticationPassphrase,
+		privPass:  sp.PrivacyPassphrase,
+		authProto: sp.AuthenticationProtocol,
+		privProto: sp.PrivacyProtocol,
+		engineID:  sp.AuthoritativeEngineID,
+	}
+}
+
+// userSetKey identifies a set of users for the credential-table cache. Every
+// field is length-prefixed, so no operator-chosen value can act as a field
+// boundary and make two user sets one table.
+func userSetKey(users []V3User) string {
+	var key strings.Builder
+	for _, u := range users {
+		for _, field := range []string{u.Username, u.AuthProtocol, u.AuthPassphrase, u.PrivProtocol, u.PrivPassphrase} {
+			key.WriteString(strconv.Itoa(len(field)))
+			key.WriteByte(':')
+			key.WriteString(field)
+		}
+		key.WriteByte(';')
+	}
+	return key.String()
 }
 
 // credentialMatcher reports whether a registered user is the credential the

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -51,6 +51,11 @@ type Receiver struct {
 
 	stopOnce sync.Once
 	done     chan struct{}
+
+	// beforeCount, when set, runs after a datagram is parsed and before the
+	// policies it is counted under are resolved. Tests use it to change the
+	// registry in that window; it is nil otherwise.
+	beforeCount func()
 }
 
 // Listen binds addr and starts reading. The bind is synchronous so a failure
@@ -232,13 +237,30 @@ func (r *Receiver) loop() {
 			}
 		}
 
+		if r.beforeCount != nil {
+			r.beforeCount()
+		}
+
+		// The policies a trap is counted under are resolved now, not from
+		// the lookup that admitted the datagram: a policy released while
+		// the datagram was being parsed must not be counted, and one that
+		// replaced it under the same name gets the count only if it claims
+		// the device. For a v3 trap only the policies holding the credential
+		// that verified it qualify; every user at the address was handed to
+		// the parser together, and the parser reports which one matched.
+		var holding func(V3User) bool
+		if tr.Version == V3 {
+			holding = credentialMatcher(pkt.SecurityParameters.(*gosnmp.UsmSecurityParameters))
+		}
+		deviceIP := src
+		policies = r.reg.PoliciesAt(src, holding)
+
 		// The agent-addr override is a claim about provenance, and only a
 		// registered sender has one to make; every sender past this point
 		// is one. The claim is honoured only when the named address has a
 		// policy of its own.
-		deviceIP := src
 		if tr.AgentAddr.IsValid() && tr.AgentAddr != src {
-			if agentPolicies := r.reg.Lookup(tr.AgentAddr); len(agentPolicies) > 0 {
+			if agentPolicies := r.reg.PoliciesAt(tr.AgentAddr, holding); len(agentPolicies) > 0 {
 				deviceIP = canonical(tr.AgentAddr)
 				policies = agentPolicies
 				// Which address a count was attributed to is the one thing an
@@ -246,6 +268,10 @@ func (r *Receiver) loop() {
 				// the series names only the winner.
 				r.logger.Debug("Attributed a trap to its agent-addr rather than its source", "source", src.String(), "agent_addr", deviceIP.String())
 			}
+		}
+		if len(policies) == 0 {
+			r.drop(DropUnknownSource, src, "")
+			continue
 		}
 
 		// Each policy names the trap from its own profile set, so two
@@ -284,6 +310,25 @@ func (r *Receiver) parse(b []byte) (pkt *gosnmp.SnmpPacket, err error) {
 		}
 	}()
 	return r.params.UnmarshalTrap(b, false)
+}
+
+// credentialMatcher reports whether a registered user is the credential the
+// parser verified a packet with. gosnmp returns the table entry it matched as
+// the packet's security parameters, passphrases and protocols included, so
+// the comparison is on the whole credential rather than the username alone,
+// which two policies may share with different passphrases.
+func credentialMatcher(sp *gosnmp.UsmSecurityParameters) func(V3User) bool {
+	return func(u V3User) bool {
+		if u.Username != sp.UserName || u.AuthPassphrase != sp.AuthenticationPassphrase || u.PrivPassphrase != sp.PrivacyPassphrase {
+			return false
+		}
+		authProto, err := snmp.AuthProtocol(u.AuthProtocol)
+		if err != nil || authProto != sp.AuthenticationProtocol {
+			return false
+		}
+		privProto, err := snmp.PrivProtocol(u.PrivProtocol)
+		return err == nil && privProto == sp.PrivacyProtocol
+	}
 }
 
 // parseErrorCategory keeps the part of a parse error that names the fault and

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -43,9 +43,9 @@ type Receiver struct {
 
 	params   *gosnmp.GoSNMP
 	usersGen uint64
-	// tables caches one credential table per set of claiming policies,
-	// keyed by the sorted policy names joined; reset when the registry
-	// changes. Only the loop goroutine touches it.
+	// tables caches one credential table per distinct set of users, keyed
+	// by their contents; reset when the registry changes. Only the loop
+	// goroutine touches it.
 	tables map[string]*gosnmp.SnmpV3SecurityParametersTable
 	clocks *timeliness
 
@@ -121,26 +121,30 @@ func (r *Receiver) wait() {
 	}
 }
 
-// tableFor returns gosnmp's credential table for a datagram whose source the
-// given policies claimed: the v3 users of those policies and no others.
-// gosnmp keys its table by username and tries every entry under a name in
-// turn, localising keys for each, so a table holding every user on the
-// socket would make a trap from a device whose credential sits late in a
-// shared username cost the receive goroutine one localisation per candidate.
-// Tables are cached per policy set and rebuilt whole when the registry
-// changes, since gosnmp's table has Add but no Remove. Only the loop
-// goroutine touches r.params and the cache, so this needs no lock.
-func (r *Receiver) tableFor(policies []string) *gosnmp.SnmpV3SecurityParametersTable {
+// tableFor returns gosnmp's credential table for a datagram from src: the v3
+// users the claiming policies poll that device with, and no others. gosnmp
+// keys its table by username and tries every entry under a name in turn,
+// localising keys for each, so a wider table would both let another
+// device's credential vouch for this source and cost the receive goroutine
+// one localisation per candidate. Tables are cached per distinct user set
+// and rebuilt whole when the registry changes, since gosnmp's table has Add
+// but no Remove. Only the loop goroutine touches r.params and the cache, so
+// this needs no lock.
+func (r *Receiver) tableFor(src netip.Addr) *gosnmp.SnmpV3SecurityParametersTable {
 	if gen := r.reg.Generation(); r.tables == nil || gen != r.usersGen {
 		r.tables = make(map[string]*gosnmp.SnmpV3SecurityParametersTable)
 		r.usersGen = gen
 	}
-	key := strings.Join(policies, "\x00")
-	if table, ok := r.tables[key]; ok {
+	users := r.reg.UsersAt(src)
+	var key strings.Builder
+	for _, u := range users {
+		key.WriteString(u.Username + "\x00" + u.AuthProtocol + "\x00" + u.AuthPassphrase + "\x00" + u.PrivProtocol + "\x00" + u.PrivPassphrase + "\x01")
+	}
+	if table, ok := r.tables[key.String()]; ok {
 		return table
 	}
 	table := gosnmp.NewSnmpV3SecurityParametersTable(r.params.Logger)
-	for _, u := range r.reg.UsersFor(policies) {
+	for _, u := range users {
 		authProto, err := snmp.AuthProtocol(u.AuthProtocol)
 		if err != nil {
 			r.logger.Warn("Skipping a trap v3 user with an unsupported auth protocol", "username", u.Username, "error", err)
@@ -163,9 +167,12 @@ func (r *Receiver) tableFor(policies []string) *gosnmp.SnmpV3SecurityParametersT
 			r.logger.Warn("Could not add a trap v3 user", "username", u.Username, "error", err)
 		}
 	}
-	r.tables[key] = table
+	r.tables[key.String()] = table
 	return table
 }
+
+// tableCacheSize is a test accessor.
+func (r *Receiver) tableCacheSize() int { return len(r.tables) }
 
 // loop is the receive path, in the order the spec's section 6.2 gives: read,
 // canonicalise, look the source up before the datagram is judged on anything
@@ -199,7 +206,7 @@ func (r *Receiver) loop() {
 			continue
 		}
 
-		r.params.TrapSecurityParametersTable = r.tableFor(policies)
+		r.params.TrapSecurityParametersTable = r.tableFor(src)
 		pkt, err := r.parse(buf[:n])
 		if err != nil {
 			r.drop(DropMalformed, src, parseErrorCategory(err))
@@ -213,10 +220,13 @@ func (r *Receiver) loop() {
 		}
 		// Decode has established that a v3 trap carries USM parameters and a
 		// verified digest, so the boots and time in them are the engine's
-		// own word; what remains is whether that word is current.
+		// own word; what remains is whether that word is current. The clock
+		// is kept per sender as well as per engine ID: a device writing
+		// another device's engine ID with higher boots, authenticated with
+		// its own credential, poisons only its own clock.
 		if tr.Version == V3 {
 			sp := pkt.SecurityParameters.(*gosnmp.UsmSecurityParameters)
-			if !r.clocks.check(sp.AuthoritativeEngineID, sp.AuthoritativeEngineBoots, sp.AuthoritativeEngineTime) {
+			if !r.clocks.check(src.String()+"|"+sp.AuthoritativeEngineID, sp.AuthoritativeEngineBoots, sp.AuthoritativeEngineTime) {
 				r.drop(DropV3NotInTimeWindow, src, "")
 				continue
 			}

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -159,9 +159,20 @@ func (r *Receiver) intake(fn func()) bool {
 
 // wait waits for the read goroutine to exit, up to its bound.
 func (r *Receiver) wait() {
+	expired := make(chan struct{})
+	timer := time.AfterFunc(stopTimeout, func() { close(expired) })
+	defer timer.Stop()
+	r.waitUntil(expired)
+}
+
+// waitUntil waits for the read goroutine to exit or expired to close,
+// whichever is first, so a pool can wait for every receiver under one
+// deadline: a closed channel is observed by every waiter, where a timer's
+// channel would be drained by the first.
+func (r *Receiver) waitUntil(expired <-chan struct{}) {
 	select {
 	case <-r.done:
-	case <-time.After(stopTimeout):
+	case <-expired:
 		r.logger.Warn("Trap receiver did not stop within its bound", "timeout", stopTimeout)
 	}
 }

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -268,7 +268,7 @@ func (r *Receiver) loop() {
 		// judged by, and two credentials at one address are two principals.
 		if tr.Version == V3 {
 			sp := pkt.SecurityParameters.(*gosnmp.UsmSecurityParameters)
-			if !r.clocks.check(clockKey(src, sp), sp.AuthoritativeEngineBoots, sp.AuthoritativeEngineTime) {
+			if !r.clocks.check(clockKey(src, sp, pkt.MsgFlags), sp.AuthoritativeEngineBoots, sp.AuthoritativeEngineTime) {
 				r.drop(DropV3NotInTimeWindow, src, "")
 				continue
 			}
@@ -287,7 +287,7 @@ func (r *Receiver) loop() {
 		// the parser together, and the parser reports which one matched.
 		var holding func(V3User) bool
 		if tr.Version == V3 {
-			holding = credentialMatcher(pkt.SecurityParameters.(*gosnmp.UsmSecurityParameters))
+			holding = credentialMatcher(pkt.SecurityParameters.(*gosnmp.UsmSecurityParameters), pkt.MsgFlags)
 		}
 
 		// The agent-addr override is a claim about provenance, and only a
@@ -386,20 +386,31 @@ func (r *Receiver) parse(b []byte) (pkt *gosnmp.SnmpPacket, err error) {
 	return r.params.UnmarshalTrap(b, false)
 }
 
+// privacyVerified reports whether a message at these flags proved a privacy
+// key: only an authPriv message did. An authNoPriv message carries and
+// verifies nothing about privacy, so two credentials differing only in
+// privacy settings are the same principal to it.
+func privacyVerified(flags gosnmp.SnmpV3MsgFlags) bool {
+	return flags&gosnmp.AuthPriv == gosnmp.AuthPriv
+}
+
 // clockKey names the clock a v3 message is judged by: the sender's address,
 // the credential that verified it, and the engine ID it carries. The
-// credential is identified by everything a registered user is compared on,
-// so two users sharing a name with different passphrases are two clocks.
-func clockKey(src netip.Addr, sp *gosnmp.UsmSecurityParameters) clockID {
-	return clockID{
+// credential is identified by the fields the message's security level
+// verified: username, auth protocol and passphrase always, the privacy
+// fields only for an authPriv message.
+func clockKey(src netip.Addr, sp *gosnmp.UsmSecurityParameters, flags gosnmp.SnmpV3MsgFlags) clockID {
+	id := clockID{
 		src:       src,
 		user:      sp.UserName,
 		authPass:  sp.AuthenticationPassphrase,
-		privPass:  sp.PrivacyPassphrase,
 		authProto: sp.AuthenticationProtocol,
-		privProto: sp.PrivacyProtocol,
 		engineID:  sp.AuthoritativeEngineID,
 	}
+	if privacyVerified(flags) {
+		id.privPass, id.privProto = sp.PrivacyPassphrase, sp.PrivacyProtocol
+	}
+	return id
 }
 
 // userSetKey identifies a set of users for the credential-table cache. Every
@@ -418,22 +429,29 @@ func userSetKey(users []V3User) string {
 	return key.String()
 }
 
-// credentialMatcher reports whether a registered user is the credential the
-// parser verified a packet with. gosnmp returns the table entry it matched as
-// the packet's security parameters, passphrases and protocols included, so
-// the comparison is on the whole credential rather than the username alone,
-// which two policies may share with different passphrases.
-func credentialMatcher(sp *gosnmp.UsmSecurityParameters) func(V3User) bool {
+// credentialMatcher reports whether a registered user is a credential the
+// parser verified a packet with. gosnmp returns the table entry it matched
+// as the packet's security parameters, passphrases and protocols included,
+// so the comparison is on the fields the packet's security level actually
+// verified: username, auth protocol and auth passphrase always, and the
+// privacy protocol and passphrase only for an authPriv packet. An authNoPriv
+// packet proves nothing about privacy, and gosnmp returns whichever
+// same-auth entry it tried first, so two users differing only in privacy
+// settings both verified it and both count.
+func credentialMatcher(sp *gosnmp.UsmSecurityParameters, flags gosnmp.SnmpV3MsgFlags) func(V3User) bool {
 	return func(u V3User) bool {
-		if u.Username != sp.UserName || u.AuthPassphrase != sp.AuthenticationPassphrase || u.PrivPassphrase != sp.PrivacyPassphrase {
+		if u.Username != sp.UserName || u.AuthPassphrase != sp.AuthenticationPassphrase {
 			return false
 		}
 		authProto, err := snmp.AuthProtocol(u.AuthProtocol)
 		if err != nil || authProto != sp.AuthenticationProtocol {
 			return false
 		}
+		if !privacyVerified(flags) {
+			return true
+		}
 		privProto, err := snmp.PrivProtocol(u.PrivProtocol)
-		return err == nil && privProto == sp.PrivacyProtocol
+		return err == nil && privProto == sp.PrivacyProtocol && u.PrivPassphrase == sp.PrivacyPassphrase
 	}
 }
 

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -71,6 +71,10 @@ type Receiver struct {
 	// bound. Shutdown relies on that to run the final export after Close.
 	intakeMu sync.RWMutex
 	stopped  bool
+	// closing is set as close begins, before it waits for the intake lock,
+	// so a test can tell that every receiver in a pool was asked to close
+	// at once rather than one after another.
+	closing atomic.Bool
 
 	// beforeCount, when set, runs after a datagram is parsed and before the
 	// policies it is counted under are resolved. Tests use it to change the
@@ -81,7 +85,15 @@ type Receiver struct {
 	// read-locked, before the first count. Tests use it to race a release
 	// against the count from another goroutine; it is nil otherwise.
 	duringCount atomic.Pointer[func()]
+	// beforeAccount, when set, runs inside the intake section, before the
+	// tally transaction and the claims visit, holding neither lock. Tests
+	// use it to park a receiver inside its intake section; it is nil
+	// otherwise.
+	beforeAccount atomic.Pointer[func()]
 }
+
+// setBeforeAccount is a test seam.
+func (r *Receiver) setBeforeAccount(f func()) { r.beforeAccount.Store(&f) }
 
 // setBeforeCount is a test seam. A nil f clears it.
 func (r *Receiver) setBeforeCount(f func()) {
@@ -150,12 +162,17 @@ func (r *Receiver) Stop() {
 // same address fails, and the wait below is far too long to hold a lock for.
 func (r *Receiver) close() {
 	r.stopOnce.Do(func() {
+		r.closing.Store(true)
 		r.intakeMu.Lock()
 		r.stopped = true
 		r.intakeMu.Unlock()
 		_ = r.conn.Close()
 	})
 }
+
+// closeRequested is a test accessor: whether close has begun, whether or
+// not it has yet taken the intake lock.
+func (r *Receiver) closeRequested() bool { return r.closing.Load() }
 
 // intake runs fn, which touches the tally, unless the receiver has been
 // closed, and reports whether it ran.
@@ -370,15 +387,13 @@ func (r *Receiver) loop() {
 		// The agent-addr override is a claim about provenance, and only a
 		// registered sender has one to make; every sender past this point
 		// is one. The claim is honoured only when the named address has a
-		// policy of its own.
-		deviceIP := src
-		if tr.AgentAddr.IsValid() && tr.AgentAddr != src && len(r.reg.PoliciesAt(tr.AgentAddr, holding)) > 0 {
-			deviceIP = canonical(tr.AgentAddr)
-			// Which address a count was attributed to is the one thing an
-			// operator cannot reconstruct from the exported series, since
-			// the series names only the winner.
-			r.logger.Debug("Attributed a trap to its agent-addr rather than its source", "source", src.String(), "agent_addr", deviceIP.String())
+		// policy of its own, decided inside the same locked visit as the
+		// claims, with the source's own claims as the fallback.
+		agent := netip.Addr{}
+		if tr.AgentAddr.IsValid() && tr.AgentAddr != src {
+			agent = tr.AgentAddr
 		}
+		deviceIP := src
 
 		// Each policy names the trap from its own profile set, so two
 		// policies on one socket can count one OID under two names; a policy
@@ -395,9 +410,13 @@ func (r *Receiver) loop() {
 		claimed, counted := 0, 0
 		var dropped DropReason
 		ran := r.intake(func() {
+			if hook := r.beforeAccount.Load(); hook != nil {
+				(*hook)()
+			}
 			r.tally.Account(func(a *Account) {
 				a.Datagram()
-				claimed = r.reg.VisitClaims(deviceIP, holding, func(policy string, names map[string]string) {
+				var counts []func(deviceIP string) bool
+				deviceIP, claimed = r.reg.VisitClaimsPreferring(agent, src, holding, func(policy string, names map[string]string) {
 					if first {
 						first = false
 						if hook := r.duringCount.Load(); hook != nil {
@@ -407,10 +426,14 @@ func (r *Receiver) loop() {
 					if names == nil {
 						names = r.names
 					}
-					if a.Received(deviceIP.String(), policy, NameFor(names, tr.OID), tr.Version) {
+					name := NameFor(names, tr.OID)
+					counts = append(counts, func(ip string) bool { return a.Received(ip, policy, name, tr.Version) })
+				})
+				for _, count := range counts {
+					if count(deviceIP.String()) {
 						counted++
 					}
-				})
+				}
 				switch {
 				case claimed == 0:
 					dropped = DropUnknownSource
@@ -436,6 +459,12 @@ func (r *Receiver) loop() {
 		}
 		if dropped != "" {
 			r.logDrop(dropped, src, "")
+		}
+		if deviceIP != src && claimed > 0 {
+			// Which address a count was attributed to is the one thing an
+			// operator cannot reconstruct from the exported series, since
+			// the series names only the winner.
+			r.logger.Debug("Attributed a trap to its agent-addr rather than its source", "source", src.String(), "agent_addr", deviceIP.String())
 		}
 	}
 }

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -43,7 +43,11 @@ type Receiver struct {
 
 	params   *gosnmp.GoSNMP
 	usersGen uint64
-	clocks   *timeliness
+	// tables caches one credential table per set of claiming policies,
+	// keyed by the sorted policy names joined; reset when the registry
+	// changes. Only the loop goroutine touches it.
+	tables map[string]*gosnmp.SnmpV3SecurityParametersTable
+	clocks *timeliness
 
 	stopOnce sync.Once
 	done     chan struct{}
@@ -83,7 +87,6 @@ func Listen(addr string, reg *Registry, tally *Tally, names map[string]string, l
 		// community to redact.
 		Logger: gosnmp.NewLogger(nil),
 	}
-	r.rebuildUsersIfChanged()
 	go r.loop()
 	return r, nil
 }
@@ -118,16 +121,26 @@ func (r *Receiver) wait() {
 	}
 }
 
-// rebuildUsersIfChanged refreshes gosnmp's credential table when the registry
-// has changed. gosnmp's table has Add but no Remove, so it is rebuilt whole.
-// Only the loop goroutine touches r.params, so this needs no lock.
-func (r *Receiver) rebuildUsersIfChanged() {
-	gen := r.reg.Generation()
-	if r.params.TrapSecurityParametersTable != nil && gen == r.usersGen {
-		return
+// tableFor returns gosnmp's credential table for a datagram whose source the
+// given policies claimed: the v3 users of those policies and no others.
+// gosnmp keys its table by username and tries every entry under a name in
+// turn, localising keys for each, so a table holding every user on the
+// socket would make a trap from a device whose credential sits late in a
+// shared username cost the receive goroutine one localisation per candidate.
+// Tables are cached per policy set and rebuilt whole when the registry
+// changes, since gosnmp's table has Add but no Remove. Only the loop
+// goroutine touches r.params and the cache, so this needs no lock.
+func (r *Receiver) tableFor(policies []string) *gosnmp.SnmpV3SecurityParametersTable {
+	if gen := r.reg.Generation(); r.tables == nil || gen != r.usersGen {
+		r.tables = make(map[string]*gosnmp.SnmpV3SecurityParametersTable)
+		r.usersGen = gen
+	}
+	key := strings.Join(policies, "\x00")
+	if table, ok := r.tables[key]; ok {
+		return table
 	}
 	table := gosnmp.NewSnmpV3SecurityParametersTable(r.params.Logger)
-	for _, u := range r.reg.Users() {
+	for _, u := range r.reg.UsersFor(policies) {
 		authProto, err := snmp.AuthProtocol(u.AuthProtocol)
 		if err != nil {
 			r.logger.Warn("Skipping a trap v3 user with an unsupported auth protocol", "username", u.Username, "error", err)
@@ -150,8 +163,8 @@ func (r *Receiver) rebuildUsersIfChanged() {
 			r.logger.Warn("Could not add a trap v3 user", "username", u.Username, "error", err)
 		}
 	}
-	r.params.TrapSecurityParametersTable = table
-	r.usersGen = gen
+	r.tables[key] = table
+	return table
 }
 
 // loop is the receive path, in the order the spec's section 6.2 gives: read,
@@ -186,7 +199,7 @@ func (r *Receiver) loop() {
 			continue
 		}
 
-		r.rebuildUsersIfChanged()
+		r.params.TrapSecurityParametersTable = r.tableFor(policies)
 		pkt, err := r.parse(buf[:n])
 		if err != nil {
 			r.drop(DropMalformed, src, parseErrorCategory(err))

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -22,6 +22,10 @@ import (
 // the parser's length check, so it is counted as oversized instead.
 const maxDatagram = 4096
 
+// ackTimeout bounds the write of an inform acknowledgement, which runs
+// inside the intake section a close waits for.
+const ackTimeout = 100 * time.Millisecond
+
 // stopTimeout bounds how long Stop waits for the read goroutine. gosnmp's
 // listener waits three seconds, which spent out of the agent's five second
 // stop grace would starve the final export.
@@ -558,6 +562,10 @@ func (r *Receiver) logDrop(reason DropReason, src netip.Addr, detail string) {
 // acknowledge answers an inform the way an agent expects, so a registered
 // sender does not retransmit. The packet is reused with its PDU type and
 // error fields changed, which is what gosnmp's own listener does.
+//
+// The write runs inside the intake section, which close waits for, so it
+// carries a deadline: a UDP send blocks only when the local send buffer is
+// full, but a shutdown must not wait behind it.
 func (r *Receiver) acknowledge(pkt *gosnmp.SnmpPacket, to netip.AddrPort) {
 	pkt.PDUType = gosnmp.GetResponse
 	pkt.Error = gosnmp.NoError
@@ -565,6 +573,10 @@ func (r *Receiver) acknowledge(pkt *gosnmp.SnmpPacket, to netip.AddrPort) {
 	out, err := pkt.MarshalMsg()
 	if err != nil {
 		r.logger.Debug("Could not build an inform acknowledgement", "error", err)
+		return
+	}
+	if err := r.conn.SetWriteDeadline(time.Now().Add(ackTimeout)); err != nil {
+		r.logger.Debug("Could not bound an inform acknowledgement", "error", err)
 		return
 	}
 	if _, err := r.conn.WriteToUDPAddrPort(out, to); err != nil {

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -309,8 +309,15 @@ func (r *Receiver) loop() {
 		// that registered no names uses the socket's. The visit counts under
 		// the registry's read lock, so the claims a count is attributed
 		// under are the claims at the moment it lands.
+		// One intake section decides the datagram's whole outcome: the
+		// datagram counter, the counts, and the drop when there is one, so
+		// a close arriving meanwhile waits for all of it and the final
+		// export never holds a datagram without an outcome. series_limit is
+		// a datagram outcome: one drop, and only when no claiming policy
+		// could count the trap.
 		first := true
 		claimed, counted := 0, 0
+		var dropped DropReason
 		ran := r.intake(func() {
 			r.tally.Datagram()
 			claimed = r.reg.VisitClaims(deviceIP, holding, func(policy string, names map[string]string) {
@@ -327,23 +334,30 @@ func (r *Receiver) loop() {
 					counted++
 				}
 			})
+			switch {
+			case claimed == 0:
+				dropped = DropUnknownSource
+			case counted == 0:
+				dropped = DropSeriesLimit
+			}
+			if dropped != "" {
+				r.tally.Dropped(dropped)
+			}
 		})
 		if !ran {
 			continue
 		}
-		// The datagram is already counted with this outcome, so these two
-		// drops record the reason alone.
-		if claimed == 0 {
-			r.dropDecided(DropUnknownSource, src, "")
+		if dropped == DropUnknownSource {
+			r.logDrop(dropped, src, "")
 			continue
 		}
-		// series_limit is a datagram outcome: one drop, and only when no
-		// claiming policy could count the trap.
-		if counted == 0 {
-			r.dropDecided(DropSeriesLimit, src, "")
-			continue
+		if dropped != "" {
+			r.logDrop(dropped, src, "")
 		}
-
+		// An inform that parsed and was attributed is acknowledged whether
+		// or not a series could be allocated for it: the limit is the
+		// tally's, not the device's, and an unacknowledged inform is sent
+		// again.
 		if tr.Inform {
 			r.acknowledge(pkt, from)
 		}
@@ -410,15 +424,6 @@ func parseErrorCategory(err error) string {
 // counter never runs ahead of the outcomes.
 func (r *Receiver) drop(reason DropReason, src netip.Addr, detail string) {
 	if !r.intake(func() { r.tally.Datagram(); r.tally.Dropped(reason) }) {
-		return
-	}
-	r.logDrop(reason, src, detail)
-}
-
-// dropDecided records a drop reason for a datagram already counted in the
-// same intake section as its claims visit.
-func (r *Receiver) dropDecided(reason DropReason, src netip.Addr, detail string) {
-	if !r.intake(func() { r.tally.Dropped(reason) }) {
 		return
 	}
 	r.logDrop(reason, src, detail)

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -58,10 +58,23 @@ type Receiver struct {
 	// registry in that window, from their own goroutine, hence the atomic;
 	// it is nil otherwise.
 	beforeCount atomic.Pointer[func()]
+	// duringCount, when set, runs inside the claims visit, with the registry
+	// read-locked, before the first count. Tests use it to race a release
+	// against the count from another goroutine; it is nil otherwise.
+	duringCount atomic.Pointer[func()]
 }
 
-// setBeforeCount is a test seam.
-func (r *Receiver) setBeforeCount(f func()) { r.beforeCount.Store(&f) }
+// setBeforeCount is a test seam. A nil f clears it.
+func (r *Receiver) setBeforeCount(f func()) {
+	if f == nil {
+		r.beforeCount.Store(nil)
+		return
+	}
+	r.beforeCount.Store(&f)
+}
+
+// setDuringCount is a test seam.
+func (r *Receiver) setDuringCount(f func()) { r.duringCount.Store(&f) }
 
 // Listen binds addr and starts reading. The bind is synchronous so a failure
 // is reported to the caller rather than logged from a goroutine.
@@ -257,37 +270,41 @@ func (r *Receiver) loop() {
 		if tr.Version == V3 {
 			holding = credentialMatcher(pkt.SecurityParameters.(*gosnmp.UsmSecurityParameters))
 		}
-		deviceIP := src
-		policies = r.reg.PoliciesAt(src, holding)
 
 		// The agent-addr override is a claim about provenance, and only a
 		// registered sender has one to make; every sender past this point
 		// is one. The claim is honoured only when the named address has a
 		// policy of its own.
-		if tr.AgentAddr.IsValid() && tr.AgentAddr != src {
-			if agentPolicies := r.reg.PoliciesAt(tr.AgentAddr, holding); len(agentPolicies) > 0 {
-				deviceIP = canonical(tr.AgentAddr)
-				policies = agentPolicies
-				// Which address a count was attributed to is the one thing an
-				// operator cannot reconstruct from the exported series, since
-				// the series names only the winner.
-				r.logger.Debug("Attributed a trap to its agent-addr rather than its source", "source", src.String(), "agent_addr", deviceIP.String())
-			}
-		}
-		if len(policies) == 0 {
-			r.drop(DropUnknownSource, src, "")
-			continue
+		deviceIP := src
+		if tr.AgentAddr.IsValid() && tr.AgentAddr != src && len(r.reg.PoliciesAt(tr.AgentAddr, holding)) > 0 {
+			deviceIP = canonical(tr.AgentAddr)
+			// Which address a count was attributed to is the one thing an
+			// operator cannot reconstruct from the exported series, since
+			// the series names only the winner.
+			r.logger.Debug("Attributed a trap to its agent-addr rather than its source", "source", src.String(), "agent_addr", deviceIP.String())
 		}
 
 		// Each policy names the trap from its own profile set, so two
 		// policies on one socket can count one OID under two names; a policy
-		// that registered no names uses the socket's.
-		for _, policy := range policies {
-			names := r.reg.NamesFor(policy)
+		// that registered no names uses the socket's. The visit counts under
+		// the registry's read lock, so the claims a count is attributed
+		// under are the claims at the moment it lands.
+		first := true
+		counted := r.reg.VisitClaims(deviceIP, holding, func(policy string, names map[string]string) {
+			if first {
+				first = false
+				if hook := r.duringCount.Load(); hook != nil {
+					(*hook)()
+				}
+			}
 			if names == nil {
 				names = r.names
 			}
 			r.tally.Received(deviceIP.String(), policy, NameFor(names, tr.OID), tr.Version)
+		})
+		if counted == 0 {
+			r.drop(DropUnknownSource, src, "")
+			continue
 		}
 
 		if tr.Inform {

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -92,14 +92,27 @@ func (r *Receiver) Addr() netip.AddrPort {
 
 // Stop closes the socket and waits briefly for the loop to exit.
 func (r *Receiver) Stop() {
+	r.close()
+	r.wait()
+}
+
+// close closes the socket, which is what ends the read loop, and does nothing
+// on a second call. It is separate from the wait so a caller holding its own
+// lock can close under it: while this socket is open, another bind of the
+// same address fails, and the wait below is far too long to hold a lock for.
+func (r *Receiver) close() {
 	r.stopOnce.Do(func() {
 		_ = r.conn.Close()
-		select {
-		case <-r.done:
-		case <-time.After(stopTimeout):
-			r.logger.Warn("Trap receiver did not stop within its bound", "timeout", stopTimeout)
-		}
 	})
+}
+
+// wait waits for the read goroutine to exit, up to its bound.
+func (r *Receiver) wait() {
+	select {
+	case <-r.done:
+	case <-time.After(stopTimeout):
+		r.logger.Warn("Trap receiver did not stop within its bound", "timeout", stopTimeout)
+	}
 }
 
 // rebuildUsersIfChanged refreshes gosnmp's credential table when the registry

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -1,0 +1,228 @@
+package traps
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/netip"
+	"sync"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+
+	"github.com/netboxlabs/orb-agent/orb-telemetry/snmp-telemetry/snmp"
+)
+
+// maxDatagram is the largest trap the receiver reads. It matches gosnmp's own
+// default buffer; a longer datagram is truncated by the kernel and would fail
+// the parser's length check, so it is counted as oversized instead.
+const maxDatagram = 4096
+
+// stopTimeout bounds how long Stop waits for the read goroutine. gosnmp's
+// listener waits three seconds, which spent out of the agent's five second
+// stop grace would starve the final export.
+const stopTimeout = 250 * time.Millisecond
+
+// Receiver owns the UDP socket and the one goroutine that reads it.
+//
+// It does not use gosnmp.TrapListener. That wrapper parses every datagram
+// before the handler sees it, so no source check can run ahead of the cost of
+// parsing (F5); it acknowledges every inform after the handler returns
+// regardless of what the handler decided (F4); and it hides the connection,
+// so the read buffer cannot be sized or its loss observed. What it provides
+// beyond that is a hundred lines of bind and loop, which live here instead.
+// gosnmp still does every byte of the decoding through UnmarshalTrap.
+type Receiver struct {
+	conn          *net.UDPConn
+	reg           *Registry
+	tally         *Tally
+	names         map[string]string
+	acceptUnknown bool
+	logger        *slog.Logger
+
+	params   *gosnmp.GoSNMP
+	usersGen uint64
+
+	stopOnce sync.Once
+	done     chan struct{}
+}
+
+// Listen binds addr and starts reading. The bind is synchronous so a failure
+// is reported to the caller rather than logged from a goroutine.
+func Listen(addr string, reg *Registry, tally *Tally, names map[string]string, acceptUnknown bool, logger *slog.Logger) (*Receiver, error) {
+	udpAddr, err := net.ResolveUDPAddr("udp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("trap listen address %q: %w", addr, err)
+	}
+	conn, err := net.ListenUDP("udp", udpAddr)
+	if err != nil {
+		return nil, fmt.Errorf("binding trap listener on %s: %w", addr, err)
+	}
+	if err := conn.SetReadBuffer(4 << 20); err != nil {
+		logger.Warn("Could not size the trap socket read buffer", "error", err)
+	}
+	r := &Receiver{
+		conn:          conn,
+		reg:           reg,
+		tally:         tally,
+		names:         names,
+		acceptUnknown: acceptUnknown,
+		logger:        logger,
+		done:          make(chan struct{}),
+	}
+	r.params = &gosnmp.GoSNMP{
+		// Version3 with the user security model is what lets UnmarshalTrap
+		// take a v3 packet at all; v1 and v2c parse regardless (F2). Which
+		// versions are then accepted is decided by Decode, not here.
+		Version:       gosnmp.Version3,
+		SecurityModel: gosnmp.UserSecurityModel,
+		// No logger: gosnmp's would format every message before any level
+		// filter, at a pace strangers set, and a trap has no per-device
+		// community to redact.
+		Logger: gosnmp.NewLogger(nil),
+	}
+	r.rebuildUsersIfChanged()
+	go r.loop()
+	return r, nil
+}
+
+// Addr is the bound address, useful when the port was chosen by the kernel.
+func (r *Receiver) Addr() netip.AddrPort {
+	return r.conn.LocalAddr().(*net.UDPAddr).AddrPort()
+}
+
+// Stop closes the socket and waits briefly for the loop to exit.
+func (r *Receiver) Stop() {
+	r.stopOnce.Do(func() {
+		_ = r.conn.Close()
+		select {
+		case <-r.done:
+		case <-time.After(stopTimeout):
+			r.logger.Warn("Trap receiver did not stop within its bound", "timeout", stopTimeout)
+		}
+	})
+}
+
+// rebuildUsersIfChanged refreshes gosnmp's credential table when the registry
+// has changed. gosnmp's table has Add but no Remove, so it is rebuilt whole.
+// Only the loop goroutine touches r.params, so this needs no lock.
+func (r *Receiver) rebuildUsersIfChanged() {
+	gen := r.reg.Generation()
+	if r.params.TrapSecurityParametersTable != nil && gen == r.usersGen {
+		return
+	}
+	table := gosnmp.NewSnmpV3SecurityParametersTable(r.params.Logger)
+	for _, u := range r.reg.Users() {
+		authProto, err := snmp.AuthProtocol(u.AuthProtocol)
+		if err != nil {
+			r.logger.Warn("Skipping a trap v3 user with an unsupported auth protocol", "username", u.Username, "error", err)
+			continue
+		}
+		privProto, err := snmp.PrivProtocol(u.PrivProtocol)
+		if err != nil {
+			r.logger.Warn("Skipping a trap v3 user with an unsupported priv protocol", "username", u.Username, "error", err)
+			continue
+		}
+		sp := &gosnmp.UsmSecurityParameters{
+			UserName:                 u.Username,
+			AuthenticationProtocol:   authProto,
+			AuthenticationPassphrase: u.AuthPassphrase,
+			PrivacyProtocol:          privProto,
+			PrivacyPassphrase:        u.PrivPassphrase,
+			Logger:                   r.params.Logger,
+		}
+		if err := table.Add(u.Username, sp); err != nil {
+			r.logger.Warn("Could not add a trap v3 user", "username", u.Username, "error", err)
+		}
+	}
+	r.params.TrapSecurityParametersTable = table
+	r.usersGen = gen
+}
+
+// loop is the receive path, in the order the spec's section 6.2 gives: read,
+// canonicalise, look the source up before parsing, parse, filter, decode,
+// count, and acknowledge an inform only for a registered source.
+func (r *Receiver) loop() {
+	defer close(r.done)
+	buf := make([]byte, maxDatagram+1)
+	for {
+		n, from, err := r.conn.ReadFromUDPAddrPort(buf)
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
+			r.logger.Debug("Trap socket read failed", "error", err)
+			continue
+		}
+		r.tally.Datagram()
+		src := canonical(from.Addr())
+
+		if n > maxDatagram {
+			r.drop(DropOversized, src, "")
+			continue
+		}
+
+		policies := r.reg.Lookup(src)
+		registered := len(policies) > 0
+		if !registered {
+			if !r.acceptUnknown {
+				r.drop(DropUnknownSource, src, "")
+				continue
+			}
+			policies = []string{""}
+		}
+
+		r.rebuildUsersIfChanged()
+		pkt, err := r.params.UnmarshalTrap(buf[:n], false)
+		if err != nil {
+			r.drop(DropMalformed, src, err.Error())
+			continue
+		}
+
+		tr, reason := Decode(pkt)
+		if reason != "" {
+			r.drop(reason, src, "")
+			continue
+		}
+
+		deviceIP := src
+		if tr.AgentAddr.IsValid() && tr.AgentAddr != src {
+			if agentPolicies := r.reg.Lookup(tr.AgentAddr); len(agentPolicies) > 0 {
+				deviceIP = canonical(tr.AgentAddr)
+				policies = agentPolicies
+			}
+		}
+
+		name := NameFor(r.names, tr.OID)
+		for _, policy := range policies {
+			r.tally.Received(deviceIP.String(), policy, name, tr.Version)
+		}
+
+		if tr.Inform && registered {
+			r.acknowledge(pkt, from)
+		}
+	}
+}
+
+func (r *Receiver) drop(reason DropReason, src netip.Addr, detail string) {
+	r.tally.Dropped(reason)
+	r.logger.Debug("Dropped a trap datagram", "reason", string(reason), "source", src.String(), "registered_addresses", r.reg.Size(), "detail", detail)
+}
+
+// acknowledge answers an inform the way an agent expects, so a registered
+// sender does not retransmit. The packet is reused with its PDU type and
+// error fields changed, which is what gosnmp's own listener does.
+func (r *Receiver) acknowledge(pkt *gosnmp.SnmpPacket, to netip.AddrPort) {
+	pkt.PDUType = gosnmp.GetResponse
+	pkt.Error = gosnmp.NoError
+	pkt.ErrorIndex = 0
+	out, err := pkt.MarshalMsg()
+	if err != nil {
+		r.logger.Debug("Could not build an inform acknowledgement", "error", err)
+		return
+	}
+	if _, err := r.conn.WriteToUDPAddrPort(out, to); err != nil {
+		r.logger.Debug("Could not send an inform acknowledgement", "error", err)
+	}
+}

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -236,9 +236,6 @@ func (r *Receiver) loop() {
 			r.logger.Debug("Trap socket read failed", "error", err)
 			continue
 		}
-		if !r.intake(r.tally.Datagram) {
-			continue
-		}
 		src := canonical(from.Addr())
 
 		policies := r.reg.Lookup(src)
@@ -315,6 +312,7 @@ func (r *Receiver) loop() {
 		first := true
 		claimed, counted := 0, 0
 		ran := r.intake(func() {
+			r.tally.Datagram()
 			claimed = r.reg.VisitClaims(deviceIP, holding, func(policy string, names map[string]string) {
 				if first {
 					first = false
@@ -333,14 +331,16 @@ func (r *Receiver) loop() {
 		if !ran {
 			continue
 		}
+		// The datagram is already counted with this outcome, so these two
+		// drops record the reason alone.
 		if claimed == 0 {
-			r.drop(DropUnknownSource, src, "")
+			r.dropDecided(DropUnknownSource, src, "")
 			continue
 		}
 		// series_limit is a datagram outcome: one drop, and only when no
 		// claiming policy could count the trap.
 		if counted == 0 {
-			r.drop(DropSeriesLimit, src, "")
+			r.dropDecided(DropSeriesLimit, src, "")
 			continue
 		}
 
@@ -406,10 +406,25 @@ func parseErrorCategory(err error) string {
 	return strings.TrimSpace(s)
 }
 
+// drop records a datagram and its drop reason together, so the datagram
+// counter never runs ahead of the outcomes.
 func (r *Receiver) drop(reason DropReason, src netip.Addr, detail string) {
+	if !r.intake(func() { r.tally.Datagram(); r.tally.Dropped(reason) }) {
+		return
+	}
+	r.logDrop(reason, src, detail)
+}
+
+// dropDecided records a drop reason for a datagram already counted in the
+// same intake section as its claims visit.
+func (r *Receiver) dropDecided(reason DropReason, src netip.Addr, detail string) {
 	if !r.intake(func() { r.tally.Dropped(reason) }) {
 		return
 	}
+	r.logDrop(reason, src, detail)
+}
+
+func (r *Receiver) logDrop(reason DropReason, src netip.Addr, detail string) {
 	r.logger.Debug("Dropped a trap datagram", "reason", string(reason), "source", src.String(), "registered_addresses", r.reg.Size(), "detail", detail)
 }
 

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -34,12 +34,11 @@ const stopTimeout = 250 * time.Millisecond
 // beyond that is a hundred lines of bind and loop, which live here instead.
 // gosnmp still does every byte of the decoding through UnmarshalTrap.
 type Receiver struct {
-	conn          *net.UDPConn
-	reg           *Registry
-	tally         *Tally
-	names         map[string]string
-	acceptUnknown bool
-	logger        *slog.Logger
+	conn   *net.UDPConn
+	reg    *Registry
+	tally  *Tally
+	names  map[string]string
+	logger *slog.Logger
 
 	params   *gosnmp.GoSNMP
 	usersGen uint64
@@ -50,26 +49,25 @@ type Receiver struct {
 
 // Listen binds addr and starts reading. The bind is synchronous so a failure
 // is reported to the caller rather than logged from a goroutine.
-func Listen(addr string, reg *Registry, tally *Tally, names map[string]string, acceptUnknown bool, logger *slog.Logger) (*Receiver, error) {
+func Listen(addr string, reg *Registry, tally *Tally, names map[string]string, logger *slog.Logger) (*Receiver, error) {
 	udpAddr, err := net.ResolveUDPAddr("udp", addr)
 	if err != nil {
 		return nil, fmt.Errorf("trap listen address %q: %w", addr, err)
 	}
 	conn, err := net.ListenUDP("udp", udpAddr)
 	if err != nil {
-		return nil, fmt.Errorf("binding trap listener on %s: %w", addr, err)
+		return nil, fmt.Errorf("binding trap socket %s: %w", addr, err)
 	}
 	if err := conn.SetReadBuffer(4 << 20); err != nil {
 		logger.Warn("Could not size the trap socket read buffer", "error", err)
 	}
 	r := &Receiver{
-		conn:          conn,
-		reg:           reg,
-		tally:         tally,
-		names:         names,
-		acceptUnknown: acceptUnknown,
-		logger:        logger,
-		done:          make(chan struct{}),
+		conn:   conn,
+		reg:    reg,
+		tally:  tally,
+		names:  names,
+		logger: logger,
+		done:   make(chan struct{}),
 	}
 	r.params = &gosnmp.GoSNMP{
 		// Version3 with the user security model is what lets UnmarshalTrap
@@ -142,9 +140,10 @@ func (r *Receiver) rebuildUsersIfChanged() {
 
 // loop is the receive path, in the order the spec's section 6.2 gives: read,
 // canonicalise, look the source up before the datagram is judged on anything
-// else, size check, parse, filter, decode, count, and acknowledge an inform
-// only for a registered source. The source is first because every later drop
-// reason names a fault an operator reads as their own devices'.
+// else, size check, parse, filter, decode, count, and acknowledge an inform.
+// The source is first because every later drop reason names a fault an
+// operator reads as their own devices', and because every sender that
+// reaches those later steps is one a policy has already claimed.
 func (r *Receiver) loop() {
 	defer close(r.done)
 	buf := make([]byte, maxDatagram+1)
@@ -161,13 +160,9 @@ func (r *Receiver) loop() {
 		src := canonical(from.Addr())
 
 		policies := r.reg.Lookup(src)
-		registered := len(policies) > 0
-		if !registered {
-			if !r.acceptUnknown {
-				r.drop(DropUnknownSource, src, "")
-				continue
-			}
-			policies = []string{""}
+		if len(policies) == 0 {
+			r.drop(DropUnknownSource, src, "")
+			continue
 		}
 
 		if n > maxDatagram {
@@ -189,11 +184,11 @@ func (r *Receiver) loop() {
 		}
 
 		// The agent-addr override is a claim about provenance, and only a
-		// registered sender has one to make. An unregistered sender reaching
-		// here is one accept-unknown let through, and its packet must not
-		// re-attribute to a device that does have a policy.
+		// registered sender has one to make; every sender past this point
+		// is one. The claim is honoured only when the named address has a
+		// policy of its own.
 		deviceIP := src
-		if registered && tr.AgentAddr.IsValid() && tr.AgentAddr != src {
+		if tr.AgentAddr.IsValid() && tr.AgentAddr != src {
 			if agentPolicies := r.reg.Lookup(tr.AgentAddr); len(agentPolicies) > 0 {
 				deviceIP = canonical(tr.AgentAddr)
 				policies = agentPolicies
@@ -209,7 +204,7 @@ func (r *Receiver) loop() {
 			r.tally.Received(deviceIP.String(), policy, name, tr.Version)
 		}
 
-		if tr.Inform && registered {
+		if tr.Inform {
 			r.acknowledge(pkt, from)
 		}
 	}

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -197,6 +197,10 @@ func (r *Receiver) loop() {
 			if agentPolicies := r.reg.Lookup(tr.AgentAddr); len(agentPolicies) > 0 {
 				deviceIP = canonical(tr.AgentAddr)
 				policies = agentPolicies
+				// Which address a count was attributed to is the one thing an
+				// operator cannot reconstruct from the exported series, since
+				// the series names only the winner.
+				r.logger.Debug("Attributed a trap to its agent-addr rather than its source", "source", src.String(), "agent_addr", deviceIP.String())
 			}
 		}
 

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -8,6 +8,7 @@ import (
 	"net/netip"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gosnmp/gosnmp"
@@ -54,9 +55,13 @@ type Receiver struct {
 
 	// beforeCount, when set, runs after a datagram is parsed and before the
 	// policies it is counted under are resolved. Tests use it to change the
-	// registry in that window; it is nil otherwise.
-	beforeCount func()
+	// registry in that window, from their own goroutine, hence the atomic;
+	// it is nil otherwise.
+	beforeCount atomic.Pointer[func()]
 }
+
+// setBeforeCount is a test seam.
+func (r *Receiver) setBeforeCount(f func()) { r.beforeCount.Store(&f) }
 
 // Listen binds addr and starts reading. The bind is synchronous so a failure
 // is reported to the caller rather than logged from a goroutine.
@@ -237,8 +242,8 @@ func (r *Receiver) loop() {
 			}
 		}
 
-		if r.beforeCount != nil {
-			r.beforeCount()
+		if hook := r.beforeCount.Load(); hook != nil {
+			(*hook)()
 		}
 
 		// The policies a trap is counted under are resolved now, not from

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -46,10 +46,18 @@ type Receiver struct {
 	params   *gosnmp.GoSNMP
 	usersGen uint64
 	// tables caches one credential table per distinct set of users, keyed
-	// by their contents; reset when the registry changes. Only the loop
-	// goroutine touches it.
-	tables map[string]*gosnmp.SnmpV3SecurityParametersTable
-	clocks *timeliness
+	// by their contents, and sourceKeys caches each source's key, so a
+	// source's user set is resolved once per registry generation rather
+	// than per datagram; both reset when the registry changes. Only the
+	// loop goroutine touches them. builds and resolutions are test counters.
+	tables     map[string]*gosnmp.SnmpV3SecurityParametersTable
+	sourceKeys map[netip.Addr]string
+	// statsMu guards the test counters and the cache sizes, which a test
+	// reads from its own goroutine.
+	statsMu     sync.Mutex
+	builds      int
+	resolutions int
+	clocks      *timeliness
 
 	stopOnce sync.Once
 	done     chan struct{}
@@ -187,15 +195,28 @@ func (r *Receiver) waitUntil(expired <-chan struct{}) {
 // but no Remove. Only the loop goroutine touches r.params and the cache, so
 // this needs no lock.
 func (r *Receiver) tableFor(src netip.Addr) *gosnmp.SnmpV3SecurityParametersTable {
+	r.statsMu.Lock()
+	defer r.statsMu.Unlock()
 	if gen := r.reg.Generation(); r.tables == nil || gen != r.usersGen {
 		r.tables = make(map[string]*gosnmp.SnmpV3SecurityParametersTable)
+		r.sourceKeys = make(map[netip.Addr]string)
 		r.usersGen = gen
 	}
-	users := r.reg.UsersAt(src)
-	key := userSetKey(users)
+	key, known := r.sourceKeys[src]
+	var users []V3User
+	if !known {
+		users = r.reg.UsersAt(src)
+		key = userSetKey(users)
+		r.sourceKeys[src] = key
+		r.resolutions++
+	}
 	if table, ok := r.tables[key]; ok {
 		return table
 	}
+	if known {
+		users = r.reg.UsersAt(src)
+	}
+	r.builds++
 	table := gosnmp.NewSnmpV3SecurityParametersTable(r.params.Logger)
 	for _, u := range users {
 		authProto, err := snmp.AuthProtocol(u.AuthProtocol)
@@ -224,8 +245,42 @@ func (r *Receiver) tableFor(src netip.Addr) *gosnmp.SnmpV3SecurityParametersTabl
 	return table
 }
 
-// tableCacheSize is a test accessor.
-func (r *Receiver) tableCacheSize() int { return len(r.tables) }
+// Test accessors, read under statsMu.
+func (r *Receiver) tableCacheSize() int {
+	r.statsMu.Lock()
+	defer r.statsMu.Unlock()
+	return len(r.tables)
+}
+
+func (r *Receiver) tableBuilds() int {
+	r.statsMu.Lock()
+	defer r.statsMu.Unlock()
+	return r.builds
+}
+
+func (r *Receiver) userSetResolutions() int {
+	r.statsMu.Lock()
+	defer r.statsMu.Unlock()
+	return r.resolutions
+}
+
+// wireVersion reads the SNMP version integer off the first bytes of a
+// datagram: the outer SEQUENCE header, then an INTEGER of one byte. It is
+// what decides whether a credential table is needed at all, since only a v3
+// datagram is authenticated, and it costs nothing a parse would not.
+func wireVersion(b []byte) (int, bool) {
+	if len(b) < 2 || b[0] != 0x30 {
+		return 0, false
+	}
+	i := 2
+	if b[1]&0x80 != 0 {
+		i += int(b[1] & 0x7f)
+	}
+	if len(b) < i+3 || b[i] != 0x02 || b[i+1] != 0x01 {
+		return 0, false
+	}
+	return int(b[i+2]), true
+}
 
 // loop is the receive path, in the order the spec's section 6.2 gives: read,
 // canonicalise, look the source up before the datagram is judged on anything
@@ -258,7 +313,14 @@ func (r *Receiver) loop() {
 			continue
 		}
 
-		r.params.TrapSecurityParametersTable = r.tableFor(src)
+		// Only a v3 datagram is authenticated, so only a v3 datagram gets
+		// the source's credential table; a v1 or v2c one pays nothing for
+		// the credentials its source carries. A datagram whose version
+		// cannot be read gets the table and lets the parser judge it.
+		r.params.TrapSecurityParametersTable = nil
+		if v, ok := wireVersion(buf[:n]); !ok || v == int(gosnmp.Version3) {
+			r.params.TrapSecurityParametersTable = r.tableFor(src)
+		}
 		pkt, err := r.parse(buf[:n])
 		if err != nil {
 			r.drop(DropMalformed, src, parseErrorCategory(err))

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -52,6 +52,12 @@ type Receiver struct {
 
 	stopOnce sync.Once
 	done     chan struct{}
+	// intakeMu guards every call into the tally against close: close takes
+	// it for writing and sets stopped, so once close has returned no count
+	// or drop can land, even from a read whose parse outlasted the stop
+	// bound. Shutdown relies on that to run the final export after Close.
+	intakeMu sync.RWMutex
+	stopped  bool
 
 	// beforeCount, when set, runs after a datagram is parsed and before the
 	// policies it is counted under are resolved. Tests use it to change the
@@ -131,8 +137,23 @@ func (r *Receiver) Stop() {
 // same address fails, and the wait below is far too long to hold a lock for.
 func (r *Receiver) close() {
 	r.stopOnce.Do(func() {
+		r.intakeMu.Lock()
+		r.stopped = true
+		r.intakeMu.Unlock()
 		_ = r.conn.Close()
 	})
+}
+
+// intake runs fn, which touches the tally, unless the receiver has been
+// closed, and reports whether it ran.
+func (r *Receiver) intake(fn func()) bool {
+	r.intakeMu.RLock()
+	defer r.intakeMu.RUnlock()
+	if r.stopped {
+		return false
+	}
+	fn()
+	return true
 }
 
 // wait waits for the read goroutine to exit, up to its bound.
@@ -215,7 +236,9 @@ func (r *Receiver) loop() {
 			r.logger.Debug("Trap socket read failed", "error", err)
 			continue
 		}
-		r.tally.Datagram()
+		if !r.intake(r.tally.Datagram) {
+			continue
+		}
 		src := canonical(from.Addr())
 
 		policies := r.reg.Lookup(src)
@@ -290,20 +313,34 @@ func (r *Receiver) loop() {
 		// the registry's read lock, so the claims a count is attributed
 		// under are the claims at the moment it lands.
 		first := true
-		counted := r.reg.VisitClaims(deviceIP, holding, func(policy string, names map[string]string) {
-			if first {
-				first = false
-				if hook := r.duringCount.Load(); hook != nil {
-					(*hook)()
+		claimed, counted := 0, 0
+		ran := r.intake(func() {
+			claimed = r.reg.VisitClaims(deviceIP, holding, func(policy string, names map[string]string) {
+				if first {
+					first = false
+					if hook := r.duringCount.Load(); hook != nil {
+						(*hook)()
+					}
 				}
-			}
-			if names == nil {
-				names = r.names
-			}
-			r.tally.Received(deviceIP.String(), policy, NameFor(names, tr.OID), tr.Version)
+				if names == nil {
+					names = r.names
+				}
+				if r.tally.Received(deviceIP.String(), policy, NameFor(names, tr.OID), tr.Version) {
+					counted++
+				}
+			})
 		})
-		if counted == 0 {
+		if !ran {
+			continue
+		}
+		if claimed == 0 {
 			r.drop(DropUnknownSource, src, "")
+			continue
+		}
+		// series_limit is a datagram outcome: one drop, and only when no
+		// claiming policy could count the trap.
+		if counted == 0 {
+			r.drop(DropSeriesLimit, src, "")
 			continue
 		}
 
@@ -370,7 +407,9 @@ func parseErrorCategory(err error) string {
 }
 
 func (r *Receiver) drop(reason DropReason, src netip.Addr, detail string) {
-	r.tally.Dropped(reason)
+	if !r.intake(func() { r.tally.Dropped(reason) }) {
+		return
+	}
 	r.logger.Debug("Dropped a trap datagram", "reason", string(reason), "source", src.String(), "registered_addresses", r.reg.Size(), "detail", detail)
 }
 

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net"
 	"net/netip"
+	"strings"
 	"sync"
 	"time"
 
@@ -42,6 +43,7 @@ type Receiver struct {
 
 	params   *gosnmp.GoSNMP
 	usersGen uint64
+	clocks   *timeliness
 
 	stopOnce sync.Once
 	done     chan struct{}
@@ -68,6 +70,7 @@ func Listen(addr string, reg *Registry, tally *Tally, names map[string]string, l
 		names:  names,
 		logger: logger,
 		done:   make(chan struct{}),
+		clocks: newTimeliness(time.Now),
 	}
 	r.params = &gosnmp.GoSNMP{
 		// Version3 with the user security model is what lets UnmarshalTrap
@@ -186,7 +189,7 @@ func (r *Receiver) loop() {
 		r.rebuildUsersIfChanged()
 		pkt, err := r.parse(buf[:n])
 		if err != nil {
-			r.drop(DropMalformed, src, err.Error())
+			r.drop(DropMalformed, src, parseErrorCategory(err))
 			continue
 		}
 
@@ -194,6 +197,16 @@ func (r *Receiver) loop() {
 		if reason != "" {
 			r.drop(reason, src, "")
 			continue
+		}
+		// Decode has established that a v3 trap carries USM parameters and a
+		// verified digest, so the boots and time in them are the engine's
+		// own word; what remains is whether that word is current.
+		if tr.Version == V3 {
+			sp := pkt.SecurityParameters.(*gosnmp.UsmSecurityParameters)
+			if !r.clocks.check(sp.AuthoritativeEngineID, sp.AuthoritativeEngineBoots, sp.AuthoritativeEngineTime) {
+				r.drop(DropV3NotInTimeWindow, src, "")
+				continue
+			}
 		}
 
 		// The agent-addr override is a claim about provenance, and only a
@@ -242,6 +255,22 @@ func (r *Receiver) parse(b []byte) (pkt *gosnmp.SnmpPacket, err error) {
 		}
 	}()
 	return r.params.UnmarshalTrap(b, false)
+}
+
+// parseErrorCategory keeps the part of a parse error that names the fault and
+// drops the part that quotes the packet. gosnmp reports a malformed message
+// by appending the bytes it could not parse, and in a v1 or v2c message those
+// begin at or just after the community, which is the polling credential more
+// often than not. The poller redacts the community it knows from such errors;
+// the receiver knows no community, so it keeps the category alone, which is
+// everything before the first colon or parenthesis: the stage that failed
+// and what it expected.
+func parseErrorCategory(err error) string {
+	s := err.Error()
+	if i := strings.IndexAny(s, ":("); i >= 0 {
+		s = s[:i]
+	}
+	return strings.TrimSpace(s)
 }
 
 func (r *Receiver) drop(reason DropReason, src netip.Addr, detail string) {

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -176,7 +176,7 @@ func (r *Receiver) loop() {
 		}
 
 		r.rebuildUsersIfChanged()
-		pkt, err := r.params.UnmarshalTrap(buf[:n], false)
+		pkt, err := r.parse(buf[:n])
 		if err != nil {
 			r.drop(DropMalformed, src, err.Error())
 			continue
@@ -209,6 +209,27 @@ func (r *Receiver) loop() {
 			r.acknowledge(pkt, from)
 		}
 	}
+}
+
+// parse hands the datagram to gosnmp and turns a panic in it into an error.
+//
+// The spec says the receive goroutine recovers nothing, and that stays true of
+// this package's own code: a panic there is a bug, and a process that carries
+// on with a dead receiver hides it. A panic inside a vendored ASN.1 parser fed
+// bytes a stranger chose is a different thing, and the two do not share a
+// policy. F16: gosnmp blanks the authentication parameters in place with an
+// unchecked copy(packet[cursor+2:cursor+len(mac)], ...) (v3_usm.go:1059) as
+// soon as the auth bit is set and the named user has a real auth protocol, so
+// a datagram that ends before the digest is wide enough panics. Without this
+// the socket is a remote kill switch. The recover is this narrow on purpose:
+// it wraps the third-party call and nothing else, so nothing here is caught.
+func (r *Receiver) parse(b []byte) (pkt *gosnmp.SnmpPacket, err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			pkt, err = nil, fmt.Errorf("panic in the SNMP parser: %v", rec)
+		}
+	}()
+	return r.params.UnmarshalTrap(b, false)
 }
 
 func (r *Receiver) drop(reason DropReason, src netip.Addr, detail string) {

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -417,23 +417,21 @@ func (r *Receiver) loop() {
 					a.Dropped(dropped)
 				}
 			})
+			// An inform that parsed and was attributed is acknowledged
+			// whether or not a series could be allocated for it: the limit
+			// is the tally's, not the device's, and an unacknowledged inform
+			// is sent again. It is acknowledged inside the intake section
+			// that counted it, so a close cannot land between the two and
+			// have the device retransmit an inform already counted.
+			if tr.Inform && dropped != DropUnknownSource {
+				r.acknowledge(pkt, from)
+			}
 		})
 		if !ran {
 			continue
 		}
-		if dropped == DropUnknownSource {
-			r.logDrop(dropped, src, "")
-			continue
-		}
 		if dropped != "" {
 			r.logDrop(dropped, src, "")
-		}
-		// An inform that parsed and was attributed is acknowledged whether
-		// or not a series could be allocated for it: the limit is the
-		// tally's, not the device's, and an unacknowledged inform is sent
-		// again.
-		if tr.Inform {
-			r.acknowledge(pkt, from)
 		}
 	}
 }

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -318,30 +318,32 @@ func (r *Receiver) loop() {
 		claimed, counted := 0, 0
 		var dropped DropReason
 		ran := r.intake(func() {
-			r.tally.Datagram()
-			claimed = r.reg.VisitClaims(deviceIP, holding, func(policy string, names map[string]string) {
-				if first {
-					first = false
-					if hook := r.duringCount.Load(); hook != nil {
-						(*hook)()
+			r.tally.Account(func(a *Account) {
+				a.Datagram()
+				claimed = r.reg.VisitClaims(deviceIP, holding, func(policy string, names map[string]string) {
+					if first {
+						first = false
+						if hook := r.duringCount.Load(); hook != nil {
+							(*hook)()
+						}
 					}
+					if names == nil {
+						names = r.names
+					}
+					if a.Received(deviceIP.String(), policy, NameFor(names, tr.OID), tr.Version) {
+						counted++
+					}
+				})
+				switch {
+				case claimed == 0:
+					dropped = DropUnknownSource
+				case counted == 0:
+					dropped = DropSeriesLimit
 				}
-				if names == nil {
-					names = r.names
-				}
-				if r.tally.Received(deviceIP.String(), policy, NameFor(names, tr.OID), tr.Version) {
-					counted++
+				if dropped != "" {
+					a.Dropped(dropped)
 				}
 			})
-			switch {
-			case claimed == 0:
-				dropped = DropUnknownSource
-			case counted == 0:
-				dropped = DropSeriesLimit
-			}
-			if dropped != "" {
-				r.tally.Dropped(dropped)
-			}
 		})
 		if !ran {
 			continue
@@ -454,7 +456,7 @@ func parseErrorCategory(err error) string {
 // drop records a datagram and its drop reason together, so the datagram
 // counter never runs ahead of the outcomes.
 func (r *Receiver) drop(reason DropReason, src netip.Addr, detail string) {
-	if !r.intake(func() { r.tally.Datagram(); r.tally.Dropped(reason) }) {
+	if !r.intake(func() { r.tally.Account(func(a *Account) { a.Datagram(); a.Dropped(reason) }) }) {
 		return
 	}
 	r.logDrop(reason, src, detail)

--- a/orb-telemetry/snmp-telemetry/traps/receiver.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver.go
@@ -141,8 +141,10 @@ func (r *Receiver) rebuildUsersIfChanged() {
 }
 
 // loop is the receive path, in the order the spec's section 6.2 gives: read,
-// canonicalise, look the source up before parsing, parse, filter, decode,
-// count, and acknowledge an inform only for a registered source.
+// canonicalise, look the source up before the datagram is judged on anything
+// else, size check, parse, filter, decode, count, and acknowledge an inform
+// only for a registered source. The source is first because every later drop
+// reason names a fault an operator reads as their own devices'.
 func (r *Receiver) loop() {
 	defer close(r.done)
 	buf := make([]byte, maxDatagram+1)
@@ -158,11 +160,6 @@ func (r *Receiver) loop() {
 		r.tally.Datagram()
 		src := canonical(from.Addr())
 
-		if n > maxDatagram {
-			r.drop(DropOversized, src, "")
-			continue
-		}
-
 		policies := r.reg.Lookup(src)
 		registered := len(policies) > 0
 		if !registered {
@@ -171,6 +168,11 @@ func (r *Receiver) loop() {
 				continue
 			}
 			policies = []string{""}
+		}
+
+		if n > maxDatagram {
+			r.drop(DropOversized, src, "")
+			continue
 		}
 
 		r.rebuildUsersIfChanged()
@@ -186,8 +188,12 @@ func (r *Receiver) loop() {
 			continue
 		}
 
+		// The agent-addr override is a claim about provenance, and only a
+		// registered sender has one to make. An unregistered sender reaching
+		// here is one accept-unknown let through, and its packet must not
+		// re-attribute to a device that does have a policy.
 		deviceIP := src
-		if tr.AgentAddr.IsValid() && tr.AgentAddr != src {
+		if registered && tr.AgentAddr.IsValid() && tr.AgentAddr != src {
 			if agentPolicies := r.reg.Lookup(tr.AgentAddr); len(agentPolicies) > 0 {
 				deviceIP = canonical(tr.AgentAddr)
 				policies = agentPolicies

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -819,3 +819,51 @@ func TestReceiver_AttributesAnAuthNoPrivTrapToEveryCredentialItVerified(t *testi
 	assert.Equal(t, int64(0), h.tally.droppedCount(DropMalformed))
 	assert.Equal(t, int64(0), h.tally.droppedCount(DropV3NotInTimeWindow), "one principal at authNoPriv, its clock shared by both entries")
 }
+
+// The wire version is read off the first bytes of the datagram, before any
+// parse, so the credential table is built only for a v3 datagram.
+func TestWireVersion(t *testing.T) {
+	const engineID = "\x80\x00\x1f\x88\x80\x41\x42\x43"
+	cases := map[string]struct {
+		pkt  []byte
+		want int
+		ok   bool
+	}{
+		"v1":              {v1Trap("public", [4]byte{0, 0, 0, 0}, 2, 0), 0, true},
+		"v2c":             {v2cTrap("public"), 1, true},
+		"v3, long length": {v3AuthPrivTrap(t, trapAuthPrivUser, engineID), 3, true},
+		"garbage":         {[]byte{0x30, 0x01, 0xff}, 0, false},
+		"empty":           {nil, 0, false},
+		"not a sequence":  {[]byte{0x04, 0x03, 0x02, 0x01, 0x03}, 0, false},
+	}
+	for name, tc := range cases {
+		v, ok := wireVersion(tc.pkt)
+		assert.Equal(t, tc.ok, ok, name)
+		if ok {
+			assert.Equal(t, tc.want, v, name)
+		}
+	}
+	require.Greater(t, len(v3AuthPrivTrap(t, trapAuthPrivUser, engineID)), 127, "the v3 fixture exercises the long length form")
+}
+
+// A v1 or v2c datagram never touches the credential table, and a v3 source
+// has its user set resolved once per registry generation, however many
+// datagrams it sends and however many credentials it carries.
+func TestReceiver_ResolvesASourcesCredentialsOncePerGeneration(t *testing.T) {
+	const engineID = "\x80\x00\x1f\x88\x80\x41\x42\x43"
+	h := newHarness(t)
+	src := h.registerSender(t, "core", trapAuthPrivUser)
+	for range 5 {
+		h.send(t, v2cTrap("public"))
+	}
+	waitFor(t, 5, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V2c) })
+	assert.Equal(t, 0, h.rcv.tableBuilds(), "no table for v2c")
+	assert.Equal(t, 0, h.rcv.tableCacheSize())
+
+	for i := range 5 {
+		h.send(t, v3AuthPrivTrapAt(t, trapAuthPrivUser, engineID, 1, uint32(i+1)))
+	}
+	waitFor(t, 5, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V3) })
+	assert.Equal(t, 1, h.rcv.tableBuilds(), "one table for the source's credentials")
+	assert.Equal(t, 1, h.rcv.userSetResolutions(), "and the user set resolved once, not per datagram")
+}

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -130,18 +130,35 @@ func TestReceiver_RejectsANonTrapPDU(t *testing.T) {
 	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropUnsupportedPDU) })
 }
 
+// trapUser is the credential the v3 tests register. gosnmp selects security
+// parameters by username before it parses, so a v3 packet only reaches the
+// parser under a name the registry holds.
+var trapUser = V3User{
+	Username:       "trapuser",
+	AuthProtocol:   "SHA",
+	AuthPassphrase: "authpassphrase",
+	PrivProtocol:   "NoPriv",
+}
+
 // F1, end to end: the engine discovery shape reaches gosnmp's parser and is
 // accepted there, and is rejected here.
 func TestReceiver_RejectsUnauthenticatedV3(t *testing.T) {
 	h := newHarness(t, false)
-	h.registerSender(t, "core", V3User{
-		Username:       "trapuser",
-		AuthProtocol:   "SHA",
-		AuthPassphrase: "authpassphrase",
-		PrivProtocol:   "NoPriv",
-	})
-	h.send(t, v3Unauthenticated("trapuser"))
+	h.registerSender(t, "core", trapUser)
+	h.send(t, v3Unauthenticated("trapuser", ""))
 	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropV3Unauthenticated) })
+}
+
+// F1's residual, end to end: a username is not a secret, so naming a known
+// user with any engine ID and noAuthNoPriv flags satisfies the identity check
+// while gosnmp verifies no digest at all. Nothing about that packet was
+// authenticated, so it must not be counted as a v3 trap.
+func TestReceiver_RejectsV3WithoutTheAuthFlag(t *testing.T) {
+	h := newHarness(t, false)
+	src := h.registerSender(t, "core", trapUser)
+	h.send(t, v3Unauthenticated("trapuser", "\x80\x00\x1f\x88\x80"))
+	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropV3Unauthenticated) })
+	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "core", "linkDown", V3))
 }
 
 func TestReceiver_V1TrapIsNormalisedAndCounted(t *testing.T) {

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -211,6 +211,32 @@ func TestReceiver_SurvivesAV3DatagramThatPanicsTheParser(t *testing.T) {
 	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V2c) })
 }
 
+// trapAuthPrivUser is the credential the acceptance test registers. SHA and
+// AES, the pair a real authPriv target is configured with.
+var trapAuthPrivUser = V3User{
+	Username:       "authprivuser",
+	AuthProtocol:   "SHA",
+	AuthPassphrase: "authpassphrase",
+	PrivProtocol:   "AES",
+	PrivPassphrase: "privpassphrase",
+}
+
+// The load-bearing acceptance path: a v3 trap a policy's own credentials
+// authenticate is counted. Every other v3 test here asserts a drop, so
+// without this one rebuildUsersIfChanged, the protocol name mapping, gosnmp's
+// credential table and the generation rebuild are all unverified against a
+// packet that is supposed to be accepted. The packet is marshalled by gosnmp
+// itself, digest and encrypted scoped PDU included.
+func TestReceiver_AcceptsAnAuthenticatedV3Trap(t *testing.T) {
+	const engineID = "\x80\x00\x1f\x88\x80\x41\x42\x43"
+	h := newHarness(t, false)
+	src := h.registerSender(t, "core", trapAuthPrivUser)
+	h.send(t, v3AuthPrivTrap(t, trapAuthPrivUser, engineID))
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V3) })
+	assert.Equal(t, int64(0), h.tally.droppedCount(DropV3Unauthenticated))
+	assert.Equal(t, int64(0), h.tally.droppedCount(DropMalformed))
+}
+
 func TestReceiver_V1TrapIsNormalisedAndCounted(t *testing.T) {
 	h := newHarness(t, false)
 	src := h.registerSender(t, "core")

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -774,3 +774,20 @@ func TestReceiver_CredentialKeysAreInjective(t *testing.T) {
 	assert.NotEqual(t, userSetKey([]V3User{{Username: "ab", AuthPassphrase: "c"}}), userSetKey([]V3User{{Username: "a", AuthPassphrase: "bc"}}))
 	assert.Equal(t, userSetKey(ua), userSetKey(ua))
 }
+
+// The receiver accounts a datagram and its outcome in one tally transaction,
+// so a periodic export taken while the claims are being visited sees the
+// datagram together with its count, never the datagram alone.
+func TestReceiver_AccountsADatagramAndItsCountUnderOneTallyLock(t *testing.T) {
+	h := newHarness(t)
+	src := h.registerSender(t, "core")
+	seen := make(chan [2]int64, 1)
+	h.rcv.setDuringCount(func() {
+		go func() {
+			seen <- [2]int64{h.tally.datagramCount(), h.tally.receivedCount(src.String(), "core", "linkDown", V2c)}
+		}()
+		time.Sleep(50 * time.Millisecond)
+	})
+	h.send(t, v2cTrap("public"))
+	assert.Equal(t, [2]int64{1, 1}, <-seen, "the export waited for the outcome")
+}

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -1,0 +1,177 @@
+package traps
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// harness binds a receiver on loopback and returns a sender socket.
+type harness struct {
+	rcv    *Receiver
+	reg    *Registry
+	tally  *Tally
+	sender *net.UDPConn
+}
+
+func newHarness(t *testing.T, acceptUnknown bool) *harness {
+	t.Helper()
+	reg := NewRegistry()
+	tally := NewTally(testLogger)
+	rcv, err := Listen("127.0.0.1:0", reg, tally, BuildNames(nil), acceptUnknown, testLogger)
+	require.NoError(t, err)
+	t.Cleanup(rcv.Stop)
+	sender, err := net.DialUDP("udp", nil, net.UDPAddrFromAddrPort(rcv.Addr()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sender.Close() })
+	return &harness{rcv: rcv, reg: reg, tally: tally, sender: sender}
+}
+
+// registerSender claims the sender socket's own address for a policy, which
+// is what makes a loopback test's source "known".
+func (h *harness) registerSender(t *testing.T, policy string, users ...V3User) netip.Addr {
+	t.Helper()
+	local := h.sender.LocalAddr().(*net.UDPAddr).AddrPort().Addr()
+	h.reg.Register(policy, []Device{{Policy: policy, Addr: local}}, users)
+	return canonical(local)
+}
+
+func (h *harness) send(t *testing.T, pkt []byte) {
+	t.Helper()
+	_, err := h.sender.Write(pkt)
+	require.NoError(t, err)
+}
+
+// waitFor polls a tally accessor until it reaches want or the deadline passes.
+func waitFor(t *testing.T, want int64, get func() int64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if get() >= want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	assert.Equal(t, want, get())
+}
+
+func TestReceiver_CountsAKnownV2cTrap(t *testing.T) {
+	h := newHarness(t, false)
+	src := h.registerSender(t, "core")
+	h.send(t, v2cTrap("public"))
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V2c) })
+	assert.Equal(t, int64(1), h.tally.datagramCount())
+}
+
+// The source check runs before any parsing, so an unknown sender costs a map
+// lookup and nothing else (F5), and is counted as dropped.
+func TestReceiver_DropsAnUnknownSourceBeforeParsing(t *testing.T) {
+	h := newHarness(t, false)
+	h.send(t, v2cTrap("public"))
+	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropUnknownSource) })
+	assert.Equal(t, int64(0), h.tally.receivedCount("127.0.0.1", "", "linkDown", V2c))
+
+	// A datagram no parser could read still drops on the source, which is only
+	// true if the source check runs ahead of the parse.
+	h.send(t, []byte{0x30, 0x01, 0xff})
+	waitFor(t, 2, func() int64 { return h.tally.droppedCount(DropUnknownSource) })
+	assert.Equal(t, int64(0), h.tally.droppedCount(DropMalformed))
+}
+
+func TestReceiver_AcceptUnknownLabelsBySourceAddressWithNoPolicy(t *testing.T) {
+	h := newHarness(t, true)
+	h.send(t, v2cTrap("public"))
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount("127.0.0.1", "", "linkDown", V2c) })
+}
+
+// A trap from an address two policies name counts once per policy.
+func TestReceiver_CountsOncePerClaimingPolicy(t *testing.T) {
+	h := newHarness(t, false)
+	src := h.registerSender(t, "core")
+	h.reg.Register("edge", []Device{{Policy: "edge", Addr: src}}, nil)
+	h.send(t, v2cTrap("public"))
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V2c) })
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "edge", "linkDown", V2c) })
+}
+
+// F4: an inform from a registered source is acknowledged, so the device does
+// not retransmit and double count. An inform from anyone else never is, so
+// the socket does not reflect.
+func TestReceiver_AcknowledgesInformsOnlyFromRegisteredSources(t *testing.T) {
+	h := newHarness(t, true)
+	require.NoError(t, h.sender.SetReadDeadline(time.Now().Add(500*time.Millisecond)))
+	buf := make([]byte, 512)
+
+	h.send(t, v2cInform("public"))
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount("127.0.0.1", "", "linkDown", V2c) })
+	_, err := h.sender.Read(buf)
+	assert.Error(t, err, "an accepted-unknown inform is counted but never answered")
+
+	src := h.registerSender(t, "core")
+	h.send(t, v2cInform("public"))
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V2c) })
+	require.NoError(t, h.sender.SetReadDeadline(time.Now().Add(2*time.Second)))
+	n, err := h.sender.Read(buf)
+	require.NoError(t, err, "a registered inform gets its acknowledgement")
+	pkt, err := (&gosnmp.GoSNMP{Version: gosnmp.Version2c}).UnmarshalTrap(buf[:n], false)
+	require.NoError(t, err)
+	assert.Equal(t, gosnmp.GetResponse, pkt.PDUType)
+}
+
+func TestReceiver_RejectsANonTrapPDU(t *testing.T) {
+	h := newHarness(t, false)
+	h.registerSender(t, "core")
+	h.send(t, v2cGet("public"))
+	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropUnsupportedPDU) })
+}
+
+// F1, end to end: the engine discovery shape reaches gosnmp's parser and is
+// accepted there, and is rejected here.
+func TestReceiver_RejectsUnauthenticatedV3(t *testing.T) {
+	h := newHarness(t, false)
+	h.registerSender(t, "core", V3User{
+		Username:       "trapuser",
+		AuthProtocol:   "SHA",
+		AuthPassphrase: "authpassphrase",
+		PrivProtocol:   "NoPriv",
+	})
+	h.send(t, v3Unauthenticated("trapuser"))
+	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropV3Unauthenticated) })
+}
+
+func TestReceiver_V1TrapIsNormalisedAndCounted(t *testing.T) {
+	h := newHarness(t, false)
+	src := h.registerSender(t, "core")
+	h.send(t, v1Trap("public", [4]byte{0, 0, 0, 0}, 2, 0))
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V1) })
+}
+
+// F9, narrow phase 1 rule: a v1 agent-addr that is itself registered wins
+// over the source address.
+func TestReceiver_V1AgentAddrWinsWhenRegistered(t *testing.T) {
+	h := newHarness(t, false)
+	h.registerSender(t, "core")
+	h.reg.Register("agent", []Device{{Policy: "agent", Addr: netip.MustParseAddr("10.9.9.9")}}, nil)
+	h.send(t, v1Trap("public", [4]byte{10, 9, 9, 9}, 2, 0))
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount("10.9.9.9", "agent", "linkDown", V1) })
+}
+
+func TestReceiver_OversizedDatagramIsDropped(t *testing.T) {
+	h := newHarness(t, false)
+	h.registerSender(t, "core")
+	h.send(t, make([]byte, maxDatagram+1))
+	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropOversized) })
+}
+
+func TestReceiver_StopIsPromptAndIdempotent(t *testing.T) {
+	h := newHarness(t, false)
+	start := time.Now()
+	h.rcv.Stop()
+	h.rcv.Stop()
+	assert.Less(t, time.Since(start), time.Second)
+}

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -751,3 +751,26 @@ func TestReceiver_KeepsEngineClocksPerCredential(t *testing.T) {
 	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropV3NotInTimeWindow) })
 	assert.Equal(t, int64(1), h.tally.receivedCount(src.String(), "core", "linkDown", V3), "and for the same credential it still is one")
 }
+
+// The clock key and the credential-table cache key are both built from
+// operator-chosen strings, so neither may be a delimiter join: a username
+// containing the delimiter could make two principals one clock, or two user
+// sets one table. Both are injective: the clock key is a struct, the cache
+// key length-prefixes every field.
+func TestReceiver_CredentialKeysAreInjective(t *testing.T) {
+	src := netip.MustParseAddr("10.0.0.5")
+	a := &gosnmp.UsmSecurityParameters{UserName: "u|x", AuthenticationPassphrase: "password", AuthenticationProtocol: gosnmp.SHA, PrivacyProtocol: gosnmp.AES, AuthoritativeEngineID: "e"}
+	b := &gosnmp.UsmSecurityParameters{UserName: "u", AuthenticationPassphrase: "x|password", AuthenticationProtocol: gosnmp.SHA, PrivacyProtocol: gosnmp.AES, AuthoritativeEngineID: "e"}
+	assert.NotEqual(t, clockKey(src, a), clockKey(src, b), "a delimiter in a username is not a field boundary")
+	authOnly := &gosnmp.UsmSecurityParameters{UserName: "u", AuthenticationPassphrase: "other", AuthenticationProtocol: gosnmp.SHA, PrivacyProtocol: gosnmp.AES, AuthoritativeEngineID: "e"}
+	assert.NotEqual(t, clockKey(src, b), clockKey(src, authOnly), "the auth passphrase is part of the identity")
+	privOnly := &gosnmp.UsmSecurityParameters{UserName: "u", AuthenticationPassphrase: "x|password", PrivacyPassphrase: "other", AuthenticationProtocol: gosnmp.SHA, PrivacyProtocol: gosnmp.AES, AuthoritativeEngineID: "e"}
+	assert.NotEqual(t, clockKey(src, b), clockKey(src, privOnly), "so is the priv passphrase")
+	assert.Equal(t, clockKey(src, b), clockKey(src, b))
+
+	ua := []V3User{{Username: "u\x00x", AuthProtocol: "SHA", AuthPassphrase: "p"}}
+	ub := []V3User{{Username: "u", AuthProtocol: "x\x00SHA", AuthPassphrase: "p"}}
+	assert.NotEqual(t, userSetKey(ua), userSetKey(ub), "a NUL in a field is not a field boundary")
+	assert.NotEqual(t, userSetKey([]V3User{{Username: "ab", AuthPassphrase: "c"}}), userSetKey([]V3User{{Username: "a", AuthPassphrase: "bc"}}))
+	assert.Equal(t, userSetKey(ua), userSetKey(ua))
+}

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -528,10 +528,10 @@ func TestReceiver_CountsAV3TrapOnlyForThePoliciesHoldingItsCredential(t *testing
 func TestReceiver_ResolvesTheClaimingPoliciesAtCountTime(t *testing.T) {
 	h := newHarness(t)
 	src := h.registerSender(t, "core")
-	h.rcv.beforeCount = func() {
+	h.rcv.setBeforeCount(func() {
 		h.reg.Withdraw("core")
 		h.reg.Register("next", []Device{{Policy: "next", Addr: netip.MustParseAddr("10.9.9.9")}}, nil)
-	}
+	})
 	h.send(t, v2cTrap("public"))
 	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropUnknownSource) })
 	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "core", "linkDown", V2c), "the released policy is not counted")
@@ -540,10 +540,10 @@ func TestReceiver_ResolvesTheClaimingPoliciesAtCountTime(t *testing.T) {
 	// The sender must be claimed when the datagram is read, or it is dropped
 	// before the hook runs; the hook then swaps the claim to the replacement.
 	h.registerSender(t, "core")
-	h.rcv.beforeCount = func() {
+	h.rcv.setBeforeCount(func() {
 		h.reg.Withdraw("core")
 		h.reg.Register("next", []Device{{Policy: "next", Addr: src}}, nil)
-	}
+	})
 	h.send(t, v2cTrap("public"))
 	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "next", "linkDown", V2c) })
 	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "core", "linkDown", V2c))

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -564,3 +564,24 @@ func TestReceiver_ResolvesAndCountsTheClaimsAtomically(t *testing.T) {
 	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "core", "linkDown", V2c), "the count went to the outgoing incarnation and left with it")
 	assert.Equal(t, int64(1), h.tally.retainedCount(src.String(), "core", "linkDown", V2c), "kept as a dormant total, not exported")
 }
+
+// An authNoPriv trap carries a digest and no encryption. One signed with a
+// wrong passphrase, that is a forged digest under a known username from a
+// registered source, must be rejected the same way an authPriv one is: the
+// receiver always installs a credential table, and gosnmp's table path
+// verifies the digest against the packet's own flags, not the receiver's.
+func TestReceiver_RejectsAForgedDigestOnAnAuthNoPrivTrap(t *testing.T) {
+	const engineID = "\x80\x00\x1f\x88\x80\x41\x42\x43"
+	h := newHarness(t)
+	src := h.registerSender(t, "core", trapAuthPrivUser)
+
+	forged := trapAuthPrivUser
+	forged.AuthPassphrase = "not-the-passphrase"
+	h.send(t, v3AuthNoPrivTrap(t, forged, engineID))
+	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropMalformed) })
+	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "core", "linkDown", V3), "a forged digest authenticates nothing")
+
+	h.send(t, v3AuthNoPrivTrap(t, trapAuthPrivUser, engineID))
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V3) })
+	assert.Equal(t, int64(1), h.tally.droppedCount(DropMalformed), "the genuine authNoPriv trap is counted")
+}

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -892,3 +892,22 @@ func TestReceiver_AcknowledgesAnInformBeforeACloseCanIntervene(t *testing.T) {
 	assert.Equal(t, gosnmp.GetResponse, pkt.PDUType)
 	<-stopped
 }
+
+// The agent-addr override is resolved inside the same locked visit as the
+// claims it selects. A policy claiming the agent address that is released
+// between the read and the count no longer decides anything: the visit sees
+// no claim on the agent address and falls back to the relay's own claims,
+// so the trap is counted under the relay's policy rather than dropped.
+func TestReceiver_ResolvesTheAgentAddrFallbackUnderTheClaimsLock(t *testing.T) {
+	h := newHarness(t)
+	src := h.registerSender(t, "relay")
+	h.reg.Register("agent", []Device{{Policy: "agent", Addr: netip.MustParseAddr("10.9.9.9")}}, nil)
+	// Withdrawn inside the intake section, after the datagram was admitted
+	// and before the claims are visited: the window an unlocked
+	// pre-selection of the agent address would have left open.
+	h.rcv.setBeforeAccount(func() { h.reg.Withdraw("agent") })
+	h.send(t, v1Trap("public", [4]byte{10, 9, 9, 9}, 2, 0))
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "relay", "linkDown", V1) })
+	assert.Equal(t, int64(0), h.tally.receivedCount("10.9.9.9", "agent", "linkDown", V1))
+	assert.Equal(t, int64(0), h.tally.droppedCount(DropUnknownSource), "the relay still claims the source")
+}

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -483,3 +483,68 @@ func TestReceiver_NamesATrapWithThePolicysOwnNames(t *testing.T) {
 	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "plain", "linkDown", V2c) })
 	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "vendor", "vendorLinkDown", V2c), "RFC 1215 wins over the profile's spelling")
 }
+
+// Two policies claiming one device with different credentials share a
+// credential table, since gosnmp is handed every user at the address, but a
+// v3 trap is counted only under the policies holding the credential that
+// verified it. A policy naming the device with no v3 user, or with another
+// credential, counts its v1 and v2c traps and not its authenticated v3 ones.
+func TestReceiver_CountsAV3TrapOnlyForThePoliciesHoldingItsCredential(t *testing.T) {
+	const engineID = "\x80\x00\x1f\x88\x80\x41\x42\x43"
+	mine := trapAuthPrivUser
+	theirs := trapAuthPrivUser
+	theirs.AuthPassphrase = "someone-elses-authpass"
+	theirs.PrivPassphrase = "someone-elses-privpass"
+
+	h := newHarness(t)
+	src := canonical(h.sender.LocalAddr().(*net.UDPAddr).AddrPort().Addr())
+	h.reg.Register("core", []Device{{Policy: "core", Addr: src, User: &mine}}, nil)
+	h.reg.Register("edge", []Device{{Policy: "edge", Addr: src, User: &theirs}}, nil)
+	h.reg.Register("plain", []Device{{Policy: "plain", Addr: src}}, nil)
+	count := func(policy string, v Version) int64 {
+		return h.tally.receivedCount(src.String(), policy, "linkDown", v)
+	}
+
+	h.send(t, v3AuthPrivTrapAt(t, mine, engineID, 1, 1))
+	waitFor(t, 1, func() int64 { return count("core", V3) })
+	h.send(t, v3AuthPrivTrapAt(t, theirs, engineID, 1, 2))
+	waitFor(t, 1, func() int64 { return count("edge", V3) })
+	h.send(t, v2cTrap("public"))
+	waitFor(t, 1, func() int64 { return count("plain", V2c) })
+
+	assert.Equal(t, int64(1), count("core", V3), "core saw only the trap its credential verified")
+	assert.Equal(t, int64(1), count("edge", V3), "edge likewise")
+	assert.Equal(t, int64(0), count("plain", V3), "a policy without the credential counts no authenticated v3 trap")
+	assert.Equal(t, int64(1), count("core", V2c), "but every claim counts the v2c one")
+	assert.Equal(t, int64(1), count("edge", V2c))
+	assert.Equal(t, int64(0), h.tally.droppedCount(DropMalformed))
+}
+
+// The policies a trap is counted under are resolved when it is counted, not
+// when it was read. A policy released while the datagram was being parsed,
+// and replaced by one that does not claim the device, gets nothing and the
+// datagram is an unknown source; a replacement that does claim the device
+// gets the count.
+func TestReceiver_ResolvesTheClaimingPoliciesAtCountTime(t *testing.T) {
+	h := newHarness(t)
+	src := h.registerSender(t, "core")
+	h.rcv.beforeCount = func() {
+		h.reg.Withdraw("core")
+		h.reg.Register("next", []Device{{Policy: "next", Addr: netip.MustParseAddr("10.9.9.9")}}, nil)
+	}
+	h.send(t, v2cTrap("public"))
+	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropUnknownSource) })
+	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "core", "linkDown", V2c), "the released policy is not counted")
+	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "next", "linkDown", V2c), "nor a replacement that does not claim the device")
+
+	// The sender must be claimed when the datagram is read, or it is dropped
+	// before the hook runs; the hook then swaps the claim to the replacement.
+	h.registerSender(t, "core")
+	h.rcv.beforeCount = func() {
+		h.reg.Withdraw("core")
+		h.reg.Register("next", []Device{{Policy: "next", Addr: src}}, nil)
+	}
+	h.send(t, v2cTrap("public"))
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "next", "linkDown", V2c) })
+	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "core", "linkDown", V2c))
+}

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -867,3 +867,28 @@ func TestReceiver_ResolvesASourcesCredentialsOncePerGeneration(t *testing.T) {
 	assert.Equal(t, 1, h.rcv.tableBuilds(), "one table for the source's credentials")
 	assert.Equal(t, 1, h.rcv.userSetResolutions(), "and the user set resolved once, not per datagram")
 }
+
+// An inform is acknowledged inside the same intake section that counted it,
+// so a close cannot land between the count and the acknowledgement: it waits
+// for both, and the device never retransmits an inform that was counted.
+func TestReceiver_AcknowledgesAnInformBeforeACloseCanIntervene(t *testing.T) {
+	h := newHarness(t)
+	h.registerSender(t, "core")
+	require.NoError(t, h.sender.SetReadDeadline(time.Now().Add(2*time.Second)))
+	stopped := make(chan struct{})
+	h.rcv.setDuringCount(func() {
+		go func() {
+			defer close(stopped)
+			h.rcv.Stop()
+		}()
+		time.Sleep(50 * time.Millisecond)
+	})
+	h.send(t, v2cInform("public"))
+	buf := make([]byte, 512)
+	n, err := h.sender.Read(buf)
+	require.NoError(t, err, "the acknowledgement was sent before the socket closed")
+	pkt, err := (&gosnmp.GoSNMP{Version: gosnmp.Version2c}).UnmarshalTrap(buf[:n], false)
+	require.NoError(t, err)
+	assert.Equal(t, gosnmp.GetResponse, pkt.PDUType)
+	<-stopped
+}

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -666,3 +666,61 @@ func TestReceiver_CountsADatagramWithItsOutcome(t *testing.T) {
 	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropMalformed) })
 	assert.Equal(t, int64(2), h.tally.datagramCount())
 }
+
+// A v2 trap PDU under wire version 1 is not a v1 trap: it is dropped as an
+// unsupported PDU, never counted as a coldStart under version 1.
+func TestReceiver_DropsAV2TrapPDUUnderVersion1(t *testing.T) {
+	h := newHarness(t)
+	src := h.registerSender(t, "core")
+	h.send(t, trapWithVersion(0, "public"))
+	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropUnsupportedPDU) })
+	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "core", "coldStart", V1))
+	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "core", "linkDown", V1))
+}
+
+// A parsed and attributed inform is acknowledged whether or not a series
+// could be allocated for it: the series limit is the tally's problem, not
+// the device's, and an unacknowledged inform is retransmitted.
+func TestReceiver_AcknowledgesAnInformTheSeriesLimitRefused(t *testing.T) {
+	h := newHarness(t)
+	src := h.registerSender(t, "full")
+	fillSeries(t, h.tally)
+	h.tally.Received("203.0.113.1", "taker", "warmStart", V2c)
+	require.Equal(t, maxSeries, h.tally.seriesCount())
+	require.NoError(t, h.sender.SetReadDeadline(time.Now().Add(2*time.Second)))
+
+	h.send(t, v2cInform("public"))
+	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropSeriesLimit) })
+	buf := make([]byte, 512)
+	n, err := h.sender.Read(buf)
+	require.NoError(t, err, "the inform is acknowledged although it was not counted")
+	pkt, err := (&gosnmp.GoSNMP{Version: gosnmp.Version2c}).UnmarshalTrap(buf[:n], false)
+	require.NoError(t, err)
+	assert.Equal(t, gosnmp.GetResponse, pkt.PDUType)
+	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "full", "linkDown", V2c))
+}
+
+// A datagram's terminal drop after the claims visit, series_limit here, is
+// recorded in the same intake section as the datagram itself. A close that
+// arrives while that section runs waits for it, so the final export never
+// holds a datagram without an outcome.
+func TestReceiver_RecordsAPostClaimDropWithItsDatagram(t *testing.T) {
+	h := newHarness(t)
+	h.registerSender(t, "full")
+	fillSeries(t, h.tally)
+	h.tally.Received("203.0.113.1", "taker", "warmStart", V2c)
+	require.Equal(t, maxSeries, h.tally.seriesCount())
+
+	stopped := make(chan struct{})
+	h.rcv.setDuringCount(func() {
+		go func() {
+			defer close(stopped)
+			h.rcv.Stop()
+		}()
+		time.Sleep(50 * time.Millisecond)
+	})
+	h.send(t, v2cTrap("public"))
+	<-stopped
+	assert.Equal(t, int64(1), h.tally.datagramCount())
+	assert.Equal(t, int64(1), h.tally.droppedCount(DropSeriesLimit), "the outcome landed with the datagram, ahead of the close")
+}

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -761,12 +761,12 @@ func TestReceiver_CredentialKeysAreInjective(t *testing.T) {
 	src := netip.MustParseAddr("10.0.0.5")
 	a := &gosnmp.UsmSecurityParameters{UserName: "u|x", AuthenticationPassphrase: "password", AuthenticationProtocol: gosnmp.SHA, PrivacyProtocol: gosnmp.AES, AuthoritativeEngineID: "e"}
 	b := &gosnmp.UsmSecurityParameters{UserName: "u", AuthenticationPassphrase: "x|password", AuthenticationProtocol: gosnmp.SHA, PrivacyProtocol: gosnmp.AES, AuthoritativeEngineID: "e"}
-	assert.NotEqual(t, clockKey(src, a), clockKey(src, b), "a delimiter in a username is not a field boundary")
+	assert.NotEqual(t, clockKey(src, a, gosnmp.AuthPriv), clockKey(src, b, gosnmp.AuthPriv), "a delimiter in a username is not a field boundary")
 	authOnly := &gosnmp.UsmSecurityParameters{UserName: "u", AuthenticationPassphrase: "other", AuthenticationProtocol: gosnmp.SHA, PrivacyProtocol: gosnmp.AES, AuthoritativeEngineID: "e"}
-	assert.NotEqual(t, clockKey(src, b), clockKey(src, authOnly), "the auth passphrase is part of the identity")
+	assert.NotEqual(t, clockKey(src, b, gosnmp.AuthPriv), clockKey(src, authOnly, gosnmp.AuthPriv), "the auth passphrase is part of the identity")
 	privOnly := &gosnmp.UsmSecurityParameters{UserName: "u", AuthenticationPassphrase: "x|password", PrivacyPassphrase: "other", AuthenticationProtocol: gosnmp.SHA, PrivacyProtocol: gosnmp.AES, AuthoritativeEngineID: "e"}
-	assert.NotEqual(t, clockKey(src, b), clockKey(src, privOnly), "so is the priv passphrase")
-	assert.Equal(t, clockKey(src, b), clockKey(src, b))
+	assert.NotEqual(t, clockKey(src, b, gosnmp.AuthPriv), clockKey(src, privOnly, gosnmp.AuthPriv), "so is the priv passphrase")
+	assert.Equal(t, clockKey(src, b, gosnmp.AuthPriv), clockKey(src, b, gosnmp.AuthPriv))
 
 	ua := []V3User{{Username: "u\x00x", AuthProtocol: "SHA", AuthPassphrase: "p"}}
 	ub := []V3User{{Username: "u", AuthProtocol: "x\x00SHA", AuthPassphrase: "p"}}
@@ -790,4 +790,32 @@ func TestReceiver_AccountsADatagramAndItsCountUnderOneTallyLock(t *testing.T) {
 	})
 	h.send(t, v2cTrap("public"))
 	assert.Equal(t, [2]int64{1, 1}, <-seen, "the export waited for the outcome")
+}
+
+// An authNoPriv trap verifies the username, the auth protocol and the auth
+// passphrase and nothing about privacy, so two credentials that differ only
+// in privacy settings are both verified by it and both their policies count
+// it. An authPriv trap verifies the privacy key too and is counted only
+// under the credential that decrypted it.
+func TestReceiver_AttributesAnAuthNoPrivTrapToEveryCredentialItVerified(t *testing.T) {
+	const engineID = "\x80\x00\x1f\x88\x80\x41\x42\x43"
+	a := trapAuthPrivUser
+	b := trapAuthPrivUser
+	b.PrivPassphrase = "a-different-privpassphrase"
+
+	h := newHarness(t)
+	src := canonical(h.sender.LocalAddr().(*net.UDPAddr).AddrPort().Addr())
+	h.reg.Register("alpha", []Device{{Policy: "alpha", Addr: src, User: &a}}, nil)
+	h.reg.Register("beta", []Device{{Policy: "beta", Addr: src, User: &b}}, nil)
+	count := func(policy string) int64 { return h.tally.receivedCount(src.String(), policy, "linkDown", V3) }
+
+	h.send(t, v3AuthNoPrivTrap(t, a, engineID))
+	waitFor(t, 1, func() int64 { return count("alpha") })
+	waitFor(t, 1, func() int64 { return count("beta") })
+
+	h.send(t, v3AuthPrivTrapAt(t, b, engineID, 1, 2))
+	waitFor(t, 2, func() int64 { return count("beta") })
+	assert.Equal(t, int64(1), count("alpha"), "the authPriv trap verified beta's privacy key, not alpha's")
+	assert.Equal(t, int64(0), h.tally.droppedCount(DropMalformed))
+	assert.Equal(t, int64(0), h.tally.droppedCount(DropV3NotInTimeWindow), "one principal at authNoPriv, its clock shared by both entries")
 }

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -3,6 +3,7 @@ package traps
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/netip"
@@ -584,4 +585,70 @@ func TestReceiver_RejectsAForgedDigestOnAnAuthNoPrivTrap(t *testing.T) {
 	h.send(t, v3AuthNoPrivTrap(t, trapAuthPrivUser, engineID))
 	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V3) })
 	assert.Equal(t, int64(1), h.tally.droppedCount(DropMalformed), "the genuine authNoPriv trap is counted")
+}
+
+// fillSeries takes the tally to one slot short of its limit: every real
+// series slot, and the overflow reserve but one, each reserve slot holding a
+// filler policy's overflow series.
+func fillSeries(t *testing.T, tally *Tally) {
+	t.Helper()
+	for i := range seriesLimit {
+		tally.Received(fmt.Sprintf("10.%d.%d.%d", i>>16&255, i>>8&255, i&255), "filler", "linkDown", V2c)
+	}
+	for i := range maxSeries - seriesLimit - 1 {
+		tally.Received("198.51.100.1", fmt.Sprintf("filler%d", i), "linkUp", V2c)
+	}
+	require.Equal(t, maxSeries-1, tally.seriesCount())
+}
+
+// series_limit is a datagram outcome, recorded once and only when no policy
+// could count the trap. A datagram that one claiming policy counts and
+// another cannot is not a drop, and one that no policy can count is one
+// drop however many policies claimed it.
+func TestReceiver_RecordsSeriesLimitOncePerUncountedDatagram(t *testing.T) {
+	h := newHarness(t)
+	src := canonical(h.sender.LocalAddr().(*net.UDPAddr).AddrPort().Addr())
+	fillSeries(t, h.tally)
+	// "room" already has an overflow series; "full" and "fuller" have none
+	// and cannot get one.
+	h.tally.Received("203.0.113.1", "room", "warmStart", V2c)
+	require.Equal(t, int64(1), h.tally.receivedCount(OtherName, "room", OtherName, V2c))
+	require.Equal(t, maxSeries, h.tally.seriesCount(), "room took the last slot")
+	h.reg.Register("room", []Device{{Policy: "room", Addr: src}}, nil)
+	h.reg.Register("full", []Device{{Policy: "full", Addr: src}}, nil)
+	h.reg.Register("fuller", []Device{{Policy: "fuller", Addr: src}}, nil)
+
+	h.send(t, v2cTrap("public"))
+	waitFor(t, 2, func() int64 { return h.tally.receivedCount(OtherName, "room", OtherName, V2c) })
+	assert.Equal(t, int64(0), h.tally.droppedCount(DropSeriesLimit), "a datagram one policy counted is not a drop")
+
+	// Take room's claim off the sender, keeping its series live so nothing
+	// dormant can be evicted to make room for the others.
+	h.reg.Register("room", []Device{{Policy: "room", Addr: netip.MustParseAddr("10.9.9.9")}}, nil)
+	h.send(t, v2cTrap("public"))
+	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropSeriesLimit) })
+	assert.Equal(t, int64(1), h.tally.droppedCount(DropSeriesLimit), "one drop for the datagram, not one per policy")
+	assert.Equal(t, int64(2), h.tally.datagramCount())
+}
+
+// Once the receiver is closed, nothing it was still doing reaches the tally:
+// a datagram whose parse outlasted the stop bound is discarded rather than
+// counted after the final export has run.
+func TestReceiver_CountsNothingAfterItIsClosed(t *testing.T) {
+	h := newHarness(t)
+	src := h.registerSender(t, "core")
+	release := make(chan struct{})
+	entered := make(chan struct{})
+	h.rcv.setBeforeCount(func() {
+		close(entered)
+		<-release
+	})
+	h.send(t, v2cTrap("public"))
+	<-entered
+	h.rcv.Stop()
+	close(release)
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, int64(1), h.tally.datagramCount(), "read before the stop")
+	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "core", "linkDown", V2c), "not counted after it")
+	assert.Equal(t, int64(0), h.tally.droppedCount(DropUnknownSource))
 }

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -168,6 +168,25 @@ func TestReceiver_RejectsV3WithoutTheAuthFlag(t *testing.T) {
 	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "core", "linkDown", V3))
 }
 
+// F15, end to end: gosnmp authenticates only a packet whose msgSecurityModel
+// is the user security model, and that field is read straight off the wire.
+// A sender that names any other model gets the auth bit believed without a
+// digest ever being verified, while its security parameters still carry a
+// username and engine ID, so every other guard passes.
+func TestReceiver_RejectsV3WithANonUSMSecurityModel(t *testing.T) {
+	h := newHarness(t, false)
+	src := h.registerSender(t, "core", trapUser)
+	h.send(t, v3Packet(v3Options{
+		username:     "trapuser",
+		engineID:     "\x80\x00\x1f\x88\x80",
+		secModel:     1,
+		flags:        0x01,
+		authParamLen: 12,
+	}))
+	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropV3Unauthenticated) })
+	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "core", "linkDown", V3))
+}
+
 func TestReceiver_V1TrapIsNormalisedAndCounted(t *testing.T) {
 	h := newHarness(t, false)
 	src := h.registerSender(t, "core")

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -19,11 +19,11 @@ type harness struct {
 	sender *net.UDPConn
 }
 
-func newHarness(t *testing.T, acceptUnknown bool) *harness {
+func newHarness(t *testing.T) *harness {
 	t.Helper()
 	reg := NewRegistry()
 	tally := NewTally(testLogger)
-	rcv, err := Listen("127.0.0.1:0", reg, tally, BuildNames(nil), acceptUnknown, testLogger)
+	rcv, err := Listen("127.0.0.1:0", reg, tally, BuildNames(nil), testLogger)
 	require.NoError(t, err)
 	t.Cleanup(rcv.Stop)
 	sender, err := net.DialUDP("udp", nil, net.UDPAddrFromAddrPort(rcv.Addr()))
@@ -61,7 +61,7 @@ func waitFor(t *testing.T, want int64, get func() int64) {
 }
 
 func TestReceiver_CountsAKnownV2cTrap(t *testing.T) {
-	h := newHarness(t, false)
+	h := newHarness(t)
 	src := h.registerSender(t, "core")
 	h.send(t, v2cTrap("public"))
 	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V2c) })
@@ -71,7 +71,7 @@ func TestReceiver_CountsAKnownV2cTrap(t *testing.T) {
 // The source check runs before any parsing, so an unknown sender costs a map
 // lookup and nothing else (F5), and is counted as dropped.
 func TestReceiver_DropsAnUnknownSourceBeforeParsing(t *testing.T) {
-	h := newHarness(t, false)
+	h := newHarness(t)
 	h.send(t, v2cTrap("public"))
 	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropUnknownSource) })
 	assert.Equal(t, int64(0), h.tally.receivedCount("127.0.0.1", "", "linkDown", V2c))
@@ -90,15 +90,9 @@ func TestReceiver_DropsAnUnknownSourceBeforeParsing(t *testing.T) {
 	assert.Equal(t, int64(0), h.tally.droppedCount(DropOversized))
 }
 
-func TestReceiver_AcceptUnknownLabelsBySourceAddressWithNoPolicy(t *testing.T) {
-	h := newHarness(t, true)
-	h.send(t, v2cTrap("public"))
-	waitFor(t, 1, func() int64 { return h.tally.receivedCount("127.0.0.1", "", "linkDown", V2c) })
-}
-
 // A trap from an address two policies name counts once per policy.
 func TestReceiver_CountsOncePerClaimingPolicy(t *testing.T) {
-	h := newHarness(t, false)
+	h := newHarness(t)
 	src := h.registerSender(t, "core")
 	h.reg.Register("edge", []Device{{Policy: "edge", Addr: src}}, nil)
 	h.send(t, v2cTrap("public"))
@@ -107,17 +101,17 @@ func TestReceiver_CountsOncePerClaimingPolicy(t *testing.T) {
 }
 
 // F4: an inform from a registered source is acknowledged, so the device does
-// not retransmit and double count. An inform from anyone else never is, so
-// the socket does not reflect.
+// not retransmit and double count. An inform from anyone else is dropped
+// before it is parsed and never answered, so the socket does not reflect.
 func TestReceiver_AcknowledgesInformsOnlyFromRegisteredSources(t *testing.T) {
-	h := newHarness(t, true)
+	h := newHarness(t)
 	require.NoError(t, h.sender.SetReadDeadline(time.Now().Add(500*time.Millisecond)))
 	buf := make([]byte, 512)
 
 	h.send(t, v2cInform("public"))
-	waitFor(t, 1, func() int64 { return h.tally.receivedCount("127.0.0.1", "", "linkDown", V2c) })
+	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropUnknownSource) })
 	_, err := h.sender.Read(buf)
-	assert.Error(t, err, "an accepted-unknown inform is counted but never answered")
+	assert.Error(t, err, "an inform from an unregistered source is never answered")
 
 	src := h.registerSender(t, "core")
 	h.send(t, v2cInform("public"))
@@ -131,7 +125,7 @@ func TestReceiver_AcknowledgesInformsOnlyFromRegisteredSources(t *testing.T) {
 }
 
 func TestReceiver_RejectsANonTrapPDU(t *testing.T) {
-	h := newHarness(t, false)
+	h := newHarness(t)
 	h.registerSender(t, "core")
 	h.send(t, v2cGet("public"))
 	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropUnsupportedPDU) })
@@ -150,7 +144,7 @@ var trapUser = V3User{
 // F1, end to end: the engine discovery shape reaches gosnmp's parser and is
 // accepted there, and is rejected here.
 func TestReceiver_RejectsUnauthenticatedV3(t *testing.T) {
-	h := newHarness(t, false)
+	h := newHarness(t)
 	h.registerSender(t, "core", trapUser)
 	h.send(t, v3Unauthenticated("trapuser", ""))
 	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropV3Unauthenticated) })
@@ -161,7 +155,7 @@ func TestReceiver_RejectsUnauthenticatedV3(t *testing.T) {
 // while gosnmp verifies no digest at all. Nothing about that packet was
 // authenticated, so it must not be counted as a v3 trap.
 func TestReceiver_RejectsV3WithoutTheAuthFlag(t *testing.T) {
-	h := newHarness(t, false)
+	h := newHarness(t)
 	src := h.registerSender(t, "core", trapUser)
 	h.send(t, v3Unauthenticated("trapuser", "\x80\x00\x1f\x88\x80"))
 	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropV3Unauthenticated) })
@@ -174,7 +168,7 @@ func TestReceiver_RejectsV3WithoutTheAuthFlag(t *testing.T) {
 // digest ever being verified, while its security parameters still carry a
 // username and engine ID, so every other guard passes.
 func TestReceiver_RejectsV3WithANonUSMSecurityModel(t *testing.T) {
-	h := newHarness(t, false)
+	h := newHarness(t)
 	src := h.registerSender(t, "core", trapUser)
 	h.send(t, v3Packet(v3Options{
 		username:     "trapuser",
@@ -195,7 +189,7 @@ func TestReceiver_RejectsV3WithANonUSMSecurityModel(t *testing.T) {
 // the only reader of the socket, so one such datagram from anyone the
 // registry knows would take the process down with it.
 func TestReceiver_SurvivesAV3DatagramThatPanicsTheParser(t *testing.T) {
-	h := newHarness(t, false)
+	h := newHarness(t)
 	src := h.registerSender(t, "core", trapUser)
 	h.send(t, v3Packet(v3Options{
 		username:         "trapuser",
@@ -229,7 +223,7 @@ var trapAuthPrivUser = V3User{
 // itself, digest and encrypted scoped PDU included.
 func TestReceiver_AcceptsAnAuthenticatedV3Trap(t *testing.T) {
 	const engineID = "\x80\x00\x1f\x88\x80\x41\x42\x43"
-	h := newHarness(t, false)
+	h := newHarness(t)
 	src := h.registerSender(t, "core", trapAuthPrivUser)
 	h.send(t, v3AuthPrivTrap(t, trapAuthPrivUser, engineID))
 	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V3) })
@@ -238,7 +232,7 @@ func TestReceiver_AcceptsAnAuthenticatedV3Trap(t *testing.T) {
 }
 
 func TestReceiver_V1TrapIsNormalisedAndCounted(t *testing.T) {
-	h := newHarness(t, false)
+	h := newHarness(t)
 	src := h.registerSender(t, "core")
 	h.send(t, v1Trap("public", [4]byte{0, 0, 0, 0}, 2, 0))
 	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V1) })
@@ -247,7 +241,7 @@ func TestReceiver_V1TrapIsNormalisedAndCounted(t *testing.T) {
 // F9, narrow phase 1 rule: a v1 agent-addr that is itself registered wins
 // over the source address.
 func TestReceiver_V1AgentAddrWinsWhenRegistered(t *testing.T) {
-	h := newHarness(t, false)
+	h := newHarness(t)
 	h.registerSender(t, "core")
 	h.reg.Register("agent", []Device{{Policy: "agent", Addr: netip.MustParseAddr("10.9.9.9")}}, nil)
 	h.send(t, v1Trap("public", [4]byte{10, 9, 9, 9}, 2, 0))
@@ -255,14 +249,13 @@ func TestReceiver_V1AgentAddrWinsWhenRegistered(t *testing.T) {
 }
 
 // The agent-addr override is a claim about provenance, and an unregistered
-// sender has none to make. With accept-unknown on, a stranger naming a known
-// device would otherwise have its trap counted under that device and policy,
-// indistinguishable from the device's own.
+// sender has none to make. A stranger naming a known device in a v1 trap is
+// dropped as an unknown source before the field is ever read.
 func TestReceiver_V1AgentAddrIsIgnoredFromAnUnregisteredSender(t *testing.T) {
-	h := newHarness(t, true)
+	h := newHarness(t)
 	h.reg.Register("agent", []Device{{Policy: "agent", Addr: netip.MustParseAddr("10.9.9.9")}}, nil)
 	h.send(t, v1Trap("public", [4]byte{10, 9, 9, 9}, 2, 0))
-	waitFor(t, 1, func() int64 { return h.tally.receivedCount("127.0.0.1", "", "linkDown", V1) })
+	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropUnknownSource) })
 	assert.Equal(t, int64(0), h.tally.receivedCount("10.9.9.9", "agent", "linkDown", V1))
 }
 
@@ -272,7 +265,7 @@ func TestReceiver_V1AgentAddrIsIgnoredFromAnUnregisteredSender(t *testing.T) {
 // guard in place this is also where hostile v3 under an unknown username
 // ends up, since gosnmp fails the credential lookup before it parses.
 func TestReceiver_MalformedFromARegisteredSourceIsCounted(t *testing.T) {
-	h := newHarness(t, false)
+	h := newHarness(t)
 	h.registerSender(t, "core")
 	h.send(t, []byte{0x30, 0x01, 0xff})
 	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropMalformed) })
@@ -280,14 +273,14 @@ func TestReceiver_MalformedFromARegisteredSourceIsCounted(t *testing.T) {
 }
 
 func TestReceiver_OversizedDatagramIsDropped(t *testing.T) {
-	h := newHarness(t, false)
+	h := newHarness(t)
 	h.registerSender(t, "core")
 	h.send(t, make([]byte, maxDatagram+1))
 	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropOversized) })
 }
 
 func TestReceiver_StopIsPromptAndIdempotent(t *testing.T) {
-	h := newHarness(t, false)
+	h := newHarness(t)
 	start := time.Now()
 	h.rcv.Stop()
 	h.rcv.Stop()

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -648,7 +648,21 @@ func TestReceiver_CountsNothingAfterItIsClosed(t *testing.T) {
 	h.rcv.Stop()
 	close(release)
 	time.Sleep(50 * time.Millisecond)
-	assert.Equal(t, int64(1), h.tally.datagramCount(), "read before the stop")
+	assert.Equal(t, int64(0), h.tally.datagramCount(), "a datagram is counted with its outcome, and this one had none before the stop")
 	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "core", "linkDown", V2c), "not counted after it")
 	assert.Equal(t, int64(0), h.tally.droppedCount(DropUnknownSource))
+}
+
+// The datagram counter is recorded together with the datagram's outcome, a
+// drop or a count, so the two sides of the accounting never disagree, not
+// even in a final export taken while a datagram is in flight.
+func TestReceiver_CountsADatagramWithItsOutcome(t *testing.T) {
+	h := newHarness(t)
+	src := h.registerSender(t, "core")
+	h.send(t, v2cTrap("public"))
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V2c) })
+	assert.Equal(t, int64(1), h.tally.datagramCount())
+	h.send(t, []byte{0x30, 0x01, 0xff})
+	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropMalformed) })
+	assert.Equal(t, int64(2), h.tally.datagramCount())
 }

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -187,6 +187,30 @@ func TestReceiver_RejectsV3WithANonUSMSecurityModel(t *testing.T) {
 	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "core", "linkDown", V3))
 }
 
+// F16: gosnmp blanks the authentication parameters in place with an unchecked
+// copy(packet[cursor+2:cursor+len(mac)], ...) (v3_usm.go:1059) as soon as the
+// auth bit is set and the named user has a real auth protocol. A datagram
+// that ends right after the USM parameter block leaves fewer bytes than the
+// digest is wide, and the slice expression panics. The receive goroutine is
+// the only reader of the socket, so one such datagram from anyone the
+// registry knows would take the process down with it.
+func TestReceiver_SurvivesAV3DatagramThatPanicsTheParser(t *testing.T) {
+	h := newHarness(t, false)
+	src := h.registerSender(t, "core", trapUser)
+	h.send(t, v3Packet(v3Options{
+		username:         "trapuser",
+		engineID:         "\x80\x00\x1f\x88\x80",
+		secModel:         3,
+		flags:            0x01,
+		truncateAfterUSM: true,
+	}))
+	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropMalformed) })
+
+	// The receiver is still reading, which is the whole point.
+	h.send(t, v2cTrap("public"))
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V2c) })
+}
+
 func TestReceiver_V1TrapIsNormalisedAndCounted(t *testing.T) {
 	h := newHarness(t, false)
 	src := h.registerSender(t, "core")

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -81,6 +81,13 @@ func TestReceiver_DropsAnUnknownSourceBeforeParsing(t *testing.T) {
 	h.send(t, []byte{0x30, 0x01, 0xff})
 	waitFor(t, 2, func() int64 { return h.tally.droppedCount(DropUnknownSource) })
 	assert.Equal(t, int64(0), h.tally.droppedCount(DropMalformed))
+
+	// Nor is a stranger's datagram judged on its size first: oversized is a
+	// counter an operator reads as "my devices send oversized traps", and a
+	// stranger is not one of their devices.
+	h.send(t, make([]byte, maxDatagram+1))
+	waitFor(t, 3, func() int64 { return h.tally.droppedCount(DropUnknownSource) })
+	assert.Equal(t, int64(0), h.tally.droppedCount(DropOversized))
 }
 
 func TestReceiver_AcceptUnknownLabelsBySourceAddressWithNoPolicy(t *testing.T) {
@@ -176,6 +183,18 @@ func TestReceiver_V1AgentAddrWinsWhenRegistered(t *testing.T) {
 	h.reg.Register("agent", []Device{{Policy: "agent", Addr: netip.MustParseAddr("10.9.9.9")}}, nil)
 	h.send(t, v1Trap("public", [4]byte{10, 9, 9, 9}, 2, 0))
 	waitFor(t, 1, func() int64 { return h.tally.receivedCount("10.9.9.9", "agent", "linkDown", V1) })
+}
+
+// The agent-addr override is a claim about provenance, and an unregistered
+// sender has none to make. With accept-unknown on, a stranger naming a known
+// device would otherwise have its trap counted under that device and policy,
+// indistinguishable from the device's own.
+func TestReceiver_V1AgentAddrIsIgnoredFromAnUnregisteredSender(t *testing.T) {
+	h := newHarness(t, true)
+	h.reg.Register("agent", []Device{{Policy: "agent", Addr: netip.MustParseAddr("10.9.9.9")}}, nil)
+	h.send(t, v1Trap("public", [4]byte{10, 9, 9, 9}, 2, 0))
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount("127.0.0.1", "", "linkDown", V1) })
+	assert.Equal(t, int64(0), h.tally.receivedCount("10.9.9.9", "agent", "linkDown", V1))
 }
 
 func TestReceiver_OversizedDatagramIsDropped(t *testing.T) {

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -371,3 +371,45 @@ func (b *lockedBuffer) String() string {
 	defer b.mu.Unlock()
 	return b.buf.String()
 }
+
+// A registered sender writing a version integer this backend does not speak
+// is dropped under its own reason, never counted as 2c.
+func TestReceiver_DropsAVersionItDoesNotSpeak(t *testing.T) {
+	h := newHarness(t)
+	src := h.registerSender(t, "core")
+	h.send(t, trapWithVersion(2, "public"))
+	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropUnsupportedVersion) })
+	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "core", "linkDown", V2c))
+	assert.Equal(t, int64(0), h.tally.droppedCount(DropMalformed))
+}
+
+// gosnmp keys its credential table by username and tries every entry under a
+// name in turn, localising keys for each, so the table a trap is parsed with
+// holds only the users of the policies that claimed its source. A credential
+// another policy carries under the same username is not tried: the trap is
+// not authenticated by it, and the receive goroutine does not pay for it.
+func TestReceiver_TriesOnlyTheSourcePoliciesCredentials(t *testing.T) {
+	const engineID = "\x80\x00\x1f\x88\x80\x41\x42\x43"
+	mine := trapAuthPrivUser
+	theirs := trapAuthPrivUser
+	theirs.AuthPassphrase = "someone-elses-authpass"
+	theirs.PrivPassphrase = "someone-elses-privpass"
+
+	h := newHarness(t)
+	src := h.registerSender(t, "core", mine)
+	h.reg.Register("edge", []Device{{Policy: "edge", Addr: netip.MustParseAddr("10.9.9.9")}}, []V3User{theirs})
+
+	h.send(t, v3AuthPrivTrapAt(t, theirs, engineID, 1, 1))
+	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropMalformed) })
+	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "core", "linkDown", V3), "another policy's credential does not authenticate this source")
+
+	h.send(t, v3AuthPrivTrapAt(t, mine, engineID, 1, 2))
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V3) })
+
+	// Once the policy naming the source carries the credential, it is
+	// tried: the same policy set, so the same cache key, and the table must
+	// follow the registry rather than serve what it built before.
+	h.reg.Register("core", []Device{{Policy: "core", Addr: src}}, []V3User{mine, theirs})
+	h.send(t, v3AuthPrivTrapAt(t, theirs, engineID, 1, 3))
+	waitFor(t, 2, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V3) })
+}

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -266,6 +266,19 @@ func TestReceiver_V1AgentAddrIsIgnoredFromAnUnregisteredSender(t *testing.T) {
 	assert.Equal(t, int64(0), h.tally.receivedCount("10.9.9.9", "agent", "linkDown", V1))
 }
 
+// A datagram no parser can read, from an address a policy does name, is the
+// operator's own device sending something wrong, and lands in malformed
+// rather than in any of the source-shaped buckets. With the security model
+// guard in place this is also where hostile v3 under an unknown username
+// ends up, since gosnmp fails the credential lookup before it parses.
+func TestReceiver_MalformedFromARegisteredSourceIsCounted(t *testing.T) {
+	h := newHarness(t, false)
+	h.registerSender(t, "core")
+	h.send(t, []byte{0x30, 0x01, 0xff})
+	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropMalformed) })
+	assert.Equal(t, int64(0), h.tally.droppedCount(DropUnknownSource))
+}
+
 func TestReceiver_OversizedDatagramIsDropped(t *testing.T) {
 	h := newHarness(t, false)
 	h.registerSender(t, "core")

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -521,11 +521,14 @@ func TestReceiver_CountsAV3TrapOnlyForThePoliciesHoldingItsCredential(t *testing
 }
 
 // The policies a trap is counted under are resolved when it is counted, not
-// when it was read. A policy released while the datagram was being parsed,
-// and replaced by one that does not claim the device, gets nothing and the
-// datagram is an unknown source; a replacement that does claim the device
-// gets the count.
-func TestReceiver_ResolvesTheClaimingPoliciesAtCountTime(t *testing.T) {
+// when it was read, and the count happens in the same critical section as
+// the resolution. A policy released before the count, and replaced by one
+// that does not claim the device, gets nothing and the datagram is an
+// unknown source. A release that races the count cannot slip between the
+// two: it waits for the count, which lands under the old policy and is then
+// withdrawn with it, so the replacement never inherits a trap for a device it
+// does not claim.
+func TestReceiver_ResolvesAndCountsTheClaimsAtomically(t *testing.T) {
 	h := newHarness(t)
 	src := h.registerSender(t, "core")
 	h.rcv.setBeforeCount(func() {
@@ -536,15 +539,28 @@ func TestReceiver_ResolvesTheClaimingPoliciesAtCountTime(t *testing.T) {
 	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropUnknownSource) })
 	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "core", "linkDown", V2c), "the released policy is not counted")
 	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "next", "linkDown", V2c), "nor a replacement that does not claim the device")
+	h.rcv.setBeforeCount(nil)
 
-	// The sender must be claimed when the datagram is read, or it is dropped
-	// before the hook runs; the hook then swaps the claim to the replacement.
+	// Now the race: the replacement under the same name is released and
+	// recreated, claiming another device, while the claims are held for
+	// counting. It has to wait, so the count lands under the outgoing
+	// incarnation and its withdrawal takes the count with it.
 	h.registerSender(t, "core")
-	h.rcv.setBeforeCount(func() {
-		h.reg.Withdraw("core")
-		h.reg.Register("next", []Device{{Policy: "next", Addr: src}}, nil)
+	h.tally.Activate("core")
+	replaced := make(chan struct{})
+	h.rcv.setDuringCount(func() {
+		go func() {
+			defer close(replaced)
+			h.reg.Withdraw("core")
+			h.tally.Withdraw("core")
+			h.reg.Register("core", []Device{{Policy: "core", Addr: netip.MustParseAddr("10.9.9.9")}}, nil)
+			h.tally.Activate("core")
+		}()
+		time.Sleep(50 * time.Millisecond)
 	})
 	h.send(t, v2cTrap("public"))
-	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "next", "linkDown", V2c) })
-	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "core", "linkDown", V2c))
+	<-replaced
+	waitFor(t, 1, func() int64 { return h.tally.datagramCount() - 1 })
+	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "core", "linkDown", V2c), "the count went to the outgoing incarnation and left with it")
+	assert.Equal(t, int64(1), h.tally.retainedCount(src.String(), "core", "linkDown", V2c), "kept as a dormant total, not exported")
 }

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -1,8 +1,12 @@
 package traps
 
 import (
+	"bytes"
+	"encoding/hex"
+	"log/slog"
 	"net"
 	"net/netip"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,9 +25,16 @@ type harness struct {
 
 func newHarness(t *testing.T) *harness {
 	t.Helper()
+	return newHarnessWith(t, testLogger)
+}
+
+// newHarnessWith binds the receiver with the given logger, for tests that
+// read what the receiver logs.
+func newHarnessWith(t *testing.T, logger *slog.Logger) *harness {
+	t.Helper()
 	reg := NewRegistry()
-	tally := NewTally(testLogger)
-	rcv, err := Listen("127.0.0.1:0", reg, tally, BuildNames(nil), testLogger)
+	tally := NewTally(logger)
+	rcv, err := Listen("127.0.0.1:0", reg, tally, BuildNames(nil), logger)
 	require.NoError(t, err)
 	t.Cleanup(rcv.Stop)
 	sender, err := net.DialUDP("udp", nil, net.UDPAddrFromAddrPort(rcv.Addr()))
@@ -285,4 +296,78 @@ func TestReceiver_StopIsPromptAndIdempotent(t *testing.T) {
 	h.rcv.Stop()
 	h.rcv.Stop()
 	assert.Less(t, time.Since(start), time.Second)
+}
+
+// RFC 3414 timeliness on the non-authoritative side: a trap whose engine
+// boots are lower than last seen, or whose engine time is more than the
+// window behind the clock learned for that engine, is a replay and is
+// dropped even though its digest verifies. A later time is accepted and
+// learned, so a device's own stream is never refused.
+func TestReceiver_RejectsAV3TrapOutsideItsEngineTimeWindow(t *testing.T) {
+	const engineID = "\x80\x00\x1f\x88\x80\x41\x42\x43"
+	h := newHarness(t)
+	src := h.registerSender(t, "core", trapAuthPrivUser)
+	counted := func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V3) }
+	replayed := func() int64 { return h.tally.droppedCount(DropV3NotInTimeWindow) }
+
+	h.send(t, v3AuthPrivTrapAt(t, trapAuthPrivUser, engineID, 5, 1000))
+	waitFor(t, 1, counted)
+	h.send(t, v3AuthPrivTrapAt(t, trapAuthPrivUser, engineID, 4, 1000))
+	waitFor(t, 1, replayed)
+	h.send(t, v3AuthPrivTrapAt(t, trapAuthPrivUser, engineID, 5, 700))
+	waitFor(t, 2, replayed)
+	h.send(t, v3AuthPrivTrapAt(t, trapAuthPrivUser, engineID, 5, 1001))
+	waitFor(t, 2, counted)
+	h.send(t, v3AuthPrivTrapAt(t, trapAuthPrivUser, engineID, 6, 0))
+	waitFor(t, 3, counted)
+	assert.Equal(t, int64(2), replayed())
+	assert.Equal(t, int64(0), h.tally.droppedCount(DropMalformed))
+	assert.Equal(t, int64(0), h.tally.droppedCount(DropV3Unauthenticated))
+}
+
+// A malformed v1 or v2c datagram from a registered sender is the operator's
+// own device misbehaving, and gosnmp reports such a fault by quoting the bytes
+// it could not parse, which begin right after the community. The community is
+// the polling credential more often than not, so the log carries the fault's
+// category and nothing the packet said. The corruption here is the one the
+// poller's own redaction documents: a community length octet larger than the
+// packet, which makes the parser dump everything from the community on.
+func TestReceiver_MalformedDetailNeverQuotesThePacket(t *testing.T) {
+	buf := &lockedBuffer{}
+	logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	h := newHarnessWith(t, logger)
+	h.registerSender(t, "core")
+
+	const community = "secretcommunity"
+	pkt := v2cTrap(community)
+	at := bytes.Index(pkt, append([]byte{0x04, byte(len(community))}, community...))
+	require.Positive(t, at, "the community octet string is in the packet")
+	pkt[at+1] = 0x7f
+
+	h.send(t, pkt)
+	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropMalformed) })
+	out := buf.String()
+	assert.Contains(t, out, "reason=malformed")
+	assert.NotContains(t, out, community)
+	assert.NotContains(t, out, hex.EncodeToString([]byte(community)))
+	assert.Contains(t, out, "detail=\"error parsing community string\"")
+}
+
+// lockedBuffer is a bytes.Buffer the receive goroutine can write while the
+// test reads.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -59,7 +59,7 @@ func (h *harness) registerSender(t *testing.T, policy string, users ...V3User) n
 	if len(users) > 0 {
 		d.User = &users[0]
 	}
-	h.reg.Register(policy, []Device{d})
+	h.reg.Register(policy, []Device{d}, nil)
 	return canonical(local)
 }
 
@@ -127,7 +127,7 @@ func TestReceiver_DropsAnUnknownSourceBeforeParsing(t *testing.T) {
 func TestReceiver_CountsOncePerClaimingPolicy(t *testing.T) {
 	h := newHarness(t)
 	src := h.registerSender(t, "core")
-	h.reg.Register("edge", []Device{{Policy: "edge", Addr: src}})
+	h.reg.Register("edge", []Device{{Policy: "edge", Addr: src}}, nil)
 	h.send(t, v2cTrap("public"))
 	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V2c) })
 	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "edge", "linkDown", V2c) })
@@ -276,7 +276,7 @@ func TestReceiver_V1TrapIsNormalisedAndCounted(t *testing.T) {
 func TestReceiver_V1AgentAddrWinsWhenRegistered(t *testing.T) {
 	h := newHarness(t)
 	h.registerSender(t, "core")
-	h.reg.Register("agent", []Device{{Policy: "agent", Addr: netip.MustParseAddr("10.9.9.9")}})
+	h.reg.Register("agent", []Device{{Policy: "agent", Addr: netip.MustParseAddr("10.9.9.9")}}, nil)
 	h.send(t, v1Trap("public", [4]byte{10, 9, 9, 9}, 2, 0))
 	waitFor(t, 1, func() int64 { return h.tally.receivedCount("10.9.9.9", "agent", "linkDown", V1) })
 }
@@ -286,7 +286,7 @@ func TestReceiver_V1AgentAddrWinsWhenRegistered(t *testing.T) {
 // dropped as an unknown source before the field is ever read.
 func TestReceiver_V1AgentAddrIsIgnoredFromAnUnregisteredSender(t *testing.T) {
 	h := newHarness(t)
-	h.reg.Register("agent", []Device{{Policy: "agent", Addr: netip.MustParseAddr("10.9.9.9")}})
+	h.reg.Register("agent", []Device{{Policy: "agent", Addr: netip.MustParseAddr("10.9.9.9")}}, nil)
 	h.send(t, v1Trap("public", [4]byte{10, 9, 9, 9}, 2, 0))
 	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropUnknownSource) })
 	assert.Equal(t, int64(0), h.tally.receivedCount("10.9.9.9", "agent", "linkDown", V1))
@@ -423,7 +423,7 @@ func TestReceiver_TriesOnlyTheSourceDevicesCredentials(t *testing.T) {
 	h.reg.Register("core", []Device{
 		{Policy: "core", Addr: src, User: &mine},
 		{Policy: "core", Addr: netip.MustParseAddr("10.9.9.9"), User: &theirs},
-	})
+	}, nil)
 
 	h.send(t, v3AuthPrivTrapAt(t, theirs, engineID, 1, 1))
 	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropMalformed) })
@@ -432,7 +432,7 @@ func TestReceiver_TriesOnlyTheSourceDevicesCredentials(t *testing.T) {
 	h.send(t, v3AuthPrivTrapAt(t, mine, engineID, 1, 2))
 	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V3) })
 
-	h.reg.Register("core", []Device{{Policy: "core", Addr: src, User: &theirs}})
+	h.reg.Register("core", []Device{{Policy: "core", Addr: src, User: &theirs}}, nil)
 	h.send(t, v3AuthPrivTrapAt(t, theirs, engineID, 1, 3))
 	waitFor(t, 2, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V3) })
 	assert.LessOrEqual(t, h.rcv.tableCacheSize(), 1, "the cache was rebuilt for the new registry generation")
@@ -448,8 +448,8 @@ func TestReceiver_KeepsEngineClocksPerSender(t *testing.T) {
 	first, src1 := h.newSenderOn(t, "udp4", net.IPv4(127, 0, 0, 1))
 	other, src2 := h.newSenderOn(t, "udp6", net.IPv6loopback)
 	require.NotEqual(t, src1, src2, "the two senders must be two devices to the registry")
-	h.reg.Register("core", []Device{{Policy: "core", Addr: src1, User: &trapAuthPrivUser}})
-	h.reg.Register("edge", []Device{{Policy: "edge", Addr: src2, User: &trapAuthPrivUser}})
+	h.reg.Register("core", []Device{{Policy: "core", Addr: src1, User: &trapAuthPrivUser}}, nil)
+	h.reg.Register("edge", []Device{{Policy: "edge", Addr: src2, User: &trapAuthPrivUser}}, nil)
 
 	_, err := first.Write(v3AuthPrivTrapAt(t, trapAuthPrivUser, engineID, 9, 1))
 	require.NoError(t, err)
@@ -459,4 +459,27 @@ func TestReceiver_KeepsEngineClocksPerSender(t *testing.T) {
 	require.NoError(t, err)
 	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src2.String(), "edge", "linkDown", V3) })
 	assert.Equal(t, int64(0), h.tally.droppedCount(DropV3NotInTimeWindow), "boots 5 after boots 9 is only a replay for the same sender")
+}
+
+// Each policy names a trap from its own profile set, so two policies on one
+// socket count the same trap under their own names, and a policy with no
+// names of its own falls back to the socket's. The RFC 1215 names take
+// precedence over any profile's spelling.
+func TestReceiver_NamesATrapWithThePolicysOwnNames(t *testing.T) {
+	h := newHarness(t)
+	src := canonical(h.sender.LocalAddr().(*net.UDPAddr).AddrPort().Addr())
+	h.reg.Register("vendor", []Device{{Policy: "vendor", Addr: src}}, map[string]string{
+		"1.3.6.1.4.1.9.9.999.0.1": "widgetFailed",
+		"1.3.6.1.6.3.1.1.5.3":     "vendorLinkDown",
+	})
+	h.reg.Register("plain", []Device{{Policy: "plain", Addr: src}}, nil)
+
+	h.send(t, v2cTrapWithOID("public", oidEnterpriseWidget))
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "vendor", "widgetFailed", V2c) })
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "plain", OtherName, V2c) })
+
+	h.send(t, v2cTrap("public"))
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "vendor", "linkDown", V2c) })
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "plain", "linkDown", V2c) })
+	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "vendor", "vendorLinkDown", V2c), "RFC 1215 wins over the profile's spelling")
 }

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -32,9 +32,16 @@ func newHarness(t *testing.T) *harness {
 // read what the receiver logs.
 func newHarnessWith(t *testing.T, logger *slog.Logger) *harness {
 	t.Helper()
+	return newHarnessOn(t, "127.0.0.1:0", logger)
+}
+
+// newHarnessOn binds the receiver on the given address, for tests that need
+// a dual-stack socket to tell two loopback senders apart.
+func newHarnessOn(t *testing.T, listen string, logger *slog.Logger) *harness {
+	t.Helper()
 	reg := NewRegistry()
 	tally := NewTally(logger)
-	rcv, err := Listen("127.0.0.1:0", reg, tally, BuildNames(nil), logger)
+	rcv, err := Listen(listen, reg, tally, BuildNames(nil), logger)
 	require.NoError(t, err)
 	t.Cleanup(rcv.Stop)
 	sender, err := net.DialUDP("udp", nil, net.UDPAddrFromAddrPort(rcv.Addr()))
@@ -48,8 +55,23 @@ func newHarnessWith(t *testing.T, logger *slog.Logger) *harness {
 func (h *harness) registerSender(t *testing.T, policy string, users ...V3User) netip.Addr {
 	t.Helper()
 	local := h.sender.LocalAddr().(*net.UDPAddr).AddrPort().Addr()
-	h.reg.Register(policy, []Device{{Policy: policy, Addr: local}}, users)
+	d := Device{Policy: policy, Addr: local}
+	if len(users) > 0 {
+		d.User = &users[0]
+	}
+	h.reg.Register(policy, []Device{d})
 	return canonical(local)
+}
+
+// newSenderOn opens a sending socket towards the receiver from the given
+// loopback address, so that a dual-stack receiver sees 127.0.0.1 and ::1 as
+// two devices.
+func (h *harness) newSenderOn(t *testing.T, network string, ip net.IP) (*net.UDPConn, netip.Addr) {
+	t.Helper()
+	conn, err := net.DialUDP(network, nil, &net.UDPAddr{IP: ip, Port: int(h.rcv.Addr().Port())})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn, canonical(conn.LocalAddr().(*net.UDPAddr).AddrPort().Addr())
 }
 
 func (h *harness) send(t *testing.T, pkt []byte) {
@@ -105,7 +127,7 @@ func TestReceiver_DropsAnUnknownSourceBeforeParsing(t *testing.T) {
 func TestReceiver_CountsOncePerClaimingPolicy(t *testing.T) {
 	h := newHarness(t)
 	src := h.registerSender(t, "core")
-	h.reg.Register("edge", []Device{{Policy: "edge", Addr: src}}, nil)
+	h.reg.Register("edge", []Device{{Policy: "edge", Addr: src}})
 	h.send(t, v2cTrap("public"))
 	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V2c) })
 	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "edge", "linkDown", V2c) })
@@ -254,7 +276,7 @@ func TestReceiver_V1TrapIsNormalisedAndCounted(t *testing.T) {
 func TestReceiver_V1AgentAddrWinsWhenRegistered(t *testing.T) {
 	h := newHarness(t)
 	h.registerSender(t, "core")
-	h.reg.Register("agent", []Device{{Policy: "agent", Addr: netip.MustParseAddr("10.9.9.9")}}, nil)
+	h.reg.Register("agent", []Device{{Policy: "agent", Addr: netip.MustParseAddr("10.9.9.9")}})
 	h.send(t, v1Trap("public", [4]byte{10, 9, 9, 9}, 2, 0))
 	waitFor(t, 1, func() int64 { return h.tally.receivedCount("10.9.9.9", "agent", "linkDown", V1) })
 }
@@ -264,7 +286,7 @@ func TestReceiver_V1AgentAddrWinsWhenRegistered(t *testing.T) {
 // dropped as an unknown source before the field is ever read.
 func TestReceiver_V1AgentAddrIsIgnoredFromAnUnregisteredSender(t *testing.T) {
 	h := newHarness(t)
-	h.reg.Register("agent", []Device{{Policy: "agent", Addr: netip.MustParseAddr("10.9.9.9")}}, nil)
+	h.reg.Register("agent", []Device{{Policy: "agent", Addr: netip.MustParseAddr("10.9.9.9")}})
 	h.send(t, v1Trap("public", [4]byte{10, 9, 9, 9}, 2, 0))
 	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropUnknownSource) })
 	assert.Equal(t, int64(0), h.tally.receivedCount("10.9.9.9", "agent", "linkDown", V1))
@@ -385,10 +407,11 @@ func TestReceiver_DropsAVersionItDoesNotSpeak(t *testing.T) {
 
 // gosnmp keys its credential table by username and tries every entry under a
 // name in turn, localising keys for each, so the table a trap is parsed with
-// holds only the users of the policies that claimed its source. A credential
-// another policy carries under the same username is not tried: the trap is
-// not authenticated by it, and the receive goroutine does not pay for it.
-func TestReceiver_TriesOnlyTheSourcePoliciesCredentials(t *testing.T) {
+// holds only the credentials of the devices claimed at its source. A
+// credential the same policy assigned to another device is not tried: it
+// does not authenticate this source, and the receive goroutine does not pay
+// for it. When the registry changes, the table follows it.
+func TestReceiver_TriesOnlyTheSourceDevicesCredentials(t *testing.T) {
 	const engineID = "\x80\x00\x1f\x88\x80\x41\x42\x43"
 	mine := trapAuthPrivUser
 	theirs := trapAuthPrivUser
@@ -396,20 +419,44 @@ func TestReceiver_TriesOnlyTheSourcePoliciesCredentials(t *testing.T) {
 	theirs.PrivPassphrase = "someone-elses-privpass"
 
 	h := newHarness(t)
-	src := h.registerSender(t, "core", mine)
-	h.reg.Register("edge", []Device{{Policy: "edge", Addr: netip.MustParseAddr("10.9.9.9")}}, []V3User{theirs})
+	src := canonical(h.sender.LocalAddr().(*net.UDPAddr).AddrPort().Addr())
+	h.reg.Register("core", []Device{
+		{Policy: "core", Addr: src, User: &mine},
+		{Policy: "core", Addr: netip.MustParseAddr("10.9.9.9"), User: &theirs},
+	})
 
 	h.send(t, v3AuthPrivTrapAt(t, theirs, engineID, 1, 1))
 	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropMalformed) })
-	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "core", "linkDown", V3), "another policy's credential does not authenticate this source")
+	assert.Equal(t, int64(0), h.tally.receivedCount(src.String(), "core", "linkDown", V3), "another device's credential does not authenticate this source")
 
 	h.send(t, v3AuthPrivTrapAt(t, mine, engineID, 1, 2))
 	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V3) })
 
-	// Once the policy naming the source carries the credential, it is
-	// tried: the same policy set, so the same cache key, and the table must
-	// follow the registry rather than serve what it built before.
-	h.reg.Register("core", []Device{{Policy: "core", Addr: src}}, []V3User{mine, theirs})
+	h.reg.Register("core", []Device{{Policy: "core", Addr: src, User: &theirs}})
 	h.send(t, v3AuthPrivTrapAt(t, theirs, engineID, 1, 3))
 	waitFor(t, 2, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V3) })
+	assert.LessOrEqual(t, h.rcv.tableCacheSize(), 1, "the cache was rebuilt for the new registry generation")
+}
+
+// The engine clocks are kept per sender as well as per engine ID. A device
+// that authenticates with its own credential and writes another device's
+// engine ID with higher boots poisons only its own clock; the other device's
+// traps under that engine ID are still inside their own window.
+func TestReceiver_KeepsEngineClocksPerSender(t *testing.T) {
+	const engineID = "\x80\x00\x1f\x88\x80\x41\x42\x43"
+	h := newHarnessOn(t, "[::]:0", testLogger)
+	first, src1 := h.newSenderOn(t, "udp4", net.IPv4(127, 0, 0, 1))
+	other, src2 := h.newSenderOn(t, "udp6", net.IPv6loopback)
+	require.NotEqual(t, src1, src2, "the two senders must be two devices to the registry")
+	h.reg.Register("core", []Device{{Policy: "core", Addr: src1, User: &trapAuthPrivUser}})
+	h.reg.Register("edge", []Device{{Policy: "edge", Addr: src2, User: &trapAuthPrivUser}})
+
+	_, err := first.Write(v3AuthPrivTrapAt(t, trapAuthPrivUser, engineID, 9, 1))
+	require.NoError(t, err)
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src1.String(), "core", "linkDown", V3) })
+
+	_, err = other.Write(v3AuthPrivTrapAt(t, trapAuthPrivUser, engineID, 5, 1))
+	require.NoError(t, err)
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src2.String(), "edge", "linkDown", V3) })
+	assert.Equal(t, int64(0), h.tally.droppedCount(DropV3NotInTimeWindow), "boots 5 after boots 9 is only a replay for the same sender")
 }

--- a/orb-telemetry/snmp-telemetry/traps/receiver_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/receiver_test.go
@@ -724,3 +724,30 @@ func TestReceiver_RecordsAPostClaimDropWithItsDatagram(t *testing.T) {
 	assert.Equal(t, int64(1), h.tally.datagramCount())
 	assert.Equal(t, int64(1), h.tally.droppedCount(DropSeriesLimit), "the outcome landed with the datagram, ahead of the close")
 }
+
+// The engine clocks are kept per credential as well as per sender and engine
+// ID. Two credentials at one address are two principals: a device holding
+// one, writing the other's engine ID with higher boots, poisons only the
+// clock its own credential is judged by, and the other principal's traps
+// under that engine ID are still inside their own window.
+func TestReceiver_KeepsEngineClocksPerCredential(t *testing.T) {
+	const engineID = "\x80\x00\x1f\x88\x80\x41\x42\x43"
+	mine := trapAuthPrivUser
+	theirs := trapAuthPrivUser
+	theirs.AuthPassphrase = "someone-elses-authpass"
+	theirs.PrivPassphrase = "someone-elses-privpass"
+
+	h := newHarness(t)
+	src := canonical(h.sender.LocalAddr().(*net.UDPAddr).AddrPort().Addr())
+	h.reg.Register("core", []Device{{Policy: "core", Addr: src, User: &mine}}, nil)
+	h.reg.Register("edge", []Device{{Policy: "edge", Addr: src, User: &theirs}}, nil)
+
+	h.send(t, v3AuthPrivTrapAt(t, mine, engineID, 9, 1))
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "core", "linkDown", V3) })
+	h.send(t, v3AuthPrivTrapAt(t, theirs, engineID, 5, 1))
+	waitFor(t, 1, func() int64 { return h.tally.receivedCount(src.String(), "edge", "linkDown", V3) })
+	assert.Equal(t, int64(0), h.tally.droppedCount(DropV3NotInTimeWindow), "boots 5 after boots 9 is only a replay for the same credential")
+	h.send(t, v3AuthPrivTrapAt(t, mine, engineID, 8, 1))
+	waitFor(t, 1, func() int64 { return h.tally.droppedCount(DropV3NotInTimeWindow) })
+	assert.Equal(t, int64(1), h.tally.receivedCount(src.String(), "core", "linkDown", V3), "and for the same credential it still is one")
+}

--- a/orb-telemetry/snmp-telemetry/traps/registry.go
+++ b/orb-telemetry/snmp-telemetry/traps/registry.go
@@ -1,0 +1,139 @@
+package traps
+
+import (
+	"maps"
+	"net/netip"
+	"slices"
+	"sync"
+	"sync/atomic"
+)
+
+// Device is one address a policy polls. The policy layer builds these from a
+// runner's expanded targets. Hostname targets have no address and are not
+// registered in phase 1.
+type Device struct {
+	Policy string
+	Addr   netip.Addr
+}
+
+// V3User is the USM credential a v3 target carries. The receiver hands every
+// registered user to gosnmp, which selects by username and localises the key
+// against the sender's own engine ID, so no engine ID is configured here.
+type V3User struct {
+	Username       string
+	AuthProtocol   string
+	AuthPassphrase string
+	PrivProtocol   string
+	PrivPassphrase string
+}
+
+// Registry maps a source address to the policies that name it, and holds the
+// v3 users those policies carry. Claims are refcounted by policy: two policies
+// naming one device is ordinary, and withdrawing one must not remove the
+// other's claim.
+//
+// It has its own lock and is never consulted under the policy manager's. The
+// manager holds its write lock across a whole policy start, including
+// expansion of up to 65536 targets, and a lookup on every datagram behind that
+// lock would stall the receive loop for the duration of every policy push.
+type Registry struct {
+	mu     sync.RWMutex
+	claims map[netip.Addr]map[string]struct{}
+	users  map[string][]V3User
+	gen    atomic.Uint64
+}
+
+// NewRegistry returns an empty registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		claims: make(map[netip.Addr]map[string]struct{}),
+		users:  make(map[string][]V3User),
+	}
+}
+
+// canonical is the one spelling every address is stored and looked up under.
+// A dual-stack socket delivers an IPv4 sender as an IPv4-mapped IPv6 address,
+// and netip.Addr compares by representation, so without this every IPv4
+// device misses the registry. The zone on a link-local address is dropped for
+// the same reason.
+func canonical(a netip.Addr) netip.Addr {
+	return a.Unmap().WithZone("")
+}
+
+// Register replaces the policy's claims and users with the ones given. A
+// runner calls it once its targets are expanded.
+func (r *Registry) Register(policy string, devices []Device, users []V3User) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.withdrawLocked(policy)
+	for _, d := range devices {
+		a := canonical(d.Addr)
+		if !a.IsValid() {
+			continue
+		}
+		if r.claims[a] == nil {
+			r.claims[a] = make(map[string]struct{})
+		}
+		r.claims[a][policy] = struct{}{}
+	}
+	if len(users) > 0 {
+		r.users[policy] = slices.Clone(users)
+	}
+	r.gen.Add(1)
+}
+
+// Withdraw removes every claim and user the policy registered.
+func (r *Registry) Withdraw(policy string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.withdrawLocked(policy)
+	r.gen.Add(1)
+}
+
+func (r *Registry) withdrawLocked(policy string) {
+	for a, policies := range r.claims {
+		delete(policies, policy)
+		if len(policies) == 0 {
+			delete(r.claims, a)
+		}
+	}
+	delete(r.users, policy)
+}
+
+// Lookup returns the policies naming an address, in sorted order, or nil.
+func (r *Registry) Lookup(addr netip.Addr) []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	policies := r.claims[canonical(addr)]
+	if len(policies) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(policies))
+	for p := range policies {
+		out = append(out, p)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// Users returns every registered v3 user across all policies.
+func (r *Registry) Users() []V3User {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var out []V3User
+	for _, policy := range slices.Sorted(maps.Keys(r.users)) {
+		out = append(out, r.users[policy]...)
+	}
+	return out
+}
+
+// Generation advances on every change, so a caller caching something derived
+// from the registry can tell when to rebuild it without diffing.
+func (r *Registry) Generation() uint64 { return r.gen.Load() }
+
+// Size is the number of addresses with at least one claim.
+func (r *Registry) Size() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.claims)
+}

--- a/orb-telemetry/snmp-telemetry/traps/registry.go
+++ b/orb-telemetry/snmp-telemetry/traps/registry.go
@@ -215,6 +215,35 @@ func (r *Registry) VisitClaims(addr netip.Addr, holding func(V3User) bool, visit
 	return visited
 }
 
+// VisitClaimsPreferring is VisitClaims for a trap that names an agent
+// address: under one read lock it visits the claims on agent when any policy
+// holds one, and the claims on src otherwise, and reports which address was
+// visited and how many policies. Resolving the preference and the claims in
+// one critical section means a claim on the agent address released between
+// the two cannot leave the trap attributed to an address nobody claims.
+func (r *Registry) VisitClaimsPreferring(agent, src netip.Addr, holding func(V3User) bool, visit func(policy string, names map[string]string)) (netip.Addr, int) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, addr := range []netip.Addr{agent, src} {
+		if !addr.IsValid() {
+			continue
+		}
+		claims := r.claimsAt(addr)
+		visited := 0
+		for _, policy := range slices.Sorted(maps.Keys(claims)) {
+			if holding != nil && !slices.ContainsFunc(claims[policy], holding) {
+				continue
+			}
+			visit(policy, r.names[policy])
+			visited++
+		}
+		if visited > 0 {
+			return canonical(addr), visited
+		}
+	}
+	return canonical(src), 0
+}
+
 // NamesFor is the trap names a policy registered, or nil when it registered
 // none.
 func (r *Registry) NamesFor(policy string) map[string]string {

--- a/orb-telemetry/snmp-telemetry/traps/registry.go
+++ b/orb-telemetry/snmp-telemetry/traps/registry.go
@@ -44,15 +44,19 @@ type V3User struct {
 // lock would stall the receive loop for the duration of every policy push.
 type Registry struct {
 	mu sync.RWMutex
-	// claims maps an address to the policies claiming it and the user each
-	// polls it with, nil for a v1 or v2c target.
-	claims map[netip.Addr]map[string]*V3User
-	gen    atomic.Uint64
+	// claims maps an address to the policies claiming it and the users each
+	// polls it with: none for a v1 or v2c target, more than one when a
+	// policy keeps two targets at the address under different IDs or
+	// contexts with different credentials.
+	claims map[netip.Addr]map[string][]V3User
+	// names is each policy's trap names, from its own profile set.
+	names map[string]map[string]string
+	gen   atomic.Uint64
 }
 
 // NewRegistry returns an empty registry.
 func NewRegistry() *Registry {
-	return &Registry{claims: make(map[netip.Addr]map[string]*V3User)}
+	return &Registry{claims: make(map[netip.Addr]map[string][]V3User), names: make(map[string]map[string]string)}
 }
 
 // canonical is the one spelling every address is stored and looked up under.
@@ -67,9 +71,10 @@ func canonical(a netip.Addr) netip.Addr {
 }
 
 // Register replaces the policy's claims with the ones given, each carrying
-// the user the policy polls that device with. A runner calls it once its
-// targets are expanded.
-func (r *Registry) Register(policy string, devices []Device) {
+// the user the policy polls that device with, and its trap names. A runner
+// calls it once its targets are expanded. Two devices at one address keep
+// both their users; a repeat of one user is kept once.
+func (r *Registry) Register(policy string, devices []Device, names map[string]string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.withdrawLocked(policy)
@@ -79,14 +84,16 @@ func (r *Registry) Register(policy string, devices []Device) {
 			continue
 		}
 		if r.claims[a] == nil {
-			r.claims[a] = make(map[string]*V3User)
+			r.claims[a] = make(map[string][]V3User)
 		}
-		var u *V3User
-		if d.User != nil {
-			copied := *d.User
-			u = &copied
+		users := r.claims[a][policy]
+		if d.User != nil && !slices.Contains(users, *d.User) {
+			users = append(users, *d.User)
 		}
-		r.claims[a][policy] = u
+		r.claims[a][policy] = users
+	}
+	if names != nil {
+		r.names[policy] = names
 	}
 	r.gen.Add(1)
 }
@@ -106,18 +113,34 @@ func (r *Registry) withdrawLocked(policy string) {
 			delete(r.claims, a)
 		}
 	}
+	delete(r.names, policy)
 }
 
 // claimsAt is the claims on an address, read under the lock. A claim written
-// without a zone names the address on every interface; a claim written with
-// one names only that interface.
-func (r *Registry) claimsAt(addr netip.Addr) map[string]*V3User {
+// without a zone names the address on every interface, so for a zoned
+// address it is merged with the claims written for that zone rather than
+// consulted only when there are none.
+func (r *Registry) claimsAt(addr netip.Addr) map[string][]V3User {
 	a := canonical(addr)
-	policies := r.claims[a]
-	if len(policies) == 0 && a.Zone() != "" {
-		policies = r.claims[a.WithZone("")]
+	exact := r.claims[a]
+	if a.Zone() == "" {
+		return exact
 	}
-	return policies
+	zoneless := r.claims[a.WithZone("")]
+	if len(zoneless) == 0 {
+		return exact
+	}
+	if len(exact) == 0 {
+		return zoneless
+	}
+	merged := make(map[string][]V3User, len(exact)+len(zoneless))
+	for p, u := range zoneless {
+		merged[p] = u
+	}
+	for p, u := range exact {
+		merged[p] = append(slices.Clone(merged[p]), u...)
+	}
+	return merged
 }
 
 // Lookup returns the policies naming an address, in sorted order, or nil.
@@ -142,11 +165,21 @@ func (r *Registry) UsersAt(addr netip.Addr) []V3User {
 	policies := r.claimsAt(addr)
 	var out []V3User
 	for _, policy := range slices.Sorted(maps.Keys(policies)) {
-		if u := policies[policy]; u != nil {
-			out = append(out, *u)
+		for _, u := range policies[policy] {
+			if !slices.Contains(out, u) {
+				out = append(out, u)
+			}
 		}
 	}
 	return out
+}
+
+// NamesFor is the trap names a policy registered, or nil when it registered
+// none.
+func (r *Registry) NamesFor(policy string) map[string]string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.names[policy]
 }
 
 // Generation advances on every change, so a caller caching something derived

--- a/orb-telemetry/snmp-telemetry/traps/registry.go
+++ b/orb-telemetry/snmp-telemetry/traps/registry.go
@@ -192,6 +192,29 @@ func (r *Registry) UsersAt(addr netip.Addr) []V3User {
 	return out
 }
 
+// VisitClaims calls visit for every policy claiming an address, with that
+// policy's trap names, under the registry's read lock, and reports how many
+// it visited. With a predicate, only the policies holding a user satisfying
+// it are visited. Counting inside the visit is what keeps a count consistent
+// with the claims it was attributed under: a release needs the write lock
+// and so waits for the visit, rather than slipping between the resolution
+// and the count. The tally's own lock nests inside this one and nothing
+// takes the two in the other order.
+func (r *Registry) VisitClaims(addr netip.Addr, holding func(V3User) bool, visit func(policy string, names map[string]string)) int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	claims := r.claimsAt(addr)
+	visited := 0
+	for _, policy := range slices.Sorted(maps.Keys(claims)) {
+		if holding != nil && !slices.ContainsFunc(claims[policy], holding) {
+			continue
+		}
+		visit(policy, r.names[policy])
+		visited++
+	}
+	return visited
+}
+
 // NamesFor is the trap names a policy registered, or nil when it registered
 // none.
 func (r *Registry) NamesFor(policy string) map[string]string {

--- a/orb-telemetry/snmp-telemetry/traps/registry.go
+++ b/orb-telemetry/snmp-telemetry/traps/registry.go
@@ -54,10 +54,12 @@ func NewRegistry() *Registry {
 // canonical is the one spelling every address is stored and looked up under.
 // A dual-stack socket delivers an IPv4 sender as an IPv4-mapped IPv6 address,
 // and netip.Addr compares by representation, so without this every IPv4
-// device misses the registry. The zone on a link-local address is dropped for
-// the same reason.
+// device misses the registry. The zone on a link-local address is kept: such
+// an address is unique only per interface, and a wildcard socket sees the
+// same fe80::1 from two interfaces as two devices. Lookup falls back to the
+// zoneless form so a claim written without a zone still matches.
 func canonical(a netip.Addr) netip.Addr {
-	return a.Unmap().WithZone("")
+	return a.Unmap()
 }
 
 // Register replaces the policy's claims and users with the ones given. A
@@ -104,7 +106,13 @@ func (r *Registry) withdrawLocked(policy string) {
 func (r *Registry) Lookup(addr netip.Addr) []string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	policies := r.claims[canonical(addr)]
+	a := canonical(addr)
+	policies := r.claims[a]
+	if len(policies) == 0 && a.Zone() != "" {
+		// A claim written without a zone names the address on every
+		// interface; a claim written with one names only that interface.
+		policies = r.claims[a.WithZone("")]
+	}
 	if len(policies) == 0 {
 		return nil
 	}

--- a/orb-telemetry/snmp-telemetry/traps/registry.go
+++ b/orb-telemetry/snmp-telemetry/traps/registry.go
@@ -14,11 +14,17 @@ import (
 type Device struct {
 	Policy string
 	Addr   netip.Addr
+	// User is the USM credential the policy polls this device with, nil for
+	// a v1 or v2c target. A trap from the device is authenticated with this
+	// credential and no other: one a policy assigned to a different device
+	// must not vouch for this one.
+	User *V3User
 }
 
-// V3User is the USM credential a v3 target carries. The receiver hands every
-// registered user to gosnmp, which selects by username and localises the key
-// against the sender's own engine ID, so no engine ID is configured here.
+// V3User is the USM credential a v3 target carries. The receiver hands gosnmp
+// the users of the devices claimed at a datagram's source, and gosnmp selects
+// by username and localises the key against the sender's own engine ID, so no
+// engine ID is configured here.
 type V3User struct {
 	Username       string
 	AuthProtocol   string
@@ -27,28 +33,26 @@ type V3User struct {
 	PrivPassphrase string
 }
 
-// Registry maps a source address to the policies that name it, and holds the
-// v3 users those policies carry. Claims are refcounted by policy: two policies
-// naming one device is ordinary, and withdrawing one must not remove the
-// other's claim.
+// Registry maps a source address to the policies that name it, each with the
+// v3 user it polls that device with. Claims are refcounted by policy: two
+// policies naming one device is ordinary, and withdrawing one must not remove
+// the other's claim.
 //
 // It has its own lock and is never consulted under the policy manager's. The
 // manager holds its write lock across a whole policy start, including
 // expansion of up to 65536 targets, and a lookup on every datagram behind that
 // lock would stall the receive loop for the duration of every policy push.
 type Registry struct {
-	mu     sync.RWMutex
-	claims map[netip.Addr]map[string]struct{}
-	users  map[string][]V3User
+	mu sync.RWMutex
+	// claims maps an address to the policies claiming it and the user each
+	// polls it with, nil for a v1 or v2c target.
+	claims map[netip.Addr]map[string]*V3User
 	gen    atomic.Uint64
 }
 
 // NewRegistry returns an empty registry.
 func NewRegistry() *Registry {
-	return &Registry{
-		claims: make(map[netip.Addr]map[string]struct{}),
-		users:  make(map[string][]V3User),
-	}
+	return &Registry{claims: make(map[netip.Addr]map[string]*V3User)}
 }
 
 // canonical is the one spelling every address is stored and looked up under.
@@ -62,9 +66,10 @@ func canonical(a netip.Addr) netip.Addr {
 	return a.Unmap()
 }
 
-// Register replaces the policy's claims and users with the ones given. A
-// runner calls it once its targets are expanded.
-func (r *Registry) Register(policy string, devices []Device, users []V3User) {
+// Register replaces the policy's claims with the ones given, each carrying
+// the user the policy polls that device with. A runner calls it once its
+// targets are expanded.
+func (r *Registry) Register(policy string, devices []Device) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.withdrawLocked(policy)
@@ -74,17 +79,19 @@ func (r *Registry) Register(policy string, devices []Device, users []V3User) {
 			continue
 		}
 		if r.claims[a] == nil {
-			r.claims[a] = make(map[string]struct{})
+			r.claims[a] = make(map[string]*V3User)
 		}
-		r.claims[a][policy] = struct{}{}
-	}
-	if len(users) > 0 {
-		r.users[policy] = slices.Clone(users)
+		var u *V3User
+		if d.User != nil {
+			copied := *d.User
+			u = &copied
+		}
+		r.claims[a][policy] = u
 	}
 	r.gen.Add(1)
 }
 
-// Withdraw removes every claim and user the policy registered.
+// Withdraw removes every claim the policy registered.
 func (r *Registry) Withdraw(policy string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -99,52 +106,45 @@ func (r *Registry) withdrawLocked(policy string) {
 			delete(r.claims, a)
 		}
 	}
-	delete(r.users, policy)
+}
+
+// claimsAt is the claims on an address, read under the lock. A claim written
+// without a zone names the address on every interface; a claim written with
+// one names only that interface.
+func (r *Registry) claimsAt(addr netip.Addr) map[string]*V3User {
+	a := canonical(addr)
+	policies := r.claims[a]
+	if len(policies) == 0 && a.Zone() != "" {
+		policies = r.claims[a.WithZone("")]
+	}
+	return policies
 }
 
 // Lookup returns the policies naming an address, in sorted order, or nil.
 func (r *Registry) Lookup(addr netip.Addr) []string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	a := canonical(addr)
-	policies := r.claims[a]
-	if len(policies) == 0 && a.Zone() != "" {
-		// A claim written without a zone names the address on every
-		// interface; a claim written with one names only that interface.
-		policies = r.claims[a.WithZone("")]
-	}
+	policies := r.claimsAt(addr)
 	if len(policies) == 0 {
 		return nil
 	}
-	out := make([]string, 0, len(policies))
-	for p := range policies {
-		out = append(out, p)
-	}
-	slices.Sort(out)
-	return out
+	return slices.Sorted(maps.Keys(policies))
 }
 
-// Users returns every registered v3 user across all policies.
-func (r *Registry) Users() []V3User {
+// UsersAt returns the v3 users the claiming policies poll an address with,
+// in policy order, and nothing else. It is what a receiver hands gosnmp for a
+// datagram from that address: gosnmp tries every same-username entry in turn,
+// localising keys for each, so the table is kept to the credentials assigned
+// to this device.
+func (r *Registry) UsersAt(addr netip.Addr) []V3User {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
+	policies := r.claimsAt(addr)
 	var out []V3User
-	for _, policy := range slices.Sorted(maps.Keys(r.users)) {
-		out = append(out, r.users[policy]...)
-	}
-	return out
-}
-
-// UsersFor returns the v3 users of exactly the policies named, in policy
-// order. It is what a receiver hands gosnmp for a datagram whose source those
-// policies claimed: gosnmp tries every same-username entry in turn, localising
-// keys for each, so the table is kept to the credentials that can apply.
-func (r *Registry) UsersFor(policies []string) []V3User {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	var out []V3User
-	for _, policy := range slices.Sorted(slices.Values(policies)) {
-		out = append(out, r.users[policy]...)
+	for _, policy := range slices.Sorted(maps.Keys(policies)) {
+		if u := policies[policy]; u != nil {
+			out = append(out, *u)
+		}
 	}
 	return out
 }

--- a/orb-telemetry/snmp-telemetry/traps/registry.go
+++ b/orb-telemetry/snmp-telemetry/traps/registry.go
@@ -135,6 +135,20 @@ func (r *Registry) Users() []V3User {
 	return out
 }
 
+// UsersFor returns the v3 users of exactly the policies named, in policy
+// order. It is what a receiver hands gosnmp for a datagram whose source those
+// policies claimed: gosnmp tries every same-username entry in turn, localising
+// keys for each, so the table is kept to the credentials that can apply.
+func (r *Registry) UsersFor(policies []string) []V3User {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var out []V3User
+	for _, policy := range slices.Sorted(slices.Values(policies)) {
+		out = append(out, r.users[policy]...)
+	}
+	return out
+}
+
 // Generation advances on every change, so a caller caching something derived
 // from the registry can tell when to rebuild it without diffing.
 func (r *Registry) Generation() uint64 { return r.gen.Load() }

--- a/orb-telemetry/snmp-telemetry/traps/registry.go
+++ b/orb-telemetry/snmp-telemetry/traps/registry.go
@@ -145,13 +145,31 @@ func (r *Registry) claimsAt(addr netip.Addr) map[string][]V3User {
 
 // Lookup returns the policies naming an address, in sorted order, or nil.
 func (r *Registry) Lookup(addr netip.Addr) []string {
+	return r.PoliciesAt(addr, nil)
+}
+
+// PoliciesAt returns the policies naming an address, in sorted order, or nil.
+// With a predicate, only the policies with at least one registered user at
+// that address satisfying it are returned: this is how an authenticated v3
+// trap is attributed to the policies holding the credential that verified
+// it, and to no other, even though every user at the address was handed to
+// the parser together.
+func (r *Registry) PoliciesAt(addr netip.Addr, holding func(V3User) bool) []string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	policies := r.claimsAt(addr)
-	if len(policies) == 0 {
+	claims := r.claimsAt(addr)
+	var out []string
+	for policy, users := range claims {
+		if holding != nil && !slices.ContainsFunc(users, holding) {
+			continue
+		}
+		out = append(out, policy)
+	}
+	if len(out) == 0 {
 		return nil
 	}
-	return slices.Sorted(maps.Keys(policies))
+	slices.Sort(out)
+	return out
 }
 
 // UsersAt returns the v3 users the claiming policies poll an address with,

--- a/orb-telemetry/snmp-telemetry/traps/registry_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/registry_test.go
@@ -14,8 +14,8 @@ func addr(s string) netip.Addr { return netip.MustParseAddr(s) }
 // the other's claim with it; that is why claims are refcounted by policy.
 func TestRegistry_TwoPoliciesOneAddress(t *testing.T) {
 	r := NewRegistry()
-	r.Register("core", []Device{{Policy: "core", Addr: addr("10.0.0.5")}})
-	r.Register("edge", []Device{{Policy: "edge", Addr: addr("10.0.0.5")}})
+	r.Register("core", []Device{{Policy: "core", Addr: addr("10.0.0.5")}}, nil)
+	r.Register("edge", []Device{{Policy: "edge", Addr: addr("10.0.0.5")}}, nil)
 
 	assert.ElementsMatch(t, []string{"core", "edge"}, r.Lookup(addr("10.0.0.5")))
 
@@ -29,7 +29,7 @@ func TestRegistry_TwoPoliciesOneAddress(t *testing.T) {
 
 func TestRegistry_WithdrawOfAnUnknownPolicyIsANoOp(t *testing.T) {
 	r := NewRegistry()
-	r.Register("core", []Device{{Policy: "core", Addr: addr("10.0.0.5")}})
+	r.Register("core", []Device{{Policy: "core", Addr: addr("10.0.0.5")}}, nil)
 	r.Withdraw("never-registered")
 	assert.Equal(t, []string{"core"}, r.Lookup(addr("10.0.0.5")))
 }
@@ -38,17 +38,17 @@ func TestRegistry_WithdrawOfAnUnknownPolicyIsANoOp(t *testing.T) {
 // netip.Addr compares by representation. Both sides canonicalise.
 func TestRegistry_CanonicalisesIPv4MappedAndZonedAddresses(t *testing.T) {
 	r := NewRegistry()
-	r.Register("p", []Device{{Policy: "p", Addr: addr("10.0.0.5")}})
+	r.Register("p", []Device{{Policy: "p", Addr: addr("10.0.0.5")}}, nil)
 
 	mapped := netip.AddrFrom16(addr("10.0.0.5").As16())
 	require.True(t, mapped.Is4In6(), "the fixture must be the 4-in-6 form")
 	assert.Equal(t, []string{"p"}, r.Lookup(mapped), "a 4-in-6 lookup finds the IPv4 registration")
 
-	r.Register("q", []Device{{Policy: "q", Addr: mapped}})
+	r.Register("q", []Device{{Policy: "q", Addr: mapped}}, nil)
 	assert.ElementsMatch(t, []string{"p", "q"}, r.Lookup(addr("10.0.0.5")), "a 4-in-6 registration is found by the IPv4 form")
 
 	zoned := addr("fe80::1").WithZone("eth0")
-	r.Register("z", []Device{{Policy: "z", Addr: zoned}})
+	r.Register("z", []Device{{Policy: "z", Addr: zoned}}, nil)
 	assert.Equal(t, []string{"z"}, r.Lookup(zoned), "the zone is part of the claim")
 	assert.Empty(t, r.Lookup(addr("fe80::1")), "and a zoned claim is not matched without it")
 }
@@ -61,8 +61,8 @@ func TestRegistry_UsersAtCollectsAcrossPoliciesAndWithdrawsPerPolicy(t *testing.
 	r := NewRegistry()
 	one := V3User{Username: "ops", AuthProtocol: "SHA", AuthPassphrase: "one"}
 	two := V3User{Username: "ops", AuthProtocol: "SHA", AuthPassphrase: "two"}
-	r.Register("a", []Device{{Policy: "a", Addr: addr("10.0.0.1"), User: &one}})
-	r.Register("b", []Device{{Policy: "b", Addr: addr("10.0.0.1"), User: &two}})
+	r.Register("a", []Device{{Policy: "a", Addr: addr("10.0.0.1"), User: &one}}, nil)
+	r.Register("b", []Device{{Policy: "b", Addr: addr("10.0.0.1"), User: &two}}, nil)
 
 	assert.Equal(t, []V3User{one, two}, r.UsersAt(addr("10.0.0.1")))
 
@@ -75,7 +75,7 @@ func TestRegistry_UsersAtCollectsAcrossPoliciesAndWithdrawsPerPolicy(t *testing.
 func TestRegistry_GenerationAdvancesOnEveryChange(t *testing.T) {
 	r := NewRegistry()
 	g0 := r.Generation()
-	r.Register("a", []Device{{Policy: "a", Addr: addr("10.0.0.1")}})
+	r.Register("a", []Device{{Policy: "a", Addr: addr("10.0.0.1")}}, nil)
 	g1 := r.Generation()
 	r.Withdraw("a")
 	g2 := r.Generation()
@@ -85,8 +85,8 @@ func TestRegistry_GenerationAdvancesOnEveryChange(t *testing.T) {
 
 func TestRegistry_ReRegisterReplacesAPolicysClaims(t *testing.T) {
 	r := NewRegistry()
-	r.Register("p", []Device{{Policy: "p", Addr: addr("10.0.0.1")}})
-	r.Register("p", []Device{{Policy: "p", Addr: addr("10.0.0.2")}})
+	r.Register("p", []Device{{Policy: "p", Addr: addr("10.0.0.1")}}, nil)
+	r.Register("p", []Device{{Policy: "p", Addr: addr("10.0.0.2")}}, nil)
 	assert.Empty(t, r.Lookup(addr("10.0.0.1")), "the old claim is gone")
 	assert.Equal(t, []string{"p"}, r.Lookup(addr("10.0.0.2")))
 }
@@ -99,9 +99,9 @@ func TestRegistry_ReRegisterReplacesAPolicysClaims(t *testing.T) {
 // spell the zone is not silently unmatched.
 func TestRegistry_ZonesDistinguishLinkLocalDevices(t *testing.T) {
 	r := NewRegistry()
-	r.Register("a", []Device{{Policy: "a", Addr: addr("fe80::1").WithZone("eth0")}})
-	r.Register("b", []Device{{Policy: "b", Addr: addr("fe80::1").WithZone("eth1")}})
-	r.Register("c", []Device{{Policy: "c", Addr: addr("fe80::2")}})
+	r.Register("a", []Device{{Policy: "a", Addr: addr("fe80::1").WithZone("eth0")}}, nil)
+	r.Register("b", []Device{{Policy: "b", Addr: addr("fe80::1").WithZone("eth1")}}, nil)
+	r.Register("c", []Device{{Policy: "c", Addr: addr("fe80::2")}}, nil)
 
 	assert.Equal(t, []string{"a"}, r.Lookup(addr("fe80::1").WithZone("eth0")))
 	assert.Equal(t, []string{"b"}, r.Lookup(addr("fe80::1").WithZone("eth1")))
@@ -123,8 +123,8 @@ func TestRegistry_UsersAtNamesOnlyThatDevicesCredentials(t *testing.T) {
 		{Policy: "core", Addr: addr("10.0.0.1"), User: &ua},
 		{Policy: "core", Addr: addr("10.0.0.2"), User: &ub},
 		{Policy: "core", Addr: addr("10.0.0.3")},
-	})
-	r.Register("edge", []Device{{Policy: "edge", Addr: addr("10.0.0.1"), User: &uc}})
+	}, nil)
+	r.Register("edge", []Device{{Policy: "edge", Addr: addr("10.0.0.1"), User: &uc}}, nil)
 
 	assert.Equal(t, []V3User{ua, uc}, r.UsersAt(addr("10.0.0.1")), "one per claiming policy, in policy order")
 	assert.Equal(t, []V3User{ub}, r.UsersAt(addr("10.0.0.2")), "a's credential is not tried for b")
@@ -134,4 +134,49 @@ func TestRegistry_UsersAtNamesOnlyThatDevicesCredentials(t *testing.T) {
 
 	r.Withdraw("edge")
 	assert.Equal(t, []V3User{ua}, r.UsersAt(addr("10.0.0.1")), "withdrawal takes the policy's credential with it")
+}
+
+// A zoneless claim names the address on every interface, so it is matched
+// alongside an exact zoned claim rather than only when no zoned claim exists.
+func TestRegistry_ZonedAndZonelessClaimsCoexist(t *testing.T) {
+	r := NewRegistry()
+	ua := V3User{Username: "a", AuthProtocol: "SHA", AuthPassphrase: "a-pass"}
+	ub := V3User{Username: "b", AuthProtocol: "SHA", AuthPassphrase: "b-pass"}
+	r.Register("any", []Device{{Policy: "any", Addr: addr("fe80::1"), User: &ua}}, nil)
+	r.Register("eth0", []Device{{Policy: "eth0", Addr: addr("fe80::1").WithZone("eth0"), User: &ub}}, nil)
+
+	assert.Equal(t, []string{"any", "eth0"}, r.Lookup(addr("fe80::1").WithZone("eth0")), "both claim the address on eth0")
+	assert.Equal(t, []V3User{ua, ub}, r.UsersAt(addr("fe80::1").WithZone("eth0")))
+	assert.Equal(t, []string{"any"}, r.Lookup(addr("fe80::1").WithZone("eth1")), "only the zoneless claim reaches eth1")
+	assert.Equal(t, []string{"any"}, r.Lookup(addr("fe80::1")))
+}
+
+// A policy may keep two targets at one address under different IDs or SNMP
+// contexts, each with its own credential. Both credentials belong to that
+// source and both are kept.
+func TestRegistry_KeepsEveryCredentialOfDuplicateAddressTargets(t *testing.T) {
+	r := NewRegistry()
+	one := V3User{Username: "ctx-a", AuthProtocol: "SHA", AuthPassphrase: "one"}
+	two := V3User{Username: "ctx-b", AuthProtocol: "SHA", AuthPassphrase: "two"}
+	r.Register("core", []Device{
+		{Policy: "core", Addr: addr("10.0.0.1"), User: &one},
+		{Policy: "core", Addr: addr("10.0.0.1"), User: &two},
+		{Policy: "core", Addr: addr("10.0.0.1"), User: &one},
+	}, nil)
+	assert.Equal(t, []V3User{one, two}, r.UsersAt(addr("10.0.0.1")), "both kept, the repeat once")
+	assert.Equal(t, 1, r.Size())
+}
+
+// A policy registers the trap names of its own profile set, so two policies
+// on one socket can name the same OID differently, and a policy registered
+// without names has none.
+func TestRegistry_NamesForPolicy(t *testing.T) {
+	r := NewRegistry()
+	r.Register("a", []Device{{Policy: "a", Addr: addr("10.0.0.1")}}, map[string]string{"1.2.3": "aName"})
+	r.Register("b", []Device{{Policy: "b", Addr: addr("10.0.0.1")}}, nil)
+	assert.Equal(t, "aName", r.NamesFor("a")["1.2.3"])
+	assert.Nil(t, r.NamesFor("b"))
+	assert.Nil(t, r.NamesFor("nobody"))
+	r.Withdraw("a")
+	assert.Nil(t, r.NamesFor("a"), "withdrawn with the claims")
 }

--- a/orb-telemetry/snmp-telemetry/traps/registry_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/registry_test.go
@@ -180,3 +180,22 @@ func TestRegistry_NamesForPolicy(t *testing.T) {
 	r.Withdraw("a")
 	assert.Nil(t, r.NamesFor("a"), "withdrawn with the claims")
 }
+
+// PoliciesAt with a credential predicate returns only the policies whose
+// registered users at the address satisfy it, so a v3 trap is attributed to
+// the policies holding the credential that verified it and to no other.
+func TestRegistry_PoliciesAtFiltersByCredential(t *testing.T) {
+	r := NewRegistry()
+	mine := V3User{Username: "shared", AuthProtocol: "SHA", AuthPassphrase: "mine"}
+	theirs := V3User{Username: "shared", AuthProtocol: "SHA", AuthPassphrase: "theirs"}
+	r.Register("core", []Device{{Policy: "core", Addr: addr("10.0.0.1"), User: &mine}}, nil)
+	r.Register("edge", []Device{{Policy: "edge", Addr: addr("10.0.0.1"), User: &theirs}}, nil)
+	r.Register("plain", []Device{{Policy: "plain", Addr: addr("10.0.0.1")}}, nil)
+
+	assert.Equal(t, []string{"core", "edge", "plain"}, r.PoliciesAt(addr("10.0.0.1"), nil), "no predicate: every claim")
+	holds := func(want V3User) func(V3User) bool { return func(u V3User) bool { return u == want } }
+	assert.Equal(t, []string{"core"}, r.PoliciesAt(addr("10.0.0.1"), holds(mine)))
+	assert.Equal(t, []string{"edge"}, r.PoliciesAt(addr("10.0.0.1"), holds(theirs)))
+	assert.Empty(t, r.PoliciesAt(addr("10.0.0.1"), holds(V3User{Username: "nobody"})))
+	assert.Empty(t, r.PoliciesAt(addr("10.0.0.9"), nil))
+}

--- a/orb-telemetry/snmp-telemetry/traps/registry_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/registry_test.go
@@ -49,7 +49,8 @@ func TestRegistry_CanonicalisesIPv4MappedAndZonedAddresses(t *testing.T) {
 
 	zoned := addr("fe80::1").WithZone("eth0")
 	r.Register("z", []Device{{Policy: "z", Addr: zoned}}, nil)
-	assert.Equal(t, []string{"z"}, r.Lookup(addr("fe80::1")), "the zone is dropped")
+	assert.Equal(t, []string{"z"}, r.Lookup(zoned), "the zone is part of the claim")
+	assert.Empty(t, r.Lookup(addr("fe80::1")), "and a zoned claim is not matched without it")
 }
 
 // F11: gosnmp's credential table is keyed by username and holds a list per
@@ -87,4 +88,24 @@ func TestRegistry_ReRegisterReplacesAPolicysClaims(t *testing.T) {
 	r.Register("p", []Device{{Policy: "p", Addr: addr("10.0.0.2")}}, nil)
 	assert.Empty(t, r.Lookup(addr("10.0.0.1")), "the old claim is gone")
 	assert.Equal(t, []string{"p"}, r.Lookup(addr("10.0.0.2")))
+}
+
+// Link-local IPv6 addresses are only unique per interface, and a wildcard
+// socket receives them from every interface with the zone the kernel saw
+// them on. Two devices at fe80::1 on different interfaces are two devices,
+// so a zoned claim matches only its own zone. A claim written without a zone
+// still matches the address on any interface, so an operator who did not
+// spell the zone is not silently unmatched.
+func TestRegistry_ZonesDistinguishLinkLocalDevices(t *testing.T) {
+	r := NewRegistry()
+	r.Register("a", []Device{{Policy: "a", Addr: addr("fe80::1").WithZone("eth0")}}, nil)
+	r.Register("b", []Device{{Policy: "b", Addr: addr("fe80::1").WithZone("eth1")}}, nil)
+	r.Register("c", []Device{{Policy: "c", Addr: addr("fe80::2")}}, nil)
+
+	assert.Equal(t, []string{"a"}, r.Lookup(addr("fe80::1").WithZone("eth0")))
+	assert.Equal(t, []string{"b"}, r.Lookup(addr("fe80::1").WithZone("eth1")))
+	assert.Empty(t, r.Lookup(addr("fe80::1").WithZone("eth2")), "a zone no policy named")
+	assert.Equal(t, []string{"c"}, r.Lookup(addr("fe80::2").WithZone("eth0")), "a claim without a zone matches the address on any interface")
+	assert.Equal(t, []string{"c"}, r.Lookup(addr("fe80::2")))
+	assert.Equal(t, 3, r.Size())
 }

--- a/orb-telemetry/snmp-telemetry/traps/registry_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/registry_test.go
@@ -14,8 +14,8 @@ func addr(s string) netip.Addr { return netip.MustParseAddr(s) }
 // the other's claim with it; that is why claims are refcounted by policy.
 func TestRegistry_TwoPoliciesOneAddress(t *testing.T) {
 	r := NewRegistry()
-	r.Register("core", []Device{{Policy: "core", Addr: addr("10.0.0.5")}}, nil)
-	r.Register("edge", []Device{{Policy: "edge", Addr: addr("10.0.0.5")}}, nil)
+	r.Register("core", []Device{{Policy: "core", Addr: addr("10.0.0.5")}})
+	r.Register("edge", []Device{{Policy: "edge", Addr: addr("10.0.0.5")}})
 
 	assert.ElementsMatch(t, []string{"core", "edge"}, r.Lookup(addr("10.0.0.5")))
 
@@ -29,7 +29,7 @@ func TestRegistry_TwoPoliciesOneAddress(t *testing.T) {
 
 func TestRegistry_WithdrawOfAnUnknownPolicyIsANoOp(t *testing.T) {
 	r := NewRegistry()
-	r.Register("core", []Device{{Policy: "core", Addr: addr("10.0.0.5")}}, nil)
+	r.Register("core", []Device{{Policy: "core", Addr: addr("10.0.0.5")}})
 	r.Withdraw("never-registered")
 	assert.Equal(t, []string{"core"}, r.Lookup(addr("10.0.0.5")))
 }
@@ -38,35 +38,36 @@ func TestRegistry_WithdrawOfAnUnknownPolicyIsANoOp(t *testing.T) {
 // netip.Addr compares by representation. Both sides canonicalise.
 func TestRegistry_CanonicalisesIPv4MappedAndZonedAddresses(t *testing.T) {
 	r := NewRegistry()
-	r.Register("p", []Device{{Policy: "p", Addr: addr("10.0.0.5")}}, nil)
+	r.Register("p", []Device{{Policy: "p", Addr: addr("10.0.0.5")}})
 
 	mapped := netip.AddrFrom16(addr("10.0.0.5").As16())
 	require.True(t, mapped.Is4In6(), "the fixture must be the 4-in-6 form")
 	assert.Equal(t, []string{"p"}, r.Lookup(mapped), "a 4-in-6 lookup finds the IPv4 registration")
 
-	r.Register("q", []Device{{Policy: "q", Addr: mapped}}, nil)
+	r.Register("q", []Device{{Policy: "q", Addr: mapped}})
 	assert.ElementsMatch(t, []string{"p", "q"}, r.Lookup(addr("10.0.0.5")), "a 4-in-6 registration is found by the IPv4 form")
 
 	zoned := addr("fe80::1").WithZone("eth0")
-	r.Register("z", []Device{{Policy: "z", Addr: zoned}}, nil)
+	r.Register("z", []Device{{Policy: "z", Addr: zoned}})
 	assert.Equal(t, []string{"z"}, r.Lookup(zoned), "the zone is part of the claim")
 	assert.Empty(t, r.Lookup(addr("fe80::1")), "and a zoned claim is not matched without it")
 }
 
 // F11: gosnmp's credential table is keyed by username and holds a list per
-// username, tried in turn. Two targets sharing a username with different
-// passphrases both have to reach it.
-func TestRegistry_UsersAreCollectedAcrossPoliciesAndWithdrawnPerPolicy(t *testing.T) {
+// username, tried in turn. Two policies polling one device under the same
+// username with different passphrases both have to reach it for that device,
+// and withdrawing one policy takes only its credential away.
+func TestRegistry_UsersAtCollectsAcrossPoliciesAndWithdrawsPerPolicy(t *testing.T) {
 	r := NewRegistry()
-	r.Register("a", nil, []V3User{{Username: "ops", AuthProtocol: "SHA", AuthPassphrase: "one"}})
-	r.Register("b", nil, []V3User{{Username: "ops", AuthProtocol: "SHA", AuthPassphrase: "two"}, {Username: "ro", AuthProtocol: "SHA", AuthPassphrase: "three"}})
+	one := V3User{Username: "ops", AuthProtocol: "SHA", AuthPassphrase: "one"}
+	two := V3User{Username: "ops", AuthProtocol: "SHA", AuthPassphrase: "two"}
+	r.Register("a", []Device{{Policy: "a", Addr: addr("10.0.0.1"), User: &one}})
+	r.Register("b", []Device{{Policy: "b", Addr: addr("10.0.0.1"), User: &two}})
 
-	assert.Len(t, r.Users(), 3)
+	assert.Equal(t, []V3User{one, two}, r.UsersAt(addr("10.0.0.1")))
 
 	r.Withdraw("b")
-	users := r.Users()
-	require.Len(t, users, 1)
-	assert.Equal(t, "one", users[0].AuthPassphrase, "only a's user remains")
+	assert.Equal(t, []V3User{one}, r.UsersAt(addr("10.0.0.1")), "only a's credential remains")
 }
 
 // The receiver rebuilds gosnmp's table when the users change. It learns that
@@ -74,7 +75,7 @@ func TestRegistry_UsersAreCollectedAcrossPoliciesAndWithdrawnPerPolicy(t *testin
 func TestRegistry_GenerationAdvancesOnEveryChange(t *testing.T) {
 	r := NewRegistry()
 	g0 := r.Generation()
-	r.Register("a", []Device{{Policy: "a", Addr: addr("10.0.0.1")}}, nil)
+	r.Register("a", []Device{{Policy: "a", Addr: addr("10.0.0.1")}})
 	g1 := r.Generation()
 	r.Withdraw("a")
 	g2 := r.Generation()
@@ -84,8 +85,8 @@ func TestRegistry_GenerationAdvancesOnEveryChange(t *testing.T) {
 
 func TestRegistry_ReRegisterReplacesAPolicysClaims(t *testing.T) {
 	r := NewRegistry()
-	r.Register("p", []Device{{Policy: "p", Addr: addr("10.0.0.1")}}, nil)
-	r.Register("p", []Device{{Policy: "p", Addr: addr("10.0.0.2")}}, nil)
+	r.Register("p", []Device{{Policy: "p", Addr: addr("10.0.0.1")}})
+	r.Register("p", []Device{{Policy: "p", Addr: addr("10.0.0.2")}})
 	assert.Empty(t, r.Lookup(addr("10.0.0.1")), "the old claim is gone")
 	assert.Equal(t, []string{"p"}, r.Lookup(addr("10.0.0.2")))
 }
@@ -98,9 +99,9 @@ func TestRegistry_ReRegisterReplacesAPolicysClaims(t *testing.T) {
 // spell the zone is not silently unmatched.
 func TestRegistry_ZonesDistinguishLinkLocalDevices(t *testing.T) {
 	r := NewRegistry()
-	r.Register("a", []Device{{Policy: "a", Addr: addr("fe80::1").WithZone("eth0")}}, nil)
-	r.Register("b", []Device{{Policy: "b", Addr: addr("fe80::1").WithZone("eth1")}}, nil)
-	r.Register("c", []Device{{Policy: "c", Addr: addr("fe80::2")}}, nil)
+	r.Register("a", []Device{{Policy: "a", Addr: addr("fe80::1").WithZone("eth0")}})
+	r.Register("b", []Device{{Policy: "b", Addr: addr("fe80::1").WithZone("eth1")}})
+	r.Register("c", []Device{{Policy: "c", Addr: addr("fe80::2")}})
 
 	assert.Equal(t, []string{"a"}, r.Lookup(addr("fe80::1").WithZone("eth0")))
 	assert.Equal(t, []string{"b"}, r.Lookup(addr("fe80::1").WithZone("eth1")))
@@ -110,21 +111,27 @@ func TestRegistry_ZonesDistinguishLinkLocalDevices(t *testing.T) {
 	assert.Equal(t, 3, r.Size())
 }
 
-// UsersFor returns the users of exactly the policies named, in policy order,
-// so a receiver can try only the credentials of the policies that claimed a
-// source rather than every credential on the socket.
-func TestRegistry_UsersForNamesOnlyThosePolicies(t *testing.T) {
+// UsersAt returns the v3 users of the devices claimed at an address, one per
+// claiming policy, so a receiver tries only the credentials a policy assigned
+// to that device rather than every credential the policy carries.
+func TestRegistry_UsersAtNamesOnlyThatDevicesCredentials(t *testing.T) {
 	r := NewRegistry()
 	ua := V3User{Username: "shared", AuthProtocol: "SHA", AuthPassphrase: "a-pass"}
 	ub := V3User{Username: "shared", AuthProtocol: "SHA", AuthPassphrase: "b-pass"}
 	uc := V3User{Username: "other", AuthProtocol: "SHA", AuthPassphrase: "c-pass"}
-	r.Register("a", []Device{{Policy: "a", Addr: addr("10.0.0.1")}}, []V3User{ua})
-	r.Register("b", []Device{{Policy: "b", Addr: addr("10.0.0.2")}}, []V3User{ub})
-	r.Register("c", []Device{{Policy: "c", Addr: addr("10.0.0.3")}}, []V3User{uc})
+	r.Register("core", []Device{
+		{Policy: "core", Addr: addr("10.0.0.1"), User: &ua},
+		{Policy: "core", Addr: addr("10.0.0.2"), User: &ub},
+		{Policy: "core", Addr: addr("10.0.0.3")},
+	})
+	r.Register("edge", []Device{{Policy: "edge", Addr: addr("10.0.0.1"), User: &uc}})
 
-	assert.Equal(t, []V3User{ua}, r.UsersFor([]string{"a"}))
-	assert.Equal(t, []V3User{ua, uc}, r.UsersFor([]string{"c", "a"}), "in policy order, whatever order was asked")
-	assert.Empty(t, r.UsersFor([]string{"nobody"}))
-	assert.Empty(t, r.UsersFor(nil))
-	assert.Len(t, r.Users(), 3, "the socket-wide view still exists")
+	assert.Equal(t, []V3User{ua, uc}, r.UsersAt(addr("10.0.0.1")), "one per claiming policy, in policy order")
+	assert.Equal(t, []V3User{ub}, r.UsersAt(addr("10.0.0.2")), "a's credential is not tried for b")
+	assert.Empty(t, r.UsersAt(addr("10.0.0.3")), "a v2c device has no user")
+	assert.Empty(t, r.UsersAt(addr("10.0.0.9")), "an unclaimed address has none")
+	assert.Equal(t, []V3User{ua, uc}, r.UsersAt(netip.AddrFrom16(addr("10.0.0.1").As16())), "through the 4-in-6 form")
+
+	r.Withdraw("edge")
+	assert.Equal(t, []V3User{ua}, r.UsersAt(addr("10.0.0.1")), "withdrawal takes the policy's credential with it")
 }

--- a/orb-telemetry/snmp-telemetry/traps/registry_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/registry_test.go
@@ -1,0 +1,90 @@
+package traps
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func addr(s string) netip.Addr { return netip.MustParseAddr(s) }
+
+// Two policies legitimately name one device. Withdrawing one must not take
+// the other's claim with it; that is why claims are refcounted by policy.
+func TestRegistry_TwoPoliciesOneAddress(t *testing.T) {
+	r := NewRegistry()
+	r.Register("core", []Device{{Policy: "core", Addr: addr("10.0.0.5")}}, nil)
+	r.Register("edge", []Device{{Policy: "edge", Addr: addr("10.0.0.5")}}, nil)
+
+	assert.ElementsMatch(t, []string{"core", "edge"}, r.Lookup(addr("10.0.0.5")))
+
+	r.Withdraw("core")
+	assert.Equal(t, []string{"edge"}, r.Lookup(addr("10.0.0.5")), "edge still names the device")
+
+	r.Withdraw("edge")
+	assert.Empty(t, r.Lookup(addr("10.0.0.5")))
+	assert.Equal(t, 0, r.Size(), "an address with no claims is deleted, not left empty")
+}
+
+func TestRegistry_WithdrawOfAnUnknownPolicyIsANoOp(t *testing.T) {
+	r := NewRegistry()
+	r.Register("core", []Device{{Policy: "core", Addr: addr("10.0.0.5")}}, nil)
+	r.Withdraw("never-registered")
+	assert.Equal(t, []string{"core"}, r.Lookup(addr("10.0.0.5")))
+}
+
+// F14: on a dual-stack bind an IPv4 sender arrives as ::ffff:10.0.0.5, and
+// netip.Addr compares by representation. Both sides canonicalise.
+func TestRegistry_CanonicalisesIPv4MappedAndZonedAddresses(t *testing.T) {
+	r := NewRegistry()
+	r.Register("p", []Device{{Policy: "p", Addr: addr("10.0.0.5")}}, nil)
+
+	mapped := netip.AddrFrom16(addr("10.0.0.5").As16())
+	require.True(t, mapped.Is4In6(), "the fixture must be the 4-in-6 form")
+	assert.Equal(t, []string{"p"}, r.Lookup(mapped), "a 4-in-6 lookup finds the IPv4 registration")
+
+	r.Register("q", []Device{{Policy: "q", Addr: mapped}}, nil)
+	assert.ElementsMatch(t, []string{"p", "q"}, r.Lookup(addr("10.0.0.5")), "a 4-in-6 registration is found by the IPv4 form")
+
+	zoned := addr("fe80::1").WithZone("eth0")
+	r.Register("z", []Device{{Policy: "z", Addr: zoned}}, nil)
+	assert.Equal(t, []string{"z"}, r.Lookup(addr("fe80::1")), "the zone is dropped")
+}
+
+// F11: gosnmp's credential table is keyed by username and holds a list per
+// username, tried in turn. Two targets sharing a username with different
+// passphrases both have to reach it.
+func TestRegistry_UsersAreCollectedAcrossPoliciesAndWithdrawnPerPolicy(t *testing.T) {
+	r := NewRegistry()
+	r.Register("a", nil, []V3User{{Username: "ops", AuthProtocol: "SHA", AuthPassphrase: "one"}})
+	r.Register("b", nil, []V3User{{Username: "ops", AuthProtocol: "SHA", AuthPassphrase: "two"}, {Username: "ro", AuthProtocol: "SHA", AuthPassphrase: "three"}})
+
+	assert.Len(t, r.Users(), 3)
+
+	r.Withdraw("b")
+	users := r.Users()
+	require.Len(t, users, 1)
+	assert.Equal(t, "one", users[0].AuthPassphrase, "only a's user remains")
+}
+
+// The receiver rebuilds gosnmp's table when the users change. It learns that
+// from a generation counter rather than by diffing lists on every packet.
+func TestRegistry_GenerationAdvancesOnEveryChange(t *testing.T) {
+	r := NewRegistry()
+	g0 := r.Generation()
+	r.Register("a", []Device{{Policy: "a", Addr: addr("10.0.0.1")}}, nil)
+	g1 := r.Generation()
+	r.Withdraw("a")
+	g2 := r.Generation()
+	assert.Less(t, g0, g1)
+	assert.Less(t, g1, g2)
+}
+
+func TestRegistry_ReRegisterReplacesAPolicysClaims(t *testing.T) {
+	r := NewRegistry()
+	r.Register("p", []Device{{Policy: "p", Addr: addr("10.0.0.1")}}, nil)
+	r.Register("p", []Device{{Policy: "p", Addr: addr("10.0.0.2")}}, nil)
+	assert.Empty(t, r.Lookup(addr("10.0.0.1")), "the old claim is gone")
+	assert.Equal(t, []string{"p"}, r.Lookup(addr("10.0.0.2")))
+}

--- a/orb-telemetry/snmp-telemetry/traps/registry_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/registry_test.go
@@ -109,3 +109,22 @@ func TestRegistry_ZonesDistinguishLinkLocalDevices(t *testing.T) {
 	assert.Equal(t, []string{"c"}, r.Lookup(addr("fe80::2")))
 	assert.Equal(t, 3, r.Size())
 }
+
+// UsersFor returns the users of exactly the policies named, in policy order,
+// so a receiver can try only the credentials of the policies that claimed a
+// source rather than every credential on the socket.
+func TestRegistry_UsersForNamesOnlyThosePolicies(t *testing.T) {
+	r := NewRegistry()
+	ua := V3User{Username: "shared", AuthProtocol: "SHA", AuthPassphrase: "a-pass"}
+	ub := V3User{Username: "shared", AuthProtocol: "SHA", AuthPassphrase: "b-pass"}
+	uc := V3User{Username: "other", AuthProtocol: "SHA", AuthPassphrase: "c-pass"}
+	r.Register("a", []Device{{Policy: "a", Addr: addr("10.0.0.1")}}, []V3User{ua})
+	r.Register("b", []Device{{Policy: "b", Addr: addr("10.0.0.2")}}, []V3User{ub})
+	r.Register("c", []Device{{Policy: "c", Addr: addr("10.0.0.3")}}, []V3User{uc})
+
+	assert.Equal(t, []V3User{ua}, r.UsersFor([]string{"a"}))
+	assert.Equal(t, []V3User{ua, uc}, r.UsersFor([]string{"c", "a"}), "in policy order, whatever order was asked")
+	assert.Empty(t, r.UsersFor([]string{"nobody"}))
+	assert.Empty(t, r.UsersFor(nil))
+	assert.Len(t, r.Users(), 3, "the socket-wide view still exists")
+}

--- a/orb-telemetry/snmp-telemetry/traps/timeliness.go
+++ b/orb-telemetry/snmp-telemetry/traps/timeliness.go
@@ -29,6 +29,9 @@ const timeWindow = 150
 
 // maxEngineBoots is the boots value an engine reports once its counter is
 // exhausted; RFC 3414 says every message carrying it is outside the window.
+// It is also the largest value either clock field may hold: gosnmp casts a
+// negative wire integer to uint32, so a value past it is a malformed clock
+// and is rejected before it can be learned.
 const maxEngineBoots = 2147483647
 
 // maxEngines bounds the clock map. A registered sender holding a v3
@@ -82,7 +85,7 @@ func newTimeliness(now func() time.Time) *timeliness {
 // clock named by id is inside the window, learning the clock or advancing it
 // as it goes.
 func (w *timeliness) check(id clockID, boots, engineTime uint32) bool {
-	if boots == maxEngineBoots {
+	if boots >= maxEngineBoots || engineTime > maxEngineBoots {
 		return false
 	}
 	now := w.now()

--- a/orb-telemetry/snmp-telemetry/traps/timeliness.go
+++ b/orb-telemetry/snmp-telemetry/traps/timeliness.go
@@ -52,8 +52,10 @@ func newTimeliness(now func() time.Time) *timeliness {
 	return &timeliness{clocks: make(map[string]engineClock), now: now}
 }
 
-// check reports whether a message carrying boots and engineTime from engineID
-// is inside the window, learning the engine or advancing its clock as it goes.
+// check reports whether a message carrying boots and engineTime from the
+// engine keyed by engineID, which the receiver composes from the sender's
+// address and the wire engine ID, is inside the window, learning the engine
+// or advancing its clock as it goes.
 func (w *timeliness) check(engineID string, boots, engineTime uint32) bool {
 	if boots == maxEngineBoots {
 		return false

--- a/orb-telemetry/snmp-telemetry/traps/timeliness.go
+++ b/orb-telemetry/snmp-telemetry/traps/timeliness.go
@@ -133,12 +133,23 @@ func (w *timeliness) check(id clockID, boots, engineTime uint32) bool {
 			mine = list.New()
 			w.perPrincipal[p] = mine
 		}
-		// The principal's own bound first, so churning engine IDs costs the
-		// churner its own clocks; the global bound only after that.
-		if mine.Len() >= maxEnginesPerPrincipal {
+		// The principal's own clocks go first: at its own bound, and at the
+		// global bound whenever it holds any, so churning engine IDs costs
+		// the churner its own clocks and never another principal's replay
+		// state. Only a principal's very first clock at the global bound
+		// displaces the globally oldest, and it can do that once.
+		switch {
+		case mine.Len() >= maxEnginesPerPrincipal || (w.order.Len() >= maxEngines && mine.Len() > 0):
 			w.evict(mine.Back().Value.(*engineClock).global)
-		} else if w.order.Len() >= maxEngines {
+		case w.order.Len() >= maxEngines:
 			w.evict(w.order.Back())
+		}
+		// An eviction that emptied this principal's list removed the list
+		// from the map; the new clock must join the list the map holds, or
+		// the principal's next clock would find none and evict globally.
+		if mine = w.perPrincipal[p]; mine == nil {
+			mine = list.New()
+			w.perPrincipal[p] = mine
 		}
 		c := &engineClock{id: id, boots: boots, time: engineTime, learned: now}
 		c.global = w.order.PushFront(c)

--- a/orb-telemetry/snmp-telemetry/traps/timeliness.go
+++ b/orb-telemetry/snmp-telemetry/traps/timeliness.go
@@ -23,6 +23,21 @@ type clockID struct {
 	engineID  string
 }
 
+// principal is the clockID without its engine ID: one sender with one
+// credential, which is what can churn engine IDs and what must not be able
+// to evict anyone else's clock by doing so.
+func (id clockID) principal() clockID {
+	id.engineID = ""
+	return id
+}
+
+// maxEnginesPerPrincipal bounds the clocks one principal may hold. A device
+// has one engine ID, two across a re-provisioning; past the bound the
+// principal's own least recently used clock goes, so a principal cycling
+// through engine IDs evicts only itself and never reaches the global bound
+// on anyone else's behalf.
+const maxEnginesPerPrincipal = 8
+
 // timeWindow is RFC 3414's bound on how far behind its engine's clock a
 // message may be and still count as timely, in seconds.
 const timeWindow = 150
@@ -53,6 +68,10 @@ type engineClock struct {
 	boots   uint32
 	time    uint32
 	learned time.Time
+	// global and local are this clock's places in the global recency list
+	// and in its principal's own.
+	global *list.Element
+	local  *list.Element
 }
 
 // timeliness is the non-authoritative side of RFC 3414 section 3.2.7. A trap's
@@ -72,13 +91,30 @@ type engineClock struct {
 type timeliness struct {
 	clocks map[clockID]*list.Element
 	// order holds the engines most recently used first; the back is the
-	// next to be evicted.
+	// next to be evicted at the global bound.
 	order *list.List
-	now   func() time.Time
+	// perPrincipal holds each principal's clocks most recently used first;
+	// the back is the next to be evicted at the principal's bound.
+	perPrincipal map[clockID]*list.List
+	now          func() time.Time
 }
 
 func newTimeliness(now func() time.Time) *timeliness {
-	return &timeliness{clocks: make(map[clockID]*list.Element), order: list.New(), now: now}
+	return &timeliness{clocks: make(map[clockID]*list.Element), order: list.New(), perPrincipal: make(map[clockID]*list.List), now: now}
+}
+
+// evict removes one clock from every structure that holds it.
+func (w *timeliness) evict(el *list.Element) {
+	c := el.Value.(*engineClock)
+	delete(w.clocks, c.id)
+	w.order.Remove(el)
+	p := c.id.principal()
+	if l := w.perPrincipal[p]; l != nil {
+		l.Remove(c.local)
+		if l.Len() == 0 {
+			delete(w.perPrincipal, p)
+		}
+	}
 }
 
 // check reports whether a message carrying boots and engineTime from the
@@ -91,18 +127,29 @@ func (w *timeliness) check(id clockID, boots, engineTime uint32) bool {
 	now := w.now()
 	el, known := w.clocks[id]
 	if !known {
-		if w.order.Len() >= maxEngines {
-			oldest := w.order.Back()
-			delete(w.clocks, oldest.Value.(*engineClock).id)
-			w.order.Remove(oldest)
+		p := id.principal()
+		mine := w.perPrincipal[p]
+		if mine == nil {
+			mine = list.New()
+			w.perPrincipal[p] = mine
 		}
-		w.clocks[id] = w.order.PushFront(&engineClock{id: id, boots: boots, time: engineTime, learned: now})
+		// The principal's own bound first, so churning engine IDs costs the
+		// churner its own clocks; the global bound only after that.
+		if mine.Len() >= maxEnginesPerPrincipal {
+			w.evict(mine.Back().Value.(*engineClock).global)
+		} else if w.order.Len() >= maxEngines {
+			w.evict(w.order.Back())
+		}
+		c := &engineClock{id: id, boots: boots, time: engineTime, learned: now}
+		c.global = w.order.PushFront(c)
+		c.local = mine.PushFront(c)
+		w.clocks[id] = c.global
 		return true
 	}
 	c := el.Value.(*engineClock)
 	if boots > c.boots {
 		c.boots, c.time, c.learned = boots, engineTime, now
-		w.order.MoveToFront(el)
+		w.touch(c)
 		return true
 	}
 	if boots < c.boots {
@@ -115,8 +162,16 @@ func (w *timeliness) check(id clockID, boots, engineTime uint32) bool {
 	if int64(engineTime) > estimate {
 		c.time, c.learned = engineTime, now
 	}
-	w.order.MoveToFront(el)
+	w.touch(c)
 	return true
+}
+
+// touch marks a clock as just used in both recency lists.
+func (w *timeliness) touch(c *engineClock) {
+	w.order.MoveToFront(c.global)
+	if l := w.perPrincipal[c.id.principal()]; l != nil {
+		l.MoveToFront(c.local)
+	}
 }
 
 // size is a test accessor.

--- a/orb-telemetry/snmp-telemetry/traps/timeliness.go
+++ b/orb-telemetry/snmp-telemetry/traps/timeliness.go
@@ -2,8 +2,26 @@ package traps
 
 import (
 	"container/list"
+	"net/netip"
 	"time"
+
+	"github.com/gosnmp/gosnmp"
 )
+
+// clockID names the clock a v3 message is judged by: the sender's address,
+// the credential that verified it, identified by everything a registered
+// user is compared on, and the engine ID it carries. It is a struct rather
+// than a joined string so no operator-chosen value can act as a field
+// boundary and make two principals one clock.
+type clockID struct {
+	src       netip.Addr
+	user      string
+	authPass  string
+	privPass  string
+	authProto gosnmp.SnmpV3AuthProtocol
+	privProto gosnmp.SnmpV3PrivProtocol
+	engineID  string
+}
 
 // timeWindow is RFC 3414's bound on how far behind its engine's clock a
 // message may be and still count as timely, in seconds.
@@ -28,7 +46,7 @@ const maxEngines = 10000
 // and time it last learned, and when it learned them, so the engine's current
 // time can be estimated without a message.
 type engineClock struct {
-	id      string
+	id      clockID
 	boots   uint32
 	time    uint32
 	learned time.Time
@@ -49,7 +67,7 @@ type engineClock struct {
 // message that verified against a registered credential, keyed by the
 // receiver with the sender's address, so a device can poison only its own.
 type timeliness struct {
-	clocks map[string]*list.Element
+	clocks map[clockID]*list.Element
 	// order holds the engines most recently used first; the back is the
 	// next to be evicted.
 	order *list.List
@@ -57,26 +75,25 @@ type timeliness struct {
 }
 
 func newTimeliness(now func() time.Time) *timeliness {
-	return &timeliness{clocks: make(map[string]*list.Element), order: list.New(), now: now}
+	return &timeliness{clocks: make(map[clockID]*list.Element), order: list.New(), now: now}
 }
 
 // check reports whether a message carrying boots and engineTime from the
-// engine keyed by engineID, which the receiver composes from the sender's
-// address and the wire engine ID, is inside the window, learning the engine
-// or advancing its clock as it goes.
-func (w *timeliness) check(engineID string, boots, engineTime uint32) bool {
+// clock named by id is inside the window, learning the clock or advancing it
+// as it goes.
+func (w *timeliness) check(id clockID, boots, engineTime uint32) bool {
 	if boots == maxEngineBoots {
 		return false
 	}
 	now := w.now()
-	el, known := w.clocks[engineID]
+	el, known := w.clocks[id]
 	if !known {
 		if w.order.Len() >= maxEngines {
 			oldest := w.order.Back()
 			delete(w.clocks, oldest.Value.(*engineClock).id)
 			w.order.Remove(oldest)
 		}
-		w.clocks[engineID] = w.order.PushFront(&engineClock{id: engineID, boots: boots, time: engineTime, learned: now})
+		w.clocks[id] = w.order.PushFront(&engineClock{id: id, boots: boots, time: engineTime, learned: now})
 		return true
 	}
 	c := el.Value.(*engineClock)

--- a/orb-telemetry/snmp-telemetry/traps/timeliness.go
+++ b/orb-telemetry/snmp-telemetry/traps/timeliness.go
@@ -1,0 +1,68 @@
+package traps
+
+import "time"
+
+// timeWindow is RFC 3414's bound on how far behind its engine's clock a
+// message may be and still count as timely, in seconds.
+const timeWindow = 150
+
+// maxEngineBoots is the boots value an engine reports once its counter is
+// exhausted; RFC 3414 says every message carrying it is outside the window.
+const maxEngineBoots = 2147483647
+
+// engineClock is what the receiver keeps for one sending engine: the boots
+// and time it last learned, and when it learned them, so the engine's current
+// time can be estimated without a message.
+type engineClock struct {
+	boots   uint32
+	time    uint32
+	learned time.Time
+}
+
+// timeliness is the non-authoritative side of RFC 3414 section 3.2.7. A trap's
+// sender is the authoritative engine, so the receiver cannot know its clock
+// ahead of time; it learns boots and time from the first authenticated message
+// and judges every later one against that. A message is outside the window
+// when its boots are lower than learned, or equal with a time more than
+// timeWindow behind the estimated clock. One ahead of the estimate moves the
+// clock forward; one behind it, inside the window, leaves the clock alone, so
+// a replayed message can never wind the clock back to admit an older one.
+//
+// The state is in memory and relearned after a restart, which is what the
+// RFC expects of a non-authoritative engine. It is read and written only by
+// the receive goroutine, so it needs no lock. Every engine ID here arrived in
+// a message that verified against a registered credential, so the map is
+// bounded by the devices that hold those credentials.
+type timeliness struct {
+	clocks map[string]engineClock
+	now    func() time.Time
+}
+
+func newTimeliness(now func() time.Time) *timeliness {
+	return &timeliness{clocks: make(map[string]engineClock), now: now}
+}
+
+// check reports whether a message carrying boots and engineTime from engineID
+// is inside the window, learning the engine or advancing its clock as it goes.
+func (w *timeliness) check(engineID string, boots, engineTime uint32) bool {
+	if boots == maxEngineBoots {
+		return false
+	}
+	now := w.now()
+	c, known := w.clocks[engineID]
+	if !known || boots > c.boots {
+		w.clocks[engineID] = engineClock{boots: boots, time: engineTime, learned: now}
+		return true
+	}
+	if boots < c.boots {
+		return false
+	}
+	estimate := int64(c.time) + int64(now.Sub(c.learned)/time.Second)
+	if int64(engineTime) < estimate-timeWindow {
+		return false
+	}
+	if int64(engineTime) > estimate {
+		w.clocks[engineID] = engineClock{boots: boots, time: engineTime, learned: now}
+	}
+	return true
+}

--- a/orb-telemetry/snmp-telemetry/traps/timeliness.go
+++ b/orb-telemetry/snmp-telemetry/traps/timeliness.go
@@ -10,13 +10,23 @@ const timeWindow = 150
 // exhausted; RFC 3414 says every message carrying it is outside the window.
 const maxEngineBoots = 2147483647
 
+// maxEngines bounds the clock map. A registered sender holding a v3
+// credential can authenticate under any engine ID it chooses, since the key
+// localises against the ID the message supplies, so the map cannot be left
+// to grow with the IDs seen. Past the bound the engine seen longest ago is
+// evicted, and loses its replay protection until it is seen again; ten
+// thousand is far more engines than the addresses a socket's policies name.
+const maxEngines = 10000
+
 // engineClock is what the receiver keeps for one sending engine: the boots
-// and time it last learned, and when it learned them, so the engine's current
-// time can be estimated without a message.
+// and time it last learned, when it learned them, so the engine's current
+// time can be estimated without a message, and when it was last seen, which
+// decides eviction.
 type engineClock struct {
 	boots   uint32
 	time    uint32
 	learned time.Time
+	seen    time.Time
 }
 
 // timeliness is the non-authoritative side of RFC 3414 section 3.2.7. A trap's
@@ -50,8 +60,13 @@ func (w *timeliness) check(engineID string, boots, engineTime uint32) bool {
 	}
 	now := w.now()
 	c, known := w.clocks[engineID]
-	if !known || boots > c.boots {
-		w.clocks[engineID] = engineClock{boots: boots, time: engineTime, learned: now}
+	if !known {
+		w.makeRoom()
+		w.clocks[engineID] = engineClock{boots: boots, time: engineTime, learned: now, seen: now}
+		return true
+	}
+	if boots > c.boots {
+		w.clocks[engineID] = engineClock{boots: boots, time: engineTime, learned: now, seen: now}
 		return true
 	}
 	if boots < c.boots {
@@ -62,7 +77,29 @@ func (w *timeliness) check(engineID string, boots, engineTime uint32) bool {
 		return false
 	}
 	if int64(engineTime) > estimate {
-		w.clocks[engineID] = engineClock{boots: boots, time: engineTime, learned: now}
+		c.time, c.learned = engineTime, now
 	}
+	c.seen = now
+	w.clocks[engineID] = c
 	return true
 }
+
+// makeRoom evicts the engine seen longest ago when the map is at its bound.
+// A scan of the map is the cost of one new engine, paid only at the bound.
+func (w *timeliness) makeRoom() {
+	if len(w.clocks) < maxEngines {
+		return
+	}
+	var oldest string
+	var oldestSeen time.Time
+	first := true
+	for id, c := range w.clocks {
+		if first || c.seen.Before(oldestSeen) {
+			oldest, oldestSeen, first = id, c.seen, false
+		}
+	}
+	delete(w.clocks, oldest)
+}
+
+// size is a test accessor.
+func (w *timeliness) size() int { return len(w.clocks) }

--- a/orb-telemetry/snmp-telemetry/traps/timeliness.go
+++ b/orb-telemetry/snmp-telemetry/traps/timeliness.go
@@ -31,6 +31,16 @@ func (id clockID) principal() clockID {
 	return id
 }
 
+// credential is the clockID without its sender or engine ID: the level above
+// the principal, since a holder of one credential can spoof every registered
+// source it covers and so mint principals at will. Eviction at the global
+// bound stays inside the credential's own group whenever it holds a clock.
+func (id clockID) credential() clockID {
+	id.src = netip.Addr{}
+	id.engineID = ""
+	return id
+}
+
 // maxEnginesPerPrincipal bounds the clocks one principal may hold. A device
 // has one engine ID, two across a re-provisioning; past the bound the
 // principal's own least recently used clock goes, so a principal cycling
@@ -68,10 +78,11 @@ type engineClock struct {
 	boots   uint32
 	time    uint32
 	learned time.Time
-	// global and local are this clock's places in the global recency list
-	// and in its principal's own.
+	// global, local and group are this clock's places in the global recency
+	// list, in its principal's own, and in its credential's.
 	global *list.Element
 	local  *list.Element
+	group  *list.Element
 }
 
 // timeliness is the non-authoritative side of RFC 3414 section 3.2.7. A trap's
@@ -96,11 +107,31 @@ type timeliness struct {
 	// perPrincipal holds each principal's clocks most recently used first;
 	// the back is the next to be evicted at the principal's bound.
 	perPrincipal map[clockID]*list.List
-	now          func() time.Time
+	// perCredential holds each credential's clocks most recently used
+	// first, across every source it is used from; the back is the next to
+	// be evicted at the global bound when the credential holds any.
+	perCredential map[clockID]*list.List
+	now           func() time.Time
 }
 
 func newTimeliness(now func() time.Time) *timeliness {
-	return &timeliness{clocks: make(map[clockID]*list.Element), order: list.New(), perPrincipal: make(map[clockID]*list.List), now: now}
+	return &timeliness{
+		clocks:        make(map[clockID]*list.Element),
+		order:         list.New(),
+		perPrincipal:  make(map[clockID]*list.List),
+		perCredential: make(map[clockID]*list.List),
+		now:           now,
+	}
+}
+
+// listFor returns the recency list under key in m, creating it.
+func listFor(m map[clockID]*list.List, key clockID) *list.List {
+	l := m[key]
+	if l == nil {
+		l = list.New()
+		m[key] = l
+	}
+	return l
 }
 
 // evict removes one clock from every structure that holds it.
@@ -115,6 +146,13 @@ func (w *timeliness) evict(el *list.Element) {
 			delete(w.perPrincipal, p)
 		}
 	}
+	g := c.id.credential()
+	if l := w.perCredential[g]; l != nil {
+		l.Remove(c.group)
+		if l.Len() == 0 {
+			delete(w.perCredential, g)
+		}
+	}
 }
 
 // check reports whether a message carrying boots and engineTime from the
@@ -127,33 +165,32 @@ func (w *timeliness) check(id clockID, boots, engineTime uint32) bool {
 	now := w.now()
 	el, known := w.clocks[id]
 	if !known {
-		p := id.principal()
-		mine := w.perPrincipal[p]
-		if mine == nil {
-			mine = list.New()
-			w.perPrincipal[p] = mine
-		}
-		// The principal's own clocks go first: at its own bound, and at the
-		// global bound whenever it holds any, so churning engine IDs costs
-		// the churner its own clocks and never another principal's replay
-		// state. Only a principal's very first clock at the global bound
-		// displaces the globally oldest, and it can do that once.
+		p, g := id.principal(), id.credential()
+		mine := listFor(w.perPrincipal, p)
+		ours := listFor(w.perCredential, g)
+		// The churner's own clocks go first. A principal past its bound
+		// evicts its own; at the global bound a principal holding any clock
+		// evicts its own, a credential holding any clock evicts within its
+		// own group, and only a credential's very first clock displaces the
+		// globally oldest, once. So neither engine-ID churn nor source churn
+		// under one credential reaches another credential's replay state.
 		switch {
 		case mine.Len() >= maxEnginesPerPrincipal || (w.order.Len() >= maxEngines && mine.Len() > 0):
 			w.evict(mine.Back().Value.(*engineClock).global)
+		case w.order.Len() >= maxEngines && ours.Len() > 0:
+			w.evict(ours.Back().Value.(*engineClock).global)
 		case w.order.Len() >= maxEngines:
 			w.evict(w.order.Back())
 		}
-		// An eviction that emptied this principal's list removed the list
-		// from the map; the new clock must join the list the map holds, or
-		// the principal's next clock would find none and evict globally.
-		if mine = w.perPrincipal[p]; mine == nil {
-			mine = list.New()
-			w.perPrincipal[p] = mine
-		}
+		// An eviction that emptied a list removed it from its map; the new
+		// clock must join the lists the maps hold, or the next clock would
+		// find none and evict globally.
+		mine = listFor(w.perPrincipal, p)
+		ours = listFor(w.perCredential, g)
 		c := &engineClock{id: id, boots: boots, time: engineTime, learned: now}
 		c.global = w.order.PushFront(c)
 		c.local = mine.PushFront(c)
+		c.group = ours.PushFront(c)
 		w.clocks[id] = c.global
 		return true
 	}
@@ -182,6 +219,9 @@ func (w *timeliness) touch(c *engineClock) {
 	w.order.MoveToFront(c.global)
 	if l := w.perPrincipal[c.id.principal()]; l != nil {
 		l.MoveToFront(c.local)
+	}
+	if l := w.perCredential[c.id.credential()]; l != nil {
+		l.MoveToFront(c.group)
 	}
 }
 

--- a/orb-telemetry/snmp-telemetry/traps/timeliness.go
+++ b/orb-telemetry/snmp-telemetry/traps/timeliness.go
@@ -174,5 +174,7 @@ func (w *timeliness) touch(c *engineClock) {
 	}
 }
 
-// size is a test accessor.
-func (w *timeliness) size() int { return len(w.clocks) }
+// Test accessors: the map's size, and the global list's length, which must
+// stay equal or a clock has leaked out of one and not the other.
+func (w *timeliness) size() int     { return len(w.clocks) }
+func (w *timeliness) orderLen() int { return w.order.Len() }

--- a/orb-telemetry/snmp-telemetry/traps/timeliness.go
+++ b/orb-telemetry/snmp-telemetry/traps/timeliness.go
@@ -1,6 +1,9 @@
 package traps
 
-import "time"
+import (
+	"container/list"
+	"time"
+)
 
 // timeWindow is RFC 3414's bound on how far behind its engine's clock a
 // message may be and still count as timely, in seconds.
@@ -13,20 +16,22 @@ const maxEngineBoots = 2147483647
 // maxEngines bounds the clock map. A registered sender holding a v3
 // credential can authenticate under any engine ID it chooses, since the key
 // localises against the ID the message supplies, so the map cannot be left
-// to grow with the IDs seen. Past the bound the engine seen longest ago is
+// to grow with the IDs seen. Past the bound the engine used longest ago is
 // evicted, and loses its replay protection until it is seen again; ten
 // thousand is far more engines than the addresses a socket's policies name.
+// The order is kept as engines are used, so an eviction costs no scan: a
+// credential holder churning engine IDs pays the receive goroutine nothing
+// beyond the localisation it already paid for.
 const maxEngines = 10000
 
 // engineClock is what the receiver keeps for one sending engine: the boots
-// and time it last learned, when it learned them, so the engine's current
-// time can be estimated without a message, and when it was last seen, which
-// decides eviction.
+// and time it last learned, and when it learned them, so the engine's current
+// time can be estimated without a message.
 type engineClock struct {
+	id      string
 	boots   uint32
 	time    uint32
 	learned time.Time
-	seen    time.Time
 }
 
 // timeliness is the non-authoritative side of RFC 3414 section 3.2.7. A trap's
@@ -40,16 +45,19 @@ type engineClock struct {
 //
 // The state is in memory and relearned after a restart, which is what the
 // RFC expects of a non-authoritative engine. It is read and written only by
-// the receive goroutine, so it needs no lock. Every engine ID here arrived in
-// a message that verified against a registered credential, so the map is
-// bounded by the devices that hold those credentials.
+// the receive goroutine, so it needs no lock. Every engine here arrived in a
+// message that verified against a registered credential, keyed by the
+// receiver with the sender's address, so a device can poison only its own.
 type timeliness struct {
-	clocks map[string]engineClock
-	now    func() time.Time
+	clocks map[string]*list.Element
+	// order holds the engines most recently used first; the back is the
+	// next to be evicted.
+	order *list.List
+	now   func() time.Time
 }
 
 func newTimeliness(now func() time.Time) *timeliness {
-	return &timeliness{clocks: make(map[string]engineClock), now: now}
+	return &timeliness{clocks: make(map[string]*list.Element), order: list.New(), now: now}
 }
 
 // check reports whether a message carrying boots and engineTime from the
@@ -61,14 +69,20 @@ func (w *timeliness) check(engineID string, boots, engineTime uint32) bool {
 		return false
 	}
 	now := w.now()
-	c, known := w.clocks[engineID]
+	el, known := w.clocks[engineID]
 	if !known {
-		w.makeRoom()
-		w.clocks[engineID] = engineClock{boots: boots, time: engineTime, learned: now, seen: now}
+		if w.order.Len() >= maxEngines {
+			oldest := w.order.Back()
+			delete(w.clocks, oldest.Value.(*engineClock).id)
+			w.order.Remove(oldest)
+		}
+		w.clocks[engineID] = w.order.PushFront(&engineClock{id: engineID, boots: boots, time: engineTime, learned: now})
 		return true
 	}
+	c := el.Value.(*engineClock)
 	if boots > c.boots {
-		w.clocks[engineID] = engineClock{boots: boots, time: engineTime, learned: now, seen: now}
+		c.boots, c.time, c.learned = boots, engineTime, now
+		w.order.MoveToFront(el)
 		return true
 	}
 	if boots < c.boots {
@@ -81,26 +95,8 @@ func (w *timeliness) check(engineID string, boots, engineTime uint32) bool {
 	if int64(engineTime) > estimate {
 		c.time, c.learned = engineTime, now
 	}
-	c.seen = now
-	w.clocks[engineID] = c
+	w.order.MoveToFront(el)
 	return true
-}
-
-// makeRoom evicts the engine seen longest ago when the map is at its bound.
-// A scan of the map is the cost of one new engine, paid only at the bound.
-func (w *timeliness) makeRoom() {
-	if len(w.clocks) < maxEngines {
-		return
-	}
-	var oldest string
-	var oldestSeen time.Time
-	first := true
-	for id, c := range w.clocks {
-		if first || c.seen.Before(oldestSeen) {
-			oldest, oldestSeen, first = id, c.seen, false
-		}
-	}
-	delete(w.clocks, oldest)
 }
 
 // size is a test accessor.

--- a/orb-telemetry/snmp-telemetry/traps/timeliness_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/timeliness_test.go
@@ -2,6 +2,7 @@ package traps
 
 import (
 	"fmt"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -170,5 +171,36 @@ func TestTimeliness_AtTheGlobalBoundAPrincipalEvictsItself(t *testing.T) {
 	}
 	assert.Equal(t, maxEngines, w.size())
 	assert.False(t, w.check(victim, 4, 100), "the victim's clock survived: only the attacker's first clock displaced anyone, and that was the oldest filler")
+	assert.True(t, w.check(filler(0), 0, 1), "the oldest filler was the one displaced, once")
+}
+
+// Source churn under one credential makes every spoofed registered source a
+// new principal, so eviction ownership has a level above the principal: the
+// credential. At the global bound a credential that holds any clock evicts
+// within its own group, so thousands of first clocks from one credential
+// displace only that credential's own state, never another's.
+func TestTimeliness_SourceChurnUnderOneCredentialEvictsOnlyThatCredential(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	w := newTimeliness(func() time.Time { return now })
+	filler := func(i int) clockID { return clockID{user: fmt.Sprintf("f%d", i), engineID: "e"} }
+	victim := clockID{src: netip.MustParseAddr("10.0.0.1"), user: "victim", authPass: "v", engineID: "ev"}
+	now = now.Add(time.Second)
+	assert.True(t, w.check(filler(0), 1, 1))
+	now = now.Add(time.Second)
+	assert.True(t, w.check(victim, 5, 100))
+	for i := 1; i < maxEngines-1; i++ {
+		now = now.Add(time.Second)
+		assert.True(t, w.check(filler(i), 1, 1))
+	}
+	require.Equal(t, maxEngines, w.size())
+
+	// One credential, spoofing a fresh registered source every time.
+	for i := range 3 * maxEngines {
+		now = now.Add(time.Second)
+		id := clockID{src: netip.AddrFrom4([4]byte{10, 1, byte(i >> 8), byte(i)}), user: "attacker", authPass: "a", engineID: "e"}
+		assert.True(t, w.check(id, 1, 1))
+	}
+	assert.Equal(t, maxEngines, w.size())
+	assert.False(t, w.check(victim, 4, 100), "the victim's clock survived: after the attacker's first clock, its churn evicted only its own credential's clocks")
 	assert.True(t, w.check(filler(0), 0, 1), "the oldest filler was the one displaced, once")
 }

--- a/orb-telemetry/snmp-telemetry/traps/timeliness_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/timeliness_test.go
@@ -1,6 +1,7 @@
 package traps
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -33,4 +34,27 @@ func TestTimeliness_LearnsThenRejectsLowerBootsAndStaleTime(t *testing.T) {
 	assert.False(t, w.check("e1", 5, 5000), "the old boots are rejected however far their time claims")
 	assert.False(t, w.check("e2", maxEngineBoots, 0), "an engine reporting the boots ceiling is never in the window")
 	assert.True(t, w.check("e2", 1, 1), "a different engine keeps its own clock")
+}
+
+// A registered sender holding a v3 credential can authenticate under any
+// engine ID it likes, since the key localises against the ID it supplies, so
+// the clock map is bounded: past maxEngines the engine seen longest ago is
+// evicted to make room, and loses its replay protection until it is seen
+// again.
+func TestTimeliness_EvictsTheEngineSeenLongestAgo(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	w := newTimeliness(func() time.Time { return now })
+	for i := range maxEngines {
+		now = now.Add(time.Second)
+		assert.True(t, w.check(fmt.Sprintf("e%d", i), 5, 1000))
+	}
+	assert.Equal(t, maxEngines, w.size())
+
+	now = now.Add(time.Second)
+	assert.True(t, w.check("e0", 5, uint32(1000+maxEngines+5)), "seeing e0 again, with its clock advanced, makes it the most recent")
+	now = now.Add(time.Second)
+	assert.True(t, w.check("new", 5, 1000), "a new engine is learned at the cap")
+	assert.Equal(t, maxEngines, w.size(), "by evicting one")
+	assert.True(t, w.check("e1", 4, 1000), "e1 was the one seen longest ago: relearned, so lower boots pass")
+	assert.False(t, w.check("e0", 4, 1000), "e0 was kept, so lower boots are still a replay")
 }

--- a/orb-telemetry/snmp-telemetry/traps/timeliness_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/timeliness_test.go
@@ -19,21 +19,21 @@ func TestTimeliness_LearnsThenRejectsLowerBootsAndStaleTime(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
 	w := newTimeliness(func() time.Time { return now })
 
-	assert.True(t, w.check("e1", 5, 1000), "an unknown engine is learned")
-	assert.True(t, w.check("e1", 5, 1000), "the same second again is inside the window")
-	assert.False(t, w.check("e1", 4, 1000), "lower boots is a replay")
-	assert.True(t, w.check("e1", 5, 1200), "a later time is accepted and moves the clock")
+	assert.True(t, w.check(clockID{engineID: "e1"}, 5, 1000), "an unknown engine is learned")
+	assert.True(t, w.check(clockID{engineID: "e1"}, 5, 1000), "the same second again is inside the window")
+	assert.False(t, w.check(clockID{engineID: "e1"}, 4, 1000), "lower boots is a replay")
+	assert.True(t, w.check(clockID{engineID: "e1"}, 5, 1200), "a later time is accepted and moves the clock")
 
 	now = now.Add(200 * time.Second)
-	assert.False(t, w.check("e1", 5, 1200), "200 seconds later the same time is 200 behind the clock, past the window")
-	assert.True(t, w.check("e1", 5, 1260), "140 behind the clock is inside the window")
-	assert.True(t, w.check("e1", 5, 1260), "and did not move the clock back, so it is still inside")
-	assert.False(t, w.check("e1", 5, 1249), "151 behind is not")
+	assert.False(t, w.check(clockID{engineID: "e1"}, 5, 1200), "200 seconds later the same time is 200 behind the clock, past the window")
+	assert.True(t, w.check(clockID{engineID: "e1"}, 5, 1260), "140 behind the clock is inside the window")
+	assert.True(t, w.check(clockID{engineID: "e1"}, 5, 1260), "and did not move the clock back, so it is still inside")
+	assert.False(t, w.check(clockID{engineID: "e1"}, 5, 1249), "151 behind is not")
 
-	assert.True(t, w.check("e1", 6, 0), "a reboot resets the clock and is accepted")
-	assert.False(t, w.check("e1", 5, 5000), "the old boots are rejected however far their time claims")
-	assert.False(t, w.check("e2", maxEngineBoots, 0), "an engine reporting the boots ceiling is never in the window")
-	assert.True(t, w.check("e2", 1, 1), "a different engine keeps its own clock")
+	assert.True(t, w.check(clockID{engineID: "e1"}, 6, 0), "a reboot resets the clock and is accepted")
+	assert.False(t, w.check(clockID{engineID: "e1"}, 5, 5000), "the old boots are rejected however far their time claims")
+	assert.False(t, w.check(clockID{engineID: "e2"}, maxEngineBoots, 0), "an engine reporting the boots ceiling is never in the window")
+	assert.True(t, w.check(clockID{engineID: "e2"}, 1, 1), "a different engine keeps its own clock")
 }
 
 // A registered sender holding a v3 credential can authenticate under any
@@ -46,17 +46,17 @@ func TestTimeliness_EvictsTheEngineSeenLongestAgo(t *testing.T) {
 	w := newTimeliness(func() time.Time { return now })
 	for i := range maxEngines {
 		now = now.Add(time.Second)
-		assert.True(t, w.check(fmt.Sprintf("e%d", i), 5, 1000))
+		assert.True(t, w.check(clockID{engineID: fmt.Sprintf("e%d", i)}, 5, 1000))
 	}
 	assert.Equal(t, maxEngines, w.size())
 
 	now = now.Add(time.Second)
-	assert.True(t, w.check("e0", 5, uint32(1000+maxEngines+5)), "seeing e0 again, with its clock advanced, makes it the most recent")
+	assert.True(t, w.check(clockID{engineID: "e0"}, 5, uint32(1000+maxEngines+5)), "seeing e0 again, with its clock advanced, makes it the most recent")
 	now = now.Add(time.Second)
-	assert.True(t, w.check("new", 5, 1000), "a new engine is learned at the cap")
+	assert.True(t, w.check(clockID{engineID: "new"}, 5, 1000), "a new engine is learned at the cap")
 	assert.Equal(t, maxEngines, w.size(), "by evicting one")
-	assert.True(t, w.check("e1", 4, 1000), "e1 was the one seen longest ago: relearned, so lower boots pass")
-	assert.False(t, w.check("e0", 4, 1000), "e0 was kept, so lower boots are still a replay")
+	assert.True(t, w.check(clockID{engineID: "e1"}, 4, 1000), "e1 was the one seen longest ago: relearned, so lower boots pass")
+	assert.False(t, w.check(clockID{engineID: "e0"}, 4, 1000), "e0 was kept, so lower boots are still a replay")
 }
 
 // Eviction is by recency of use, kept in order as engines are touched, so a
@@ -67,15 +67,15 @@ func TestTimeliness_EvictionOrderFollowsUse(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
 	w := newTimeliness(func() time.Time { return now })
 	for i := range maxEngines {
-		assert.True(t, w.check(fmt.Sprintf("e%d", i), 1, 1))
+		assert.True(t, w.check(clockID{engineID: fmt.Sprintf("e%d", i)}, 1, 1))
 	}
-	assert.True(t, w.check("e0", 1, 1), "touch the oldest")
-	assert.True(t, w.check("e2", 1, 1), "and the third oldest")
-	assert.True(t, w.check("new1", 1, 1))
-	assert.True(t, w.check("new2", 1, 1))
+	assert.True(t, w.check(clockID{engineID: "e0"}, 1, 1), "touch the oldest")
+	assert.True(t, w.check(clockID{engineID: "e2"}, 1, 1), "and the third oldest")
+	assert.True(t, w.check(clockID{engineID: "new1"}, 1, 1))
+	assert.True(t, w.check(clockID{engineID: "new2"}, 1, 1))
 	assert.Equal(t, maxEngines, w.size())
-	assert.True(t, w.check("e1", 0, 1), "e1 was evicted first: relearned, so lower boots pass")
-	assert.True(t, w.check("e3", 0, 1), "e3 second")
-	assert.False(t, w.check("e0", 0, 1), "e0 was kept")
-	assert.False(t, w.check("e2", 0, 1), "e2 was kept")
+	assert.True(t, w.check(clockID{engineID: "e1"}, 0, 1), "e1 was evicted first: relearned, so lower boots pass")
+	assert.True(t, w.check(clockID{engineID: "e3"}, 0, 1), "e3 second")
+	assert.False(t, w.check(clockID{engineID: "e0"}, 0, 1), "e0 was kept")
+	assert.False(t, w.check(clockID{engineID: "e2"}, 0, 1), "e2 was kept")
 }

--- a/orb-telemetry/snmp-telemetry/traps/timeliness_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/timeliness_test.go
@@ -58,3 +58,24 @@ func TestTimeliness_EvictsTheEngineSeenLongestAgo(t *testing.T) {
 	assert.True(t, w.check("e1", 4, 1000), "e1 was the one seen longest ago: relearned, so lower boots pass")
 	assert.False(t, w.check("e0", 4, 1000), "e0 was kept, so lower boots are still a replay")
 }
+
+// Eviction is by recency of use, kept in order as engines are touched, so a
+// new engine at the cap costs no scan of the map. Refreshing the oldest
+// engine moves it to the front; the next new engine evicts the one that
+// became oldest.
+func TestTimeliness_EvictionOrderFollowsUse(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	w := newTimeliness(func() time.Time { return now })
+	for i := range maxEngines {
+		assert.True(t, w.check(fmt.Sprintf("e%d", i), 1, 1))
+	}
+	assert.True(t, w.check("e0", 1, 1), "touch the oldest")
+	assert.True(t, w.check("e2", 1, 1), "and the third oldest")
+	assert.True(t, w.check("new1", 1, 1))
+	assert.True(t, w.check("new2", 1, 1))
+	assert.Equal(t, maxEngines, w.size())
+	assert.True(t, w.check("e1", 0, 1), "e1 was evicted first: relearned, so lower boots pass")
+	assert.True(t, w.check("e3", 0, 1), "e3 second")
+	assert.False(t, w.check("e0", 0, 1), "e0 was kept")
+	assert.False(t, w.check("e2", 0, 1), "e2 was kept")
+}

--- a/orb-telemetry/snmp-telemetry/traps/timeliness_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/timeliness_test.go
@@ -1,0 +1,36 @@
+package traps
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// RFC 3414 section 3.2.7(b), the non-authoritative side: the receiver learns
+// each engine's boots and time from the first authenticated message, then
+// treats a message as outside the window when its boots are lower than
+// learned or its time is more than 150 seconds behind the clock the receiver
+// keeps for that engine. A message ahead of that clock moves it forward; one
+// behind it, inside the window, leaves it alone, so a replay cannot wind the
+// clock back.
+func TestTimeliness_LearnsThenRejectsLowerBootsAndStaleTime(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	w := newTimeliness(func() time.Time { return now })
+
+	assert.True(t, w.check("e1", 5, 1000), "an unknown engine is learned")
+	assert.True(t, w.check("e1", 5, 1000), "the same second again is inside the window")
+	assert.False(t, w.check("e1", 4, 1000), "lower boots is a replay")
+	assert.True(t, w.check("e1", 5, 1200), "a later time is accepted and moves the clock")
+
+	now = now.Add(200 * time.Second)
+	assert.False(t, w.check("e1", 5, 1200), "200 seconds later the same time is 200 behind the clock, past the window")
+	assert.True(t, w.check("e1", 5, 1260), "140 behind the clock is inside the window")
+	assert.True(t, w.check("e1", 5, 1260), "and did not move the clock back, so it is still inside")
+	assert.False(t, w.check("e1", 5, 1249), "151 behind is not")
+
+	assert.True(t, w.check("e1", 6, 0), "a reboot resets the clock and is accepted")
+	assert.False(t, w.check("e1", 5, 5000), "the old boots are rejected however far their time claims")
+	assert.False(t, w.check("e2", maxEngineBoots, 0), "an engine reporting the boots ceiling is never in the window")
+	assert.True(t, w.check("e2", 1, 1), "a different engine keeps its own clock")
+}

--- a/orb-telemetry/snmp-telemetry/traps/timeliness_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/timeliness_test.go
@@ -19,21 +19,21 @@ func TestTimeliness_LearnsThenRejectsLowerBootsAndStaleTime(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
 	w := newTimeliness(func() time.Time { return now })
 
-	assert.True(t, w.check(clockID{engineID: "e1"}, 5, 1000), "an unknown engine is learned")
-	assert.True(t, w.check(clockID{engineID: "e1"}, 5, 1000), "the same second again is inside the window")
-	assert.False(t, w.check(clockID{engineID: "e1"}, 4, 1000), "lower boots is a replay")
-	assert.True(t, w.check(clockID{engineID: "e1"}, 5, 1200), "a later time is accepted and moves the clock")
+	assert.True(t, w.check(clockID{user: "e1", engineID: "e1"}, 5, 1000), "an unknown engine is learned")
+	assert.True(t, w.check(clockID{user: "e1", engineID: "e1"}, 5, 1000), "the same second again is inside the window")
+	assert.False(t, w.check(clockID{user: "e1", engineID: "e1"}, 4, 1000), "lower boots is a replay")
+	assert.True(t, w.check(clockID{user: "e1", engineID: "e1"}, 5, 1200), "a later time is accepted and moves the clock")
 
 	now = now.Add(200 * time.Second)
-	assert.False(t, w.check(clockID{engineID: "e1"}, 5, 1200), "200 seconds later the same time is 200 behind the clock, past the window")
-	assert.True(t, w.check(clockID{engineID: "e1"}, 5, 1260), "140 behind the clock is inside the window")
-	assert.True(t, w.check(clockID{engineID: "e1"}, 5, 1260), "and did not move the clock back, so it is still inside")
-	assert.False(t, w.check(clockID{engineID: "e1"}, 5, 1249), "151 behind is not")
+	assert.False(t, w.check(clockID{user: "e1", engineID: "e1"}, 5, 1200), "200 seconds later the same time is 200 behind the clock, past the window")
+	assert.True(t, w.check(clockID{user: "e1", engineID: "e1"}, 5, 1260), "140 behind the clock is inside the window")
+	assert.True(t, w.check(clockID{user: "e1", engineID: "e1"}, 5, 1260), "and did not move the clock back, so it is still inside")
+	assert.False(t, w.check(clockID{user: "e1", engineID: "e1"}, 5, 1249), "151 behind is not")
 
-	assert.True(t, w.check(clockID{engineID: "e1"}, 6, 0), "a reboot resets the clock and is accepted")
-	assert.False(t, w.check(clockID{engineID: "e1"}, 5, 5000), "the old boots are rejected however far their time claims")
-	assert.False(t, w.check(clockID{engineID: "e2"}, maxEngineBoots, 0), "an engine reporting the boots ceiling is never in the window")
-	assert.True(t, w.check(clockID{engineID: "e2"}, 1, 1), "a different engine keeps its own clock")
+	assert.True(t, w.check(clockID{user: "e1", engineID: "e1"}, 6, 0), "a reboot resets the clock and is accepted")
+	assert.False(t, w.check(clockID{user: "e1", engineID: "e1"}, 5, 5000), "the old boots are rejected however far their time claims")
+	assert.False(t, w.check(clockID{user: "e2", engineID: "e2"}, maxEngineBoots, 0), "an engine reporting the boots ceiling is never in the window")
+	assert.True(t, w.check(clockID{user: "e2", engineID: "e2"}, 1, 1), "a different engine keeps its own clock")
 }
 
 // A registered sender holding a v3 credential can authenticate under any
@@ -46,17 +46,17 @@ func TestTimeliness_EvictsTheEngineSeenLongestAgo(t *testing.T) {
 	w := newTimeliness(func() time.Time { return now })
 	for i := range maxEngines {
 		now = now.Add(time.Second)
-		assert.True(t, w.check(clockID{engineID: fmt.Sprintf("e%d", i)}, 5, 1000))
+		assert.True(t, w.check(clockID{user: fmt.Sprintf("e%d", i), engineID: fmt.Sprintf("e%d", i)}, 5, 1000))
 	}
 	assert.Equal(t, maxEngines, w.size())
 
 	now = now.Add(time.Second)
-	assert.True(t, w.check(clockID{engineID: "e0"}, 5, uint32(1000+maxEngines+5)), "seeing e0 again, with its clock advanced, makes it the most recent")
+	assert.True(t, w.check(clockID{user: "e0", engineID: "e0"}, 5, uint32(1000+maxEngines+5)), "seeing e0 again, with its clock advanced, makes it the most recent")
 	now = now.Add(time.Second)
-	assert.True(t, w.check(clockID{engineID: "new"}, 5, 1000), "a new engine is learned at the cap")
+	assert.True(t, w.check(clockID{user: "new", engineID: "new"}, 5, 1000), "a new engine is learned at the cap")
 	assert.Equal(t, maxEngines, w.size(), "by evicting one")
-	assert.True(t, w.check(clockID{engineID: "e1"}, 4, 1000), "e1 was the one seen longest ago: relearned, so lower boots pass")
-	assert.False(t, w.check(clockID{engineID: "e0"}, 4, 1000), "e0 was kept, so lower boots are still a replay")
+	assert.True(t, w.check(clockID{user: "e1", engineID: "e1"}, 4, 1000), "e1 was the one seen longest ago: relearned, so lower boots pass")
+	assert.False(t, w.check(clockID{user: "e0", engineID: "e0"}, 4, 1000), "e0 was kept, so lower boots are still a replay")
 }
 
 // Eviction is by recency of use, kept in order as engines are touched, so a
@@ -67,17 +67,17 @@ func TestTimeliness_EvictionOrderFollowsUse(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
 	w := newTimeliness(func() time.Time { return now })
 	for i := range maxEngines {
-		assert.True(t, w.check(clockID{engineID: fmt.Sprintf("e%d", i)}, 1, 1))
+		assert.True(t, w.check(clockID{user: fmt.Sprintf("e%d", i), engineID: fmt.Sprintf("e%d", i)}, 1, 1))
 	}
-	assert.True(t, w.check(clockID{engineID: "e0"}, 1, 1), "touch the oldest")
-	assert.True(t, w.check(clockID{engineID: "e2"}, 1, 1), "and the third oldest")
-	assert.True(t, w.check(clockID{engineID: "new1"}, 1, 1))
-	assert.True(t, w.check(clockID{engineID: "new2"}, 1, 1))
+	assert.True(t, w.check(clockID{user: "e0", engineID: "e0"}, 1, 1), "touch the oldest")
+	assert.True(t, w.check(clockID{user: "e2", engineID: "e2"}, 1, 1), "and the third oldest")
+	assert.True(t, w.check(clockID{user: "new1", engineID: "new1"}, 1, 1))
+	assert.True(t, w.check(clockID{user: "new2", engineID: "new2"}, 1, 1))
 	assert.Equal(t, maxEngines, w.size())
-	assert.True(t, w.check(clockID{engineID: "e1"}, 0, 1), "e1 was evicted first: relearned, so lower boots pass")
-	assert.True(t, w.check(clockID{engineID: "e3"}, 0, 1), "e3 second")
-	assert.False(t, w.check(clockID{engineID: "e0"}, 0, 1), "e0 was kept")
-	assert.False(t, w.check(clockID{engineID: "e2"}, 0, 1), "e2 was kept")
+	assert.True(t, w.check(clockID{user: "e1", engineID: "e1"}, 0, 1), "e1 was evicted first: relearned, so lower boots pass")
+	assert.True(t, w.check(clockID{user: "e3", engineID: "e3"}, 0, 1), "e3 second")
+	assert.False(t, w.check(clockID{user: "e0", engineID: "e0"}, 0, 1), "e0 was kept")
+	assert.False(t, w.check(clockID{user: "e2", engineID: "e2"}, 0, 1), "e2 was kept")
 }
 
 // RFC 3414 bounds engineBoots and engineTime to 2^31 minus 1. gosnmp casts a
@@ -87,7 +87,7 @@ func TestTimeliness_EvictionOrderFollowsUse(t *testing.T) {
 func TestTimeliness_RejectsOutOfRangeClockValuesWithoutLearningThem(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
 	w := newTimeliness(func() time.Time { return now })
-	id := clockID{engineID: "e1"}
+	id := clockID{user: "e1", engineID: "e1"}
 	assert.False(t, w.check(id, 0x80000000, 1), "boots past the bound")
 	assert.False(t, w.check(id, 1, 0xffffffff), "time past the bound")
 	assert.False(t, w.check(id, 0xffffffff, 0xffffffff))
@@ -95,4 +95,26 @@ func TestTimeliness_RejectsOutOfRangeClockValuesWithoutLearningThem(t *testing.T
 	assert.True(t, w.check(id, 1, 0x7fffffff), "the bound itself is a valid time")
 	assert.True(t, w.check(id, 2, 5), "and the clock is a normal one afterwards")
 	assert.False(t, w.check(id, 1, 5), "so a lower boots is still a replay")
+}
+
+// A principal, one sender and credential, may hold only a few clocks, and
+// past that its own least recently used one is evicted. So a principal
+// cycling through engine IDs never reaches another principal's clock, and a
+// captured old datagram of that other principal stays a replay.
+func TestTimeliness_OnePrincipalCannotEvictAnothersClock(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	w := newTimeliness(func() time.Time { return now })
+	victim := clockID{user: "victim", authPass: "v", engineID: "ev"}
+	assert.True(t, w.check(victim, 5, 100))
+
+	attacker := clockID{user: "attacker", authPass: "a"}
+	for i := range maxEngines + 1 {
+		now = now.Add(time.Second)
+		id := attacker
+		id.engineID = fmt.Sprintf("e%d", i)
+		assert.True(t, w.check(id, 1, 1))
+	}
+	assert.LessOrEqual(t, w.size(), maxEnginesPerPrincipal+1, "the attacker holds at most its own quota")
+	assert.False(t, w.check(victim, 4, 100), "the victim's clock survived: the old datagram is still a replay")
+	assert.True(t, w.check(victim, 5, 100+uint32(maxEngines)+1), "and its live traffic still passes")
 }

--- a/orb-telemetry/snmp-telemetry/traps/timeliness_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/timeliness_test.go
@@ -79,3 +79,20 @@ func TestTimeliness_EvictionOrderFollowsUse(t *testing.T) {
 	assert.False(t, w.check(clockID{engineID: "e0"}, 0, 1), "e0 was kept")
 	assert.False(t, w.check(clockID{engineID: "e2"}, 0, 1), "e2 was kept")
 }
+
+// RFC 3414 bounds engineBoots and engineTime to 2^31 minus 1. gosnmp casts a
+// negative wire integer to uint32, so a value past the bound is a malformed
+// clock rather than a very late one; it is rejected and, above all, never
+// learned, or every genuine value for that clock would read as older.
+func TestTimeliness_RejectsOutOfRangeClockValuesWithoutLearningThem(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	w := newTimeliness(func() time.Time { return now })
+	id := clockID{engineID: "e1"}
+	assert.False(t, w.check(id, 0x80000000, 1), "boots past the bound")
+	assert.False(t, w.check(id, 1, 0xffffffff), "time past the bound")
+	assert.False(t, w.check(id, 0xffffffff, 0xffffffff))
+	assert.Equal(t, 0, w.size(), "nothing was learned from them")
+	assert.True(t, w.check(id, 1, 0x7fffffff), "the bound itself is a valid time")
+	assert.True(t, w.check(id, 2, 5), "and the clock is a normal one afterwards")
+	assert.False(t, w.check(id, 1, 5), "so a lower boots is still a replay")
+}

--- a/orb-telemetry/snmp-telemetry/traps/timeliness_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/timeliness_test.go
@@ -204,3 +204,31 @@ func TestTimeliness_SourceChurnUnderOneCredentialEvictsOnlyThatCredential(t *tes
 	assert.False(t, w.check(victim, 4, 100), "the victim's clock survived: after the attacker's first clock, its churn evicted only its own credential's clocks")
 	assert.True(t, w.check(filler(0), 0, 1), "the oldest filler was the one displaced, once")
 }
+
+// Eviction within a credential's group follows use too: at the global bound
+// the group gives up its least recently used clock, not one a principal in
+// it has just used.
+func TestTimeliness_CredentialEvictionFollowsUse(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	w := newTimeliness(func() time.Time { return now })
+	member := func(i int) clockID {
+		return clockID{src: netip.AddrFrom4([4]byte{10, 0, 0, byte(i)}), user: "fleet", authPass: "f", engineID: "e"}
+	}
+	for i := 1; i <= 3; i++ {
+		now = now.Add(time.Second)
+		assert.True(t, w.check(member(i), 5, 1))
+	}
+	for i := range maxEngines - 3 {
+		now = now.Add(time.Second)
+		assert.True(t, w.check(clockID{user: fmt.Sprintf("f%d", i), engineID: "e"}, 1, 1))
+	}
+	require.Equal(t, maxEngines, w.size())
+
+	now = now.Add(time.Second)
+	assert.True(t, w.check(member(1), 5, uint32(maxEngines)+5), "member 1 is used again, with its clock advanced")
+	now = now.Add(time.Second)
+	assert.True(t, w.check(member(4), 5, 1), "a new member of the fleet at the global bound")
+	assert.Equal(t, maxEngines, w.size())
+	assert.False(t, w.check(member(1), 4, 1), "member 1 was kept: lower boots is still a replay")
+	assert.True(t, w.check(member(2), 4, 1), "member 2, the fleet's least recently used, was evicted and is relearned")
+}

--- a/orb-telemetry/snmp-telemetry/traps/timeliness_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/timeliness_test.go
@@ -115,6 +115,26 @@ func TestTimeliness_OnePrincipalCannotEvictAnothersClock(t *testing.T) {
 		assert.True(t, w.check(id, 1, 1))
 	}
 	assert.LessOrEqual(t, w.size(), maxEnginesPerPrincipal+1, "the attacker holds at most its own quota")
+	assert.Equal(t, w.size(), w.orderLen(), "an eviction within a principal frees its global slot too")
 	assert.False(t, w.check(victim, 4, 100), "the victim's clock survived: the old datagram is still a replay")
 	assert.True(t, w.check(victim, 5, 100+uint32(maxEngines)+1), "and its live traffic still passes")
+}
+
+// Eviction within a principal follows use, like the global order does: a
+// clock the principal just used is not the one that goes.
+func TestTimeliness_PrincipalEvictionFollowsUse(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	w := newTimeliness(func() time.Time { return now })
+	id := func(engine string) clockID { return clockID{user: "one", authPass: "p", engineID: engine} }
+	for i := range maxEnginesPerPrincipal {
+		now = now.Add(time.Second)
+		assert.True(t, w.check(id(fmt.Sprintf("e%d", i)), 5, 1))
+	}
+	now = now.Add(time.Second)
+	assert.True(t, w.check(id("e0"), 5, uint32(maxEnginesPerPrincipal)+2), "e0 is used again")
+	now = now.Add(time.Second)
+	assert.True(t, w.check(id("new"), 5, 1), "a new engine at the principal's bound")
+	assert.Equal(t, maxEnginesPerPrincipal, w.size())
+	assert.False(t, w.check(id("e0"), 4, 1), "e0 was kept: lower boots is still a replay")
+	assert.True(t, w.check(id("e1"), 4, 1), "e1, the least recently used, was evicted and is relearned")
 }

--- a/orb-telemetry/snmp-telemetry/traps/timeliness_test.go
+++ b/orb-telemetry/snmp-telemetry/traps/timeliness_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // RFC 3414 section 3.2.7(b), the non-authoritative side: the receiver learns
@@ -137,4 +138,37 @@ func TestTimeliness_PrincipalEvictionFollowsUse(t *testing.T) {
 	assert.Equal(t, maxEnginesPerPrincipal, w.size())
 	assert.False(t, w.check(id("e0"), 4, 1), "e0 was kept: lower boots is still a replay")
 	assert.True(t, w.check(id("e1"), 4, 1), "e1, the least recently used, was evicted and is relearned")
+}
+
+// At the global bound, a principal that already holds a clock evicts its
+// own rather than the globally oldest, so a credential holder below its
+// quota cannot spend the quota evicting other principals' replay state. Only
+// a principal's very first clock can displace another's, once.
+func TestTimeliness_AtTheGlobalBoundAPrincipalEvictsItself(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	w := newTimeliness(func() time.Time { return now })
+	filler := func(i int) clockID { return clockID{user: fmt.Sprintf("f%d", i), engineID: "e"} }
+	victim := clockID{user: "victim", authPass: "v", engineID: "ev"}
+	// The oldest clock is a filler, the victim the next oldest, then the
+	// rest of the fillers up to the global bound.
+	now = now.Add(time.Second)
+	assert.True(t, w.check(filler(0), 1, 1))
+	now = now.Add(time.Second)
+	assert.True(t, w.check(victim, 5, 100))
+	for i := 1; i < maxEngines-1; i++ {
+		now = now.Add(time.Second)
+		assert.True(t, w.check(filler(i), 1, 1))
+	}
+	require.Equal(t, maxEngines, w.size())
+
+	attacker := clockID{user: "attacker", authPass: "a"}
+	for i := range maxEnginesPerPrincipal - 1 {
+		now = now.Add(time.Second)
+		id := attacker
+		id.engineID = fmt.Sprintf("e%d", i)
+		assert.True(t, w.check(id, 1, 1))
+	}
+	assert.Equal(t, maxEngines, w.size())
+	assert.False(t, w.check(victim, 4, 100), "the victim's clock survived: only the attacker's first clock displaced anyone, and that was the oldest filler")
+	assert.True(t, w.check(filler(0), 0, 1), "the oldest filler was the one displaced, once")
 }


### PR DESCRIPTION
Closes MON-347.

The backend can now receive SNMP traps and informs, alongside polling, and count them as OpenTelemetry metrics. Off by default; `--trap-listen host:port` turns it on. No new backend, no new binary, no new configuration file: the devices a policy already polls are the devices the receiver accepts traps from, and a v3 policy's credentials are the credentials the receiver authenticates with.

## What a trap becomes

Three observable counters: `snmp_traps_received_total` labelled `device_ip, policy, trap_name, version`; `snmp_traps_dropped_total` labelled `reason`; `snmp_trap_datagrams_total` unlabelled. That is the whole surface. Varbind payloads are not exported in this release; that is a separate ticket.

`trap_name` is a closed set. It is drawn from the trap definitions of the policy's own profile set, the 191 the vendored tree carries plus whatever a policy's `profiles_dir` adds, and the six RFC 1215 generic traps; every other OID lands on `other`. RFC names take precedence because one vendor profile labels the standard `linkUp` OID with its own name. v1 traps are mapped to v2 identities per RFC 3584 before naming.

## What the receiver trusts, and what it does not

This is the part that took the most work, because gosnmp's trap listener does several things that are wrong for an internet-facing socket, each proven by execution before the design was settled:

- Its `NoAuthNoPriv` constant is zero, so a v3 packet that never asked to be authenticated compares equal to the "no auth required" case and passes. A v3-configured listener also accepts any v2c community, and no community is validated at all.
- It acknowledges informs unconditionally, which makes it a reflector with a 1.0 amplification ratio.
- It generates a fresh engine ID per packet, which costs about 1.4 ms per datagram.
- Its parser runs `testAuthentication` only when the wire says the security model is USM, and it panics on a truncated v3 datagram.

So the backend owns the socket and drives the parser itself. Before parsing, the source address is looked up in a registry of addresses claimed by running policies; an unregistered source is dropped without spending a parse, unless `--trap-accept-unknown` is set. Informs are acknowledged only for registered senders. A v3 trap counts only if the wire security model is USM, the USM parameters carry a username and engine ID, the auth flag is set, and the registered credentials verify it. The parse is wrapped in a recover that turns a parser panic into a `malformed` drop, and a test proves the receiver keeps working after one. Community strings are checked nowhere, which the README says plainly: a community is not a secret on the wire and the registry is the gate.

Nothing a trap says can trigger a poll. The `traps` package never imports `policy` or `collector`, and a test enforces that.

## Cardinality and memory are bounded from the network side

The SDK's default cardinality limit of 2000 attribute sets per instrument would have folded a `/16` of devices into a single overflow bucket, so the limit is raised to 10000 and the README states the ceiling. With `--trap-accept-unknown`, the number of distinct unknown `device_ip` values is capped at 1000 and the rest fold into a sentinel, so a spoofing burst cannot grow the tally without bound. Counters are observable rather than synchronous so a withdrawn policy's series can actually be forgotten.

## Policy lifecycle

A runner registers its expanded target addresses and its v3 users after target expansion and before its first job, withdraws them on stop and on a failed start, and a same-name replacement is proven to end registered. Hostname targets are skipped, since the receiver matches on source address and nothing here resolves names; the README states this limitation.

## Lab evidence

Validated in orb-test-lab with the backend running inside the lab network and an OpenTelemetry collector printing every export. Traps were sent from the snmpsim devices' own addresses, so the source-address registry was exercised the way a real device exercises it. One v2c policy polled 172.28.0.21 and one v3 policy polled 172.28.0.22; 172.28.0.20 was named by no policy.

| sent | exported as |
|---|---|
| v2c linkDown trap and inform from .21 | `traps_received{device_ip=172.28.0.21, policy=lab-v2c, trap_name=linkDown, version=2c}` = 2, inform acknowledged |
| v1 generic linkUp from .21 | `traps_received{... trap_name=linkUp, version=1}` = 1 |
| v2c trap with an OID no profile names from .21 | `traps_received{... trap_name=other, version=2c}` = 1 |
| v3 authPriv SHA/AES from .22 | `traps_received{device_ip=172.28.0.22, policy=lab-v3, trap_name=linkUp, version=3}` = 1 |
| v2c coldStart from .22 | `traps_received{... policy=lab-v3, trap_name=coldStart, version=2c}` = 1 |
| v3 with a wrong auth passphrase, and three raw bytes | `traps_dropped{reason=malformed}` = 2 |
| v3 noAuthNoPriv from .22 | `traps_dropped{reason=v3_unauthenticated}` = 1 |
| v2c trap and inform from .20 | `traps_dropped{reason=unknown_source}` = 2, inform timed out unacknowledged |
| total | `traps_datagrams` = 11 |

Deleting the v2c policy removed every 172.28.0.21 series from the next export, and a further trap from that address was dropped as `unknown_source`. With `--trap-accept-unknown`, a trap from 172.28.0.20 was counted with an empty policy label and its inform still went unacknowledged. Shutdown under SIGTERM was clean.

The run is scripted as `make traps-validate` in orb-test-lab (separate change there), which asserts each of the rows above.

## Review

Three adversarial design reviews preceded the spec. Every task had a review and a fix round where needed. The final whole-branch review found two Critical defects that per-task reviews had missed: a v3 packet with a non-USM security model was counted as authenticated, and a crafted v3 datagram killed the process through the parser. Both are fixed in their own commits with wire-level tests, and a scoped re-review confirmed every finding closed. Every assertion was mutation-tested.

Gates: build, vet, `-race` on every package, lint at 0 issues, the vendored profile tree byte-identical, the root and `orb-discovery/snmp-discovery` modules still build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
