### PR TITLE
test(device-discovery): add the FortiOS 7.4.12 device capture

### DIFF
--- a/orb-discovery/device-discovery/tests/custom_drivers/fortinet_fortios_ssh/mock_data/test_get_interfaces/7412/README.md
+++ b/orb-discovery/device-discovery/tests/custom_drivers/fortinet_fortios_ssh/mock_data/test_get_interfaces/7412/README.md
@@ -13,4 +13,7 @@ discards the block and this scenario fails.
 The issue's own field order is not evidence either way: its quoted flat line puts
 `mtu-override:` last, where all eleven vendored captures put it before `wccp:`.
 
-Replace this with a sanitised capture if the reporter supplies one.
+The reporter has since supplied a capture; it is the `7412_capture` scenario beside
+this one. This scenario is kept rather than replaced, because the device puts `medium:`
+below `status:`, where a regression that discards a block on an unknown field line would
+still pass. The deliberate ordering here is what catches it.

--- a/orb-discovery/device-discovery/tests/custom_drivers/fortinet_fortios_ssh/mock_data/test_get_interfaces/7412_capture/README.md
+++ b/orb-discovery/device-discovery/tests/custom_drivers/fortinet_fortios_ssh/mock_data/test_get_interfaces/7412_capture/README.md
@@ -1,0 +1,18 @@
+# FortiOS 7.4.12, device capture
+
+`get system interface physical` from the FortiGate-100F in netboxlabs/orb-agent#537,
+supplied by the reporter after the fix shipped. All 29 blocks, in the order and with
+the indentation the device printed.
+
+Sanitised: nothing. The capture carried only 10.10.10.1, 192.168.1.99 and 0.0.0.0,
+so no address needed replacing.
+
+`medium:` appears on port17 through port20 only, and sits **below** `status:`, between
+`speed:` and `FEC:`. That is the real position, and it is why the reconstructed
+`7412` scenario next to this one is kept rather than replaced: there `medium:` sits
+deliberately above `status:`, where a regression that treats an unknown field line as
+unreadable discards the block and fails the test. In the position the device actually
+uses, the same regression would still pass. The two scenarios test different things.
+
+No `fnsysctl_ifconfig.txt`: the reporter did not supply one, and the mock device returns
+an empty string for a missing file, so MAC addresses come out empty rather than invented.

--- a/orb-discovery/device-discovery/tests/custom_drivers/fortinet_fortios_ssh/mock_data/test_get_interfaces/7412_capture/expected_result.json
+++ b/orb-discovery/device-discovery/tests/custom_drivers/fortinet_fortios_ssh/mock_data/test_get_interfaces/7412_capture/expected_result.json
@@ -1,0 +1,263 @@
+{
+  "dmz": {
+    "is_up": false,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 0.0,
+    "mac_address": ""
+  },
+  "ha1": {
+    "is_up": false,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 0.0,
+    "mac_address": ""
+  },
+  "ha2": {
+    "is_up": false,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 0.0,
+    "mac_address": ""
+  },
+  "mgmt": {
+    "is_up": false,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 0.0,
+    "mac_address": ""
+  },
+  "port1": {
+    "is_up": true,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 1000.0,
+    "mac_address": ""
+  },
+  "port2": {
+    "is_up": true,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 1000.0,
+    "mac_address": ""
+  },
+  "port3": {
+    "is_up": true,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 1000.0,
+    "mac_address": ""
+  },
+  "port4": {
+    "is_up": true,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 1000.0,
+    "mac_address": ""
+  },
+  "port5": {
+    "is_up": false,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 0.0,
+    "mac_address": ""
+  },
+  "port6": {
+    "is_up": true,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 1000.0,
+    "mac_address": ""
+  },
+  "port7": {
+    "is_up": false,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 0.0,
+    "mac_address": ""
+  },
+  "port8": {
+    "is_up": false,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 0.0,
+    "mac_address": ""
+  },
+  "port9": {
+    "is_up": true,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 1000.0,
+    "mac_address": ""
+  },
+  "port10": {
+    "is_up": true,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 1000.0,
+    "mac_address": ""
+  },
+  "port11": {
+    "is_up": true,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 1000.0,
+    "mac_address": ""
+  },
+  "port12": {
+    "is_up": true,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 1000.0,
+    "mac_address": ""
+  },
+  "port13": {
+    "is_up": false,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 0.0,
+    "mac_address": ""
+  },
+  "port14": {
+    "is_up": false,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 0.0,
+    "mac_address": ""
+  },
+  "port15": {
+    "is_up": false,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 0.0,
+    "mac_address": ""
+  },
+  "port16": {
+    "is_up": false,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 0.0,
+    "mac_address": ""
+  },
+  "port17": {
+    "is_up": false,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 0.0,
+    "mac_address": ""
+  },
+  "port18": {
+    "is_up": false,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 0.0,
+    "mac_address": ""
+  },
+  "port19": {
+    "is_up": false,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 0.0,
+    "mac_address": ""
+  },
+  "port20": {
+    "is_up": false,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 0.0,
+    "mac_address": ""
+  },
+  "wan1": {
+    "is_up": false,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 0.0,
+    "mac_address": ""
+  },
+  "wan2": {
+    "is_up": false,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 0.0,
+    "mac_address": ""
+  },
+  "x1": {
+    "is_up": true,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 10000.0,
+    "mac_address": ""
+  },
+  "x2": {
+    "is_up": false,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 0.0,
+    "mac_address": ""
+  },
+  "modem": {
+    "is_up": false,
+    "is_enabled": true,
+    "description": "",
+    "last_flapped": -1.0,
+    "mtu": 0,
+    "speed": 0.0,
+    "mac_address": ""
+  }
+}

--- a/orb-discovery/device-discovery/tests/custom_drivers/fortinet_fortios_ssh/mock_data/test_get_interfaces/7412_capture/get_system_interface_physical.txt
+++ b/orb-discovery/device-discovery/tests/custom_drivers/fortinet_fortios_ssh/mock_data/test_get_interfaces/7412_capture/get_system_interface_physical.txt
@@ -1,0 +1,237 @@
+== [onboard]
+        ==[dmz]
+                mode: static
+                ip: 10.10.10.1 255.255.255.0
+                ipv6: ::/0
+                status: down
+                speed: n/a
+                FEC: none
+                FEC_cap: none
+        ==[ha1]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: down
+                speed: n/a
+                FEC: none
+                FEC_cap: none
+        ==[ha2]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: down
+                speed: n/a
+                FEC: none
+                FEC_cap: none
+        ==[mgmt]
+                mode: static
+                ip: 192.168.1.99 255.255.255.0
+                ipv6: ::/0
+                status: down
+                speed: n/a
+                FEC: none
+                FEC_cap: none
+        ==[port1]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: up
+                speed: 1000Mbps (Duplex: full)
+                FEC: none
+                FEC_cap: none
+        ==[port2]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: up
+                speed: 1000Mbps (Duplex: full)
+                FEC: none
+                FEC_cap: none
+        ==[port3]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: up
+                speed: 1000Mbps (Duplex: full)
+                FEC: none
+                FEC_cap: none
+        ==[port4]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: up
+                speed: 1000Mbps (Duplex: full)
+                FEC: none
+                FEC_cap: none
+        ==[port5]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: down
+                speed: n/a
+                FEC: none
+                FEC_cap: none
+        ==[port6]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: up
+                speed: 1000Mbps (Duplex: full)
+                FEC: none
+                FEC_cap: none
+        ==[port7]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: down
+                speed: n/a
+                FEC: none
+                FEC_cap: none
+        ==[port8]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: down
+                speed: n/a
+                FEC: none
+                FEC_cap: none
+        ==[port9]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: up
+                speed: 1000Mbps (Duplex: full)
+                FEC: none
+                FEC_cap: none
+        ==[port10]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: up
+                speed: 1000Mbps (Duplex: full)
+                FEC: none
+                FEC_cap: none
+        ==[port11]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: up
+                speed: 1000Mbps (Duplex: full)
+                FEC: none
+                FEC_cap: none
+        ==[port12]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: up
+                speed: 1000Mbps (Duplex: full)
+                FEC: none
+                FEC_cap: none
+        ==[port13]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: down
+                speed: n/a
+                FEC: none
+                FEC_cap: none
+        ==[port14]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: down
+                speed: n/a
+                FEC: none
+                FEC_cap: none
+        ==[port15]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: down
+                speed: n/a
+                FEC: none
+                FEC_cap: none
+        ==[port16]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: down
+                speed: n/a
+                FEC: none
+                FEC_cap: none
+        ==[port17]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: down
+                speed: n/a
+                medium: n/a
+                FEC: none
+                FEC_cap: none
+        ==[port18]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: down
+                speed: n/a
+                medium: n/a
+                FEC: none
+                FEC_cap: none
+        ==[port19]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: down
+                speed: n/a
+                medium: n/a
+                FEC: none
+                FEC_cap: none
+        ==[port20]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: down
+                speed: n/a
+                medium: n/a
+                FEC: none
+                FEC_cap: none
+        ==[wan1]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: down
+                speed: n/a
+                FEC: none
+                FEC_cap: none
+        ==[wan2]
+                mode: dhcp
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: down
+                speed: n/a
+                FEC: none
+                FEC_cap: none
+        ==[x1]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: up
+                speed: 10000Mbps (Duplex: full)
+                FEC: none
+                FEC_cap: none
+        ==[x2]
+                mode: static
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: down
+                speed: n/a
+                FEC: none
+                FEC_cap: none
+        ==[modem]
+                mode: pppoe
+                ip: 0.0.0.0 0.0.0.0
+                ipv6: ::/0
+                status: down
+                speed: n/a
+                FEC: none
+                FEC_cap: none

--- a/orb-discovery/device-discovery/tests/custom_drivers/fortinet_fortios_ssh/mock_data/test_get_interfaces_ip/7412/README.md
+++ b/orb-discovery/device-discovery/tests/custom_drivers/fortinet_fortios_ssh/mock_data/test_get_interfaces_ip/7412/README.md
@@ -13,4 +13,7 @@ the unnumbered port1 the expected result is `{}`, and the fixture could be trunc
 to zero bytes and still pass. port1 stays unnumbered because that is what keeps the
 signal-3 silence test meaningful.
 
-Replace this with a sanitised capture if the reporter supplies one.
+The reporter has since supplied a capture; it is the `7412_capture` scenario beside this
+one, where `switch:` and `aggregate:` appear with real values and positions. This scenario
+is kept for the unnumbered-port1 silence case described above, which the capture does not
+reproduce.

--- a/orb-discovery/device-discovery/tests/custom_drivers/fortinet_fortios_ssh/mock_data/test_get_interfaces_ip/7412_capture/README.md
+++ b/orb-discovery/device-discovery/tests/custom_drivers/fortinet_fortios_ssh/mock_data/test_get_interfaces_ip/7412_capture/README.md
@@ -1,0 +1,23 @@
+# FortiOS 7.4.12, device capture
+
+`get system interface` from the FortiGate-100F in netboxlabs/orb-agent#537, supplied by
+the reporter after the fix shipped. All 25 rows, with the field order and the trailing
+whitespace the device printed.
+
+Sanitised:
+
+- The reporter redacted eight addresses to `x.x.x.x`, which is not parseable. Replaced
+  with private and RFC 5737 documentation addresses, keeping the four-octet shape and
+  the netmask beside it. `dmz` and `mgmt` were given the addresses the physical capture
+  in the sibling scenario shows for the same interfaces.
+- Two `switch:` values were site-specific names. Replaced with `Lab Backup` and
+  `Lab Old Backup`, preserving the space inside the value, which is the part that matters:
+  a value containing a space sits directly before `wccp: disable`, so this row is what
+  proves the field splitter does not swallow the following key.
+
+This row set answers the question the reconstructed `7412` scenario next to it could not.
+`switch:` and `aggregate:` appear with real values and real positions rather than invented
+ones, and `mtu-override:` is last on every row that has it, which is where 7.4.12 puts it
+and not where the eleven vendored ntc-templates captures put it.
+
+Types covered: physical, tunnel, switch, aggregate, vlan, vxlan.

--- a/orb-discovery/device-discovery/tests/custom_drivers/fortinet_fortios_ssh/mock_data/test_get_interfaces_ip/7412_capture/expected_result.json
+++ b/orb-discovery/device-discovery/tests/custom_drivers/fortinet_fortios_ssh/mock_data/test_get_interfaces_ip/7412_capture/expected_result.json
@@ -1,0 +1,58 @@
+{
+  "dmz": {
+    "ipv4": {
+      "10.10.10.1": {
+        "prefix_length": 24
+      }
+    }
+  },
+  "mgmt": {
+    "ipv4": {
+      "192.168.1.99": {
+        "prefix_length": 24
+      }
+    }
+  },
+  "wan1": {
+    "ipv4": {
+      "203.0.113.10": {
+        "prefix_length": 24
+      }
+    }
+  },
+  "port6": {
+    "ipv4": {
+      "10.20.30.1": {
+        "prefix_length": 24
+      }
+    }
+  },
+  "VLAN446-SW": {
+    "ipv4": {
+      "10.44.6.1": {
+        "prefix_length": 24
+      }
+    }
+  },
+  "VLAN447-SW": {
+    "ipv4": {
+      "10.44.7.1": {
+        "prefix_length": 24
+      }
+    }
+  },
+  "VLAN2101": {
+    "ipv4": {
+      "10.21.1.1": {
+        "prefix_length": 24
+      }
+    }
+  },
+  "point1": {
+    "ipv4": {
+      "10.99.0.1": {
+        "prefix_length": 32
+      }
+    }
+  }
+}

--- a/orb-discovery/device-discovery/tests/custom_drivers/fortinet_fortios_ssh/mock_data/test_get_interfaces_ip/7412_capture/get_system_interface.txt
+++ b/orb-discovery/device-discovery/tests/custom_drivers/fortinet_fortios_ssh/mock_data/test_get_interfaces_ip/7412_capture/get_system_interface.txt
@@ -1,0 +1,50 @@
+== [ dmz ]
+name: dmz   mode: static    ip: 10.10.10.1 255.255.255.0   status: up    netbios-forward: disable    type: physical   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    wccp: disable    drop-overlapped-fragment: disable    drop-fragment: disable    mtu-override: disable    
+== [ mgmt ]
+name: mgmt   ip: 192.168.1.99 255.255.255.0   status: up    netbios-forward: disable    type: physical   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    wccp: disable    drop-overlapped-fragment: disable    drop-fragment: disable    mtu-override: disable    
+== [ wan1 ]
+name: wan1   mode: static    ip: 203.0.113.10 255.255.255.0   status: up    netbios-forward: disable    type: physical   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    wccp: disable    drop-overlapped-fragment: disable    drop-fragment: disable    mtu-override: disable    
+== [ wan2 ]
+name: wan2   mode: dhcp    ip: 0.0.0.0 0.0.0.0   status: up    netbios-forward: disable    type: physical   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    wccp: disable    drop-overlapped-fragment: disable    drop-fragment: disable    mtu-override: disable    
+== [ ha1 ]
+name: ha1   mode: static    ip: 0.0.0.0 0.0.0.0   status: up    netbios-forward: disable    type: physical   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    wccp: disable    drop-overlapped-fragment: disable    drop-fragment: disable    mtu-override: disable    
+== [ ha2 ]
+name: ha2   mode: static    ip: 0.0.0.0 0.0.0.0   status: up    netbios-forward: disable    type: physical   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    wccp: disable    drop-overlapped-fragment: disable    drop-fragment: disable    mtu-override: disable    
+== [ port1 ]
+name: port1   status: up    type: physical   src-check: enable    trunk: disable    aggregate: LAN-LAG    
+== [ port2 ]
+name: port2   status: up    type: physical   src-check: enable    trunk: disable    aggregate: LAN-LAG    
+== [ port3 ]
+name: port3   status: up    type: physical   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    switch: Lab Backup    wccp: disable    drop-overlapped-fragment: disable    drop-fragment: disable    mtu-override: disable    
+== [ port4 ]
+name: port4   status: up    type: physical   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    switch: Lab Backup    wccp: disable    drop-overlapped-fragment: disable    drop-fragment: disable    mtu-override: disable    
+== [ port5 ]
+name: port5   mode: static    ip: 0.0.0.0 0.0.0.0   status: up    netbios-forward: disable    type: physical   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    wccp: disable    drop-overlapped-fragment: disable    drop-fragment: disable    mtu-override: disable    
+== [ port6 ]
+name: port6   mode: static    ip: 10.20.30.1 255.255.255.0   status: up    netbios-forward: disable    type: physical   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    wccp: disable    drop-overlapped-fragment: disable    drop-fragment: disable    mtu-override: disable    
+== [ port9 ]
+name: port9   status: up    type: physical   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    switch: Lab Old Backup    wccp: disable    drop-overlapped-fragment: disable    drop-fragment: disable    mtu-override: disable    
+== [ port10 ]
+name: port10   status: up    type: physical   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    switch: Lab Old Backup    wccp: disable    drop-overlapped-fragment: disable    drop-fragment: disable    mtu-override: disable    
+== [ modem ]
+name: modem   mode: pppoe    ip: 0.0.0.0 0.0.0.0   status: down    netbios-forward: disable    type: physical   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    wccp: disable    drop-overlapped-fragment: disable    drop-fragment: disable    mtu-override: disable    
+== [ naf.root ]
+name: naf.root   ip: 0.0.0.0 0.0.0.0   status: up    netbios-forward: disable    type: tunnel   netflow-sampler: disable    sflow-sampler: disable    src-check: disable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    wccp: disable    
+== [ l2t.root ]
+name: l2t.root   ip: 0.0.0.0 0.0.0.0   status: up    netbios-forward: disable    type: tunnel   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    wccp: disable    
+== [ ssl.root ]
+name: ssl.root   ip: 0.0.0.0 0.0.0.0   status: up    netbios-forward: disable    type: tunnel   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    wccp: disable    
+== [ VLAN446-SW ]
+name: VLAN446-SW   mode: static    ip: 10.44.6.1 255.255.255.0   status: up    netbios-forward: disable    type: switch   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    wccp: disable    drop-overlapped-fragment: disable    drop-fragment: disable    mtu-override: disable    
+== [ VLAN447-SW ]
+name: VLAN447-SW   mode: static    ip: 10.44.7.1 255.255.255.0   status: up    netbios-forward: disable    type: switch   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    wccp: disable    drop-overlapped-fragment: disable    drop-fragment: disable    mtu-override: disable    
+== [ LAN-LAG ]
+name: LAN-LAG   mode: static    ip: 0.0.0.0 0.0.0.0   status: up    netbios-forward: disable    type: aggregate   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    wccp: disable    drop-overlapped-fragment: disable    drop-fragment: disable    mtu-override: disable    
+== [ VLAN2101 ]
+name: VLAN2101   mode: static    ip: 10.21.1.1 255.255.255.0   status: up    netbios-forward: disable    type: vlan   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    switch-controller-feature: none    wccp: disable    drop-overlapped-fragment: disable    drop-fragment: disable    mtu-override: disable    
+== [ VLAN446 ]
+name: VLAN446   status: up    type: vlan   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    switch: VLAN446-SW    switch-controller-feature: none    wccp: disable    drop-overlapped-fragment: disable    drop-fragment: disable    mtu-override: disable    
+== [ point1 ]
+name: point1   ip: 10.99.0.1 255.255.255.255   status: up    netbios-forward: disable    type: tunnel   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    wccp: disable    mtu-override: disable    
+== [ VXLAN-446 ]
+name: VXLAN-446   status: up    type: vxlan   netflow-sampler: disable    sflow-sampler: disable    src-check: enable    explicit-web-proxy: disable    explicit-ftp-proxy: disable    proxy-captive-portal: disable    trunk: disable    switch: VLAN446-SW


### PR DESCRIPTION
## Why

The 7.4.12 scenarios added with the #537 fix were reconstructed from the snippets in that issue, not captured from a device. Both their READMEs ended with "Replace this with a sanitised capture if the reporter supplies one."

The reporter has now supplied one, along with confirmation that the fix works on their FortiGate-100F.

## What the capture settles

The reconstructed fixtures had to guess at three things, and each README says so. The capture answers all three:

- **`switch:` and `aggregate:` positions and values.** Previously invented, or left out and covered only in unit tests. Now real, including `aggregate: LAN-LAG` on a member port and `switch:` on both a physical port and a VLAN.
- **`switch:` values can contain spaces.** One row carries a two-word value directly before `wccp: disable`, which is what actually exercises the field splitter. Nothing in the reconstructed data covered this.
- **`mtu-override:` really is last on 7.4.12.** The old README flagged this as unresolved, noting all eleven vendored ntc-templates captures put it before `wccp:`. The capture confirms the issue's ordering was not a transcription error.

Types covered by the flat capture: physical, tunnel, switch, aggregate, vlan, vxlan.

## Kept, not replaced

The reconstructed scenarios stay. The device puts `medium:` **below** `status:`, between `speed:` and `FEC:`. In that position, a regression that treats an unknown field line as unreadable and discards the block would still pass. The reconstructed fixture deliberately puts `medium:` above `status:`, where such a regression fails the test. The two scenarios test different things, so replacing one with the other would lose coverage. Both READMEs now explain this and cross-reference each other.

## Sanitising

- The reporter redacted eight addresses to `x.x.x.x`, which does not parse. Replaced with private and RFC 5737 documentation addresses, preserving the four-octet shape and the netmask beside it. `dmz` and `mgmt` were given the addresses the physical capture shows for the same interfaces.
- Two `switch:` values were site-specific names, replaced with neutral ones that keep the internal space.
- Nothing else altered: field order, indentation and trailing whitespace are as the device printed them. The physical capture needed no address changes at all.
- No `fnsysctl_ifconfig.txt` was supplied, and the mock device returns an empty string for a missing file, so MAC addresses come out empty rather than invented.

## Verification

`expected_result.json` for both scenarios was generated from the parser's actual output and checked by hand: 29 interfaces matching the 29 physical blocks, speeds and statuses correct, and only the 8 addressed interfaces in the IP result with `point1` correctly a /32.

```
89 passed, 4 skipped
```

Both new scenarios are picked up automatically by `parametrize_scenarios`, so no Python changed. The corpus parity fixtures are untouched: the capture cannot go there, because ntc-templates is exactly what fails to parse it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)