### PR TITLE
feat(agent): wire snmp-telemetry into the agent and ship it in the image

### DIFF
--- a/.github/actions/resolve-backend-versions/action.yml
+++ b/.github/actions/resolve-backend-versions/action.yml
@@ -1,6 +1,6 @@
 name: Resolve backend versions
 description: >-
-  Resolve the latest released version of each discovery backend (the highest
+  Resolve the latest released version of each bundled backend (the highest
   <backend>/vX.Y.Z tag, pre-releases excluded) via git ls-remote against origin
   — reachability-independent and depth-independent. A backend with no released
   tag resolves to 0.0.0; a transport/auth failure fails the step rather than
@@ -22,6 +22,9 @@ outputs:
   worker:
     description: 'Latest released worker version (X.Y.Z, or 0.0.0).'
     value: ${{ steps.resolve.outputs.worker }}
+  telemetry:
+    description: 'Latest released snmp-telemetry version (X.Y.Z, or 0.0.0).'
+    value: ${{ steps.resolve.outputs.telemetry }}
 
 runs:
   using: composite
@@ -44,10 +47,12 @@ runs:
         gd=$(backend_version gnmi-discovery)
         dd=$(backend_version device-discovery)
         wk=$(backend_version worker)
+        st=$(backend_version snmp-telemetry)
         {
           echo "network=${nd:-0.0.0}"
           echo "snmp=${sd:-0.0.0}"
           echo "gnmi=${gd:-0.0.0}"
           echo "device=${dd:-0.0.0}"
           echo "worker=${wk:-0.0.0}"
+          echo "telemetry=${st:-0.0.0}"
         } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/_agent-release.yaml
+++ b/.github/workflows/_agent-release.yaml
@@ -27,6 +27,10 @@ on:
         description: 'worker version to bundle (X.Y.Z).'
         required: true
         type: string
+      telemetry-version:
+        description: 'snmp-telemetry version to bundle (X.Y.Z).'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -125,7 +129,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,scope=${{ matrix.platform }},mode=max
-          no-cache-filters: python-builder,network-discovery,snmp-discovery,pktvisor,otlpinf,final
+          no-cache-filters: python-builder,network-discovery,snmp-discovery,snmp-telemetry,pktvisor,otlpinf,final
           pull: true
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
@@ -136,6 +140,7 @@ jobs:
             GNMI_DISCOVERY_VERSION=${{ inputs.gnmi-version }}
             DEVICE_DISCOVERY_VERSION=${{ inputs.device-version }}
             WORKER_VERSION=${{ inputs.worker-version }}
+            SNMP_TELEMETRY_VERSION=${{ inputs.telemetry-version }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -73,6 +73,7 @@ jobs:
             GNMI_DISCOVERY_VERSION=${{ steps.backend-versions.outputs.gnmi }}
             DEVICE_DISCOVERY_VERSION=${{ steps.backend-versions.outputs.device }}
             WORKER_VERSION=${{ steps.backend-versions.outputs.worker }}
+            SNMP_TELEMETRY_VERSION=${{ steps.backend-versions.outputs.telemetry }}
           tags: orb-agent:scan
 
       - name: Scan image for vulnerabilities

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -11,6 +11,8 @@ on:
       - "orb-discovery/**"
       - "!agent/docker/**"
       - "!orb-discovery/**/docker/**"
+      - "orb-telemetry/**"
+      - "!orb-telemetry/**/docker/**"
 
 permissions:
   contents: write
@@ -89,6 +91,7 @@ jobs:
             GNMI_DISCOVERY_VERSION=${{ steps.backend-versions.outputs.gnmi }}
             DEVICE_DISCOVERY_VERSION=${{ steps.backend-versions.outputs.device }}
             WORKER_VERSION=${{ steps.backend-versions.outputs.worker }}
+            SNMP_TELEMETRY_VERSION=${{ steps.backend-versions.outputs.telemetry }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,8 @@ on:
     paths:
       - "orb-discovery/**"
       - "!orb-discovery/**/docker/**"
+      - "orb-telemetry/**"
+      - "!orb-telemetry/**/docker/**"
       - "agent/**"
       - "!agent/docker/**"
       - "cmd/**"
@@ -44,6 +46,7 @@ jobs:
       network: ${{ steps.detect.outputs.network }}
       snmp: ${{ steps.detect.outputs.snmp }}
       gnmi: ${{ steps.detect.outputs.gnmi }}
+      telemetry: ${{ steps.detect.outputs.telemetry }}
       agent: ${{ steps.detect.outputs.agent }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -69,6 +72,7 @@ jobs:
               echo "network=true"
               echo "snmp=true"
               echo "gnmi=true"
+              echo "telemetry=true"
               echo "agent=true"
             } >> "$GITHUB_OUTPUT"
             exit 0
@@ -99,6 +103,7 @@ jobs:
             echo "network=$(detect '^orb-discovery/network-discovery/' '^orb-discovery/network-discovery/docker/')"
             echo "snmp=$(detect '^orb-discovery/snmp-discovery/' '^orb-discovery/snmp-discovery/docker/')"
             echo "gnmi=$(detect '^orb-discovery/gnmi-discovery/' '^orb-discovery/gnmi-discovery/docker/')"
+            echo "telemetry=$(detect '^orb-telemetry/snmp-telemetry/' '^orb-telemetry/snmp-telemetry/docker/')"
             echo "agent=$(detect '^(agent/|cmd/|go\.mod$|go\.sum$)' '^agent/docker/')"
           } >> "$GITHUB_OUTPUT"
 
@@ -114,7 +119,7 @@ jobs:
       ${{ github.event_name == 'push' && needs.changes.outputs.agent == 'true' &&
           (needs.changes.outputs.device == 'true' || needs.changes.outputs.worker == 'true' ||
            needs.changes.outputs.network == 'true' || needs.changes.outputs.snmp == 'true' ||
-           needs.changes.outputs.gnmi == 'true') }}
+           needs.changes.outputs.gnmi == 'true' || needs.changes.outputs.telemetry == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 35
     permissions:
@@ -128,6 +133,7 @@ jobs:
       NETWORK: ${{ needs.changes.outputs.network }}
       SNMP: ${{ needs.changes.outputs.snmp }}
       GNMI: ${{ needs.changes.outputs.gnmi }}
+      TELEMETRY: ${{ needs.changes.outputs.telemetry }}
     steps:
       - name: Wait for changed backend release runs
         run: |
@@ -164,6 +170,7 @@ jobs:
           if [ "$NETWORK" = "true" ]; then wait_for network-discovery-release.yaml; fi
           if [ "$SNMP" = "true" ];    then wait_for snmp-discovery-release.yaml;     fi
           if [ "$GNMI" = "true" ];    then wait_for gnmi-discovery-release.yaml;     fi
+          if [ "$TELEMETRY" = "true" ]; then wait_for snmp-telemetry-release.yaml; fi
           echo "all changed backend releases complete"
 
   resolve-versions:
@@ -178,6 +185,7 @@ jobs:
       gnmi: ${{ steps.versions.outputs.gnmi }}
       device: ${{ steps.versions.outputs.device }}
       worker: ${{ steps.versions.outputs.worker }}
+      telemetry: ${{ steps.versions.outputs.telemetry }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       # wait-for-backend-releases has ensured any changed backend already tagged
@@ -196,4 +204,5 @@ jobs:
       gnmi-version: ${{ needs.resolve-versions.outputs.gnmi }}
       device-version: ${{ needs.resolve-versions.outputs.device }}
       worker-version: ${{ needs.resolve-versions.outputs.worker }}
+      telemetry-version: ${{ needs.resolve-versions.outputs.telemetry }}
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -165,12 +165,12 @@ jobs:
             fi
             return 1
           }
-          if [ "$DEVICE" = "true" ];  then wait_for device-discovery-release.yaml;  fi
-          if [ "$WORKER" = "true" ];  then wait_for worker-release.yaml;            fi
-          if [ "$NETWORK" = "true" ]; then wait_for network-discovery-release.yaml; fi
-          if [ "$SNMP" = "true" ];    then wait_for snmp-discovery-release.yaml;     fi
-          if [ "$GNMI" = "true" ];    then wait_for gnmi-discovery-release.yaml;     fi
-          if [ "$TELEMETRY" = "true" ]; then wait_for snmp-telemetry-release.yaml; fi
+          if [ "$DEVICE" = "true" ];    then wait_for device-discovery-release.yaml;  fi
+          if [ "$WORKER" = "true" ];    then wait_for worker-release.yaml;            fi
+          if [ "$NETWORK" = "true" ];   then wait_for network-discovery-release.yaml; fi
+          if [ "$SNMP" = "true" ];      then wait_for snmp-discovery-release.yaml;    fi
+          if [ "$GNMI" = "true" ];      then wait_for gnmi-discovery-release.yaml;    fi
+          if [ "$TELEMETRY" = "true" ]; then wait_for snmp-telemetry-release.yaml;    fi
           echo "all changed backend releases complete"
 
   resolve-versions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,9 @@ pipeline keys off **PR titles** — so titles must follow the convention below.
   dash (`snmp-discovery-v1.2.3`); this is cosmetic — the git tag and ref keep the
   slash form. `worker` and `device-discovery` also publish to PyPI.
 - Pushing to `develop` rebuilds and publishes the `orb-agent:develop` image.
-  This fires on changes under `agent/`, `cmd/`, **or** `orb-discovery/`, so a
-  change to a backend the image bundles still refreshes it continuously.
-  `orb-telemetry/snmp-telemetry` is absent from that list on purpose: the agent
-  does not build or ship it yet, so rebuilding the image for it would publish
-  nothing new.
+  This fires on changes under `agent/`, `cmd/`, `orb-discovery/` or
+  `orb-telemetry/`, so a change to a backend the image bundles still refreshes
+  it continuously.
 - The **Validate PR title** check runs on every PR targeting `develop`. Once it
   is marked a required status check in branch protection, it blocks merge when
   the title doesn't match the convention; until then it reports status without

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,9 @@ ND_VERSION ?= $(shell v=$$(git tag -l 'network-discovery/v[0-9]*' | sed 's|.*/v|
 SD_VERSION ?= $(shell v=$$(git tag -l 'snmp-discovery/v[0-9]*' | sed 's|.*/v||' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1); echo $${v:-0.0.0})
 DD_VERSION ?= $(shell v=$$(git tag -l 'device-discovery/v[0-9]*' | sed 's|.*/v||' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1); echo $${v:-0.0.0})
 WK_VERSION ?= $(shell v=$$(git tag -l 'worker/v[0-9]*' | sed 's|.*/v||' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1); echo $${v:-0.0.0})
-BACKEND_VERSION_ARGS = --build-arg NETWORK_DISCOVERY_VERSION=$(ND_VERSION) --build-arg SNMP_DISCOVERY_VERSION=$(SD_VERSION) --build-arg DEVICE_DISCOVERY_VERSION=$(DD_VERSION) --build-arg WORKER_VERSION=$(WK_VERSION) --build-arg BUILD_COMMIT=$(COMMIT_HASH) --build-arg BUILD_TRACK=$(COMMIT_BRANCH)
+GD_VERSION ?= $(shell v=$$(git tag -l 'gnmi-discovery/v[0-9]*' | sed 's|.*/v||' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1); echo $${v:-0.0.0})
+ST_VERSION ?= $(shell v=$$(git tag -l 'snmp-telemetry/v[0-9]*' | sed 's|.*/v||' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1); echo $${v:-0.0.0})
+BACKEND_VERSION_ARGS = --build-arg NETWORK_DISCOVERY_VERSION=$(ND_VERSION) --build-arg SNMP_DISCOVERY_VERSION=$(SD_VERSION) --build-arg GNMI_DISCOVERY_VERSION=$(GD_VERSION) --build-arg SNMP_TELEMETRY_VERSION=$(ST_VERSION) --build-arg DEVICE_DISCOVERY_VERSION=$(DD_VERSION) --build-arg WORKER_VERSION=$(WK_VERSION) --build-arg BUILD_COMMIT=$(COMMIT_HASH) --build-arg BUILD_TRACK=$(COMMIT_BRANCH)
 
 # Make targets operate on the agent (a single module), so never use a local
 # go.work — workspace mode is incompatible with the -mod=mod build flow. The

--- a/README.md
+++ b/README.md
@@ -81,10 +81,11 @@ Only the `network_discovery`, `device_discovery`, `worker`, `snmp_discovery` and
 - [gNMI Discovery](./docs/backends/gnmi_discovery.md)
 
 #### Observability Backends
-Observability backends focus on collecting and exporting rich telemetry from network traffic or probes so you can feed metrics into your monitoring stack.
+Observability backends focus on collecting and exporting rich telemetry from network traffic, probes or device polling so you can feed metrics into your monitoring stack. SNMP Telemetry polls SNMP devices and receives their traps, exporting metrics over OTLP.
 
 - [pktvisor](./docs/backends/pktvisor.md)
 - [OpenTelemetry Infinity](./docs/backends/opentelemetry_infinity.md)
+- [SNMP Telemetry](./docs/backends/snmp_telemetry.md)
 
 #### Common
 A special `common` subsection under `backends` defines configuration settings that are shared with all backends. Currently, it supports passing [diode](https://github.com/netboxlabs/diode) server settings and OpenTelemetry configuration to all backends.
@@ -127,6 +128,9 @@ orb:
     snmp_discovery:
       snmp_policy_1:
        # see docs/backends/snmp.md
+    snmp_telemetry:
+      snmp_telemetry_policy_1:
+       # see docs/backends/snmp_telemetry.md
  ```
 
 ## System Requirements
@@ -182,6 +186,8 @@ podman run --privileged --net=host \
 ```
 
 **Note for rootless podman users:** If running podman without root/sudo privileges, network discovery requires specific configuration to avoid raw socket limitations. The command above requires `sudo` for full NMAP functionality. For rootless operation, see the [Network Discovery backend documentation](./docs/backends/network_discovery.md#rootless-podman-deployment) for TCP connect scan configuration.
+
+An `snmp_telemetry` policy that receives traps binds the UDP port its `listen` names on the agent host, conventionally 162, which `--net=host` already exposes. In bridge mode publish that port, `-p 162:162/udp` for a policy listening on 162. There is no default port: `listen` is required and the policy chooses it. The container runs as root by default, the image sets no other user, so binding a port below 1024 inside it needs no capability.
 
 ### Running as a service
 

--- a/agent/backend/jsonlog.go
+++ b/agent/backend/jsonlog.go
@@ -1,0 +1,68 @@
+package backend
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+)
+
+// NormalizeJSONLine parses a JSON log record, the shape slog's JSON handler
+// writes, into (msg, attrs, level, ok) under the same contract as
+// NormalizeLogfmtLine: ok=false when the line is not a JSON object or has no
+// non-empty msg; msg, level and time are removed from attrs; the remaining
+// keys are sorted; the level is parsed with ParseLogfmtLevel and an unknown
+// one keeps the fallback. Attribute values that are not strings are rendered
+// with %v, so a nested object arrives as one attribute rather than being lost.
+func NormalizeJSONLine(line string, fallback slog.Level) (string, []slog.Attr, slog.Level, bool) {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, "{") {
+		return "", nil, fallback, false
+	}
+
+	var fields map[string]any
+	if err := json.Unmarshal([]byte(trimmed), &fields); err != nil {
+		return "", nil, fallback, false
+	}
+
+	msg, ok := fields["msg"].(string)
+	if !ok || strings.TrimSpace(msg) == "" {
+		return "", nil, fallback, false
+	}
+
+	level := fallback
+	if lvlValue, exists := fields["level"].(string); exists {
+		if parsedLevel, levelOK := ParseLogfmtLevel(lvlValue); levelOK {
+			level = parsedLevel
+		}
+	}
+
+	delete(fields, "msg")
+	delete(fields, "level")
+	delete(fields, "time")
+
+	keys := make([]string, 0, len(fields))
+	for key := range fields {
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	if len(keys) == 0 {
+		return msg, nil, level, true
+	}
+	sort.Strings(keys)
+
+	attrs := make([]slog.Attr, 0, len(keys))
+	for _, key := range keys {
+		switch value := fields[key].(type) {
+		case string:
+			attrs = append(attrs, slog.String(key, value))
+		default:
+			attrs = append(attrs, slog.String(key, fmt.Sprintf("%v", value)))
+		}
+	}
+
+	return msg, attrs, level, true
+}

--- a/agent/backend/jsonlog_test.go
+++ b/agent/backend/jsonlog_test.go
@@ -1,0 +1,63 @@
+package backend
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeJSONLine_Valid(t *testing.T) {
+	msg, attrs, level, ok := NormalizeJSONLine(
+		`{"time":"2026-09-04T12:00:00Z","level":"WARN","msg":"trap dropped","reason":"unknown_source","count":3}`,
+		slog.LevelInfo)
+	require.True(t, ok)
+	assert.Equal(t, "trap dropped", msg)
+	assert.Equal(t, slog.LevelWarn, level)
+	assert.Equal(t, []slog.Attr{slog.String("count", "3"), slog.String("reason", "unknown_source")}, attrs)
+}
+
+func TestNormalizeJSONLine_ErrorLevel(t *testing.T) {
+	_, _, level, ok := NormalizeJSONLine(`{"level":"ERROR","msg":"bind failed"}`, slog.LevelInfo)
+	require.True(t, ok)
+	assert.Equal(t, slog.LevelError, level)
+}
+
+func TestNormalizeJSONLine_UnknownLevel_UsesFallback(t *testing.T) {
+	_, _, level, ok := NormalizeJSONLine(`{"level":"WARN+2","msg":"custom"}`, slog.LevelInfo)
+	require.True(t, ok)
+	assert.Equal(t, slog.LevelInfo, level)
+}
+
+func TestNormalizeJSONLine_NoMsg(t *testing.T) {
+	for _, line := range []string{
+		`{"level":"ERROR","detail":"x"}`,
+		`{"level":"ERROR","msg":"   "}`,
+		`{"level":"ERROR","msg":7}`,
+	} {
+		_, _, level, ok := NormalizeJSONLine(line, slog.LevelInfo)
+		assert.False(t, ok, line)
+		assert.Equal(t, slog.LevelInfo, level, line)
+	}
+}
+
+func TestNormalizeJSONLine_NotJSON(t *testing.T) {
+	_, _, _, ok := NormalizeJSONLine(`time=now level=INFO msg=hello`, slog.LevelInfo)
+	assert.False(t, ok)
+	_, _, _, ok = NormalizeJSONLine(`{not json`, slog.LevelInfo)
+	assert.False(t, ok)
+}
+
+func TestNormalizeJSONLine_NoAttrs(t *testing.T) {
+	msg, attrs, _, ok := NormalizeJSONLine(`{"time":"t","level":"INFO","msg":"ready"}`, slog.LevelError)
+	require.True(t, ok)
+	assert.Equal(t, "ready", msg)
+	assert.Nil(t, attrs)
+}
+
+func TestNormalizeJSONLine_NestedValueRendered(t *testing.T) {
+	_, attrs, _, ok := NormalizeJSONLine(`{"msg":"m","policy":{"name":"core","targets":2}}`, slog.LevelInfo)
+	require.True(t, ok)
+	assert.Equal(t, []slog.Attr{slog.String("policy", "map[name:core targets:2]")}, attrs)
+}

--- a/agent/backend/snmptelemetry/args_test.go
+++ b/agent/backend/snmptelemetry/args_test.go
@@ -1,9 +1,11 @@
 package snmptelemetry
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -366,4 +368,27 @@ func TestAPIURLBracketsAnIPv6Host(t *testing.T) {
 	require.NoError(t, b.Configure(quietLogger(slog.LevelInfo), nil, map[string]any{"host": "::1"}, commonsWithOTLP("collector:4317"), nil))
 	assert.Equal(t, "http://[::1]:8078/api/v1/status", b.apiURL("status"))
 	assert.Equal(t, "http://[::1]:8078/api/v1/policies/a%20b", b.apiURL("policies/a%20b"))
+}
+
+// The binary's log lines are re-logged by the agent. A JSON record, the
+// binary's output under log_format JSON, must keep its severity and
+// attributes rather than arrive as one INFO string.
+func TestLogLineAdapterKeepsSeverityForBothFormats(t *testing.T) {
+	var out bytes.Buffer
+	b := &snmpTelemetryBackend{apiProtocol: "http", exec: defaultExec}
+	require.NoError(t, b.Configure(slog.New(slog.NewTextHandler(&out, &slog.HandlerOptions{Level: slog.LevelDebug})), nil, map[string]any{}, commonsWithOTLP("collector:4317"), nil))
+
+	b.logLineAdapter(`{"time":"2026-09-04T12:00:00Z","level":"ERROR","msg":"trap socket bind failed","listen":"0.0.0.0:162"}`, false)
+	b.logLineAdapter(`time=2026-09-04T12:00:00Z level=WARN msg="trap dropped" reason=unknown_source`, false)
+	b.logLineAdapter(`plain text from the child`, true)
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	require.Len(t, lines, 4, "configure line plus the three forwarded lines")
+	assert.Contains(t, lines[1], "level=ERROR")
+	assert.Contains(t, lines[1], `msg="trap socket bind failed"`)
+	assert.Contains(t, lines[1], "listen=0.0.0.0:162")
+	assert.Contains(t, lines[2], "level=WARN")
+	assert.Contains(t, lines[2], "reason=unknown_source")
+	assert.Contains(t, lines[3], "level=ERROR", "stderr keeps the error fallback")
+	assert.Contains(t, lines[3], `msg="plain text from the child"`)
 }

--- a/agent/backend/snmptelemetry/args_test.go
+++ b/agent/backend/snmptelemetry/args_test.go
@@ -104,6 +104,42 @@ func TestConfigureBuildsArgs(t *testing.T) {
 			want:    []string{"--host", "localhost", "--port", "8078", "--otel-endpoint", "collector:4317", "--otel-export-period", "20"},
 		},
 		{
+			name:    "a nil map, the documented bare snmp_telemetry key, uses the defaults",
+			cfg:     nil,
+			commons: commonsWithOTLP("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8078", "--otel-endpoint", "collector:4317"},
+		},
+		{
+			name:    "an empty host or port stays on the default rather than binding everywhere",
+			cfg:     map[string]any{"host": "", "port": ""},
+			commons: commonsWithOTLP("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8078", "--otel-endpoint", "collector:4317"},
+		},
+		{
+			name:    "an empty log_level still follows the debug rule",
+			cfg:     map[string]any{"log_level": "", "debug": true},
+			commons: commonsWithOTLP("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8078", "--otel-endpoint", "collector:4317", "--log-level", "DEBUG"},
+		},
+		{
+			name:    "a non-string log_level is refused",
+			cfg:     map[string]any{"log_level": false},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "snmp_telemetry: log_level must be a string, got bool",
+		},
+		{
+			name:    "a non-string log_format is refused",
+			cfg:     map[string]any{"log_format": 7},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "snmp_telemetry: log_format must be a string, got int",
+		},
+		{
+			name:    "a non-string profiles path is refused",
+			cfg:     map[string]any{"snmp_profiles_root": true},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "snmp_telemetry: snmp_profiles_root must be a string, got bool",
+		},
+		{
 			name:    "missing OTLP endpoint is refused",
 			cfg:     map[string]any{},
 			commons: config.BackendCommons{},

--- a/agent/backend/snmptelemetry/args_test.go
+++ b/agent/backend/snmptelemetry/args_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/backend/mocks"
 	"github.com/netboxlabs/orb-agent/agent/config"
 )
 
@@ -114,6 +115,66 @@ func TestConfigureBuildsArgs(t *testing.T) {
 			cfg:     map[string]any{"host": "", "port": ""},
 			commons: commonsWithOTLP("collector:4317"),
 			want:    []string{"--host", "localhost", "--port", "8078", "--otel-endpoint", "collector:4317"},
+		},
+		{
+			name:    "a null host or port, a key left blank in YAML, keeps the default",
+			cfg:     map[string]any{"host": nil, "port": nil},
+			commons: commonsWithOTLP("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8078", "--otel-endpoint", "collector:4317"},
+		},
+		{
+			name:    "port accepts a whole float and a numeric string",
+			cfg:     map[string]any{"port": 9078.0},
+			commons: commonsWithOTLP("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "9078", "--otel-endpoint", "collector:4317"},
+		},
+		{
+			name:    "a non-string host is refused",
+			cfg:     map[string]any{"host": 7},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "snmp_telemetry: host must be a string, got int",
+		},
+		{
+			name:    "a fractional port is refused",
+			cfg:     map[string]any{"port": 8078.5},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "snmp_telemetry: port must be an integer from 1 to 65535, got 8078.5",
+		},
+		{
+			name:    "a port out of range is refused",
+			cfg:     map[string]any{"port": 70000},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "snmp_telemetry: port must be an integer from 1 to 65535, got 70000",
+		},
+		{
+			name:    "a port that is not a number is refused",
+			cfg:     map[string]any{"port": "eight"},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: `snmp_telemetry: port must be an integer from 1 to 65535, got "eight"`,
+		},
+		{
+			name:    "an unrecognised log_level is refused rather than run at DEBUG",
+			cfg:     map[string]any{"log_level": "verbose"},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: `snmp_telemetry: log_level must be one of DEBUG, INFO, WARN, ERROR, got "verbose"`,
+		},
+		{
+			name:    "an unrecognised log_format is refused rather than fall to JSON",
+			cfg:     map[string]any{"log_format": "yaml"},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: `snmp_telemetry: log_format must be one of TEXT, JSON, got "yaml"`,
+		},
+		{
+			name:    "policy_env_vars entries are trimmed and joined",
+			cfg:     map[string]any{"policy_env_vars": "A, B"},
+			commons: commonsWithOTLP("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8078", "--otel-endpoint", "collector:4317", "--policy-env-vars", "A,B"},
+		},
+		{
+			name:    "a resolved secret in policy_env_vars is refused",
+			cfg:     map[string]any{"policy_env_vars": []any{"SNMP_COMMUNITY", "s3cr3t-value"}},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: `snmp_telemetry: policy_env_vars takes environment variable names, not "s3cr3t-value"`,
 		},
 		{
 			name:    "an empty log_level still follows the debug rule",
@@ -238,9 +299,58 @@ func TestStopPassesTheAgentGrace(t *testing.T) {
 	require.NoError(t, b.Configure(quietLogger(slog.LevelInfo), nil, map[string]any{}, commonsWithOTLP("collector:4317"), nil))
 	_, cancel := context.WithCancel(context.Background())
 	b.cancelFunc = cancel
+	b.proc = &mocks.MockCmd{}
 
 	require.NoError(t, b.Stop(context.Background()))
 
 	assert.Equal(t, backend.DefaultStopGracePeriod, gotGrace)
 	assert.Equal(t, "snmp_telemetry", gotName)
+}
+
+// A backend that never started has no process to stop; Stop is a no-op
+// rather than a nil dereference.
+func TestStopBeforeStartIsANoOp(t *testing.T) {
+	calls := 0
+	original := stopProcess
+	stopProcess = func(*slog.Logger, backend.Commander, <-chan backend.CmdStatus, time.Duration, string) { calls++ }
+	t.Cleanup(func() { stopProcess = original })
+
+	b := &snmpTelemetryBackend{apiProtocol: "http", exec: defaultExec}
+	require.NoError(t, b.Stop(context.Background()))
+	assert.Equal(t, 0, calls)
+}
+
+// A fleet full reset walks the whole registry, reaching a backend the agent
+// never configured. It must refuse rather than start a process on empty
+// arguments through a nil logger.
+func TestStartAndResetBeforeConfigureAreRefused(t *testing.T) {
+	b := &snmpTelemetryBackend{apiProtocol: "http", exec: defaultExec}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	assert.EqualError(t, b.Start(ctx, cancel), "snmp_telemetry: started before it was configured")
+	assert.EqualError(t, b.FullReset(ctx), "snmp_telemetry: reset before it was configured")
+}
+
+// A refused reconfiguration must not move the address the agent polls the
+// running process on, or every status check would miss it until a restart.
+func TestConfigureFailureLeavesTheBackendUnchanged(t *testing.T) {
+	b := &snmpTelemetryBackend{apiProtocol: "http", exec: defaultExec}
+	logger := quietLogger(slog.LevelInfo)
+	require.NoError(t, b.Configure(logger, nil, map[string]any{"port": 9078, "log_format": "JSON"}, commonsWithOTLP("collector:4317"), nil))
+	before := b.buildArgs()
+
+	err := b.Configure(logger, nil, map[string]any{"port": 9079, "otel_export_period": 0}, commonsWithOTLP("other:4317"), nil)
+	require.Error(t, err)
+
+	assert.Equal(t, before, b.buildArgs())
+	assert.Equal(t, "http://localhost:9078/api/v1/status", b.apiURL("status"))
+}
+
+// The binary brackets an IPv6 host when it binds; the agent must do the same
+// when it dials, or readiness never passes.
+func TestAPIURLBracketsAnIPv6Host(t *testing.T) {
+	b := &snmpTelemetryBackend{apiProtocol: "http", exec: defaultExec}
+	require.NoError(t, b.Configure(quietLogger(slog.LevelInfo), nil, map[string]any{"host": "::1"}, commonsWithOTLP("collector:4317"), nil))
+	assert.Equal(t, "http://[::1]:8078/api/v1/status", b.apiURL("status"))
+	assert.Equal(t, "http://[::1]:8078/api/v1/policies/a%20b", b.apiURL("policies/a%20b"))
 }

--- a/agent/backend/snmptelemetry/args_test.go
+++ b/agent/backend/snmptelemetry/args_test.go
@@ -25,6 +25,14 @@ func commonsWithOTLP(endpoint string) config.BackendCommons {
 	return c
 }
 
+// debugCommons is what the agent hands a backend when run with its debug
+// flag; the flag arrives through the commons, not the config map.
+func debugCommons(endpoint string) config.BackendCommons {
+	c := commonsWithOTLP(endpoint)
+	c.Debug = true
+	return c
+}
+
 func TestConfigureBuildsArgs(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -79,17 +87,22 @@ func TestConfigureBuildsArgs(t *testing.T) {
 			want:    []string{"--host", "localhost", "--port", "8078", "--otel-endpoint", "collector:4317", "--log-level", "DEBUG"},
 		},
 		{
-			name:    "a debug-enabled agent logger selects DEBUG",
+			name:    "the agent's debug flag selects DEBUG",
+			cfg:     map[string]any{},
+			commons: debugCommons("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8078", "--otel-endpoint", "collector:4317", "--log-level", "DEBUG"},
+		},
+		{
+			name:    "a debug-enabled logger alone does not select DEBUG",
 			cfg:     map[string]any{},
 			commons: commonsWithOTLP("collector:4317"),
 			logger:  quietLogger(slog.LevelDebug),
-			want:    []string{"--host", "localhost", "--port", "8078", "--otel-endpoint", "collector:4317", "--log-level", "DEBUG"},
+			want:    []string{"--host", "localhost", "--port", "8078", "--otel-endpoint", "collector:4317"},
 		},
 		{
 			name:    "an explicit log_level wins over debug",
 			cfg:     map[string]any{"debug": true, "log_level": "ERROR"},
-			commons: commonsWithOTLP("collector:4317"),
-			logger:  quietLogger(slog.LevelDebug),
+			commons: debugCommons("collector:4317"),
 			want:    []string{"--host", "localhost", "--port", "8078", "--otel-endpoint", "collector:4317", "--log-level", "ERROR"},
 		},
 		{

--- a/agent/backend/snmptelemetry/args_test.go
+++ b/agent/backend/snmptelemetry/args_test.go
@@ -1,0 +1,210 @@
+package snmptelemetry
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/config"
+)
+
+func quietLogger(level slog.Level) *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: level}))
+}
+
+func commonsWithOTLP(endpoint string) config.BackendCommons {
+	var c config.BackendCommons
+	c.Otlp.Grpc = endpoint
+	return c
+}
+
+func TestConfigureBuildsArgs(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     map[string]any
+		commons config.BackendCommons
+		logger  *slog.Logger
+		want    []string
+		wantErr string
+	}{
+		{
+			name:    "defaults pass only host, port and the endpoint",
+			cfg:     map[string]any{},
+			commons: commonsWithOTLP("grpc://collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8078", "--otel-endpoint", "grpc://collector:4317"},
+		},
+		{
+			name: "every key is forwarded as its flag",
+			cfg: map[string]any{
+				"host":               "127.0.0.1",
+				"port":               9078,
+				"otel_export_period": 30,
+				"log_level":          "warn",
+				"log_format":         "JSON",
+				"policy_env_vars":    "SNMP_COMMUNITY,SNMP_PASS",
+				"snmp_profiles_root": "/opt/orb/profiles",
+				"snmp_profiles_dir":  "/opt/orb/overrides",
+			},
+			commons: commonsWithOTLP("collector:4317"),
+			want: []string{
+				"--host", "127.0.0.1", "--port", "9078", "--otel-endpoint", "collector:4317",
+				"--otel-export-period", "30", "--log-level", "warn", "--log-format", "JSON",
+				"--policy-env-vars", "SNMP_COMMUNITY,SNMP_PASS",
+				"--snmp-profiles-root", "/opt/orb/profiles", "--snmp-profiles-dir", "/opt/orb/overrides",
+			},
+		},
+		{
+			name:    "policy_env_vars as a list is joined with commas",
+			cfg:     map[string]any{"policy_env_vars": []any{"A", "B"}},
+			commons: commonsWithOTLP("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8078", "--otel-endpoint", "collector:4317", "--policy-env-vars", "A,B"},
+		},
+		{
+			name:    "empty strings are unset",
+			cfg:     map[string]any{"log_format": "", "policy_env_vars": "", "snmp_profiles_root": "", "snmp_profiles_dir": ""},
+			commons: commonsWithOTLP("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8078", "--otel-endpoint", "collector:4317"},
+		},
+		{
+			name:    "debug true selects DEBUG",
+			cfg:     map[string]any{"debug": true},
+			commons: commonsWithOTLP("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8078", "--otel-endpoint", "collector:4317", "--log-level", "DEBUG"},
+		},
+		{
+			name:    "a debug-enabled agent logger selects DEBUG",
+			cfg:     map[string]any{},
+			commons: commonsWithOTLP("collector:4317"),
+			logger:  quietLogger(slog.LevelDebug),
+			want:    []string{"--host", "localhost", "--port", "8078", "--otel-endpoint", "collector:4317", "--log-level", "DEBUG"},
+		},
+		{
+			name:    "an explicit log_level wins over debug",
+			cfg:     map[string]any{"debug": true, "log_level": "ERROR"},
+			commons: commonsWithOTLP("collector:4317"),
+			logger:  quietLogger(slog.LevelDebug),
+			want:    []string{"--host", "localhost", "--port", "8078", "--otel-endpoint", "collector:4317", "--log-level", "ERROR"},
+		},
+		{
+			name:    "export period accepts a whole float",
+			cfg:     map[string]any{"otel_export_period": 15.0},
+			commons: commonsWithOTLP("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8078", "--otel-endpoint", "collector:4317", "--otel-export-period", "15"},
+		},
+		{
+			name:    "export period accepts a numeric string",
+			cfg:     map[string]any{"otel_export_period": "20"},
+			commons: commonsWithOTLP("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8078", "--otel-endpoint", "collector:4317", "--otel-export-period", "20"},
+		},
+		{
+			name:    "missing OTLP endpoint is refused",
+			cfg:     map[string]any{},
+			commons: config.BackendCommons{},
+			wantErr: "snmp_telemetry: common.otlp.grpc is required, the backend exports its metrics over OTLP",
+		},
+		{
+			name:    "export period zero is refused",
+			cfg:     map[string]any{"otel_export_period": 0},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "snmp_telemetry: otel_export_period must be >= 1, got 0",
+		},
+		{
+			name:    "export period above one year is refused",
+			cfg:     map[string]any{"otel_export_period": 31536001},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "snmp_telemetry: otel_export_period must be <= 31536000, got 31536001",
+		},
+		{
+			name:    "export period fractional is refused",
+			cfg:     map[string]any{"otel_export_period": 1.5},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "snmp_telemetry: otel_export_period must be a whole number, got 1.5",
+		},
+		{
+			name:    "export period text is refused",
+			cfg:     map[string]any{"otel_export_period": "soon"},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: `snmp_telemetry: otel_export_period: invalid integer "soon"`,
+		},
+		{
+			name:    "export period bool is refused",
+			cfg:     map[string]any{"otel_export_period": true},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "snmp_telemetry: otel_export_period must be an integer, got bool",
+		},
+		{
+			name:    "policy_env_vars with a non-string entry is refused",
+			cfg:     map[string]any{"policy_env_vars": []any{"A", 2}},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "snmp_telemetry: policy_env_vars entries must be strings, got int",
+		},
+		{
+			name:    "policy_env_vars of another type is refused",
+			cfg:     map[string]any{"policy_env_vars": 7},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "snmp_telemetry: policy_env_vars must be a string or a list of strings, got int",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := tc.logger
+			if logger == nil {
+				logger = quietLogger(slog.LevelInfo)
+			}
+			b := &snmpTelemetryBackend{apiProtocol: "http", exec: defaultExec}
+			err := b.Configure(logger, nil, tc.cfg, tc.commons, nil)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, b.buildArgs())
+		})
+	}
+}
+
+// A second Configure on the same backend must not carry an optional flag over
+// from the first: the agent reconfigures a registered backend in place.
+func TestConfigureResetsOptionalFlags(t *testing.T) {
+	b := &snmpTelemetryBackend{apiProtocol: "http", exec: defaultExec}
+	logger := quietLogger(slog.LevelInfo)
+	require.NoError(t, b.Configure(logger, nil, map[string]any{
+		"otel_export_period": 5, "log_level": "ERROR", "log_format": "JSON",
+		"policy_env_vars": "A", "snmp_profiles_root": "/r", "snmp_profiles_dir": "/d",
+	}, commonsWithOTLP("collector:4317"), nil))
+	require.NoError(t, b.Configure(logger, nil, map[string]any{}, commonsWithOTLP("collector:4317"), nil))
+	assert.Equal(t, []string{"--host", "localhost", "--port", "8078", "--otel-endpoint", "collector:4317"}, b.buildArgs())
+}
+
+// The binary sizes its shutdown, trap sockets closed and then the final
+// OTLP flush, to the agent's default stop grace. Stop must hand it exactly
+// that grace; a shorter one would SIGKILL it with the last export unsent.
+func TestStopPassesTheAgentGrace(t *testing.T) {
+	var gotGrace time.Duration
+	var gotName string
+	original := stopProcess
+	stopProcess = func(_ *slog.Logger, _ backend.Commander, _ <-chan backend.CmdStatus, grace time.Duration, name string) {
+		gotGrace = grace
+		gotName = name
+	}
+	t.Cleanup(func() { stopProcess = original })
+
+	b := &snmpTelemetryBackend{apiProtocol: "http", exec: defaultExec}
+	require.NoError(t, b.Configure(quietLogger(slog.LevelInfo), nil, map[string]any{}, commonsWithOTLP("collector:4317"), nil))
+	_, cancel := context.WithCancel(context.Background())
+	b.cancelFunc = cancel
+
+	require.NoError(t, b.Stop(context.Background()))
+
+	assert.Equal(t, backend.DefaultStopGracePeriod, gotGrace)
+	assert.Equal(t, "snmp_telemetry", gotName)
+}

--- a/agent/backend/snmptelemetry/snmp_telemetry.go
+++ b/agent/backend/snmptelemetry/snmp_telemetry.go
@@ -1,0 +1,400 @@
+package snmptelemetry
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	neturl "net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/config"
+	"github.com/netboxlabs/orb-agent/agent/filesmgr"
+	"github.com/netboxlabs/orb-agent/agent/policies"
+	"github.com/netboxlabs/orb-agent/agent/redact"
+)
+
+var _ backend.Backend = (*snmpTelemetryBackend)(nil)
+
+const (
+	versionTimeout      = 2
+	capabilitiesTimeout = 5
+	applyPolicyTimeout  = 10
+	removePolicyTimeout = 20
+	defaultExec         = "snmp-telemetry"
+	defaultAPIHost      = "localhost"
+	defaultAPIPort      = "8078"
+
+	// maxExportPeriodSeconds is the binary's own cap on --otel-export-period,
+	// one year. The binary exits on a larger value, which the agent would
+	// then restart in a loop, so the agent refuses it at configuration.
+	maxExportPeriodSeconds = 365 * 24 * 60 * 60
+)
+
+// stopProcess is backend.StopProcess behind a seam so a test can observe the
+// grace Stop hands the process.
+var stopProcess = backend.StopProcess
+
+// snmpTelemetryBackend runs the snmp-telemetry binary, which polls SNMP
+// devices and receives their traps under policies and exports metrics over
+// OTLP. Every metric leaves over OTLP, so the backend refuses to configure
+// without common.otlp.grpc rather than start a process with nowhere to export.
+//
+// It does not implement backend.PolicyStatusProvider. The agent uses that
+// provider only to feed each policy's runs into the policy repo, and a
+// telemetry policy is a continuous collector with no runs to report: its
+// status carries a name, a state and a last error. Implementing the provider
+// would poll the status endpoint every cycle to update nothing.
+type snmpTelemetryBackend struct {
+	logger     *slog.Logger
+	policyRepo policies.PolicyRepo
+	exec       string
+
+	apiHost     string
+	apiPort     string
+	apiProtocol string
+
+	otelEndpoint string
+
+	// Optional flags, passed only when non-empty. Reset on every Configure
+	// so a reconfiguration cannot carry a value over.
+	otelExportPeriod string
+	logLevel         string
+	logFormat        string
+	policyEnvVars    string
+	profilesRoot     string
+	profilesDir      string
+
+	startTime  time.Time
+	proc       backend.Commander
+	statusChan <-chan backend.CmdStatus
+	cancelFunc context.CancelFunc
+	ctx        context.Context
+}
+
+type info struct {
+	Version string `json:"version"`
+}
+
+// Register registers the snmp telemetry backend
+func Register() bool {
+	backend.Register("snmp_telemetry", &snmpTelemetryBackend{
+		apiProtocol: "http",
+		exec:        defaultExec,
+	})
+	return true
+}
+
+func parseExportPeriod(v any) (int, error) {
+	var n int
+
+	switch val := v.(type) {
+	case int:
+		n = val
+	case int64:
+		n = int(val)
+	case float64:
+		if val != float64(int64(val)) {
+			return 0, fmt.Errorf("otel_export_period must be a whole number, got %v", val)
+		}
+		n = int(val)
+	case string:
+		parsed, err := strconv.Atoi(val)
+		if err != nil {
+			return 0, fmt.Errorf("otel_export_period: invalid integer %q: %w", val, err)
+		}
+		n = parsed
+	default:
+		return 0, fmt.Errorf("otel_export_period must be an integer, got %T", v)
+	}
+
+	if n < 1 {
+		return 0, fmt.Errorf("otel_export_period must be >= 1, got %d", n)
+	}
+	if n > maxExportPeriodSeconds {
+		return 0, fmt.Errorf("otel_export_period must be <= %d, got %d", maxExportPeriodSeconds, n)
+	}
+
+	return n, nil
+}
+
+// parsePolicyEnvVars accepts the flag's own comma-separated string, or a YAML
+// list of names so an operator does not have to write the comma form by hand.
+func parsePolicyEnvVars(v any) (string, error) {
+	switch val := v.(type) {
+	case string:
+		return val, nil
+	case []string:
+		return strings.Join(val, ","), nil
+	case []any:
+		names := make([]string, 0, len(val))
+		for _, item := range val {
+			name, ok := item.(string)
+			if !ok {
+				return "", fmt.Errorf("policy_env_vars entries must be strings, got %T", item)
+			}
+			names = append(names, name)
+		}
+		return strings.Join(names, ","), nil
+	default:
+		return "", fmt.Errorf("policy_env_vars must be a string or a list of strings, got %T", v)
+	}
+}
+
+func (d *snmpTelemetryBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
+	cfg map[string]any, common config.BackendCommons, _ filesmgr.Manager,
+) error {
+	d.logger = logger.With("backend", "snmp_telemetry")
+	d.policyRepo = repo
+
+	if common.Otlp.Grpc == "" {
+		return errors.New("snmp_telemetry: common.otlp.grpc is required, the backend exports its metrics over OTLP")
+	}
+	d.otelEndpoint = common.Otlp.Grpc
+
+	d.apiHost = backend.ConfigValueOrDefault(cfg, "host", defaultAPIHost)
+	d.apiPort = backend.ConfigValueOrDefault(cfg, "port", defaultAPIPort)
+
+	d.otelExportPeriod = ""
+	if v, prs := cfg["otel_export_period"]; prs {
+		period, err := parseExportPeriod(v)
+		if err != nil {
+			return fmt.Errorf("snmp_telemetry: %w", err)
+		}
+		d.otelExportPeriod = strconv.Itoa(period)
+	}
+
+	d.logLevel = ""
+	if level, prs := cfg["log_level"].(string); prs && level != "" {
+		d.logLevel = level
+	} else if debug, prs := cfg["debug"].(bool); prs && debug {
+		d.logLevel = "DEBUG"
+	} else if logger.Enabled(context.Background(), slog.LevelDebug) {
+		d.logLevel = "DEBUG"
+	}
+
+	d.logFormat = backend.ConfigValueOrDefault(cfg, "log_format", "")
+
+	d.policyEnvVars = ""
+	if v, prs := cfg["policy_env_vars"]; prs {
+		names, err := parsePolicyEnvVars(v)
+		if err != nil {
+			return fmt.Errorf("snmp_telemetry: %w", err)
+		}
+		d.policyEnvVars = names
+	}
+
+	d.profilesRoot = backend.ConfigValueOrDefault(cfg, "snmp_profiles_root", "")
+	d.profilesDir = backend.ConfigValueOrDefault(cfg, "snmp_profiles_dir", "")
+
+	d.logger.Info("snmp-telemetry using OTLP endpoint", "endpoint", d.otelEndpoint)
+
+	return nil
+}
+
+func (d *snmpTelemetryBackend) Version() (string, error) {
+	var info info
+	url := fmt.Sprintf("%s://%s:%s/api/v1/status", d.apiProtocol, d.apiHost, d.apiPort)
+	err := backend.CommonRequest("snmp-telemetry", d.proc, d.logger, url, &info, http.MethodGet,
+		http.NoBody, "application/json", versionTimeout, "detail")
+	if err != nil {
+		return "", err
+	}
+	return info.Version, nil
+}
+
+// buildArgs lists the required flags first, then every optional flag that has
+// a value. An optional flag left out leaves the binary on its own default.
+func (d *snmpTelemetryBackend) buildArgs() []string {
+	args := []string{
+		"--host", d.apiHost,
+		"--port", d.apiPort,
+		"--otel-endpoint", d.otelEndpoint,
+	}
+	optional := []struct{ flag, value string }{
+		{"--otel-export-period", d.otelExportPeriod},
+		{"--log-level", d.logLevel},
+		{"--log-format", d.logFormat},
+		{"--policy-env-vars", d.policyEnvVars},
+		{"--snmp-profiles-root", d.profilesRoot},
+		{"--snmp-profiles-dir", d.profilesDir},
+	}
+	for _, opt := range optional {
+		if opt.value != "" {
+			args = append(args, opt.flag, opt.value)
+		}
+	}
+	return args
+}
+
+func (d *snmpTelemetryBackend) Start(ctx context.Context, cancelFunc context.CancelFunc) error {
+	d.startTime = time.Now()
+	d.cancelFunc = cancelFunc
+	d.ctx = ctx
+
+	args := d.buildArgs()
+
+	d.logger.Info("snmp-telemetry startup", "arguments", redact.Args(args))
+
+	return backend.StartProcess(backend.StartSpec{
+		Logger:         d.logger,
+		NameDisplay:    "snmp-telemetry",
+		NameUnderscore: "snmp_telemetry",
+		Exec:           d.exec,
+		Args:           args,
+		LogLine:        d.logLineAdapter,
+		SetProc: func(p backend.Commander, ch <-chan backend.CmdStatus) {
+			d.proc = p
+			d.statusChan = ch
+		},
+		ReadinessCheck: d.Version,
+	})
+}
+
+// logLineAdapter routes a streamed stdout/stderr line to the logfmt normalizer
+// with the level matching the source stream.
+func (d *snmpTelemetryBackend) logLineAdapter(line string, isStderr bool) {
+	fallback := slog.LevelInfo
+	if isStderr {
+		fallback = slog.LevelError
+	}
+
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return
+	}
+
+	msg := trimmed
+	attrs := []slog.Attr(nil)
+	level := fallback
+
+	if parsedMsg, parsedAttrs, parsedLevel, ok := backend.NormalizeLogfmtLine(trimmed, fallback); ok {
+		msg = parsedMsg
+		attrs = parsedAttrs
+		level = parsedLevel
+	}
+
+	ctx := d.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	d.logger.LogAttrs(ctx, level, msg, attrs...)
+}
+
+// Stop hands the process the agent's default grace. The binary sizes its own
+// shutdown, closing the trap sockets and then flushing the last OTLP export,
+// to that five seconds; a shorter grace would SIGKILL it with traps in hand
+// and the final export unsent.
+func (d *snmpTelemetryBackend) Stop(ctx context.Context) error {
+	d.logger.Info("routine call to stop snmp-telemetry", "routine", ctx.Value(config.ContextKey("routine")))
+	defer d.cancelFunc()
+	stopProcess(d.logger, d.proc, d.statusChan, backend.DefaultStopGracePeriod, "snmp_telemetry")
+	return nil
+}
+
+func (d *snmpTelemetryBackend) FullReset(ctx context.Context) error {
+	if state, _, _ := backend.GetRunningStatus(d.proc); state == backend.Running {
+		if err := d.Stop(ctx); err != nil {
+			d.logger.Error("failed to stop backend on restart procedure", "error", err)
+			return err
+		}
+	}
+	backendCtx, cancelFunc := context.WithCancel(context.WithValue(ctx, config.ContextKey("routine"), "snmp-telemetry"))
+	if err := d.Start(backendCtx, cancelFunc); err != nil {
+		d.logger.Error("failed to start backend on restart procedure", "error", err)
+		return err
+	}
+	return nil
+}
+
+func (d *snmpTelemetryBackend) GetStartTime() time.Time {
+	return d.startTime
+}
+
+func (d *snmpTelemetryBackend) GetCapabilities() (map[string]any, error) {
+	caps := make(map[string]any)
+	url := fmt.Sprintf("%s://%s:%s/api/v1/capabilities", d.apiProtocol, d.apiHost, d.apiPort)
+	err := backend.CommonRequest("snmp-telemetry", d.proc, d.logger, url, &caps, http.MethodGet,
+		http.NoBody, "application/json", capabilitiesTimeout, "detail")
+	if err != nil {
+		return nil, err
+	}
+	return caps, nil
+}
+
+func (d *snmpTelemetryBackend) GetRunningStatus() (backend.RunningStatus, string, error) {
+	runningStatus, errMsg, err := backend.GetRunningStatus(d.proc)
+	if runningStatus != backend.Running {
+		return runningStatus, errMsg, err
+	}
+	if _, aiErr := d.Version(); aiErr != nil {
+		return backend.BackendError, "process running, REST API unavailable", aiErr
+	}
+	return runningStatus, "", nil
+}
+
+func (d *snmpTelemetryBackend) GetInitialState() backend.RunningStatus {
+	return backend.Unknown
+}
+
+func (d *snmpTelemetryBackend) ApplyPolicy(data policies.PolicyData, updatePolicy bool) error {
+	if updatePolicy {
+		// The binary answers 409 for a name already running, so an update is a
+		// remove followed by a fresh apply.
+		if err := d.RemovePolicy(data); err != nil {
+			d.logger.Warn("policy failed to remove", "policy_id", data.ID,
+				"policy_name", data.Name, "error", err)
+		}
+	}
+
+	d.logger.Debug("snmp-telemetry policy apply", "policy_id", data.ID, "data", data.Data)
+
+	fullPolicy := map[string]any{
+		"policies": map[string]any{
+			data.Name: data.Data,
+		},
+	}
+
+	policyYaml, err := yaml.Marshal(fullPolicy)
+	if err != nil {
+		d.logger.Warn("policy yaml marshal failure", "policy_id", data.ID, "policy_name", data.Name)
+		return err
+	}
+
+	var resp map[string]any
+	url := fmt.Sprintf("%s://%s:%s/api/v1/policies", d.apiProtocol, d.apiHost, d.apiPort)
+	err = backend.CommonRequest("snmp-telemetry", d.proc, d.logger, url, &resp, http.MethodPost,
+		bytes.NewBuffer(policyYaml), "application/x-yaml", applyPolicyTimeout, "detail")
+	if err != nil {
+		d.logger.Warn("policy application failure", "policy_id", data.ID, "policy_name", data.Name)
+		return err
+	}
+
+	return nil
+}
+
+func (d *snmpTelemetryBackend) RemovePolicy(data policies.PolicyData) error {
+	d.logger.Debug("snmp-telemetry policy remove", "policy_id", data.ID)
+	var resp any
+	name := data.Name
+	// Policies are removed by name, so a renamed policy is removed under the
+	// name the binary knows it by.
+	if data.PreviousPolicyData != nil && data.PreviousPolicyData.Name != data.Name {
+		name = data.PreviousPolicyData.Name
+	}
+	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", d.apiProtocol, d.apiHost, d.apiPort, neturl.PathEscape(name))
+	err := backend.CommonRequest("snmp-telemetry", d.proc, d.logger, url, &resp, http.MethodDelete,
+		http.NoBody, "application/json", removePolicyTimeout, "detail")
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/agent/backend/snmptelemetry/snmp_telemetry.go
+++ b/agent/backend/snmptelemetry/snmp_telemetry.go
@@ -125,6 +125,21 @@ func parseExportPeriod(v any) (int, error) {
 	return n, nil
 }
 
+// optionalString reads a key that is either absent, or a string passed to the
+// binary verbatim. Any other type is refused rather than coerced, so a stray
+// YAML boolean does not reach a flag the binary would silently reinterpret.
+func optionalString(cfg map[string]any, key string) (string, error) {
+	v, prs := cfg[key]
+	if !prs {
+		return "", nil
+	}
+	str, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("%s must be a string, got %T", key, v)
+	}
+	return str, nil
+}
+
 // parsePolicyEnvVars accepts the flag's own comma-separated string, or a YAML
 // list of names so an operator does not have to write the comma form by hand.
 func parsePolicyEnvVars(v any) (string, error) {
@@ -159,8 +174,16 @@ func (d *snmpTelemetryBackend) Configure(logger *slog.Logger, repo policies.Poli
 	}
 	d.otelEndpoint = common.Otlp.Grpc
 
+	// An empty host would bind the unauthenticated API on every interface,
+	// since the binary joins "" with the port; keep it on loopback.
 	d.apiHost = backend.ConfigValueOrDefault(cfg, "host", defaultAPIHost)
+	if d.apiHost == "" {
+		d.apiHost = defaultAPIHost
+	}
 	d.apiPort = backend.ConfigValueOrDefault(cfg, "port", defaultAPIPort)
+	if d.apiPort == "" {
+		d.apiPort = defaultAPIPort
+	}
 
 	d.otelExportPeriod = ""
 	if v, prs := cfg["otel_export_period"]; prs {
@@ -171,16 +194,22 @@ func (d *snmpTelemetryBackend) Configure(logger *slog.Logger, repo policies.Poli
 		d.otelExportPeriod = strconv.Itoa(period)
 	}
 
-	d.logLevel = ""
-	if level, prs := cfg["log_level"].(string); prs && level != "" {
-		d.logLevel = level
-	} else if debug, prs := cfg["debug"].(bool); prs && debug {
-		d.logLevel = "DEBUG"
-	} else if logger.Enabled(context.Background(), slog.LevelDebug) {
-		d.logLevel = "DEBUG"
+	level, err := optionalString(cfg, "log_level")
+	if err != nil {
+		return fmt.Errorf("snmp_telemetry: %w", err)
+	}
+	d.logLevel = level
+	if d.logLevel == "" {
+		if debug, prs := cfg["debug"].(bool); prs && debug {
+			d.logLevel = "DEBUG"
+		} else if logger.Enabled(context.Background(), slog.LevelDebug) {
+			d.logLevel = "DEBUG"
+		}
 	}
 
-	d.logFormat = backend.ConfigValueOrDefault(cfg, "log_format", "")
+	if d.logFormat, err = optionalString(cfg, "log_format"); err != nil {
+		return fmt.Errorf("snmp_telemetry: %w", err)
+	}
 
 	d.policyEnvVars = ""
 	if v, prs := cfg["policy_env_vars"]; prs {
@@ -191,8 +220,12 @@ func (d *snmpTelemetryBackend) Configure(logger *slog.Logger, repo policies.Poli
 		d.policyEnvVars = names
 	}
 
-	d.profilesRoot = backend.ConfigValueOrDefault(cfg, "snmp_profiles_root", "")
-	d.profilesDir = backend.ConfigValueOrDefault(cfg, "snmp_profiles_dir", "")
+	if d.profilesRoot, err = optionalString(cfg, "snmp_profiles_root"); err != nil {
+		return fmt.Errorf("snmp_telemetry: %w", err)
+	}
+	if d.profilesDir, err = optionalString(cfg, "snmp_profiles_dir"); err != nil {
+		return fmt.Errorf("snmp_telemetry: %w", err)
+	}
 
 	d.logger.Info("snmp-telemetry using OTLP endpoint", "endpoint", d.otelEndpoint)
 
@@ -289,10 +322,12 @@ func (d *snmpTelemetryBackend) logLineAdapter(line string, isStderr bool) {
 	d.logger.LogAttrs(ctx, level, msg, attrs...)
 }
 
-// Stop hands the process the agent's default grace. The binary sizes its own
-// shutdown, closing the trap sockets and then flushing the last OTLP export,
-// to that five seconds; a shorter grace would SIGKILL it with traps in hand
-// and the final export unsent.
+// Stop hands the process the agent's default grace. The binary bounds the
+// part of its shutdown that carries data, closing the trap sockets and then
+// flushing the last OTLP export, to that same five seconds, and what follows
+// (cancelling collections, stopping its API) normally takes milliseconds. A
+// shorter grace would SIGKILL it with traps in hand and the final export
+// unsent; a kill after the flush costs nothing but a warning in the log.
 func (d *snmpTelemetryBackend) Stop(ctx context.Context) error {
 	d.logger.Info("routine call to stop snmp-telemetry", "routine", ctx.Value(config.ContextKey("routine")))
 	defer d.cancelFunc()

--- a/agent/backend/snmptelemetry/snmp_telemetry.go
+++ b/agent/backend/snmptelemetry/snmp_telemetry.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	neturl "net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -26,8 +28,12 @@ var _ backend.Backend = (*snmpTelemetryBackend)(nil)
 const (
 	versionTimeout      = 2
 	capabilitiesTimeout = 5
-	applyPolicyTimeout  = 10
-	removePolicyTimeout = 20
+	// The binary's DELETE blocks on the policy's scheduler shutdown, which it
+	// bounds at 24 seconds, and a POST for a name still stopping waits on that
+	// same shutdown; both timeouts clear that bound.
+	applyPolicyTimeout  = 30
+	removePolicyTimeout = 30
+	maxPort             = 65535
 	defaultExec         = "snmp-telemetry"
 	defaultAPIHost      = "localhost"
 	defaultAPIPort      = "8078"
@@ -92,6 +98,80 @@ func Register() bool {
 	return true
 }
 
+// envVarName is what --policy-env-vars accepts: variable names. A value that
+// is not a name, such as a secrets-manager reference the agent has resolved
+// into a secret, must not reach the command line.
+var envVarName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// readHost reads the API host. Absent, null or empty keeps the loopback
+// default: the binary joins an empty host with the port and binds every
+// interface, and its API has no authentication.
+func readHost(cfg map[string]any) (string, error) {
+	v, prs := cfg["host"]
+	if !prs || v == nil {
+		return defaultAPIHost, nil
+	}
+	host, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("host must be a string, got %T", v)
+	}
+	if host == "" {
+		return defaultAPIHost, nil
+	}
+	return host, nil
+}
+
+// readPort reads the API port as the binary's integer flag takes it. Absent,
+// null or empty keeps the default; anything the flag would reject is refused
+// here rather than at the binary's startup, which the agent would repeat.
+func readPort(cfg map[string]any) (string, error) {
+	v, prs := cfg["port"]
+	if !prs || v == nil || v == "" {
+		return defaultAPIPort, nil
+	}
+	var n int
+	switch val := v.(type) {
+	case int:
+		n = val
+	case int64:
+		n = int(val)
+	case float64:
+		if val != float64(int64(val)) {
+			return "", fmt.Errorf("port must be an integer from 1 to %d, got %v", maxPort, val)
+		}
+		n = int(val)
+	case string:
+		parsed, err := strconv.Atoi(val)
+		if err != nil {
+			return "", fmt.Errorf("port must be an integer from 1 to %d, got %q", maxPort, val)
+		}
+		n = parsed
+	default:
+		return "", fmt.Errorf("port must be an integer from 1 to %d, got %T", maxPort, v)
+	}
+	if n < 1 || n > maxPort {
+		return "", fmt.Errorf("port must be an integer from 1 to %d, got %d", maxPort, n)
+	}
+	return strconv.Itoa(n), nil
+}
+
+// readChoice reads an optional key whose value the binary matches
+// case-insensitively against a fixed set. An unrecognised value is refused
+// here because the binary falls back silently: any other level runs at
+// DEBUG and any other format is JSON.
+func readChoice(cfg map[string]any, key string, choices ...string) (string, error) {
+	value, err := optionalString(cfg, key)
+	if err != nil || value == "" {
+		return value, err
+	}
+	for _, choice := range choices {
+		if strings.EqualFold(value, choice) {
+			return value, nil
+		}
+	}
+	return "", fmt.Errorf("%s must be one of %s, got %q", key, strings.Join(choices, ", "), value)
+}
+
 func parseExportPeriod(v any) (int, error) {
 	var n int
 
@@ -143,13 +223,16 @@ func optionalString(cfg map[string]any, key string) (string, error) {
 // parsePolicyEnvVars accepts the flag's own comma-separated string, or a YAML
 // list of names so an operator does not have to write the comma form by hand.
 func parsePolicyEnvVars(v any) (string, error) {
+	var names []string
 	switch val := v.(type) {
 	case string:
-		return val, nil
+		if val == "" {
+			return "", nil
+		}
+		names = strings.Split(val, ",")
 	case []string:
-		return strings.Join(val, ","), nil
+		names = val
 	case []any:
-		names := make([]string, 0, len(val))
 		for _, item := range val {
 			name, ok := item.(string)
 			if !ok {
@@ -157,84 +240,117 @@ func parsePolicyEnvVars(v any) (string, error) {
 			}
 			names = append(names, name)
 		}
-		return strings.Join(names, ","), nil
 	default:
 		return "", fmt.Errorf("policy_env_vars must be a string or a list of strings, got %T", v)
 	}
+	for i, name := range names {
+		names[i] = strings.TrimSpace(name)
+		if !envVarName.MatchString(names[i]) {
+			return "", fmt.Errorf("policy_env_vars takes environment variable names, not %q", name)
+		}
+	}
+	return strings.Join(names, ","), nil
+}
+
+// settings is what Configure derives from the backend map. It is applied to
+// the backend only once every key has been read, so a refused reconfiguration
+// leaves the running backend, and the address the agent polls it on, as they
+// were.
+type settings struct {
+	apiHost, apiPort, otelEndpoint           string
+	otelExportPeriod, logLevel, logFormat    string
+	policyEnvVars, profilesRoot, profilesDir string
 }
 
 func (d *snmpTelemetryBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	cfg map[string]any, common config.BackendCommons, _ filesmgr.Manager,
 ) error {
-	d.logger = logger.With("backend", "snmp_telemetry")
-	d.policyRepo = repo
-
-	if common.Otlp.Grpc == "" {
-		return errors.New("snmp_telemetry: common.otlp.grpc is required, the backend exports its metrics over OTLP")
-	}
-	d.otelEndpoint = common.Otlp.Grpc
-
-	// An empty host would bind the unauthenticated API on every interface,
-	// since the binary joins "" with the port; keep it on loopback.
-	d.apiHost = backend.ConfigValueOrDefault(cfg, "host", defaultAPIHost)
-	if d.apiHost == "" {
-		d.apiHost = defaultAPIHost
-	}
-	d.apiPort = backend.ConfigValueOrDefault(cfg, "port", defaultAPIPort)
-	if d.apiPort == "" {
-		d.apiPort = defaultAPIPort
-	}
-
-	d.otelExportPeriod = ""
-	if v, prs := cfg["otel_export_period"]; prs {
-		period, err := parseExportPeriod(v)
-		if err != nil {
-			return fmt.Errorf("snmp_telemetry: %w", err)
-		}
-		d.otelExportPeriod = strconv.Itoa(period)
-	}
-
-	level, err := optionalString(cfg, "log_level")
+	st, err := readSettings(logger, cfg, common)
 	if err != nil {
 		return fmt.Errorf("snmp_telemetry: %w", err)
 	}
-	d.logLevel = level
-	if d.logLevel == "" {
-		if debug, prs := cfg["debug"].(bool); prs && debug {
-			d.logLevel = "DEBUG"
-		} else if logger.Enabled(context.Background(), slog.LevelDebug) {
-			d.logLevel = "DEBUG"
-		}
-	}
 
-	if d.logFormat, err = optionalString(cfg, "log_format"); err != nil {
-		return fmt.Errorf("snmp_telemetry: %w", err)
-	}
-
-	d.policyEnvVars = ""
-	if v, prs := cfg["policy_env_vars"]; prs {
-		names, err := parsePolicyEnvVars(v)
-		if err != nil {
-			return fmt.Errorf("snmp_telemetry: %w", err)
-		}
-		d.policyEnvVars = names
-	}
-
-	if d.profilesRoot, err = optionalString(cfg, "snmp_profiles_root"); err != nil {
-		return fmt.Errorf("snmp_telemetry: %w", err)
-	}
-	if d.profilesDir, err = optionalString(cfg, "snmp_profiles_dir"); err != nil {
-		return fmt.Errorf("snmp_telemetry: %w", err)
-	}
+	d.logger = logger.With("backend", "snmp_telemetry")
+	d.policyRepo = repo
+	d.apiHost = st.apiHost
+	d.apiPort = st.apiPort
+	d.otelEndpoint = st.otelEndpoint
+	d.otelExportPeriod = st.otelExportPeriod
+	d.logLevel = st.logLevel
+	d.logFormat = st.logFormat
+	d.policyEnvVars = st.policyEnvVars
+	d.profilesRoot = st.profilesRoot
+	d.profilesDir = st.profilesDir
 
 	d.logger.Info("snmp-telemetry using OTLP endpoint", "endpoint", d.otelEndpoint)
 
 	return nil
 }
 
+func readSettings(logger *slog.Logger, cfg map[string]any, common config.BackendCommons) (settings, error) {
+	var st settings
+	var err error
+
+	if common.Otlp.Grpc == "" {
+		return st, errors.New("common.otlp.grpc is required, the backend exports its metrics over OTLP")
+	}
+	st.otelEndpoint = common.Otlp.Grpc
+
+	if st.apiHost, err = readHost(cfg); err != nil {
+		return st, err
+	}
+	if st.apiPort, err = readPort(cfg); err != nil {
+		return st, err
+	}
+
+	if v, prs := cfg["otel_export_period"]; prs {
+		period, err := parseExportPeriod(v)
+		if err != nil {
+			return st, err
+		}
+		st.otelExportPeriod = strconv.Itoa(period)
+	}
+
+	if st.logLevel, err = readChoice(cfg, "log_level", "DEBUG", "INFO", "WARN", "ERROR"); err != nil {
+		return st, err
+	}
+	if st.logLevel == "" {
+		if debug, prs := cfg["debug"].(bool); prs && debug {
+			st.logLevel = "DEBUG"
+		} else if logger.Enabled(context.Background(), slog.LevelDebug) {
+			st.logLevel = "DEBUG"
+		}
+	}
+
+	if st.logFormat, err = readChoice(cfg, "log_format", "TEXT", "JSON"); err != nil {
+		return st, err
+	}
+
+	if v, prs := cfg["policy_env_vars"]; prs {
+		if st.policyEnvVars, err = parsePolicyEnvVars(v); err != nil {
+			return st, err
+		}
+	}
+
+	if st.profilesRoot, err = optionalString(cfg, "snmp_profiles_root"); err != nil {
+		return st, err
+	}
+	if st.profilesDir, err = optionalString(cfg, "snmp_profiles_dir"); err != nil {
+		return st, err
+	}
+
+	return st, nil
+}
+
+// apiURL joins the API address the way the binary binds it, so an IPv6 host
+// is bracketed.
+func (d *snmpTelemetryBackend) apiURL(path string) string {
+	return fmt.Sprintf("%s://%s/api/v1/%s", d.apiProtocol, net.JoinHostPort(d.apiHost, d.apiPort), path)
+}
+
 func (d *snmpTelemetryBackend) Version() (string, error) {
 	var info info
-	url := fmt.Sprintf("%s://%s:%s/api/v1/status", d.apiProtocol, d.apiHost, d.apiPort)
+	url := d.apiURL("status")
 	err := backend.CommonRequest("snmp-telemetry", d.proc, d.logger, url, &info, http.MethodGet,
 		http.NoBody, "application/json", versionTimeout, "detail")
 	if err != nil {
@@ -268,6 +384,12 @@ func (d *snmpTelemetryBackend) buildArgs() []string {
 }
 
 func (d *snmpTelemetryBackend) Start(ctx context.Context, cancelFunc context.CancelFunc) error {
+	// A registered backend the agent never configured has no logger and no
+	// arguments; a fleet full reset walks the whole registry and would reach
+	// it, so refuse rather than start a process on empty flags.
+	if d.logger == nil {
+		return errors.New("snmp_telemetry: started before it was configured")
+	}
 	d.startTime = time.Now()
 	d.cancelFunc = cancelFunc
 	d.ctx = ctx
@@ -329,13 +451,21 @@ func (d *snmpTelemetryBackend) logLineAdapter(line string, isStderr bool) {
 // shorter grace would SIGKILL it with traps in hand and the final export
 // unsent; a kill after the flush costs nothing but a warning in the log.
 func (d *snmpTelemetryBackend) Stop(ctx context.Context) error {
+	if d.cancelFunc != nil {
+		defer d.cancelFunc()
+	}
+	if d.proc == nil {
+		return nil
+	}
 	d.logger.Info("routine call to stop snmp-telemetry", "routine", ctx.Value(config.ContextKey("routine")))
-	defer d.cancelFunc()
 	stopProcess(d.logger, d.proc, d.statusChan, backend.DefaultStopGracePeriod, "snmp_telemetry")
 	return nil
 }
 
 func (d *snmpTelemetryBackend) FullReset(ctx context.Context) error {
+	if d.logger == nil {
+		return errors.New("snmp_telemetry: reset before it was configured")
+	}
 	if state, _, _ := backend.GetRunningStatus(d.proc); state == backend.Running {
 		if err := d.Stop(ctx); err != nil {
 			d.logger.Error("failed to stop backend on restart procedure", "error", err)
@@ -356,7 +486,7 @@ func (d *snmpTelemetryBackend) GetStartTime() time.Time {
 
 func (d *snmpTelemetryBackend) GetCapabilities() (map[string]any, error) {
 	caps := make(map[string]any)
-	url := fmt.Sprintf("%s://%s:%s/api/v1/capabilities", d.apiProtocol, d.apiHost, d.apiPort)
+	url := d.apiURL("capabilities")
 	err := backend.CommonRequest("snmp-telemetry", d.proc, d.logger, url, &caps, http.MethodGet,
 		http.NoBody, "application/json", capabilitiesTimeout, "detail")
 	if err != nil {
@@ -405,7 +535,7 @@ func (d *snmpTelemetryBackend) ApplyPolicy(data policies.PolicyData, updatePolic
 	}
 
 	var resp map[string]any
-	url := fmt.Sprintf("%s://%s:%s/api/v1/policies", d.apiProtocol, d.apiHost, d.apiPort)
+	url := d.apiURL("policies")
 	err = backend.CommonRequest("snmp-telemetry", d.proc, d.logger, url, &resp, http.MethodPost,
 		bytes.NewBuffer(policyYaml), "application/x-yaml", applyPolicyTimeout, "detail")
 	if err != nil {
@@ -425,7 +555,7 @@ func (d *snmpTelemetryBackend) RemovePolicy(data policies.PolicyData) error {
 	if data.PreviousPolicyData != nil && data.PreviousPolicyData.Name != data.Name {
 		name = data.PreviousPolicyData.Name
 	}
-	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", d.apiProtocol, d.apiHost, d.apiPort, neturl.PathEscape(name))
+	url := d.apiURL("policies/" + neturl.PathEscape(name))
 	err := backend.CommonRequest("snmp-telemetry", d.proc, d.logger, url, &resp, http.MethodDelete,
 		http.NoBody, "application/json", removePolicyTimeout, "detail")
 	if err != nil {

--- a/agent/backend/snmptelemetry/snmp_telemetry.go
+++ b/agent/backend/snmptelemetry/snmp_telemetry.go
@@ -265,7 +265,7 @@ type settings struct {
 func (d *snmpTelemetryBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
 	cfg map[string]any, common config.BackendCommons, _ filesmgr.Manager,
 ) error {
-	st, err := readSettings(logger, cfg, common)
+	st, err := readSettings(cfg, common)
 	if err != nil {
 		return fmt.Errorf("snmp_telemetry: %w", err)
 	}
@@ -287,7 +287,7 @@ func (d *snmpTelemetryBackend) Configure(logger *slog.Logger, repo policies.Poli
 	return nil
 }
 
-func readSettings(logger *slog.Logger, cfg map[string]any, common config.BackendCommons) (settings, error) {
+func readSettings(cfg map[string]any, common config.BackendCommons) (settings, error) {
 	var st settings
 	var err error
 
@@ -314,10 +314,14 @@ func readSettings(logger *slog.Logger, cfg map[string]any, common config.Backend
 	if st.logLevel, err = readChoice(cfg, "log_level", "DEBUG", "INFO", "WARN", "ERROR"); err != nil {
 		return st, err
 	}
+	// The agent's debug flag comes through the commons. The logger is not
+	// consulted: when OTLP log export is on, the agent wraps it in a handler
+	// that accepts debug records whatever the console level, so asking the
+	// logger would put every OTLP-exporting agent's backend at DEBUG.
 	if st.logLevel == "" {
 		if debug, prs := cfg["debug"].(bool); prs && debug {
 			st.logLevel = "DEBUG"
-		} else if logger.Enabled(context.Background(), slog.LevelDebug) {
+		} else if common.Debug {
 			st.logLevel = "DEBUG"
 		}
 	}
@@ -520,7 +524,10 @@ func (d *snmpTelemetryBackend) ApplyPolicy(data policies.PolicyData, updatePolic
 		}
 	}
 
-	d.logger.Debug("snmp-telemetry policy apply", "policy_id", data.ID, "data", data.Data)
+	// The body carries solved secrets (community, passphrases), and a debug
+	// record reaches the OTLP log collector when export is on, so only the
+	// policy's identity is logged.
+	d.logger.Debug("snmp-telemetry policy apply", "policy_id", data.ID, "policy_name", data.Name)
 
 	fullPolicy := map[string]any{
 		"policies": map[string]any{

--- a/agent/backend/snmptelemetry/snmp_telemetry.go
+++ b/agent/backend/snmptelemetry/snmp_telemetry.go
@@ -417,8 +417,10 @@ func (d *snmpTelemetryBackend) Start(ctx context.Context, cancelFunc context.Can
 	})
 }
 
-// logLineAdapter routes a streamed stdout/stderr line to the logfmt normalizer
-// with the level matching the source stream.
+// logLineAdapter routes a streamed stdout/stderr line to the agent's logger
+// with the level matching the source stream. The binary writes logfmt under
+// its TEXT format and one JSON object per line under JSON; both are parsed,
+// so a WARN or ERROR record keeps its severity and attributes either way.
 func (d *snmpTelemetryBackend) logLineAdapter(line string, isStderr bool) {
 	fallback := slog.LevelInfo
 	if isStderr {
@@ -435,6 +437,10 @@ func (d *snmpTelemetryBackend) logLineAdapter(line string, isStderr bool) {
 	level := fallback
 
 	if parsedMsg, parsedAttrs, parsedLevel, ok := backend.NormalizeLogfmtLine(trimmed, fallback); ok {
+		msg = parsedMsg
+		attrs = parsedAttrs
+		level = parsedLevel
+	} else if parsedMsg, parsedAttrs, parsedLevel, ok := backend.NormalizeJSONLine(trimmed, fallback); ok {
 		msg = parsedMsg
 		attrs = parsedAttrs
 		level = parsedLevel

--- a/agent/backend/snmptelemetry/snmp_telemetry_test.go
+++ b/agent/backend/snmptelemetry/snmp_telemetry_test.go
@@ -97,7 +97,9 @@ func TestSnmpTelemetryBackendStart(t *testing.T) {
 	require.NoError(t, err)
 
 	mockCmd := &mocks.MockCmd{}
-	mocks.SetupSuccessfulProcess(mockCmd, 12345)
+	// PID 0: a stray Stop on the mock's single status would wait out the
+	// grace, but StopProcess skips the SIGKILL escalation for an invalid pid.
+	mocks.SetupSuccessfulProcess(mockCmd, 0)
 
 	overrideNewCmdOptions(t, mockCmd, func(options backend.CmdOptions, name string, args []string) {
 		assert.Equal(t, "snmp-telemetry", name)
@@ -144,11 +146,10 @@ func TestSnmpTelemetryBackendStart(t *testing.T) {
 	assert.Equal(t, backend.Running, status)
 	assert.Empty(t, msg)
 
-	// A name with a slash: PathEscape turns it into one path segment,
-	// core%2Fmetrics, while the raw name would be a different route.
+	// A name the binary accepts (one path segment) that still needs escaping.
 	policy := policies.PolicyData{
 		ID:   "id-1",
-		Name: "core/metrics",
+		Name: "core metrics",
 		Data: map[string]any{
 			"config": map[string]any{"metrics_interval": 60},
 			"scope":  map[string]any{"targets": []any{map[string]any{"host": "10.0.0.1"}}},
@@ -167,11 +168,11 @@ func TestSnmpTelemetryBackendStart(t *testing.T) {
 	assert.Equal(t, http.MethodPost, reqs[0].method)
 	assert.Equal(t, "/api/v1/policies", reqs[0].path)
 	assert.Equal(t, "application/x-yaml", reqs[0].contentType)
-	assert.Contains(t, reqs[0].body, "policies:\n    core/metrics:\n")
+	assert.Contains(t, reqs[0].body, "policies:\n    core metrics:\n")
 	assert.Contains(t, reqs[0].body, "metrics_interval: 60")
 
 	assert.Equal(t, http.MethodDelete, reqs[1].method)
-	assert.Equal(t, "/api/v1/policies/core%2Fmetrics", reqs[1].path, "an update removes the previous name first, escaped as one segment")
+	assert.Equal(t, "/api/v1/policies/core%20metrics", reqs[1].path, "an update removes the previous name first, escaped")
 
 	assert.Equal(t, http.MethodPost, reqs[2].method)
 	assert.Contains(t, reqs[2].body, "policies:\n    core:\n")
@@ -189,9 +190,48 @@ func TestSnmpTelemetryBackendStart(t *testing.T) {
 	assert.Equal(t, "process running, REST API unavailable", msg)
 
 	// No trailing Stop: the mock delivers exactly one process status, which
-	// FullReset's Stop consumed. A second Stop would wait out the whole grace
-	// on an empty channel and then SIGKILL the mock's PID on this host.
+	// FullReset's Stop consumed; a second Stop would wait out the whole grace.
 	mockCmd.AssertExpectations(t)
+}
+
+// The binary validates policy names and bodies itself and answers 400 with a
+// detail; that detail is the error the agent surfaces.
+func TestSnmpTelemetryBackendSurfacesTheServersRejection(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/status" {
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(statusResponse{Version: "1.0.0"})
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"detail": `policy name must be a single path segment, so it may not contain "/": "core/metrics"`})
+	}))
+	defer server.Close()
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 0)
+	overrideNewCmdOptions(t, mockCmd, nil)
+
+	assert.True(t, snmptelemetry.Register())
+	be := backend.GetBackend("snmp_telemetry")
+	var commons config.BackendCommons
+	commons.Otlp.Grpc = "collector:4317"
+	require.NoError(t, be.Configure(slog.New(slog.NewTextHandler(os.Stdout, nil)), nil, map[string]any{
+		"host": serverURL.Hostname(), "port": serverURL.Port(),
+	}, commons, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, be.Start(ctx, cancel))
+
+	err = be.ApplyPolicy(policies.PolicyData{ID: "id-2", Name: "core/metrics", Data: map[string]any{}}, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "policy name must be a single path segment")
+
+	require.NoError(t, be.Stop(ctx))
 }
 
 func TestSnmpTelemetryBackendCompleted(t *testing.T) {

--- a/agent/backend/snmptelemetry/snmp_telemetry_test.go
+++ b/agent/backend/snmptelemetry/snmp_telemetry_test.go
@@ -1,0 +1,241 @@
+package snmptelemetry_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/backend/mocks"
+	"github.com/netboxlabs/orb-agent/agent/backend/snmptelemetry"
+	"github.com/netboxlabs/orb-agent/agent/config"
+	"github.com/netboxlabs/orb-agent/agent/policies"
+)
+
+type statusResponse struct {
+	Version       string `json:"version"`
+	StartTime     string `json:"start_time"`
+	UpTimeSeconds int64  `json:"up_time_seconds"`
+}
+
+// apiRecorder answers the binary's API and records every policy request.
+// Handlers run on the server's goroutines, so failures are reported with
+// t.Error rather than require, which must not leave the test goroutine.
+type apiRecorder struct {
+	mu       sync.Mutex
+	requests []recorded
+}
+
+type recorded struct {
+	method      string
+	path        string
+	contentType string
+	body        string
+}
+
+func (a *apiRecorder) handler(t *testing.T) http.HandlerFunc {
+	encode := func(w http.ResponseWriter, v any) {
+		w.WriteHeader(http.StatusOK)
+		if err := json.NewEncoder(w).Encode(v); err != nil {
+			t.Error(err)
+		}
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/status":
+			encode(w, statusResponse{Version: "1.0.0", StartTime: "2026-09-04T12:00:00Z", UpTimeSeconds: 42})
+		case r.URL.Path == "/api/v1/capabilities":
+			// The binary's body: {"capabilities": ["targets"]}.
+			encode(w, map[string]any{"capabilities": []string{"targets"}})
+		case strings.HasPrefix(r.URL.Path, "/api/v1/policies"):
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Error(err)
+			}
+			a.mu.Lock()
+			a.requests = append(a.requests, recorded{
+				method: r.Method, path: r.URL.EscapedPath(),
+				contentType: r.Header.Get("Content-Type"), body: string(body),
+			})
+			a.mu.Unlock()
+			encode(w, map[string]any{"message": "ok"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}
+}
+
+func (a *apiRecorder) policyRequests() []recorded {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return append([]recorded(nil), a.requests...)
+}
+
+func TestSnmpTelemetryBackendStart(t *testing.T) {
+	rec := &apiRecorder{}
+	server := httptest.NewServer(rec.handler(t))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 12345)
+
+	overrideNewCmdOptions(t, mockCmd, func(options backend.CmdOptions, name string, args []string) {
+		assert.Equal(t, "snmp-telemetry", name)
+		assert.False(t, options.Buffered)
+		assert.True(t, options.Streaming)
+		assert.Equal(t, []string{
+			"--host", serverURL.Hostname(),
+			"--port", serverURL.Port(),
+			"--otel-endpoint", "grpc://collector:4317",
+			"--log-level", "INFO",
+		}, args)
+	})
+
+	assert.True(t, snmptelemetry.Register())
+	assert.True(t, backend.HaveBackend("snmp_telemetry"))
+
+	be := backend.GetBackend("snmp_telemetry")
+	assert.Equal(t, backend.Unknown, be.GetInitialState())
+
+	var commons config.BackendCommons
+	commons.Otlp.Grpc = "grpc://collector:4317"
+
+	require.NoError(t, be.Configure(logger, repo, map[string]any{
+		"host":      serverURL.Hostname(),
+		"port":      serverURL.Port(),
+		"log_level": "INFO",
+	}, commons, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, be.Start(ctx, cancel))
+
+	version, err := be.Version()
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.0", version)
+
+	caps, err := be.GetCapabilities()
+	require.NoError(t, err)
+	assert.Equal(t, []any{"targets"}, caps["capabilities"])
+
+	status, msg, err := be.GetRunningStatus()
+	require.NoError(t, err)
+	assert.Equal(t, backend.Running, status)
+	assert.Empty(t, msg)
+
+	// A name with a slash: PathEscape turns it into one path segment,
+	// core%2Fmetrics, while the raw name would be a different route.
+	policy := policies.PolicyData{
+		ID:   "id-1",
+		Name: "core/metrics",
+		Data: map[string]any{
+			"config": map[string]any{"metrics_interval": 60},
+			"scope":  map[string]any{"targets": []any{map[string]any{"host": "10.0.0.1"}}},
+		},
+	}
+	require.NoError(t, be.ApplyPolicy(policy, false))
+
+	renamed := policies.PolicyData{ID: "id-1", Name: "core", Data: policy.Data, PreviousPolicyData: &policy}
+	require.NoError(t, be.ApplyPolicy(renamed, true))
+
+	require.NoError(t, be.RemovePolicy(policies.PolicyData{ID: "id-1", Name: "core"}))
+
+	reqs := rec.policyRequests()
+	require.Len(t, reqs, 4, "apply, then remove-and-apply for the update, then remove")
+
+	assert.Equal(t, http.MethodPost, reqs[0].method)
+	assert.Equal(t, "/api/v1/policies", reqs[0].path)
+	assert.Equal(t, "application/x-yaml", reqs[0].contentType)
+	assert.Contains(t, reqs[0].body, "policies:\n    core/metrics:\n")
+	assert.Contains(t, reqs[0].body, "metrics_interval: 60")
+
+	assert.Equal(t, http.MethodDelete, reqs[1].method)
+	assert.Equal(t, "/api/v1/policies/core%2Fmetrics", reqs[1].path, "an update removes the previous name first, escaped as one segment")
+
+	assert.Equal(t, http.MethodPost, reqs[2].method)
+	assert.Contains(t, reqs[2].body, "policies:\n    core:\n")
+
+	assert.Equal(t, http.MethodDelete, reqs[3].method)
+	assert.Equal(t, "/api/v1/policies/core", reqs[3].path, "a remove without rename history uses the current name")
+
+	require.NoError(t, be.FullReset(ctx))
+
+	// With the API gone the process still runs, and the backend says so.
+	server.Close()
+	status, msg, err = be.GetRunningStatus()
+	assert.Error(t, err)
+	assert.Equal(t, backend.BackendError, status)
+	assert.Equal(t, "process running, REST API unavailable", msg)
+
+	// No trailing Stop: the mock delivers exactly one process status, which
+	// FullReset's Stop consumed. A second Stop would wait out the whole grace
+	// on an empty channel and then SIGKILL the mock's PID on this host.
+	mockCmd.AssertExpectations(t)
+}
+
+func TestSnmpTelemetryBackendCompleted(t *testing.T) {
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupCompletedProcess(mockCmd, 0, nil)
+
+	overrideNewCmdOptions(t, mockCmd, nil)
+
+	assert.True(t, snmptelemetry.Register())
+	be := backend.GetBackend("snmp_telemetry")
+
+	var commons config.BackendCommons
+	commons.Otlp.Grpc = "collector:4317"
+	require.NoError(t, be.Configure(slog.Default(), nil, map[string]any{"host": "invalid-host"}, commons, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	assert.Error(t, be.Start(ctx, cancel))
+
+	mockCmd.AssertExpectations(t)
+}
+
+func TestSnmpTelemetryBackendRefusesToConfigureWithoutOTLP(t *testing.T) {
+	assert.True(t, snmptelemetry.Register())
+	be := backend.GetBackend("snmp_telemetry")
+
+	err := be.Configure(slog.Default(), nil, map[string]any{}, config.BackendCommons{}, nil)
+	require.Error(t, err)
+	assert.Equal(t, "snmp_telemetry: common.otlp.grpc is required, the backend exports its metrics over OTLP", err.Error())
+}
+
+func overrideNewCmdOptions(t *testing.T, cmd backend.Commander, assertFn func(options backend.CmdOptions, name string, args []string)) {
+	t.Helper()
+
+	original := backend.NewCmdOptions
+	backend.NewCmdOptions = func(options backend.CmdOptions, name string, args ...string) backend.Commander {
+		if assertFn != nil {
+			assertFn(options, name, args)
+		}
+		return cmd
+	}
+
+	t.Cleanup(func() {
+		backend.NewCmdOptions = original
+	})
+}

--- a/agent/backend/snmptelemetry/snmp_telemetry_test.go
+++ b/agent/backend/snmptelemetry/snmp_telemetry_test.go
@@ -1,6 +1,7 @@
 package snmptelemetry_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -192,6 +193,49 @@ func TestSnmpTelemetryBackendStart(t *testing.T) {
 	// No trailing Stop: the mock delivers exactly one process status, which
 	// FullReset's Stop consumed; a second Stop would wait out the whole grace.
 	mockCmd.AssertExpectations(t)
+}
+
+// A policy body reaches the agent with its secrets solved, and a debug record
+// reaches the OTLP log collector when export is on, so the apply log must not
+// carry the body.
+func TestSnmpTelemetryBackendDoesNotLogPolicyCredentials(t *testing.T) {
+	rec := &apiRecorder{}
+	server := httptest.NewServer(rec.handler(t))
+	defer server.Close()
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 0)
+	overrideNewCmdOptions(t, mockCmd, nil)
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	assert.True(t, snmptelemetry.Register())
+	be := backend.GetBackend("snmp_telemetry")
+	var commons config.BackendCommons
+	commons.Otlp.Grpc = "collector:4317"
+	require.NoError(t, be.Configure(logger, nil, map[string]any{
+		"host": serverURL.Hostname(), "port": serverURL.Port(),
+	}, commons, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, be.Start(ctx, cancel))
+
+	require.NoError(t, be.ApplyPolicy(policies.PolicyData{ID: "id-3", Name: "core", Data: map[string]any{
+		"scope": map[string]any{"authentication": map[string]any{
+			"community": "c0mmun1ty-secret", "auth_passphrase": "auth-secret", "priv_passphrase": "priv-secret",
+		}},
+	}}, false))
+	require.NoError(t, be.Stop(ctx))
+
+	out := logs.String()
+	assert.Contains(t, out, "snmp-telemetry policy apply", "the apply is still logged")
+	for _, secret := range []string{"c0mmun1ty-secret", "auth-secret", "priv-secret"} {
+		assert.NotContains(t, out, secret)
+	}
 }
 
 // The binary validates policy names and bodies itself and answers 400 with a

--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -83,6 +83,25 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     go build -ldflags="-s -w" -trimpath -o /usr/local/bin/gnmi-discovery ./cmd/main.go
 
 ########################################################################
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-trixie AS snmp-telemetry
+
+WORKDIR /src/snmp-telemetry
+
+COPY orb-telemetry/snmp-telemetry/ .
+
+ARG TARGETOS TARGETARCH
+# Stamp the backend version: its version package go:embeds version/BUILD_*.txt.
+ARG SNMP_TELEMETRY_VERSION=0.0.0
+ARG BUILD_COMMIT=unknown
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    echo "${SNMP_TELEMETRY_VERSION}" > version/BUILD_VERSION.txt && \
+    echo "${BUILD_COMMIT}" > version/BUILD_COMMIT.txt && \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -ldflags="-s -w" -trimpath -o /usr/local/bin/snmp-telemetry ./cmd/main.go
+
+########################################################################
 FROM netboxlabs/pktvisor:${PKTVISOR_TAG} AS pktvisor
 
 ########################################################################
@@ -167,6 +186,8 @@ COPY --from=network-discovery /usr/local/bin/network-discovery /usr/local/bin/ne
 COPY --from=snmp-discovery /usr/local/bin/snmp-discovery /usr/local/bin/snmp-discovery
 
 COPY --from=gnmi-discovery /usr/local/bin/gnmi-discovery /usr/local/bin/gnmi-discovery
+
+COPY --from=snmp-telemetry /usr/local/bin/snmp-telemetry /usr/local/bin/snmp-telemetry
 
 COPY --from=builder /build/orb-agent /usr/local/bin/orb-agent
 COPY --from=builder /src/orb-agent/agent/docker/orb-agent-entry.sh /usr/local/bin/orb-agent-entry.sh

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/backend/opentelemetryinfinity"
 	"github.com/netboxlabs/orb-agent/agent/backend/pktvisor"
 	"github.com/netboxlabs/orb-agent/agent/backend/snmpdiscovery"
+	"github.com/netboxlabs/orb-agent/agent/backend/snmptelemetry"
 	"github.com/netboxlabs/orb-agent/agent/backend/worker"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/redact"
@@ -39,6 +40,7 @@ func init() {
 	networkdiscovery.Register()
 	opentelemetryinfinity.Register()
 	snmpdiscovery.Register()
+	snmptelemetry.Register()
 	pktvisor.Register()
 	worker.Register()
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/config"
 )
 
@@ -76,4 +77,9 @@ func TestApplyConfigDebug_BothOnNoDuplicateAnnounce(t *testing.T) {
 	assert.Equal(t, slog.LevelDebug, level.Level())
 	assert.NotContains(t, buf.String(), "debug logging enabled via config file",
 		"flag already enabled debug; config adds nothing to announce")
+}
+
+// init registers every bundled backend; snmp_telemetry must be among them.
+func TestInitRegistersSnmpTelemetry(t *testing.T) {
+	assert.True(t, backend.HaveBackend("snmp_telemetry"))
 }

--- a/docs/backends/snmp_telemetry.md
+++ b/docs/backends/snmp_telemetry.md
@@ -1,0 +1,102 @@
+# SNMP Telemetry
+The SNMP telemetry backend polls SNMP devices under policies and exports the collected metrics over OTLP through the agent's `common.otlp` settings. A policy may also receive SNMP traps and informs from the devices it names and count them. It ingests nothing into Diode.
+
+The backend's own [README](../../orb-telemetry/snmp-telemetry/README.md) is the reference for the metric model, the bundled SNMP profiles, the security posture and trap reception. This page covers how to reach the backend through the agent.
+
+## Configuration
+`common.otlp.grpc` is required: every metric the backend produces leaves over OTLP. With `snmp_telemetry` enabled and no endpoint, the agent reports the missing setting and refuses to start, the way it does for any backend that fails to configure. Every other key is optional.
+
+```yaml
+orb:
+  backends:
+    common:
+      otlp:
+        grpc: "grpc://otel-collector:4317"
+    snmp_telemetry:
+      host: 127.0.0.1                    # default localhost
+      port: 8078                         # default 8078
+      log_level: INFO                    # default INFO (DEBUG, INFO, WARN, ERROR)
+      log_format: TEXT                   # default TEXT (TEXT, JSON)
+      otel_export_period: 10             # seconds between exports, default 10
+      policy_env_vars: [SNMP_COMMUNITY]  # unset by default: every ${NAME} reference in a policy is refused
+      snmp_profiles_root: /opt/orb/profiles   # unset by default: every per-policy profiles_dir is refused
+      snmp_profiles_dir: /opt/orb/overrides   # unset by default: only the bundled profiles are used; the directory must exist
+```
+
+| Parameter | Type | Default | Description |
+|:---------:|:----:|:-------:|:------------|
+| host | str | `localhost` | Address the backend's API binds. The agent reaches it on loopback; the API has no authentication, so widen it only behind your own access control. |
+| port | int | 8078 | Port of the backend's API. |
+| log_level | str | `INFO` | `DEBUG`, `INFO`, `WARN` or `ERROR`. The agent passes `DEBUG` when the backend has `debug: true` or the agent itself logs at debug. |
+| log_format | str | `TEXT` | `TEXT` or `JSON`. |
+| otel_export_period | int | 10 | Seconds between OTLP exports, 1 to 31536000. |
+| policy_env_vars | str or list | unset | Environment variable names a policy may read through `${NAME}` in `community`, `username`, `auth_passphrase` or `priv_passphrase`. A comma-separated string or a list. Unset refuses every reference. |
+| snmp_profiles_root | str | unset | Directory a policy's own `profiles_dir` must resolve inside. Unset refuses every per-policy `profiles_dir`. |
+| snmp_profiles_dir | str | unset | Directory of profile YAML files overlaid on the bundled profiles. |
+
+The environment variables `policy_env_vars` names must be present in the agent's environment; the backend inherits it.
+
+## Policy
+A policy names the targets to poll and the SNMP credentials to use. `metrics_interval` is the number of seconds between collection runs for every target in the policy.
+
+```yaml
+orb:
+  policies:
+    snmp_telemetry:
+      core_metrics:
+        config:
+          metrics_interval: 60
+        scope:
+          targets:
+            - host: "192.168.1.1"
+            - host: "192.168.1.2"
+          authentication:
+            protocol_version: "v2c"
+            community: "public"
+```
+
+A policy receives traps by declaring the address they arrive on:
+
+```yaml
+orb:
+  policies:
+    snmp_telemetry:
+      core_traps:
+        scope:
+          authentication:
+            protocol_version: "v3"
+            security_level: "authPriv"
+            username: "netbox-poller"
+            auth_protocol: "SHA"
+            auth_passphrase: "authpass123"
+            priv_protocol: "AES"
+            priv_passphrase: "privpass123"
+          targets:
+            - host: "10.0.0.0/24"
+          traps:
+            listen: "0.0.0.0:162"
+```
+
+A credential may be read from the agent's environment as `${NAME}` only when `policy_env_vars` in the backend configuration names it; otherwise the policy is refused.
+
+Three rules matter when writing agent config:
+
+- Policies naming the same `listen` string share one socket, opened when the first of them starts and closed when the last stops.
+- The string is the identity. `0.0.0.0:162` and `:162` are two bind attempts at one port, and the second policy fails to apply with the bind error, which the agent logs. Spell `listen` identically across policies.
+- A policy may omit `metrics_interval` to receive traps only, as `core_traps` above does. Its targets are still expanded: they are the addresses the socket accepts traps from.
+
+The full parameter tables are in the backend README under [Policy Configuration](../../orb-telemetry/snmp-telemetry/README.md#policy-configuration) and [Receiving traps](../../orb-telemetry/snmp-telemetry/README.md#receiving-traps).
+
+## Metrics
+Poll metrics are described in the backend README. Trap reception adds three:
+
+- `snmp.traps_received{device_ip, policy, trap_name, version}` counts traps and informs attributed to a policy.
+- `snmp.traps_dropped{reason}` counts datagrams that produced no trap.
+- `snmp.traps_datagrams` counts every datagram read from any trap socket.
+
+The `trap_name` set and the drop reasons are listed under [Receiving traps](../../orb-telemetry/snmp-telemetry/README.md#receiving-traps).
+
+## Traps and the container
+The trap socket is the one listener in the backend that must be reachable from the device network. With `--net=host` the port a policy's `listen` names is already exposed. In bridge mode publish it, `-p 162:162/udp` for a policy listening on 162. The container runs as root by default, the image sets no other user, so binding a port below 1024 inside it needs no capability.
+
+What a policy body can do through `listen`, and why the listen address is not access control, is described under [Binding and access control](../../orb-telemetry/snmp-telemetry/README.md#binding-and-access-control) and [Receiving traps](../../orb-telemetry/snmp-telemetry/README.md#receiving-traps).

--- a/docs/backends/snmp_telemetry.md
+++ b/docs/backends/snmp_telemetry.md
@@ -26,11 +26,11 @@ orb:
 | Parameter | Type | Default | Description |
 |:---------:|:----:|:-------:|:------------|
 | host | str | `localhost` | Address the backend's API binds. The agent reaches it on loopback; the API has no authentication, so widen it only behind your own access control. |
-| port | int | 8078 | Port of the backend's API. |
-| log_level | str | `INFO` | `DEBUG`, `INFO`, `WARN` or `ERROR`. The agent passes `DEBUG` when the backend has `debug: true` or the agent itself logs at debug. |
-| log_format | str | `TEXT` | `TEXT` or `JSON`. |
+| port | int | 8078 | Port of the backend's API, 1 to 65535. |
+| log_level | str | `INFO` | `DEBUG`, `INFO`, `WARN` or `ERROR`; any other value is refused. The agent passes `DEBUG` when the backend has `debug: true` or the agent itself logs at debug. |
+| log_format | str | `TEXT` | `TEXT` or `JSON`; any other value is refused. |
 | otel_export_period | int | 10 | Seconds between OTLP exports, 1 to 31536000. |
-| policy_env_vars | str or list | unset | Environment variable names a policy may read through `${NAME}` in `community`, `username`, `auth_passphrase` or `priv_passphrase`. A comma-separated string or a list. Unset refuses every reference. |
+| policy_env_vars | str or list | unset | Environment variable names a policy may read through `${NAME}` in `community`, `username`, `auth_passphrase` or `priv_passphrase`. A comma-separated string or a list of names, never `${...}` references. Unset refuses every reference. |
 | snmp_profiles_root | str | unset | Directory a policy's own `profiles_dir` must resolve inside. Unset refuses every per-policy `profiles_dir`. |
 | snmp_profiles_dir | str | unset | Directory of profile YAML files overlaid on the bundled profiles. |
 

--- a/docs/backends/snmp_telemetry.md
+++ b/docs/backends/snmp_telemetry.md
@@ -19,8 +19,9 @@ orb:
       log_format: TEXT                   # default TEXT (TEXT, JSON)
       otel_export_period: 10             # seconds between exports, default 10
       policy_env_vars: [SNMP_COMMUNITY]  # unset by default: every ${NAME} reference in a policy is refused
-      snmp_profiles_root: /opt/orb/profiles   # unset by default: every per-policy profiles_dir is refused
-      snmp_profiles_dir: /opt/orb/overrides   # unset by default: only the bundled profiles are used; the directory must exist
+      # Both directories must exist; the image creates neither, so they are shown commented out.
+      # snmp_profiles_root: /opt/orb/profiles   # unset by default: every per-policy profiles_dir is refused
+      # snmp_profiles_dir: /opt/orb/overrides   # unset by default: only the bundled profiles are used
 ```
 
 | Parameter | Type | Default | Description |

--- a/docs/backends/snmp_telemetry.md
+++ b/docs/backends/snmp_telemetry.md
@@ -28,7 +28,7 @@ orb:
 |:---------:|:----:|:-------:|:------------|
 | host | str | `localhost` | Address the backend's API binds. The agent reaches it on loopback; the API has no authentication, so widen it only behind your own access control. |
 | port | int | 8078 | Port of the backend's API, 1 to 65535. |
-| log_level | str | `INFO` | `DEBUG`, `INFO`, `WARN` or `ERROR`; any other value is refused. The agent passes `DEBUG` when the backend has `debug: true` or the agent itself logs at debug. |
+| log_level | str | `INFO` | `DEBUG`, `INFO`, `WARN` or `ERROR`; any other value is refused. The agent passes `DEBUG` when the backend has `debug: true` or the agent runs with its debug flag. |
 | log_format | str | `TEXT` | `TEXT` or `JSON`; any other value is refused. |
 | otel_export_period | int | 10 | Seconds between OTLP exports, 1 to 31536000. |
 | policy_env_vars | str or list | unset | Environment variable names a policy may read through `${NAME}` in `community`, `username`, `auth_passphrase` or `priv_passphrase`. A comma-separated string or a list of names, never `${...}` references. Unset refuses every reference. |

--- a/docs/config_samples.md
+++ b/docs/config_samples.md
@@ -599,6 +599,62 @@ docker run --net=host \
     run -c "/opt/orb/snmp-config.yaml"
 ```
 
+## SNMP Telemetry Backend
+
+The SNMP telemetry backend polls SNMP devices and receives their traps, exporting metrics over OTLP to the collector named in `common.otlp`. It ingests nothing into Diode. See the [backend documentation](backends/snmp_telemetry.md) for every parameter.
+
+### Basic Configuration
+```yaml
+orb:
+  config_manager:
+    active: local
+  backends:
+    common:
+      otlp:
+        grpc: "grpc://otel-collector:4317"
+    snmp_telemetry:
+  policies:
+    snmp_telemetry:
+      core_metrics:
+        config:
+          metrics_interval: 60 # seconds between collection runs
+        scope:
+          targets:
+            - host: "192.168.1.0/24"
+          authentication:
+            protocol_version: "v2c"
+            community: "public"
+      core_traps: # receives traps only: no metrics_interval
+        scope:
+          targets:
+            - host: "192.168.1.0/24"
+          authentication:
+            protocol_version: "v2c"
+            community: "public"
+          traps:
+            listen: "0.0.0.0:162"
+```
+
+### Running the SNMP Telemetry Backend
+
+With host networking the trap port is already exposed:
+
+```bash
+docker run --net=host \
+    -v "/local/orb:/opt/orb/" \
+    netboxlabs/orb-agent:latest \
+    run -c "/opt/orb/snmp-telemetry-config.yaml"
+```
+
+In bridge mode publish the port the policy listens on:
+
+```bash
+docker run -p 162:162/udp \
+    -v "/local/orb:/opt/orb/" \
+    netboxlabs/orb-agent:latest \
+    run -c "/opt/orb/snmp-telemetry-config.yaml"
+```
+
 ## Diode Dry Run Mode
 
 The Orb Agent supports a diode dry run mode that allows you to test your configuration without sending data to the Diode server. This is useful for debugging and validating your configuration.

--- a/docs/configs/agent_yaml.md
+++ b/docs/configs/agent_yaml.md
@@ -148,7 +148,7 @@ Optional OpenTelemetry export for backend metrics.
 
 ### Backend keys
 
-Each backend key enables that backend. An empty value (no sub-keys) uses all defaults. All discovery backends accept optional `host` and `port` overrides.
+Each backend key enables that backend. An empty value (no sub-keys) uses all defaults. All discovery backends and `snmp_telemetry` accept optional `host` and `port` overrides.
 
 | Key | Backend | Default port | Notes |
 |-----|---------|-------------|-------|
@@ -158,6 +158,7 @@ Each backend key enables that backend. An empty value (no sub-keys) uses all def
 | `worker` | Custom worker backend | 8071 | Optional `host`/`port` overrides |
 | `pktvisor` | pktvisor packet analytics | — | See [pktvisor docs](../backends/pktvisor.md) |
 | `opentelemetry_infinity` | OpenTelemetry Infinity | — | See [OTel Infinity docs](../backends/opentelemetry_infinity.md) |
+| `snmp_telemetry` | SNMP metrics and traps | 8078 | Optional `host`/`port` overrides; requires `common.otlp.grpc`. See [SNMP Telemetry docs](../backends/snmp_telemetry.md) |
 
 ---
 
@@ -192,6 +193,7 @@ For the full list of parameters per backend, see:
 - [SNMP Discovery](../backends/snmp_discovery/README.md)
 - [Network Discovery](../backends/network_discovery.md)
 - [Worker](../backends/worker.md)
+- [SNMP Telemetry](../backends/snmp_telemetry.md)
 
 ---
 

--- a/docs/configs/agent_yaml.md
+++ b/docs/configs/agent_yaml.md
@@ -346,6 +346,7 @@ Values can reference environment variables using `${VAR_NAME}` syntax. Resolutio
 | CyberArk secrets manager | `url`, `app_id`, `reason`, `ca_bundle`, `client_cert`, `client_key` | Go agent at startup |
 | `device_discovery` policy (all fields) | Any string value in `scope` and `defaults` | Python backend at policy execution |
 | `snmp_discovery` policy authentication | `community`, `username`, `auth_passphrase`, `priv_passphrase`, `context_name` | Go SNMP backend at policy execution |
+| `snmp_telemetry` policy authentication | `community`, `username`, `auth_passphrase`, `priv_passphrase`, only for variables named in `backends.snmp_telemetry.policy_env_vars`; unset refuses every reference | Go SNMP telemetry backend at policy execution |
 
 ```yaml
 # Git config (resolved by Go agent)

--- a/orb-telemetry/snmp-telemetry/README.md
+++ b/orb-telemetry/snmp-telemetry/README.md
@@ -148,9 +148,10 @@ policies:
 
 Without `traps`, a policy receives nothing and no socket is opened. `listen`
 is `host:port`; an empty host binds every interface, and the host must be an
-address, not a name. Port 162 is privileged; run with `CAP_NET_BIND_SERVICE`
-or choose a higher port and redirect to it. Do not run the backend as root to
-bind it.
+address, not a name. Port 162 is privileged. Outside the agent image, run with
+`CAP_NET_BIND_SERVICE` or choose a higher port and redirect to it rather than
+running the backend as root. The agent image runs as root already, so a
+policy there binds 162 as it is.
 
 Policies naming the same `listen` string share one socket, opened when the
 first of them starts and closed when the last stops, the way pktvisor shares


### PR DESCRIPTION
Wires `orb-telemetry/snmp-telemetry` into the agent and ships it in the image. MON-348.

## What changes

- **Backend package** `agent/backend/snmptelemetry`, in the shape of `snmpdiscovery`. Backend keys become the binary's flags: `host`, `port`, `log_level`, `log_format`, `otel_export_period`, and the three security keys `policy_env_vars`, `snmp_profiles_root`, `snmp_profiles_dir`. Each optional key is passed only when set, so an unset key keeps the binary's refusing default; an absent, null or empty `host` or `port` stays on the loopback default rather than binding the unauthenticated API everywhere; a port outside 1 to 65535, an unrecognised log level or format, a non-string key, or a `policy_env_vars` entry that is not a variable name is refused at configuration, where the error names the key, rather than at the binary's startup, which the agent would restart in a loop. `Configure` applies its settings only once every key is valid, so a refused reconfiguration leaves the address the agent polls unchanged, and API URLs bracket an IPv6 host. `common.otlp.grpc` is required and passed verbatim; every metric the backend produces leaves over OTLP, so an agent that enables the backend without an endpoint refuses to start and names the missing setting. Stop hands the binary the agent's default five-second grace; the binary bounds the data-carrying part of its shutdown, closing the trap sockets and then the final flush, to that same budget.
- **Registration** in `cmd/main.go`.
- **Image**: a `snmp-telemetry` build stage stamping `SNMP_TELEMETRY_VERSION` and `BUILD_COMMIT`, copied into the final stage. The binary embeds the bundled profile tree and adds 20,594,850 bytes; the amd64 image is 311,691,328 bytes with it.
- **Release parity**: `resolve-backend-versions` gains a `telemetry` output from `snmp-telemetry/v*` tags; `release.yaml` detects the backend's changes, waits on `snmp-telemetry-release.yaml`, and passes `telemetry-version` into `_agent-release.yaml`, which gains the input, the build arg and the no-cache filter; `develop.yaml` and `build.yaml` pass the build arg. `orb-telemetry/**` joins the develop and release path filters, and the CONTRIBUTING sentence about its deliberate absence goes.
- **Docs**: SNMP Telemetry under Observability Backends and in the policies example in the root README, with a note on publishing the trap port; a new `docs/backends/snmp_telemetry.md`; a row and link in `docs/configs/agent_yaml.md`; a sample in `docs/config_samples.md`; the backend README's non-root guidance scoped to outside the image.

## Decisions

1. Off by default: `default_config.yaml` is unchanged, as for `gnmi_discovery`.
2. All three security flags are exposed as optional backend keys; unset refuses, as the binary does.
3. Full release parity with the discovery backends. No `snmp-telemetry/v*` tag exists yet, so the image stamps `0.0.0` for this backend until the first release is cut.
4. The image keeps root. The docs say the container runs as root by default, so a trap policy binds 162 without a capability; the backend README's non-root guidance now applies outside the image.
5. `PolicyStatusProvider` is not implemented: the agent uses it only to feed per-policy runs into the policy repo, and a telemetry policy is a continuous collector with no runs to report.

## Dependencies

The binary's `golang.org/x/crypto`, `x/net` and `x/text` carried HIGH and CRITICAL advisories that the image scan would fail on once the binary ships. #582 bumped them on develop; this branch is rebased on it, and the Trivy scan of the locally built image is clean at HIGH and CRITICAL.

## Verification

- `go test -race ./...` at the root and in `orb-telemetry/snmp-telemetry` green; `make lint` at 0 issues in every Go module.
- Backend package tests drive a real HTTP server for the binary's API; every assertion is backed by a mutant that fails it (28 mutants).
- The stage builds for `linux/amd64` and `--help` prints the binary's usage.
- Release scenarios traced in review: a backend-only push to `release` runs only change detection, as for `snmp-discovery`; a push touching `agent/` and the backend waits on the backend release and bundles the resolved version; `workflow_dispatch` carries the backend.
- Still to do after the image publishes: the lab run in the ticket's verification section (agent starts the backend to ready, a polling policy and a trap-only policy applied through the agent, `snmp.traps_received` at the collector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
