### PR TITLE
fix(agent): escape the policy name in the backend delete path

### DIFF
--- a/agent/backend/devicediscovery/device_discovery.go
+++ b/agent/backend/devicediscovery/device_discovery.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	neturl "net/url"
 	"strings"
 	"time"
 
@@ -337,8 +336,12 @@ func (d *deviceDiscoveryBackend) RemovePolicy(data policies.PolicyData) error {
 	} else {
 		name = data.Name
 	}
-	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", d.apiProtocol, d.apiHost, d.apiPort, neturl.PathEscape(name))
-	err := backend.CommonRequest("device-discovery", d.proc, d.logger, url, &resp, http.MethodDelete,
+	segment, err := backend.PolicyPathSegment(name)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", d.apiProtocol, d.apiHost, d.apiPort, segment)
+	err = backend.CommonRequest("device-discovery", d.proc, d.logger, url, &resp, http.MethodDelete,
 		http.NoBody, "application/json", removePolicyTimeout, "detail")
 	if err != nil {
 		return err

--- a/agent/backend/gnmidiscovery/gnmi_discovery.go
+++ b/agent/backend/gnmidiscovery/gnmi_discovery.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	neturl "net/url"
 	"strings"
 	"time"
 
@@ -362,8 +361,12 @@ func (d *gnmiDiscoveryBackend) RemovePolicy(data policies.PolicyData) error {
 	if data.PreviousPolicyData != nil && data.PreviousPolicyData.Name != data.Name {
 		name = data.PreviousPolicyData.Name
 	}
-	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", d.apiProtocol, d.apiHost, d.apiPort, neturl.PathEscape(name))
-	err := backend.CommonRequest("gnmi-discovery", d.proc, d.logger, url, &resp, http.MethodDelete,
+	segment, err := backend.PolicyPathSegment(name)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", d.apiProtocol, d.apiHost, d.apiPort, segment)
+	err = backend.CommonRequest("gnmi-discovery", d.proc, d.logger, url, &resp, http.MethodDelete,
 		http.NoBody, "application/json", removePolicyTimeout, "detail")
 	if err != nil {
 		return err

--- a/agent/backend/networkdiscovery/network_discovery.go
+++ b/agent/backend/networkdiscovery/network_discovery.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	neturl "net/url"
 	"strings"
 	"time"
 
@@ -317,8 +316,12 @@ func (d *networkDiscoveryBackend) RemovePolicy(data policies.PolicyData) error {
 	if data.PreviousPolicyData != nil && data.PreviousPolicyData.Name != data.Name {
 		name = data.PreviousPolicyData.Name
 	}
-	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", d.apiProtocol, d.apiHost, d.apiPort, neturl.PathEscape(name))
-	err := backend.CommonRequest("network-discovery", d.proc, d.logger, url, &resp, http.MethodDelete,
+	segment, err := backend.PolicyPathSegment(name)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", d.apiProtocol, d.apiHost, d.apiPort, segment)
+	err = backend.CommonRequest("network-discovery", d.proc, d.logger, url, &resp, http.MethodDelete,
 		http.NoBody, "application/json", removePolicyTimeout, "detail")
 	if err != nil {
 		return err

--- a/agent/backend/opentelemetryinfinity/opentelemetry_infinity.go
+++ b/agent/backend/opentelemetryinfinity/opentelemetry_infinity.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	neturl "net/url"
 	"sort"
 	"strings"
 	"time"
@@ -239,7 +240,7 @@ func (o *openTelemetryBackend) RemovePolicy(data policies.PolicyData) error {
 	} else {
 		name = data.Name
 	}
-	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", o.apiProtocol, o.apiHost, o.apiPort, name)
+	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", o.apiProtocol, o.apiHost, o.apiPort, neturl.PathEscape(name))
 	err := backend.CommonRequest("opentelemetry-infinity", o.proc, o.logger, url, &resp, http.MethodDelete,
 		http.NoBody, "application/json", removePolicyTimeout, "message")
 	if err != nil {

--- a/agent/backend/opentelemetryinfinity/opentelemetry_infinity.go
+++ b/agent/backend/opentelemetryinfinity/opentelemetry_infinity.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	neturl "net/url"
 	"sort"
 	"strings"
 	"time"
@@ -240,8 +239,12 @@ func (o *openTelemetryBackend) RemovePolicy(data policies.PolicyData) error {
 	} else {
 		name = data.Name
 	}
-	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", o.apiProtocol, o.apiHost, o.apiPort, neturl.PathEscape(name))
-	err := backend.CommonRequest("opentelemetry-infinity", o.proc, o.logger, url, &resp, http.MethodDelete,
+	segment, err := backend.PolicyPathSegment(name)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", o.apiProtocol, o.apiHost, o.apiPort, segment)
+	err = backend.CommonRequest("opentelemetry-infinity", o.proc, o.logger, url, &resp, http.MethodDelete,
 		http.NoBody, "application/json", removePolicyTimeout, "message")
 	if err != nil {
 		return err

--- a/agent/backend/opentelemetryinfinity/opentelemetry_infinity_policy_name_test.go
+++ b/agent/backend/opentelemetryinfinity/opentelemetry_infinity_policy_name_test.go
@@ -1,0 +1,102 @@
+package opentelemetryinfinity_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/backend/mocks"
+	"github.com/netboxlabs/orb-agent/agent/backend/opentelemetryinfinity"
+	"github.com/netboxlabs/orb-agent/agent/config"
+	"github.com/netboxlabs/orb-agent/agent/policies"
+)
+
+// TestOpenTelemetryRemovePolicyEscapesTheName pins that the policy name
+// reaches the backend as one intact path segment. See the worker backend's
+// test of the same name for why each character below breaks.
+func TestOpenTelemetryRemovePolicyEscapesTheName(t *testing.T) {
+	var mu sync.Mutex
+	var deletes []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/status" {
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(StatusResponse{Version: "1.3.4"}))
+			return
+		}
+		if r.Method == http.MethodDelete {
+			mu.Lock()
+			deletes = append(deletes, r.URL.EscapedPath())
+			mu.Unlock()
+		}
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"status": "success"}))
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 12345)
+
+	originalNewCmdOptions := backend.NewCmdOptions
+	defer func() { backend.NewCmdOptions = originalNewCmdOptions }()
+	backend.NewCmdOptions = func(_ backend.CmdOptions, _ string, _ ...string) backend.Commander {
+		return mockCmd
+	}
+
+	require.True(t, opentelemetryinfinity.Register())
+	be := backend.GetBackend("opentelemetry_infinity")
+
+	require.NoError(t, be.Configure(slog.New(slog.NewTextHandler(os.Stdout, nil)), repo, map[string]any{
+		"host": serverURL.Hostname(),
+		"port": serverURL.Port(),
+	}, config.BackendCommons{}, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, be.Start(ctx, cancel))
+
+	for _, c := range policyNameEscapingCases {
+		require.NoError(t, be.RemovePolicy(policies.PolicyData{ID: "id-1", Name: c.name}),
+			"removing %q must not fail", c.name)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, deletes, len(policyNameEscapingCases))
+	for i, c := range policyNameEscapingCases {
+		assert.Equal(t, c.wantPath, deletes[i], "policy name %q", c.name)
+	}
+}
+
+// policyNameEscapingCases is duplicated per backend on purpose: each one
+// builds its own URL, so a shared table would let a backend that stopped
+// escaping pass on another's coverage.
+var policyNameEscapingCases = []struct {
+	name     string
+	wantPath string
+}{
+	// Names that already worked, byte-identical after the change.
+	{"dummy-policy-name", "/api/v1/policies/dummy-policy-name"},
+	{"core metrics", "/api/v1/policies/core%20metrics"},
+	{"My Office Network #2", "/api/v1/policies/My%20Office%20Network%20%232"},
+	{"reports?live", "/api/v1/policies/reports%3Flive"},
+	{"100%", "/api/v1/policies/100%25"},
+	{"nightly/", "/api/v1/policies/nightly%2F"},
+}

--- a/agent/backend/opentelemetryinfinity/opentelemetry_infinity_policy_name_test.go
+++ b/agent/backend/opentelemetryinfinity/opentelemetry_infinity_policy_name_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 
@@ -33,6 +34,16 @@ func TestOpenTelemetryRemovePolicyEscapesTheName(t *testing.T) {
 		if r.URL.Path == "/api/v1/status" {
 			w.WriteHeader(http.StatusOK)
 			require.NoError(t, json.NewEncoder(w).Encode(StatusResponse{Version: "1.3.4"}))
+			return
+		}
+		// Model the receiving framework rather than accepting every path.
+		// ASGI decodes percent-escapes before routing, so a "%2F" arrives as
+		// a separator, and Starlette's redirect_slashes then 307s a trailing
+		// slash to the route without it. A handler that accepted everything
+		// would report a slash name as delivered when it had in fact been
+		// redirected onto a different policy.
+		if strings.HasSuffix(r.URL.Path, "/") && r.URL.Path != "/" {
+			http.Redirect(w, r, strings.TrimSuffix(r.URL.Path, "/"), http.StatusTemporaryRedirect)
 			return
 		}
 		if r.Method == http.MethodDelete {
@@ -77,8 +88,19 @@ func TestOpenTelemetryRemovePolicyEscapesTheName(t *testing.T) {
 			"removing %q must not fail", c.name)
 	}
 
+	// A slash cannot be kept inside one path segment, so the name is refused
+	// before a request is built. Escaping it would send "%2F", which the
+	// framework decodes back into a separator and redirects, deleting the
+	// policy without the slash and reporting success.
+	mu.Lock()
+	sent := len(deletes)
+	mu.Unlock()
+	require.Error(t, be.RemovePolicy(policies.PolicyData{ID: "id-1", Name: "nightly/"}),
+		"a name carrying a slash must fail rather than address another policy")
+
 	mu.Lock()
 	defer mu.Unlock()
+	assert.Len(t, deletes, sent, "the refused name must not reach the backend at all")
 	require.Len(t, deletes, len(policyNameEscapingCases))
 	for i, c := range policyNameEscapingCases {
 		assert.Equal(t, c.wantPath, deletes[i], "policy name %q", c.name)
@@ -98,5 +120,4 @@ var policyNameEscapingCases = []struct {
 	{"My Office Network #2", "/api/v1/policies/My%20Office%20Network%20%232"},
 	{"reports?live", "/api/v1/policies/reports%3Flive"},
 	{"100%", "/api/v1/policies/100%25"},
-	{"nightly/", "/api/v1/policies/nightly%2F"},
 }

--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"net/url"
+	neturl "net/url"
 	"os"
 	"os/exec"
 	"strconv"
@@ -334,7 +334,7 @@ func (p *pktvisorBackend) Configure(logger *slog.Logger, repo policies.PolicyRep
 	p.configFile = tmpFile.Name()
 
 	if common.Otlp.HTTP != "" {
-		uri, err := url.Parse(common.Otlp.HTTP)
+		uri, err := neturl.Parse(common.Otlp.HTTP)
 		if err != nil {
 			return fmt.Errorf("failed to parse otlp receiver http url: %w", err)
 		}
@@ -440,7 +440,7 @@ func (p *pktvisorBackend) RemovePolicy(data policies.PolicyData) error {
 	} else {
 		name = data.Name
 	}
-	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", p.adminAPIProtocol, p.adminAPIHost, p.adminAPIPort, name)
+	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", p.adminAPIProtocol, p.adminAPIHost, p.adminAPIPort, neturl.PathEscape(name))
 	err := backend.CommonRequest("pktvisor", p.proc, p.logger, url, &resp, http.MethodDelete,
 		http.NoBody, "application/json", removePolicyTimeout, "error")
 	if err != nil {

--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -440,8 +440,12 @@ func (p *pktvisorBackend) RemovePolicy(data policies.PolicyData) error {
 	} else {
 		name = data.Name
 	}
-	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", p.adminAPIProtocol, p.adminAPIHost, p.adminAPIPort, neturl.PathEscape(name))
-	err := backend.CommonRequest("pktvisor", p.proc, p.logger, url, &resp, http.MethodDelete,
+	segment, err := backend.PolicyPathSegment(name)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", p.adminAPIProtocol, p.adminAPIHost, p.adminAPIPort, segment)
+	err = backend.CommonRequest("pktvisor", p.proc, p.logger, url, &resp, http.MethodDelete,
 		http.NoBody, "application/json", removePolicyTimeout, "error")
 	if err != nil {
 		return err

--- a/agent/backend/pktvisor/pktvisor_policy_name_test.go
+++ b/agent/backend/pktvisor/pktvisor_policy_name_test.go
@@ -1,0 +1,105 @@
+package pktvisor_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/backend/mocks"
+	"github.com/netboxlabs/orb-agent/agent/backend/pktvisor"
+	"github.com/netboxlabs/orb-agent/agent/config"
+	"github.com/netboxlabs/orb-agent/agent/policies"
+)
+
+// TestPktvisorRemovePolicyEscapesTheName pins that the policy name reaches
+// the backend as one intact path segment. See the worker backend's test of
+// the same name for why each character below breaks.
+func TestPktvisorRemovePolicyEscapesTheName(t *testing.T) {
+	var mu sync.Mutex
+	var deletes []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/metrics/app" {
+			var response pktvisor.AppInfo
+			response.App.Version = "1.2.3"
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(response))
+			return
+		}
+		if r.Method == http.MethodDelete {
+			mu.Lock()
+			deletes = append(deletes, r.URL.EscapedPath())
+			mu.Unlock()
+		}
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"status": "success"}))
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	createExecutable(t, "pktvisord")
+
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 12345)
+	overrideNewCmdOptions(t, mockCmd, func(_ backend.CmdOptions, _ string, _ []string) {})
+
+	require.True(t, pktvisor.Register())
+	be := backend.GetBackend("pktvisor")
+
+	commons := config.BackendCommons{}
+	commons.Otlp.HTTP = server.URL
+
+	require.NoError(t, be.Configure(slog.New(slog.NewTextHandler(os.Stdout, nil)), repo, map[string]any{
+		"host": serverURL.Hostname(),
+		"port": serverURL.Port(),
+	}, commons, nil))
+
+	baseCtx := context.WithValue(context.Background(), config.ContextKey("agent_id"), "test-agent")
+	ctx, cancel := context.WithCancel(baseCtx)
+	defer cancel()
+	require.NoError(t, be.Start(ctx, cancel))
+
+	for _, c := range policyNameEscapingCases {
+		require.NoError(t, be.RemovePolicy(policies.PolicyData{ID: "id-1", Name: c.name}),
+			"removing %q must not fail", c.name)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, deletes, len(policyNameEscapingCases))
+	for i, c := range policyNameEscapingCases {
+		assert.Equal(t, c.wantPath, deletes[i], "policy name %q", c.name)
+	}
+}
+
+// policyNameEscapingCases is duplicated per backend on purpose: each one
+// builds its own URL, so a shared table would let a backend that stopped
+// escaping pass on another's coverage.
+var policyNameEscapingCases = []struct {
+	name     string
+	wantPath string
+}{
+	// Names that already worked, byte-identical after the change.
+	{"dummy-policy-name", "/api/v1/policies/dummy-policy-name"},
+	{"core metrics", "/api/v1/policies/core%20metrics"},
+	{"My Office Network #2", "/api/v1/policies/My%20Office%20Network%20%232"},
+	{"reports?live", "/api/v1/policies/reports%3Flive"},
+	{"100%", "/api/v1/policies/100%25"},
+	{"nightly/", "/api/v1/policies/nightly%2F"},
+}

--- a/agent/backend/pktvisor/pktvisor_policy_name_test.go
+++ b/agent/backend/pktvisor/pktvisor_policy_name_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 
@@ -35,6 +36,16 @@ func TestPktvisorRemovePolicyEscapesTheName(t *testing.T) {
 			response.App.Version = "1.2.3"
 			w.WriteHeader(http.StatusOK)
 			require.NoError(t, json.NewEncoder(w).Encode(response))
+			return
+		}
+		// Model the receiving framework rather than accepting every path.
+		// ASGI decodes percent-escapes before routing, so a "%2F" arrives as
+		// a separator, and Starlette's redirect_slashes then 307s a trailing
+		// slash to the route without it. A handler that accepted everything
+		// would report a slash name as delivered when it had in fact been
+		// redirected onto a different policy.
+		if strings.HasSuffix(r.URL.Path, "/") && r.URL.Path != "/" {
+			http.Redirect(w, r, strings.TrimSuffix(r.URL.Path, "/"), http.StatusTemporaryRedirect)
 			return
 		}
 		if r.Method == http.MethodDelete {
@@ -80,8 +91,19 @@ func TestPktvisorRemovePolicyEscapesTheName(t *testing.T) {
 			"removing %q must not fail", c.name)
 	}
 
+	// A slash cannot be kept inside one path segment, so the name is refused
+	// before a request is built. Escaping it would send "%2F", which the
+	// framework decodes back into a separator and redirects, deleting the
+	// policy without the slash and reporting success.
+	mu.Lock()
+	sent := len(deletes)
+	mu.Unlock()
+	require.Error(t, be.RemovePolicy(policies.PolicyData{ID: "id-1", Name: "nightly/"}),
+		"a name carrying a slash must fail rather than address another policy")
+
 	mu.Lock()
 	defer mu.Unlock()
+	assert.Len(t, deletes, sent, "the refused name must not reach the backend at all")
 	require.Len(t, deletes, len(policyNameEscapingCases))
 	for i, c := range policyNameEscapingCases {
 		assert.Equal(t, c.wantPath, deletes[i], "policy name %q", c.name)
@@ -101,5 +123,4 @@ var policyNameEscapingCases = []struct {
 	{"My Office Network #2", "/api/v1/policies/My%20Office%20Network%20%232"},
 	{"reports?live", "/api/v1/policies/reports%3Flive"},
 	{"100%", "/api/v1/policies/100%25"},
-	{"nightly/", "/api/v1/policies/nightly%2F"},
 }

--- a/agent/backend/policy_path.go
+++ b/agent/backend/policy_path.go
@@ -1,0 +1,30 @@
+package backend
+
+import (
+	"fmt"
+	neturl "net/url"
+	"strings"
+)
+
+// PolicyPathSegment renders a policy name as one path segment of a backend's
+// API URL.
+//
+// Policy names are operator-written and forwarded verbatim, so a name may
+// carry any character. Left raw, several of them never reach the backend:
+// "#" is read as a fragment and "?" as a query, so the request lands on a
+// truncated name, and "%" does not parse as a URL at all. Percent-escaping
+// settles those.
+//
+// A "/" is the exception escaping cannot settle, and it is refused instead.
+// The receiving frameworks decode percent-escapes before routing (the ASGI
+// spec requires it), so "%2F" becomes a separator again on arrival. A
+// trailing one then earns a 307 to the route without it, which the Go client
+// follows with the method intact, deleting a different policy and reporting
+// success. Failing here is the only outcome that does not act on the wrong
+// policy.
+func PolicyPathSegment(name string) (string, error) {
+	if strings.Contains(name, "/") {
+		return "", fmt.Errorf("policy name %q contains a slash, which cannot address a single policy over the backend API; rename the policy", name)
+	}
+	return neturl.PathEscape(name), nil
+}

--- a/agent/backend/policy_path_test.go
+++ b/agent/backend/policy_path_test.go
@@ -1,0 +1,51 @@
+package backend_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/backend"
+)
+
+// TestPolicyPathSegment covers the two halves of the contract: names that
+// reach the backend intact once escaped, and the one that cannot.
+func TestPolicyPathSegment(t *testing.T) {
+	// Names that already worked. These must come back byte-identical to what
+	// the client was sending before escaping was added, or the escaping is
+	// double-encoding: the client was already sending a space as %20.
+	for name, want := range map[string]string{
+		"dummy-policy-name": "dummy-policy-name",
+		"core metrics":      "core%20metrics",
+		"café":              "caf%C3%A9",
+		"policy-1_v2.0":     "policy-1_v2.0",
+		"a+b":               "a+b",
+		"a&b":               "a&b",
+		"a:b":               "a:b",
+	} {
+		got, err := backend.PolicyPathSegment(name)
+		require.NoError(t, err, "name %q", name)
+		assert.Equal(t, want, got, "name %q", name)
+	}
+
+	// Characters that never reached the backend before escaping.
+	for name, want := range map[string]string{
+		"My Office Network #2": "My%20Office%20Network%20%232",
+		"reports?live":         "reports%3Flive",
+		"100%":                 "100%25",
+	} {
+		got, err := backend.PolicyPathSegment(name)
+		require.NoError(t, err, "name %q", name)
+		assert.Equal(t, want, got, "name %q", name)
+	}
+
+	// A slash is refused rather than escaped. %2F is decoded back into a
+	// separator before the receiving framework routes, so escaping cannot
+	// keep the name in one segment; see the helper's doc comment.
+	for _, name := range []string{"nightly/", "a/b", "/leading"} {
+		_, err := backend.PolicyPathSegment(name)
+		require.Error(t, err, "name %q must be refused", name)
+		assert.Contains(t, err.Error(), "slash")
+	}
+}

--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	neturl "net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -360,8 +359,12 @@ func (d *snmpDiscoveryBackend) RemovePolicy(data policies.PolicyData) error {
 	if data.PreviousPolicyData != nil && data.PreviousPolicyData.Name != data.Name {
 		name = data.PreviousPolicyData.Name
 	}
-	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", d.apiProtocol, d.apiHost, d.apiPort, neturl.PathEscape(name))
-	err := backend.CommonRequest("snmp-discovery", d.proc, d.logger, url, &resp, http.MethodDelete,
+	segment, err := backend.PolicyPathSegment(name)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", d.apiProtocol, d.apiHost, d.apiPort, segment)
+	err = backend.CommonRequest("snmp-discovery", d.proc, d.logger, url, &resp, http.MethodDelete,
 		http.NoBody, "application/json", removePolicyTimeout, "detail")
 	if err != nil {
 		return err

--- a/agent/backend/snmptelemetry/snmp_telemetry.go
+++ b/agent/backend/snmptelemetry/snmp_telemetry.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	neturl "net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -568,8 +567,12 @@ func (d *snmpTelemetryBackend) RemovePolicy(data policies.PolicyData) error {
 	if data.PreviousPolicyData != nil && data.PreviousPolicyData.Name != data.Name {
 		name = data.PreviousPolicyData.Name
 	}
-	url := d.apiURL("policies/" + neturl.PathEscape(name))
-	err := backend.CommonRequest("snmp-telemetry", d.proc, d.logger, url, &resp, http.MethodDelete,
+	segment, err := backend.PolicyPathSegment(name)
+	if err != nil {
+		return err
+	}
+	url := d.apiURL("policies/" + segment)
+	err = backend.CommonRequest("snmp-telemetry", d.proc, d.logger, url, &resp, http.MethodDelete,
 		http.NoBody, "application/json", removePolicyTimeout, "detail")
 	if err != nil {
 		return err

--- a/agent/backend/worker/worker.go
+++ b/agent/backend/worker/worker.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	neturl "net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -371,7 +372,7 @@ func (d *workerBackend) RemovePolicy(data policies.PolicyData) error {
 	} else {
 		name = data.Name
 	}
-	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", d.apiProtocol, d.apiHost, d.apiPort, name)
+	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", d.apiProtocol, d.apiHost, d.apiPort, neturl.PathEscape(name))
 	err := backend.CommonRequest("worker", d.proc, d.logger, url, &resp, http.MethodDelete,
 		http.NoBody, "application/json", removePolicyTimeout, "detail")
 	if err != nil {

--- a/agent/backend/worker/worker.go
+++ b/agent/backend/worker/worker.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	neturl "net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -372,8 +371,12 @@ func (d *workerBackend) RemovePolicy(data policies.PolicyData) error {
 	} else {
 		name = data.Name
 	}
-	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", d.apiProtocol, d.apiHost, d.apiPort, neturl.PathEscape(name))
-	err := backend.CommonRequest("worker", d.proc, d.logger, url, &resp, http.MethodDelete,
+	segment, err := backend.PolicyPathSegment(name)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", d.apiProtocol, d.apiHost, d.apiPort, segment)
+	err = backend.CommonRequest("worker", d.proc, d.logger, url, &resp, http.MethodDelete,
 		http.NoBody, "application/json", removePolicyTimeout, "detail")
 	if err != nil {
 		return err

--- a/agent/backend/worker/worker_policy_name_test.go
+++ b/agent/backend/worker/worker_policy_name_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 
@@ -42,6 +43,16 @@ func TestWorkerRemovePolicyEscapesTheName(t *testing.T) {
 		if r.URL.Path == "/api/v1/status" {
 			w.WriteHeader(http.StatusOK)
 			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"version": "1.0.0"}))
+			return
+		}
+		// Model the receiving framework rather than accepting every path.
+		// ASGI decodes percent-escapes before routing, so a "%2F" arrives as
+		// a separator, and Starlette's redirect_slashes then 307s a trailing
+		// slash to the route without it. A handler that accepted everything
+		// would report a slash name as delivered when it had in fact been
+		// redirected onto a different policy.
+		if strings.HasSuffix(r.URL.Path, "/") && r.URL.Path != "/" {
+			http.Redirect(w, r, strings.TrimSuffix(r.URL.Path, "/"), http.StatusTemporaryRedirect)
 			return
 		}
 		if r.Method == http.MethodDelete {
@@ -83,8 +94,19 @@ func TestWorkerRemovePolicyEscapesTheName(t *testing.T) {
 			"removing %q must not fail; before escaping, %%  did not even parse as a URL", c.name)
 	}
 
+	// A slash cannot be kept inside one path segment, so the name is refused
+	// before a request is built. Escaping it would send "%2F", which the
+	// framework decodes back into a separator and redirects, deleting the
+	// policy without the slash and reporting success.
+	mu.Lock()
+	sent := len(deletes)
+	mu.Unlock()
+	require.Error(t, be.RemovePolicy(policies.PolicyData{ID: "id-1", Name: "nightly/"}),
+		"a name carrying a slash must fail rather than address another policy")
+
 	mu.Lock()
 	defer mu.Unlock()
+	assert.Len(t, deletes, sent, "the refused name must not reach the backend at all")
 	require.Len(t, deletes, len(policyNameEscapingCases))
 	for i, c := range policyNameEscapingCases {
 		assert.Equal(t, c.wantPath, deletes[i], "policy name %q", c.name)
@@ -109,7 +131,4 @@ var policyNameEscapingCases = []struct {
 	// "%" is worse: the URL does not parse at all, so the request is
 	// never made.
 	{"100%", "/api/v1/policies/100%25"},
-	// A trailing slash is not a route miss. Unescaped it earns a 307 to
-	// the name without it, so it silently deletes a different policy.
-	{"nightly/", "/api/v1/policies/nightly%2F"},
 }

--- a/agent/backend/worker/worker_policy_name_test.go
+++ b/agent/backend/worker/worker_policy_name_test.go
@@ -1,0 +1,115 @@
+package worker_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/backend/mocks"
+	"github.com/netboxlabs/orb-agent/agent/backend/worker"
+	"github.com/netboxlabs/orb-agent/agent/config"
+	"github.com/netboxlabs/orb-agent/agent/policies"
+)
+
+// TestWorkerRemovePolicyEscapesTheName pins that the policy name reaches
+// the backend as one intact path segment.
+//
+// Policy names are operator-written and forwarded verbatim, so a name such
+// as "My Office Network #2" is a legitimate thing to write. Unescaped, the
+// client reads the "#" as a fragment and never sends the rest, so the
+// request lands on a truncated name and deletes an unrelated policy or
+// nothing at all, reporting success either way.
+//
+// Asserting on EscapedPath rather than Path is the point of the test: Path
+// is already decoded, so it cannot tell an escaped name from a truncated
+// one.
+func TestWorkerRemovePolicyEscapesTheName(t *testing.T) {
+	var mu sync.Mutex
+	var deletes []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/status" {
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"version": "1.0.0"}))
+			return
+		}
+		if r.Method == http.MethodDelete {
+			mu.Lock()
+			deletes = append(deletes, r.URL.EscapedPath())
+			mu.Unlock()
+		}
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"status": "success"}))
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	createExecutable(t, "orb-worker")
+
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 12345)
+	overrideNewCmdOptions(t, mockCmd, func(_ backend.CmdOptions, _ string, _ []string) {})
+
+	require.True(t, worker.Register())
+	be := backend.GetBackend("worker")
+
+	require.NoError(t, be.Configure(slog.New(slog.NewTextHandler(os.Stdout, nil)), repo, map[string]any{
+		"host": serverURL.Hostname(),
+		"port": serverURL.Port(),
+	}, config.BackendCommons{}, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, be.Start(ctx, cancel))
+
+	for _, c := range policyNameEscapingCases {
+		require.NoError(t, be.RemovePolicy(policies.PolicyData{ID: "id-1", Name: c.name}),
+			"removing %q must not fail; before escaping, %%  did not even parse as a URL", c.name)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, deletes, len(policyNameEscapingCases))
+	for i, c := range policyNameEscapingCases {
+		assert.Equal(t, c.wantPath, deletes[i], "policy name %q", c.name)
+	}
+}
+
+// policyNameEscapingCases is duplicated per backend on purpose: each one
+// builds its own URL, so a shared table would let a backend that stopped
+// escaping pass on another's coverage.
+var policyNameEscapingCases = []struct {
+	name     string
+	wantPath string
+}{
+	// Names that already worked. These must be byte-identical after the
+	// change, or the escaping is double-encoding.
+	{"dummy-policy-name", "/api/v1/policies/dummy-policy-name"},
+	{"core metrics", "/api/v1/policies/core%20metrics"},
+	// "#" is read as a fragment and never leaves the client.
+	{"My Office Network #2", "/api/v1/policies/My%20Office%20Network%20%232"},
+	// "?" is read as a query, same outcome.
+	{"reports?live", "/api/v1/policies/reports%3Flive"},
+	// "%" is worse: the URL does not parse at all, so the request is
+	// never made.
+	{"100%", "/api/v1/policies/100%25"},
+	// A trailing slash is not a route miss. Unescaped it earns a 307 to
+	// the name without it, so it silently deletes a different policy.
+	{"nightly/", "/api/v1/policies/nightly%2F"},
+}

--- a/agent/policymgr/manager.go
+++ b/agent/policymgr/manager.go
@@ -241,6 +241,21 @@ func (a *policyManager) RemovePolicyDataset(policyID string, datasetID string, b
 }
 
 func (a *policyManager) applyPolicy(payload config.PolicyPayload, be backend.Backend, pd *policies.PolicyData, updatePolicy bool) {
+	// A name the agent cannot address over a backend's API is refused before
+	// the policy is created rather than when it is removed. Removal is the
+	// wrong place to find out: RemovePolicy discards the local record even
+	// when the backend refuses, so a policy applied under such a name would
+	// be left running with no state to retry its removal from. Checked here
+	// rather than per backend because the constraint is the agent's, and this
+	// is the one path every apply goes through.
+	if _, err := backend.PolicyPathSegment(pd.Name); err != nil {
+		a.logger.Warn("policy name cannot address a policy on the backend; not applying",
+			"policy_id", payload.ID, "policy_name", payload.Name, "backend", pd.Backend, "error", err)
+		pd.State = policies.FailedToApply
+		pd.BackendErr = err.Error()
+		return
+	}
+
 	state, detail, err := be.GetRunningStatus()
 	if state != backend.Running || err != nil {
 		pd.State = policies.FailedToApply

--- a/agent/policymgr/manager_test.go
+++ b/agent/policymgr/manager_test.go
@@ -1460,3 +1460,53 @@ func TestRemovePolicyBackendNon404StillLogsError(t *testing.T) {
 
 	assert.Contains(t, logs.String(), "level=ERROR", "non-404 backend failures must stay ERROR")
 }
+
+// TestManagePolicy_RefusesUnaddressableName pins that a policy the agent
+// could never remove is not created in the first place.
+//
+// A slash cannot be carried inside one path segment of the backend's API
+// URL, so RemovePolicy refuses such a name. Finding that out at removal
+// would be too late: RemovePolicy discards the local record even when the
+// backend refuses, so the policy would keep running on the backend with no
+// state left to retry from. The apply is refused instead, and reported
+// through the same FailedToApply path any other apply failure uses.
+func TestManagePolicy_RefusesUnaddressableName(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+
+	mockBe := &mockBackend{name: "testbackend"}
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	backend.Register("testbackend", mockBe)
+
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+
+	payload := config.PolicyPayload{
+		Action:       "manage",
+		ID:           "policy1",
+		Name:         "nightly/rollup",
+		Backend:      "testbackend",
+		Version:      1,
+		Data:         map[string]any{"key": "value"},
+		DatasetID:    "dataset1",
+		AgentGroupID: "group1",
+	}
+	secretsMgr.On("SolvePolicySecrets", payload).Return(payload, nil)
+
+	mgr.ManagePolicy(payload)
+
+	// No ApplyPolicy expectation is registered, so AssertExpectations would
+	// not catch an unwanted call on its own; the mock would panic instead.
+	// Assert the outcome the operator sees.
+	mockBe.AssertNotCalled(t, "ApplyPolicy", mock.Anything, mock.Anything)
+
+	state, err := mgr.GetPolicyState()
+	require.NoError(t, err)
+	require.Len(t, state, 1)
+	assert.Equal(t, policies.FailedToApply, state[0].State,
+		"a name the agent cannot address must not be reported as running")
+	assert.Contains(t, state[0].BackendErr, "slash",
+		"the recorded error must say why, since the operator has to rename the policy")
+
+	secretsMgr.AssertExpectations(t)
+}

--- a/docs/configs/agent_yaml.md
+++ b/docs/configs/agent_yaml.md
@@ -194,7 +194,7 @@ The key beneath a backend is the policy name. `my_policy` and `scan_policy` abov
 
 - **Forwarded verbatim.** Nothing along the path slugifies, trims or case-folds the name, and it is the name that appears in backend status and in telemetry.
 - **Spaces and non-ASCII are supported.** `My Office Network #2` and `café` are valid. The agent percent-escapes the name when it addresses the policy over the backend's API, so `#`, `?` and `%` are safe to use.
-- **A name must not contain `/`.** It is the one character escaping cannot carry: the backend decodes the escape before routing, so the name would address a different policy. The agent refuses such a name when removing the policy, and reports the error rather than acting on the wrong one.
+- **A name must not contain `/`.** It is the one character escaping cannot carry: the backend decodes the escape before routing, so the name would address a different policy. The agent refuses such a policy at apply time and reports it as failed, rather than starting one it could never remove.
 - **Must be distinct within a backend.** The name is a YAML mapping key, and a duplicate key is a YAML error, so the agent rejects the whole configuration file rather than starting with one of the two.
 - **Best kept distinct across backends too.** The agent indexes policies by name alone, so the same name under two backends can attach one policy's dataset IDs to the other's telemetry.
 

--- a/docs/configs/agent_yaml.md
+++ b/docs/configs/agent_yaml.md
@@ -193,8 +193,9 @@ orb:
 The key beneath a backend is the policy name. `my_policy` and `scan_policy` above are names, not reserved words.
 
 - **Forwarded verbatim.** Nothing along the path slugifies, trims or case-folds the name, and it is the name that appears in backend status and in telemetry.
-- **Spaces and non-ASCII are supported.** `My Office Network #2` and `café` are valid. The agent percent-escapes the name when it addresses the policy over the backend's API, so characters that carry meaning in a URL (`#`, `?`, `%`, `/`) are safe to use.
-- **Must be distinct within a backend.** The name is a YAML mapping key, so a repeat silently replaces the earlier entry rather than erroring.
+- **Spaces and non-ASCII are supported.** `My Office Network #2` and `café` are valid. The agent percent-escapes the name when it addresses the policy over the backend's API, so `#`, `?` and `%` are safe to use.
+- **A name must not contain `/`.** It is the one character escaping cannot carry: the backend decodes the escape before routing, so the name would address a different policy. The agent refuses such a name when removing the policy, and reports the error rather than acting on the wrong one.
+- **Must be distinct within a backend.** The name is a YAML mapping key, and a duplicate key is a YAML error, so the agent rejects the whole configuration file rather than starting with one of the two.
 - **Best kept distinct across backends too.** The agent indexes policies by name alone, so the same name under two backends can attach one policy's dataset IDs to the other's telemetry.
 
 For the full list of parameters per backend, see:

--- a/docs/configs/agent_yaml.md
+++ b/docs/configs/agent_yaml.md
@@ -188,6 +188,15 @@ orb:
           targets: [192.168.1.0/24]
 ```
 
+### Policy names
+
+The key beneath a backend is the policy name. `my_policy` and `scan_policy` above are names, not reserved words.
+
+- **Forwarded verbatim.** Nothing along the path slugifies, trims or case-folds the name, and it is the name that appears in backend status and in telemetry.
+- **Spaces and non-ASCII are supported.** `My Office Network #2` and `café` are valid. The agent percent-escapes the name when it addresses the policy over the backend's API, so characters that carry meaning in a URL (`#`, `?`, `%`, `/`) are safe to use.
+- **Must be distinct within a backend.** The name is a YAML mapping key, so a repeat silently replaces the earlier entry rather than erroring.
+- **Best kept distinct across backends too.** The agent indexes policies by name alone, so the same name under two backends can attach one policy's dataset IDs to the other's telemetry.
+
 For the full list of parameters per backend, see:
 - [Device Discovery](../backends/device_discovery/README.md)
 - [SNMP Discovery](../backends/snmp_discovery/README.md)


### PR DESCRIPTION
Closes [MON-333](https://linear.app/netboxlabs/issue/MON-333/agent-a-policy-name-with-or-corrupts-the-backend-delete-path).

### What

The backend DELETE URL was built by formatting the policy name straight into the path:

```go
url := fmt.Sprintf("%s://%s:%s/api/v1/policies/%s", apiProtocol, apiHost, apiPort, name)
```

Policy names are operator-written and forwarded verbatim. Nothing along the path slugifies, trims or case-folds them, and the name a backend reports in status and telemetry is the name as written, so `My Office Network #2` is a legitimate thing to write.

**The failure is silent.** `DELETE /api/v1/policies/My Office Network #2` becomes a delete of `My Office Network `, which removes an unrelated policy or nothing at all, and the agent reports success either way.

| character | what happens today |
|---|---|
| `#` | read as a fragment, never leaves the client |
| `?` | read as a query, same outcome |
| `%` | the URL does not parse, so no request is made |
| `/` | not a route miss: a 307 to the name without it, deleting a different policy |

### Escaping settles three of the four. A slash needs refusing

`#`, `?` and `%` are fixed by percent-escaping the name.

`/` is not, and the first revision of this PR wrongly claimed it was. Codex caught it. The ASGI spec requires percent-escapes to be decoded before the framework routes, so `%2F` is a separator again on arrival, `redirect_slashes` 307s it, and Go follows a 307 with the method intact. Verified end to end against a server that models that redirect:

```
sent "nightly/"   wire=/api/v1/policies/nightly%2F  handler saw="/api/v1/policies/nightly"
sent "nightly"    wire=/api/v1/policies/nightly     handler saw="/api/v1/policies/nightly"
```

So a slash-carrying name is **refused**, in `backend.PolicyPathSegment`. Failing is the only outcome that does not act on a policy the operator did not name.

**And refused at apply, not only at removal.** Codex caught that too, on the second pass. Apply puts the name in the request body rather than the URL, so a policy named `a/b` was created happily and only refused when someone tried to remove it. That is worse than it sounds: `policyManager.RemovePolicy` discards the local record even when the backend refuses, deliberately and with a comment saying so, so the policy would be left running with nothing in the agent aware it existed. The guard now sits in `policyManager.applyPolicy`, the one path every apply goes through, reported through the existing `FailedToApply` / `BackendErr` path. The delete-path guard stays, covering a policy applied by an older agent and a rename whose previous name carries a slash.

### Scope

The escaping was missing from three backends: `worker`, `pktvisor`, `opentelemetry_infinity`. The other five already had it.

The slash guard goes further: **all eight delete paths** now go through the one helper. A guard present at three of eight call sites is worse than either extreme, since nothing tells a reader which backends are safe, and logic spread across call sites is how the original three came to be missed. This is wider than the ticket asked for, and deliberately so.

### Nothing that works today changes

Measured rather than assumed. Both URL forms through `http.NewRequest`, comparing `RequestURI()`:

| name | today | escaped | differs |
|---|---|---|---|
| `mypolicy` | `/policies/mypolicy` | same | no |
| `My Office Network` | `/policies/My%20Office%20Network` | same | no |
| `café` | `/policies/caf%C3%A9` | same | no |
| `policy-1_v2.0`, `a+b`, `a&b`, `a:b` | unchanged | same | no |
| `My Office Network #2` | truncated at `#` | `...%20%232` | yes, broken today |
| `a?b` | truncated at `?` | `a%3Fb` | yes, broken today |
| `a%b` | `url.Parse` errors | `a%25b` | yes, broken today |
| `a/b` | routes elsewhere | refused with an error | yes, broken today |

`PathEscape` leaves spaces, non-ASCII and sub-delimiters alone, and the client was already encoding a space as `%20`. Every name whose behaviour changes is one that is already broken.

### Reachable in production, not just in theory

orb-pro's `buildManualPolicyName` takes the job name verbatim (truncate to 64 plus a UUID suffix, no sanitisation) and orb-pro drives the **`worker`** backend, one of the three unfixed here. So a job named `My Office Network #2` reaches the corrupt DELETE end to end. `pktvisor` and `opentelemetry_infinity` are not referenced by orb-pro, so those two are OSS exposure only.

### Tests

Per backend rather than shared, deliberately: each builds its own URL, so one shared test would let a backend that stopped escaping pass on another's coverage.

Each stands up an `httptest.Server`, calls `RemovePolicy` across the table, and asserts **`EscapedPath`** rather than `Path`. That matters: `Path` is already decoded, so it cannot tell an escaped name from a truncated one. Each table keeps a plain name and a spaced name so double-encoding would fail.

The handlers **model the receiving framework** rather than answering every path: they decode, and 307 a trailing slash the way `redirect_slashes` does. The first revision accepted everything, which is why its slash case looked delivered when it had in fact been redirected onto another policy. The slash case now asserts that `RemovePolicy` errors *and* that nothing reached the backend at all.

Mutation-verified, each failing only its own tests: removing the escaping fails that backend's test; making the helper escape a slash instead of refusing it fails the helper test and all three backend tests; dropping the apply-time check fails `TestManagePolicy_RefusesUnaddressableName`. (The first two mutations needed the now-unused imports removed too, so that they compile and the tests actually run rather than failing the build.)

### Docs

`docs/configs/agent_yaml.md` had no section on policy names. Added one covering that the key beneath a backend is the name, that it is forwarded verbatim, that spaces and non-ASCII are supported, that a name must not contain `/`, and that a name must be distinct within a backend.

Codex also caught an error in the first draft of that section: I wrote that a duplicate policy key silently replaces the earlier entry. It does not. yaml.v3 rejects a duplicate mapping key unconditionally, so the agent refuses the whole configuration file. Corrected, having checked it.

One correction to what the ticket proposed documenting: it suggested stating that names "may repeat across backends". They should not. `policyMemRepo.nameMap` is keyed by name alone, not by (backend, name), so the same name under two backends collapses in that index and `otlpbridge` can attach one policy's dataset IDs to the other's telemetry. The doc recommends keeping names distinct across backends and says why. That is a separate defect, not fixed here.

### One thing worth a look before merge

The ticket says "the backends already decode the path segment on their side". Confirmed for `worker`: it is FastAPI, `@app.delete("/api/v1/policies/{policy_name}")`, and Starlette decodes path params. **pktvisor is an external C++ binary whose router is not in this repo.** A space already goes over the wire as `%20` today and works, which implies it decodes percent-escapes, but that is an inference rather than something I verified against a running pktvisor.

Worth noting the slash guard is framework-independent, so it holds for pktvisor regardless of what its router does.

`go test ./agent/...` and `golangci-lint run ./... --config .github/golangci.yaml` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Noted, not fixed

`policyManager.RemovePolicy`, `RemovePolicyDataset` and `RemoveBackendPolicies` all discard the local record even when the backend removal fails. That is pre-existing and intentional per the comment on it, and it makes *any* failed removal unretryable, not only this case. Worth its own ticket rather than a change buried here.
