### PR TITLE
chore(repo): allow the gnmi-telemetry scope in pr titles

### DIFF
--- a/.github/semantic-release/agent.releaserc.json
+++ b/.github/semantic-release/agent.releaserc.json
@@ -18,6 +18,7 @@
         { "scope": "snmp-discovery", "release": false },
         { "scope": "gnmi-discovery", "release": false },
         { "scope": "snmp-telemetry", "release": false },
+        { "scope": "gnmi-telemetry", "release": false },
         { "scope": "worker", "release": false },
         { "scope": "repo", "release": false },
         { "scope": "ci", "release": false },

--- a/.github/workflows/pr-title-lint.yaml
+++ b/.github/workflows/pr-title-lint.yaml
@@ -33,6 +33,7 @@ jobs:
             agent
             device-discovery
             gnmi-discovery
+            gnmi-telemetry
             network-discovery
             snmp-discovery
             snmp-telemetry

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,7 @@ aggregated agent release):
 
 - `device-discovery`
 - `gnmi-discovery` *(experimental)*
+- `gnmi-telemetry`
 - `network-discovery`
 - `snmp-discovery`
 - `snmp-telemetry`
@@ -85,7 +86,7 @@ Other scopes:
 > **Agent version vs. non-agent scopes.** The mapping above is the per-component
 > rule. For the **agent** release specifically, both the backend scopes
 > (`device-discovery`, `network-discovery`, `snmp-discovery`, `gnmi-discovery`,
-> `snmp-telemetry`, `worker`) and the no-release scopes (`repo`, `ci`, `docs`,
+> `gnmi-telemetry`, `snmp-telemetry`, `worker`) and the no-release scopes (`repo`, `ci`, `docs`,
 > `deps-dev`) are set to `release: false`, so even a releasing *type* on those
 > scopes (e.g. `feat(repo)`, `fix(ci)`) does **not** bump the agent version.
 > Backend commits still appear in the aggregated agent release notes. The one


### PR DESCRIPTION
## Summary

Adds `gnmi-telemetry` to the PR title scope allowlist, the contributor guide's backend lists, and the agent release configuration (`release: false`, like every other backend scope).

The backend itself lands next under `orb-telemetry/gnmi-telemetry` (MON-355). Its PR title cannot pass the lint until this merges, because `pr-title-lint.yaml` runs on `pull_request_target` and reads `develop`'s allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)