### PR TITLE
fix(snmp-discovery): keep walking past a failed table and accept out-of-order rows

### DIFF
--- a/docs/backends/snmp_discovery/README.md
+++ b/docs/backends/snmp_discovery/README.md
@@ -431,7 +431,9 @@ BRIDGE-MIB table with a later index before an earlier one, which no operator
 can correct from this side, so the walk does not require increasing OIDs. Two
 bounds stand in for the ordering check: an agent delivering an OID it already
 delivered ends the table with the rows collected before it, and a table ends
-at 500,000 rows, kept as collected and logged as truncated.
+at 500,000 rows, kept as collected and logged as truncated. The policy's
+`timeout` bounds the whole walk: once it expires, the walk stops at the next
+row and the target fails.
 
 ## Device Model Lookup
 

--- a/docs/backends/snmp_discovery/README.md
+++ b/docs/backends/snmp_discovery/README.md
@@ -421,15 +421,17 @@ When the `discover_modules` policy option is enabled, snmp-discovery emits NetBo
 
 ## Walking the device
 
-Each table is walked on its own. A table the agent fails, by timing out or by
-refusing the request, is logged and skipped, and the target keeps everything
-the other tables returned; only a target that fails every table, or cannot be
-reached at all, fails the run. Rows an agent returns out of index order are
-kept: some agents serve a Q-BRIDGE or BRIDGE-MIB table with a later index
-before an earlier one, which no operator can correct from this side, so the
-walk does not require increasing OIDs. The one way such a walk could loop is
-an agent delivering an OID it already delivered, and that ends the table with
-the rows collected before it.
+Each table is walked on its own. A table the agent refuses is logged and
+skipped, and the target keeps everything the other tables returned; only a
+target that fails every table, or cannot be reached at all, fails the run. A
+timeout is different: it means the device stopped answering, and it fails the
+target at once rather than costing one timeout per remaining table. Rows an
+agent returns out of index order are kept: some agents serve a Q-BRIDGE or
+BRIDGE-MIB table with a later index before an earlier one, which no operator
+can correct from this side, so the walk does not require increasing OIDs. Two
+bounds stand in for the ordering check: an agent delivering an OID it already
+delivered ends the table with the rows collected before it, and a table ends
+at 500,000 rows, kept as collected and logged as truncated.
 
 ## Device Model Lookup
 

--- a/docs/backends/snmp_discovery/README.md
+++ b/docs/backends/snmp_discovery/README.md
@@ -419,6 +419,18 @@ When the `discover_modules` policy option is enabled, snmp-discovery emits NetBo
 
 **Supported vendors.** Module discovery works on any vendor that populates `entPhysicalTable` per RFC 6933 — see the [supported platforms page](./supported_platforms.md#modules--modulebays) for the platforms known-tested in v1.
 
+## Walking the device
+
+Each table is walked on its own. A table the agent fails, by timing out or by
+refusing the request, is logged and skipped, and the target keeps everything
+the other tables returned; only a target that fails every table, or cannot be
+reached at all, fails the run. Rows an agent returns out of index order are
+kept: some agents serve a Q-BRIDGE or BRIDGE-MIB table with a later index
+before an earlier one, which no operator can correct from this side, so the
+walk does not require increasing OIDs. The one way such a walk could loop is
+an agent delivering an OID it already delivered, and that ends the table with
+the rows collected before it.
+
 ## Device Model Lookup
 
 The `lookup_extensions_dir` config option points to a directory of YAML files that map SNMP `sysObjectID` OIDs to human-readable device model names. Without these files, snmp-discovery would ingest raw OIDs (for example `.1.3.6.1.4.1.9.1.489`) instead of recognizable model names (for example `catalyst2955C12`).

--- a/docs/backends/snmp_discovery/README.md
+++ b/docs/backends/snmp_discovery/README.md
@@ -421,17 +421,15 @@ When the `discover_modules` policy option is enabled, snmp-discovery emits NetBo
 
 ## Walking the device
 
-Each table is walked on its own. A table the agent refuses is logged and
-skipped, and the target keeps everything the other tables returned; only a
-target that fails every table, or cannot be reached at all, fails the run. A
-timeout is different: it means the device stopped answering, and it fails the
-target at once rather than costing one timeout per remaining table. Rows an
-agent returns out of index order are kept: some agents serve a Q-BRIDGE or
-BRIDGE-MIB table with a later index before an earlier one, which no operator
-can correct from this side, so the walk does not require increasing OIDs. Two
-bounds stand in for the ordering check: an agent delivering an OID it already
-delivered ends the table with the rows collected before it, and a table ends
-at 500,000 rows, kept as collected and logged as truncated. The policy's
+Rows an agent returns out of index order are kept: some agents serve a
+Q-BRIDGE or BRIDGE-MIB table with a later index before an earlier one, which
+no operator can correct from this side, so the walk does not require
+increasing OIDs. Two bounds stand in for the ordering check, and each ends
+the table with the rows collected before it, kept and logged as a warning: an
+agent delivering an OID it already delivered, and a table reaching 500,000
+rows. A table the walk cannot finish for any other reason, the device going
+silent or answering with something other than SNMP, fails the target, as it
+always did. An SNMP error status ends a table without failing it. The policy's
 `timeout` bounds the whole walk: once it expires, the walk stops at the next
 row and the target fails.
 

--- a/orb-discovery/snmp-discovery/policy/runner.go
+++ b/orb-discovery/snmp-discovery/policy/runner.go
@@ -374,7 +374,7 @@ func (r *Runner) probeTarget(ctx context.Context, target config.Target) bool {
 		return false
 	}
 
-	_, err = snmpClient.Walk(defaultSNMPProbeOID, 0)
+	_, err = snmpClient.Walk(ctx, defaultSNMPProbeOID, 0)
 	if err == nil {
 		return true
 	}
@@ -576,7 +576,7 @@ func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode
 	// bounded by snmpTimeout (set on the SNMP client), so it is not a permanent leak.
 	resultCh := make(chan walkResult, 1)
 	go func() {
-		oids, err := host.Walk(genericOIDs)
+		oids, err := host.Walk(ctx, genericOIDs)
 		resultCh <- walkResult{oids, err}
 	}()
 
@@ -616,7 +616,7 @@ func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode
 				"host", targetHost, "vendor", vendor, "oid_count", len(vendorOIDs))
 			vendorCh := make(chan walkResult, 1)
 			go func() {
-				out, err := host.Walk(vendorOIDs)
+				out, err := host.Walk(ctx, vendorOIDs)
 				vendorCh <- walkResult{out, err}
 			}()
 			select {

--- a/orb-discovery/snmp-discovery/policy/runner_internal_test.go
+++ b/orb-discovery/snmp-discovery/policy/runner_internal_test.go
@@ -31,7 +31,7 @@ func (s *slowWalker) Connect() error {
 	return errors.New("unblocked")
 }
 
-func (s *slowWalker) Walk(_ string, _ int) (map[string]snmp.PDU, error) {
+func (s *slowWalker) Walk(_ context.Context, _ string, _ int) (map[string]snmp.PDU, error) {
 	return nil, nil
 }
 
@@ -52,7 +52,7 @@ func (t *testWalker) Connect() error {
 	return t.connectErr
 }
 
-func (t *testWalker) Walk(objectID string, identifierSize int) (map[string]snmp.PDU, error) {
+func (t *testWalker) Walk(_ context.Context, objectID string, identifierSize int) (map[string]snmp.PDU, error) {
 	t.walkCalled = true
 	t.walkOID = objectID
 	t.walkIdentifier = identifierSize
@@ -353,7 +353,7 @@ type staticWalker struct {
 
 func (w *staticWalker) Connect() error { return nil }
 func (w *staticWalker) Close() error   { return nil }
-func (w *staticWalker) Walk(oid string, _ int) (map[string]snmp.PDU, error) {
+func (w *staticWalker) Walk(_ context.Context, oid string, _ int) (map[string]snmp.PDU, error) {
 	if p, ok := w.pdus[oid]; ok {
 		return p, nil
 	}

--- a/orb-discovery/snmp-discovery/policy/runner_test.go
+++ b/orb-discovery/snmp-discovery/policy/runner_test.go
@@ -45,7 +45,7 @@ type MockHost struct {
 	mock.Mock
 }
 
-func (m *MockHost) Walk(objectID string, identifierSize int) (map[string]snmp.PDU, error) {
+func (m *MockHost) Walk(_ context.Context, objectID string, identifierSize int) (map[string]snmp.PDU, error) {
 	args := m.Called(objectID, identifierSize)
 	return args.Get(0).(map[string]snmp.PDU), args.Error(1)
 }

--- a/orb-discovery/snmp-discovery/snmp/mocks.go
+++ b/orb-discovery/snmp-discovery/snmp/mocks.go
@@ -1,6 +1,7 @@
 package snmp
 
 import (
+	"context"
 	"log/slog"
 	"time"
 
@@ -23,7 +24,7 @@ func (n *FakeSNMPWalker) Close() error {
 }
 
 // Walk implements Walker interface
-func (n *FakeSNMPWalker) Walk(oid string, _ int) (map[string]PDU, error) {
+func (n *FakeSNMPWalker) Walk(_ context.Context, oid string, _ int) (map[string]PDU, error) {
 	if oid == "1.3.6.1.2.1.4.20.1.1" {
 		return map[string]PDU{
 			"1.3.6.1.2.1.4.20.1.1": {Value: "192.168.1.1", Type: gosnmp.IPAddress},

--- a/orb-discovery/snmp-discovery/snmp/snmp.go
+++ b/orb-discovery/snmp-discovery/snmp/snmp.go
@@ -55,7 +55,7 @@ func NewHost(host string, port uint16, retries int, timeout time.Duration, authe
 }
 
 // Walk walks the SNMP host
-func (s *Host) Walk(objectIDs map[string]int) (mapping.ObjectIDValueMap, error) {
+func (s *Host) Walk(ctx context.Context, objectIDs map[string]int) (mapping.ObjectIDValueMap, error) {
 	s.logger.Info("scanning", "host", s.address)
 
 	snmpClient, err := s.ClientFactory(s.address, s.port, s.retries, s.timeout, s.authentication, s.logger)
@@ -86,9 +86,13 @@ func (s *Host) Walk(objectIDs map[string]int) (mapping.ObjectIDValueMap, error) 
 	var lastErr error
 	for objectID, identifierSize := range objectIDs {
 		walked++
-		pdu, err := snmpClient.Walk(objectID, identifierSize)
+		pdu, err := snmpClient.Walk(ctx, objectID, identifierSize)
 		switch {
 		case err == nil:
+		case ctx.Err() != nil:
+			// The policy's timeout ended the walk: nothing more is owed to
+			// this target, and the runner has stopped waiting for it.
+			return nil, err
 		case errors.Is(err, ErrWalkTruncated):
 			s.logger.Warn("table walk truncated at the row cap; keeping what was collected", "object_id", objectID, "rows", len(pdu))
 		case isTimeout(err):
@@ -194,8 +198,8 @@ func (c *Client) EngineDiscovered() bool {
 }
 
 // Walk implements the Walker interface by walking the SNMP tree
-func (c *Client) Walk(objectIDs string, identifierSize int) (map[string]PDU, error) {
-	return collectWalk(func(fn gosnmp.WalkFunc) error { return c.GoSNMP.Walk(objectIDs, fn) }, identifierSize)
+func (c *Client) Walk(ctx context.Context, objectIDs string, identifierSize int) (map[string]PDU, error) {
+	return collectWalk(ctx, func(fn gosnmp.WalkFunc) error { return c.GoSNMP.Walk(objectIDs, fn) }, identifierSize)
 }
 
 // errWalkRepeated ends a walk that delivered an OID it had already delivered.
@@ -213,16 +217,21 @@ var ErrWalkTruncated = errors.New("walk truncated at the row cap")
 // tens of megabytes rather than the process.
 const maxWalkRows = 500_000
 
-// collectWalk gathers the rows a walk delivers, keyed by OID. The ordering
+// collectWalk gathers the rows a walk delivers, keyed by OID, and ends the
+// walk once ctx ends, so the policy's timeout bounds the walk in time as the
+// row cap bounds it in size. The ordering
 // check gosnmp applies by default is off on every client, since an agent that
 // returns a table out of index order is a quirk no operator can correct and
 // the check cost the whole target; without it, the one way a walk can loop is
 // an agent delivering an OID it already delivered, and that ends the table
 // with the rows collected before it. Any other error the walk reports fails
 // the table.
-func collectWalk(walk func(fn gosnmp.WalkFunc) error, identifierSize int) (map[string]PDU, error) {
+func collectWalk(ctx context.Context, walk func(fn gosnmp.WalkFunc) error, identifierSize int) (map[string]PDU, error) {
 	output := make(map[string]PDU)
 	err := walk(func(pdu gosnmp.SnmpPDU) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if _, seen := output[pdu.Name]; seen {
 			return errWalkRepeated
 		}
@@ -402,7 +411,7 @@ func getPrivProtocol(privProtocol string) (gosnmp.SnmpV3PrivProtocol, error) {
 // It allows for connecting to SNMP devices, traversing ObjectID trees,
 // and properly closing connections when finished
 type Walker interface {
-	Walk(objectID string, identifierSize int) (map[string]PDU, error)
+	Walk(ctx context.Context, objectID string, identifierSize int) (map[string]PDU, error)
 	Connect() error
 	Close() error
 }

--- a/orb-discovery/snmp-discovery/snmp/snmp.go
+++ b/orb-discovery/snmp-discovery/snmp/snmp.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
-	"strings"
 	"time"
 
 	"github.com/gosnmp/gosnmp"
@@ -74,22 +73,18 @@ func (s *Host) Walk(ctx context.Context, objectIDs map[string]int) (mapping.Obje
 		return nil, err
 	}
 
-	// Each table is walked on its own: one the agent fails is logged and
-	// skipped, and the target keeps everything the other tables returned.
-	// Returning on the first failure cost the whole target, device,
-	// interfaces and addresses included, for one table the agent could not
-	// serve. A timeout is not such a failure but the device going silent,
-	// and fails the target at once. Only a target that failed every table
-	// is failed otherwise.
+	// Each table is walked on its own so that a table ended short by one of
+	// the walk's bounds can be kept and reported. A table the walk cannot
+	// finish fails the target: what reaches here is a transport or decode
+	// failure, the device going silent or answering with something other
+	// than SNMP, and a device missing the tables it lost is not a
+	// discovered device.
 	output := make(mapping.ObjectIDValueMap)
-	var walked, failed int
-	var lastErr error
 	for objectID, identifierSize := range objectIDs {
 		if err := ctx.Err(); err != nil {
 			// The policy stopped waiting: no further table is started.
 			return nil, err
 		}
-		walked++
 		pdu, err := snmpClient.Walk(ctx, objectID, identifierSize)
 		switch {
 		case err == nil:
@@ -99,17 +94,11 @@ func (s *Host) Walk(ctx context.Context, objectIDs map[string]int) (mapping.Obje
 			return nil, err
 		case errors.Is(err, ErrWalkTruncated):
 			s.logger.Warn("table walk truncated at the row cap; keeping what was collected", "object_id", objectID, "rows", len(pdu))
-		case isTimeout(err):
-			// The device stopped answering: every remaining table would
-			// spend its own timeout the same way, and one is the target's
-			// whole verdict.
+		case errors.Is(err, ErrWalkRepeated):
+			s.logger.Warn("table walk ended at a repeated OID; keeping what was collected", "object_id", objectID, "rows", len(pdu))
+		default:
 			s.logger.Warn("error walking object ID", "object_id", objectID, "error", err)
 			return nil, err
-		default:
-			s.logger.Warn("error walking object ID; continuing with the other tables", "object_id", objectID, "error", err)
-			failed++
-			lastErr = err
-			continue
 		}
 		for k, value := range pdu {
 			s.logger.Debug("mapping PDU", "object_id", k, "value", value, "value_type", reflect.TypeOf(value.Value))
@@ -122,13 +111,6 @@ func (s *Host) Walk(ctx context.Context, objectIDs map[string]int) (mapping.Obje
 			s.logger.Debug("mapped PDU", "object_id", k, "value", value)
 		}
 	}
-	if walked > 0 && failed == walked {
-		return nil, lastErr
-	}
-	if failed > 0 {
-		s.logger.Warn("some tables could not be walked", "host", s.address, "failed", failed, "walked", walked)
-	}
-
 	return output, nil
 }
 
@@ -226,8 +208,11 @@ func (c *Client) Walk(ctx context.Context, objectIDs string, identifierSize int)
 	return collectWalk(ctx, func(fn gosnmp.WalkFunc) error { return c.GoSNMP.Walk(objectIDs, fn) }, identifierSize)
 }
 
-// errWalkRepeated ends a walk that delivered an OID it had already delivered.
-var errWalkRepeated = errors.New("walk repeated an OID")
+// ErrWalkRepeated is returned with the rows collected when a walk delivered
+// an OID it had already delivered, the one way a walk without the ordering
+// check can loop: the table is kept as collected and the repeat is
+// reported, since the rows after it were never read.
+var ErrWalkRepeated = errors.New("walk repeated an OID")
 
 // ErrWalkTruncated is returned with the rows collected when a table hit
 // maxWalkRows: the table is kept as collected and the truncation is
@@ -257,7 +242,7 @@ func collectWalk(ctx context.Context, walk func(fn gosnmp.WalkFunc) error, ident
 			return err
 		}
 		if _, seen := output[pdu.Name]; seen {
-			return errWalkRepeated
+			return ErrWalkRepeated
 		}
 		if len(output) >= maxWalkRows {
 			return ErrWalkTruncated
@@ -275,20 +260,12 @@ func collectWalk(ctx context.Context, walk func(fn gosnmp.WalkFunc) error, ident
 		return nil, ctxErr
 	}
 	switch {
-	case err == nil, errors.Is(err, errWalkRepeated):
+	case err == nil:
 		return output, nil
-	case errors.Is(err, ErrWalkTruncated):
-		return output, ErrWalkTruncated
+	case errors.Is(err, ErrWalkRepeated), errors.Is(err, ErrWalkTruncated):
+		return output, err
 	}
 	return nil, err
-}
-
-// isTimeout reports whether a walk failed because the device stopped
-// answering. gosnmp reports that as a plain "request timeout" error, and a
-// transport deadline reads the same way; neither is a table the agent could
-// not serve, so neither is skipped.
-func isTimeout(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "timeout")
 }
 
 // tolerantWalks is the gosnmp option that turns its OID ordering check off;

--- a/orb-discovery/snmp-discovery/snmp/snmp.go
+++ b/orb-discovery/snmp-discovery/snmp/snmp.go
@@ -85,6 +85,10 @@ func (s *Host) Walk(ctx context.Context, objectIDs map[string]int) (mapping.Obje
 	var walked, failed int
 	var lastErr error
 	for objectID, identifierSize := range objectIDs {
+		if err := ctx.Err(); err != nil {
+			// The policy stopped waiting: no further table is started.
+			return nil, err
+		}
 		walked++
 		pdu, err := snmpClient.Walk(ctx, objectID, identifierSize)
 		switch {
@@ -246,6 +250,10 @@ func collectWalk(ctx context.Context, walk func(fn gosnmp.WalkFunc) error, ident
 		}
 		return nil
 	})
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		// A walk that delivered no rows never reached the callback above.
+		return nil, ctxErr
+	}
 	switch {
 	case err == nil, errors.Is(err, errWalkRepeated):
 		return output, nil

--- a/orb-discovery/snmp-discovery/snmp/snmp.go
+++ b/orb-discovery/snmp-discovery/snmp/snmp.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/gosnmp/gosnmp"
@@ -77,14 +78,26 @@ func (s *Host) Walk(objectIDs map[string]int) (mapping.ObjectIDValueMap, error) 
 	// skipped, and the target keeps everything the other tables returned.
 	// Returning on the first failure cost the whole target, device,
 	// interfaces and addresses included, for one table the agent could not
-	// serve. Only a target that failed every table is failed.
+	// serve. A timeout is not such a failure but the device going silent,
+	// and fails the target at once. Only a target that failed every table
+	// is failed otherwise.
 	output := make(mapping.ObjectIDValueMap)
 	var walked, failed int
 	var lastErr error
 	for objectID, identifierSize := range objectIDs {
 		walked++
 		pdu, err := snmpClient.Walk(objectID, identifierSize)
-		if err != nil {
+		switch {
+		case err == nil:
+		case errors.Is(err, ErrWalkTruncated):
+			s.logger.Warn("table walk truncated at the row cap; keeping what was collected", "object_id", objectID, "rows", len(pdu))
+		case isTimeout(err):
+			// The device stopped answering: every remaining table would
+			// spend its own timeout the same way, and one is the target's
+			// whole verdict.
+			s.logger.Warn("error walking object ID", "object_id", objectID, "error", err)
+			return nil, err
+		default:
 			s.logger.Warn("error walking object ID; continuing with the other tables", "object_id", objectID, "error", err)
 			failed++
 			lastErr = err
@@ -188,6 +201,18 @@ func (c *Client) Walk(objectIDs string, identifierSize int) (map[string]PDU, err
 // errWalkRepeated ends a walk that delivered an OID it had already delivered.
 var errWalkRepeated = errors.New("walk repeated an OID")
 
+// ErrWalkTruncated is returned with the rows collected when a table hit
+// maxWalkRows: the table is kept as collected and the truncation is
+// reported, since a walk without the ordering check has no other end
+// against an agent that answers every request with a new, non-increasing
+// OID.
+var ErrWalkTruncated = errors.New("walk truncated at the row cap")
+
+// maxWalkRows bounds one table. Far past any real table, the largest
+// forwarding tables included, and small enough that a runaway agent costs
+// tens of megabytes rather than the process.
+const maxWalkRows = 500_000
+
 // collectWalk gathers the rows a walk delivers, keyed by OID. The ordering
 // check gosnmp applies by default is off on every client, since an agent that
 // returns a table out of index order is a quirk no operator can correct and
@@ -201,6 +226,9 @@ func collectWalk(walk func(fn gosnmp.WalkFunc) error, identifierSize int) (map[s
 		if _, seen := output[pdu.Name]; seen {
 			return errWalkRepeated
 		}
+		if len(output) >= maxWalkRows {
+			return ErrWalkTruncated
+		}
 		output[pdu.Name] = PDU{
 			Name:           pdu.Name,
 			Type:           pdu.Type,
@@ -209,10 +237,21 @@ func collectWalk(walk func(fn gosnmp.WalkFunc) error, identifierSize int) (map[s
 		}
 		return nil
 	})
-	if err != nil && !errors.Is(err, errWalkRepeated) {
-		return nil, err
+	switch {
+	case err == nil, errors.Is(err, errWalkRepeated):
+		return output, nil
+	case errors.Is(err, ErrWalkTruncated):
+		return output, ErrWalkTruncated
 	}
-	return output, nil
+	return nil, err
+}
+
+// isTimeout reports whether a walk failed because the device stopped
+// answering. gosnmp reports that as a plain "request timeout" error, and a
+// transport deadline reads the same way; neither is a table the agent could
+// not serve, so neither is skipped.
+func isTimeout(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "timeout")
 }
 
 // tolerantWalks is the gosnmp option that turns its OID ordering check off;

--- a/orb-discovery/snmp-discovery/snmp/snmp.go
+++ b/orb-discovery/snmp-discovery/snmp/snmp.go
@@ -207,6 +207,22 @@ func (c *Client) Walk(ctx context.Context, objectIDs string, identifierSize int)
 	// so a target that goes silent after the policy's deadline does not hold
 	// the walker through the SNMP timeout and its retries.
 	c.Context = ctx
+	// gosnmp puts only that deadline on the socket and looks at a
+	// cancellation between requests, so a read in flight when the context is
+	// cancelled with no deadline, as a shutdown does, would wait out the SNMP
+	// timeout. Moving the socket deadline to now returns that read at once,
+	// and gosnmp then reads the cancellation.
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		select {
+		case <-ctx.Done():
+			if c.Conn != nil {
+				_ = c.Conn.SetDeadline(time.Now())
+			}
+		case <-stop:
+		}
+	}()
 	return collectWalk(ctx, func(fn gosnmp.WalkFunc) error { return c.GoSNMP.Walk(objectIDs, fn) }, identifierSize)
 }
 

--- a/orb-discovery/snmp-discovery/snmp/snmp.go
+++ b/orb-discovery/snmp-discovery/snmp/snmp.go
@@ -203,6 +203,10 @@ func (c *Client) EngineDiscovered() bool {
 
 // Walk implements the Walker interface by walking the SNMP tree
 func (c *Client) Walk(ctx context.Context, objectIDs string, identifierSize int) (map[string]PDU, error) {
+	// gosnmp bounds every request in flight by the deadline of this context,
+	// so a target that goes silent after the policy's deadline does not hold
+	// the walker through the SNMP timeout and its retries.
+	c.Context = ctx
 	return collectWalk(ctx, func(fn gosnmp.WalkFunc) error { return c.GoSNMP.Walk(objectIDs, fn) }, identifierSize)
 }
 

--- a/orb-discovery/snmp-discovery/snmp/snmp.go
+++ b/orb-discovery/snmp-discovery/snmp/snmp.go
@@ -2,6 +2,7 @@ package snmp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"reflect"
@@ -72,12 +73,22 @@ func (s *Host) Walk(objectIDs map[string]int) (mapping.ObjectIDValueMap, error) 
 		return nil, err
 	}
 
+	// Each table is walked on its own: one the agent fails is logged and
+	// skipped, and the target keeps everything the other tables returned.
+	// Returning on the first failure cost the whole target, device,
+	// interfaces and addresses included, for one table the agent could not
+	// serve. Only a target that failed every table is failed.
 	output := make(mapping.ObjectIDValueMap)
+	var walked, failed int
+	var lastErr error
 	for objectID, identifierSize := range objectIDs {
+		walked++
 		pdu, err := snmpClient.Walk(objectID, identifierSize)
 		if err != nil {
-			s.logger.Warn("error walking object ID", "object_id", objectID, "error", err)
-			return nil, err
+			s.logger.Warn("error walking object ID; continuing with the other tables", "object_id", objectID, "error", err)
+			failed++
+			lastErr = err
+			continue
 		}
 		for k, value := range pdu {
 			s.logger.Debug("mapping PDU", "object_id", k, "value", value, "value_type", reflect.TypeOf(value.Value))
@@ -89,6 +100,12 @@ func (s *Host) Walk(objectIDs map[string]int) (mapping.ObjectIDValueMap, error) 
 			output[k] = value
 			s.logger.Debug("mapped PDU", "object_id", k, "value", value)
 		}
+	}
+	if walked > 0 && failed == walked {
+		return nil, lastErr
+	}
+	if failed > 0 {
+		s.logger.Warn("some tables could not be walked", "host", s.address, "failed", failed, "walked", walked)
 	}
 
 	return output, nil
@@ -165,20 +182,43 @@ func (c *Client) EngineDiscovered() bool {
 
 // Walk implements the Walker interface by walking the SNMP tree
 func (c *Client) Walk(objectIDs string, identifierSize int) (map[string]PDU, error) {
-	pdu, err := c.WalkAll(objectIDs)
-	if err != nil {
-		return nil, err
-	}
+	return collectWalk(func(fn gosnmp.WalkFunc) error { return c.GoSNMP.Walk(objectIDs, fn) }, identifierSize)
+}
+
+// errWalkRepeated ends a walk that delivered an OID it had already delivered.
+var errWalkRepeated = errors.New("walk repeated an OID")
+
+// collectWalk gathers the rows a walk delivers, keyed by OID. The ordering
+// check gosnmp applies by default is off on every client, since an agent that
+// returns a table out of index order is a quirk no operator can correct and
+// the check cost the whole target; without it, the one way a walk can loop is
+// an agent delivering an OID it already delivered, and that ends the table
+// with the rows collected before it. Any other error the walk reports fails
+// the table.
+func collectWalk(walk func(fn gosnmp.WalkFunc) error, identifierSize int) (map[string]PDU, error) {
 	output := make(map[string]PDU)
-	for _, pdu := range pdu {
+	err := walk(func(pdu gosnmp.SnmpPDU) error {
+		if _, seen := output[pdu.Name]; seen {
+			return errWalkRepeated
+		}
 		output[pdu.Name] = PDU{
 			Name:           pdu.Name,
 			Type:           pdu.Type,
 			Value:          pdu.Value,
 			IdentifierSize: identifierSize,
 		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, errWalkRepeated) {
+		return nil, err
 	}
 	return output, nil
+}
+
+// tolerantWalks is the gosnmp option that turns its OID ordering check off;
+// collectWalk guards the loop the check existed to prevent.
+func tolerantWalks() map[string]any {
+	return map[string]any{"c": true}
 }
 
 // PDU is a struct that represents an SNMP PDU
@@ -220,6 +260,7 @@ func NewClient(host string, port uint16, retries int, timeout time.Duration, aut
 				Timeout:   timeout,
 				Retries:   retries,
 				Logger:    gosnmpLogger,
+				AppOpts:   tolerantWalks(),
 			},
 		}, nil
 	case ProtocolVersion2c:
@@ -232,6 +273,7 @@ func NewClient(host string, port uint16, retries int, timeout time.Duration, aut
 				Timeout:   timeout,
 				Retries:   retries,
 				Logger:    gosnmpLogger,
+				AppOpts:   tolerantWalks(),
 			},
 		}, nil
 	case ProtocolVersion3:
@@ -263,6 +305,7 @@ func NewClient(host string, port uint16, retries int, timeout time.Duration, aut
 				SecurityModel: gosnmp.UserSecurityModel,
 				ContextName:   authentication.ContextName,
 				Logger:        gosnmpLogger,
+				AppOpts:       tolerantWalks(),
 				SecurityParameters: &gosnmp.UsmSecurityParameters{
 					UserName:                 authentication.Username,
 					AuthenticationProtocol:   authProtocol,

--- a/orb-discovery/snmp-discovery/snmp/snmp_test.go
+++ b/orb-discovery/snmp-discovery/snmp/snmp_test.go
@@ -809,7 +809,7 @@ func TestSNMPHostKeepsGoingPastAFailedTable(t *testing.T) {
 	mockWalker.On("Connect").Return(nil)
 	mockWalker.On("Close").Return(nil)
 	mockWalker.On("Walk", good, 1).Return(map[string]snmp.PDU{good + ".1": {Value: "eth0", Type: gosnmp.OctetString, IdentifierSize: 1}}, nil)
-	mockWalker.On("Walk", bad, 1).Return(map[string]snmp.PDU(nil), errors.New("request timeout"))
+	mockWalker.On("Walk", bad, 1).Return(map[string]snmp.PDU(nil), errors.New("unknown error response"))
 	factory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
 		return mockWalker, nil
 	}
@@ -823,10 +823,46 @@ func TestSNMPHostKeepsGoingPastAFailedTable(t *testing.T) {
 	allBad := &MockSNMP{}
 	allBad.On("Connect").Return(nil)
 	allBad.On("Close").Return(nil)
-	allBad.On("Walk", bad, 1).Return(map[string]snmp.PDU(nil), errors.New("request timeout"))
+	allBad.On("Walk", bad, 1).Return(map[string]snmp.PDU(nil), errors.New("unknown error response"))
 	host = snmp.NewHost("192.0.2.1", 161, 1, time.Second, nil, logger, func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
 		return allBad, nil
 	})
 	_, err = host.Walk(map[string]int{bad: 1})
 	assert.Error(t, err, "every table failing fails the target")
+}
+
+// A timeout is the device going silent, not a table the agent cannot serve:
+// it fails the target at once, whatever other tables remain, so a device that
+// stops answering costs one timeout rather than one per table.
+func TestSNMPHostFailsTheTargetOnATimeout(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	const good, silent = "1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.17.7.1.4.5.1.1"
+	mockWalker := &MockSNMP{}
+	mockWalker.On("Connect").Return(nil)
+	mockWalker.On("Close").Return(nil)
+	mockWalker.On("Walk", good, 1).Return(map[string]snmp.PDU{good + ".1": {Value: "eth0", Type: gosnmp.OctetString, IdentifierSize: 1}}, nil).Maybe()
+	mockWalker.On("Walk", silent, 1).Return(map[string]snmp.PDU(nil), errors.New("request timeout (after 0 retries)"))
+	host := snmp.NewHost("192.0.2.1", 161, 1, time.Second, nil, logger, func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
+		return mockWalker, nil
+	})
+	_, err := host.Walk(map[string]int{good: 1, silent: 1})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout")
+}
+
+// A table that hit the row cap is kept as collected: the truncation is a
+// warning, not a failure of the table or the target.
+func TestSNMPHostKeepsATruncatedTable(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	const big = "1.3.6.1.2.1.17.4.3.1.2"
+	mockWalker := &MockSNMP{}
+	mockWalker.On("Connect").Return(nil)
+	mockWalker.On("Close").Return(nil)
+	mockWalker.On("Walk", big, 1).Return(map[string]snmp.PDU{big + ".1": {Value: 3, Type: gosnmp.Integer, IdentifierSize: 1}}, snmp.ErrWalkTruncated)
+	host := snmp.NewHost("192.0.2.1", 161, 1, time.Second, nil, logger, func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
+		return mockWalker, nil
+	})
+	oids, err := host.Walk(map[string]int{big: 1})
+	require.NoError(t, err)
+	assert.Equal(t, "3", oids[big+".1"].Value)
 }

--- a/orb-discovery/snmp-discovery/snmp/snmp_test.go
+++ b/orb-discovery/snmp-discovery/snmp/snmp_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"os"
 	"testing"
 	"time"
@@ -883,4 +884,27 @@ func TestSNMPHostStartsNoTableAfterTheContextEnds(t *testing.T) {
 	_, err := host.Walk(ctx, map[string]int{"1.3.6.1.2.1.2.2.1.2": 1})
 	require.ErrorIs(t, err, context.Canceled)
 	mockWalker.AssertNotCalled(t, "Walk", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// The walk's context bounds the request in flight as well: a target that
+// goes silent after the policy deadline passes does not hold the walker
+// through the SNMP timeout and its retries.
+func TestClientWalkReturnsWhenTheContextEndsMidRequest(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	silent, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = silent.Close() }()
+	port := uint16(silent.LocalAddr().(*net.UDPAddr).Port)
+
+	client, err := snmp.NewClient("127.0.0.1", port, 2, 5*time.Second, &config.Authentication{ProtocolVersion: snmp.ProtocolVersion2c, Community: "public"}, logger)
+	require.NoError(t, err)
+	require.NoError(t, client.Connect())
+	defer func() { _ = client.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err = client.Walk(ctx, "1.3.6.1.2.1.2.2.1.2", 1)
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 2*time.Second, "the walk returns at the context deadline, not after the SNMP timeout and retries")
 }

--- a/orb-discovery/snmp-discovery/snmp/snmp_test.go
+++ b/orb-discovery/snmp-discovery/snmp/snmp_test.go
@@ -800,36 +800,29 @@ func TestNewClientDoesNotCheckOIDOrdering(t *testing.T) {
 	}
 }
 
-// A table the agent fails does not cost the target: the host keeps walking
-// the other tables and returns what it collected, failing only when every
-// table failed.
-func TestSNMPHostKeepsGoingPastAFailedTable(t *testing.T) {
+// A table the walk cannot finish fails the target, as it always did: the
+// errors that reach here are transport and decode failures, a device whose
+// agent restarted or answered with something other than SNMP, and a device
+// missing the tables it lost is not a discovered device. Only an SNMP error
+// status, which ends the table without an error, and the two bounds below
+// leave a table short without failing the target.
+func TestSNMPHostFailsTheTargetOnAFailedTable(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	const good, bad = "1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.17.7.1.4.5.1.1"
 	mockWalker := &MockSNMP{}
 	mockWalker.On("Connect").Return(nil)
 	mockWalker.On("Close").Return(nil)
-	mockWalker.On("Walk", good, 1).Return(map[string]snmp.PDU{good + ".1": {Value: "eth0", Type: gosnmp.OctetString, IdentifierSize: 1}}, nil)
-	mockWalker.On("Walk", bad, 1).Return(map[string]snmp.PDU(nil), errors.New("unknown error response"))
+	mockWalker.On("Walk", good, 1).Return(map[string]snmp.PDU{good + ".1": {Value: "eth0", Type: gosnmp.OctetString, IdentifierSize: 1}}, nil).Maybe()
+	mockWalker.On("Walk", bad, 1).Return(map[string]snmp.PDU(nil), errors.New("error parsing SNMP packet version: unknown field type: ff"))
 	factory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
 		return mockWalker, nil
 	}
 	host := snmp.NewHost("192.0.2.1", 161, 1, time.Second, nil, logger, factory)
 
 	oids, err := host.Walk(context.Background(), map[string]int{good: 1, bad: 1})
-	require.NoError(t, err, "one failed table does not fail the target")
-	assert.Len(t, oids, 1)
-	assert.Equal(t, "eth0", oids[good+".1"].Value)
-
-	allBad := &MockSNMP{}
-	allBad.On("Connect").Return(nil)
-	allBad.On("Close").Return(nil)
-	allBad.On("Walk", bad, 1).Return(map[string]snmp.PDU(nil), errors.New("unknown error response"))
-	host = snmp.NewHost("192.0.2.1", 161, 1, time.Second, nil, logger, func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
-		return allBad, nil
-	})
-	_, err = host.Walk(context.Background(), map[string]int{bad: 1})
-	assert.Error(t, err, "every table failing fails the target")
+	require.Error(t, err, "a table the walk cannot finish fails the target")
+	assert.Contains(t, err.Error(), "unknown field type")
+	assert.Nil(t, oids, "nothing of a failed target is returned")
 }
 
 // A timeout is the device going silent, not a table the agent cannot serve:
@@ -866,6 +859,23 @@ func TestSNMPHostKeepsATruncatedTable(t *testing.T) {
 	oids, err := host.Walk(context.Background(), map[string]int{big: 1})
 	require.NoError(t, err)
 	assert.Equal(t, "3", oids[big+".1"].Value)
+}
+
+// A table that ended at a repeated OID is kept as collected, like a
+// truncated one: the repeat is a warning, not a failure of the target.
+func TestSNMPHostKeepsARepeatedTable(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	const looping = "1.3.6.1.2.1.17.4.3.1.2"
+	mockWalker := &MockSNMP{}
+	mockWalker.On("Connect").Return(nil)
+	mockWalker.On("Close").Return(nil)
+	mockWalker.On("Walk", looping, 1).Return(map[string]snmp.PDU{looping + ".1": {Value: 3, Type: gosnmp.Integer, IdentifierSize: 1}}, snmp.ErrWalkRepeated)
+	host := snmp.NewHost("192.0.2.1", 161, 1, time.Second, nil, logger, func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
+		return mockWalker, nil
+	})
+	oids, err := host.Walk(context.Background(), map[string]int{looping: 1})
+	require.NoError(t, err)
+	assert.Equal(t, "3", oids[looping+".1"].Value)
 }
 
 // Once the policy's context has ended, the host starts no further table:

--- a/orb-discovery/snmp-discovery/snmp/snmp_test.go
+++ b/orb-discovery/snmp-discovery/snmp/snmp_test.go
@@ -41,7 +41,7 @@ func (m *MockSNMP) Close() error {
 }
 
 // Walk implements Walker interface
-func (m *MockSNMP) Walk(oid string, identifierSize int) (map[string]snmp.PDU, error) {
+func (m *MockSNMP) Walk(_ context.Context, oid string, identifierSize int) (map[string]snmp.PDU, error) {
 	args := m.Called(oid, identifierSize)
 	return args.Get(0).(map[string]snmp.PDU), args.Error(1)
 }
@@ -90,7 +90,7 @@ func TestSNMPHost(t *testing.T) {
 		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
 
 		// Execute
-		oids, err := host.Walk(map[string]int{
+		oids, err := host.Walk(context.Background(), map[string]int{
 			ipAddressObjectID: 4,
 		})
 
@@ -121,7 +121,7 @@ func TestSNMPHost(t *testing.T) {
 		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
 
 		// Execute
-		oids, err := host.Walk(objectIDsToQuery)
+		oids, err := host.Walk(context.Background(), objectIDsToQuery)
 
 		// Assert
 		assert.NoError(t, err)
@@ -147,7 +147,7 @@ func TestSNMPHost(t *testing.T) {
 		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
 
 		// Execute
-		oids, err := host.Walk(map[string]int{
+		oids, err := host.Walk(context.Background(), map[string]int{
 			ipAddressObjectID: 4,
 		})
 
@@ -169,7 +169,7 @@ func TestSNMPHost(t *testing.T) {
 		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
 
 		// Execute
-		oids, err := host.Walk(objectIDsToQuery)
+		oids, err := host.Walk(context.Background(), objectIDsToQuery)
 
 		// Assert
 		assert.Error(t, err)
@@ -189,7 +189,7 @@ func TestSNMPHost(t *testing.T) {
 		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
 
 		// Execute
-		oids, err := host.Walk(objectIDsToQuery)
+		oids, err := host.Walk(context.Background(), objectIDsToQuery)
 
 		// Assert
 		assert.Error(t, err)
@@ -218,7 +218,7 @@ func TestSNMPHost(t *testing.T) {
 		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
 
 		// Execute
-		oids, err := host.Walk(objectIDsToQuery)
+		oids, err := host.Walk(context.Background(), objectIDsToQuery)
 
 		// Assert
 		assert.NoError(t, err)        // Walk should continue despite PDU mapping error
@@ -243,7 +243,7 @@ func TestSNMPHost(t *testing.T) {
 		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
 
 		// Execute
-		oids, err := host.Walk(objectIDsToQuery)
+		oids, err := host.Walk(context.Background(), objectIDsToQuery)
 
 		// Assert
 		assert.Error(t, err)
@@ -815,7 +815,7 @@ func TestSNMPHostKeepsGoingPastAFailedTable(t *testing.T) {
 	}
 	host := snmp.NewHost("192.0.2.1", 161, 1, time.Second, nil, logger, factory)
 
-	oids, err := host.Walk(map[string]int{good: 1, bad: 1})
+	oids, err := host.Walk(context.Background(), map[string]int{good: 1, bad: 1})
 	require.NoError(t, err, "one failed table does not fail the target")
 	assert.Len(t, oids, 1)
 	assert.Equal(t, "eth0", oids[good+".1"].Value)
@@ -827,7 +827,7 @@ func TestSNMPHostKeepsGoingPastAFailedTable(t *testing.T) {
 	host = snmp.NewHost("192.0.2.1", 161, 1, time.Second, nil, logger, func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
 		return allBad, nil
 	})
-	_, err = host.Walk(map[string]int{bad: 1})
+	_, err = host.Walk(context.Background(), map[string]int{bad: 1})
 	assert.Error(t, err, "every table failing fails the target")
 }
 
@@ -845,7 +845,7 @@ func TestSNMPHostFailsTheTargetOnATimeout(t *testing.T) {
 	host := snmp.NewHost("192.0.2.1", 161, 1, time.Second, nil, logger, func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
 		return mockWalker, nil
 	})
-	_, err := host.Walk(map[string]int{good: 1, silent: 1})
+	_, err := host.Walk(context.Background(), map[string]int{good: 1, silent: 1})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "timeout")
 }
@@ -862,7 +862,7 @@ func TestSNMPHostKeepsATruncatedTable(t *testing.T) {
 	host := snmp.NewHost("192.0.2.1", 161, 1, time.Second, nil, logger, func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
 		return mockWalker, nil
 	})
-	oids, err := host.Walk(map[string]int{big: 1})
+	oids, err := host.Walk(context.Background(), map[string]int{big: 1})
 	require.NoError(t, err)
 	assert.Equal(t, "3", oids[big+".1"].Value)
 }

--- a/orb-discovery/snmp-discovery/snmp/snmp_test.go
+++ b/orb-discovery/snmp-discovery/snmp/snmp_test.go
@@ -3,7 +3,9 @@ package snmp_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"testing"
@@ -776,4 +778,55 @@ func TestClientEngineDiscoveredIsFalseForV2c(t *testing.T) {
 	}}
 
 	assert.False(t, client.EngineDiscovered())
+}
+
+// Every client is built with gosnmp's ordering check off: an agent that
+// returns a table out of index order is a quirk no operator can correct, and
+// the walk guards itself against the loop the check existed to prevent.
+func TestNewClientDoesNotCheckOIDOrdering(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	for _, auth := range []*config.Authentication{
+		{ProtocolVersion: snmp.ProtocolVersion1, Community: "public"},
+		{ProtocolVersion: snmp.ProtocolVersion2c, Community: "public"},
+		{ProtocolVersion: snmp.ProtocolVersion3, Username: "u", AuthProtocol: "MD5", AuthPassphrase: "p", PrivProtocol: "AES", PrivPassphrase: "p"},
+	} {
+		client, err := snmp.NewClient("192.0.2.1", 161, 1, time.Second, auth, logger)
+		require.NoError(t, err, auth.ProtocolVersion)
+		c, ok := client.(*snmp.Client)
+		require.True(t, ok)
+		_, tolerant := c.AppOpts["c"]
+		assert.True(t, tolerant, "%s: the ordering check is off", auth.ProtocolVersion)
+	}
+}
+
+// A table the agent fails does not cost the target: the host keeps walking
+// the other tables and returns what it collected, failing only when every
+// table failed.
+func TestSNMPHostKeepsGoingPastAFailedTable(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	const good, bad = "1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.17.7.1.4.5.1.1"
+	mockWalker := &MockSNMP{}
+	mockWalker.On("Connect").Return(nil)
+	mockWalker.On("Close").Return(nil)
+	mockWalker.On("Walk", good, 1).Return(map[string]snmp.PDU{good + ".1": {Value: "eth0", Type: gosnmp.OctetString, IdentifierSize: 1}}, nil)
+	mockWalker.On("Walk", bad, 1).Return(map[string]snmp.PDU(nil), errors.New("request timeout"))
+	factory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
+		return mockWalker, nil
+	}
+	host := snmp.NewHost("192.0.2.1", 161, 1, time.Second, nil, logger, factory)
+
+	oids, err := host.Walk(map[string]int{good: 1, bad: 1})
+	require.NoError(t, err, "one failed table does not fail the target")
+	assert.Len(t, oids, 1)
+	assert.Equal(t, "eth0", oids[good+".1"].Value)
+
+	allBad := &MockSNMP{}
+	allBad.On("Connect").Return(nil)
+	allBad.On("Close").Return(nil)
+	allBad.On("Walk", bad, 1).Return(map[string]snmp.PDU(nil), errors.New("request timeout"))
+	host = snmp.NewHost("192.0.2.1", 161, 1, time.Second, nil, logger, func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
+		return allBad, nil
+	})
+	_, err = host.Walk(map[string]int{bad: 1})
+	assert.Error(t, err, "every table failing fails the target")
 }

--- a/orb-discovery/snmp-discovery/snmp/snmp_test.go
+++ b/orb-discovery/snmp-discovery/snmp/snmp_test.go
@@ -908,3 +908,27 @@ func TestClientWalkReturnsWhenTheContextEndsMidRequest(t *testing.T) {
 	require.Error(t, err)
 	assert.Less(t, time.Since(start), 2*time.Second, "the walk returns at the context deadline, not after the SNMP timeout and retries")
 }
+
+// A cancellation with no deadline interrupts the request in flight too: the
+// backend's shutdown cancels the root context rather than letting a
+// deadline pass, and a blocked read must not hold it through the SNMP
+// timeout and its retries.
+func TestClientWalkReturnsWhenTheContextIsCancelledMidRequest(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	silent, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = silent.Close() }()
+	port := uint16(silent.LocalAddr().(*net.UDPAddr).Port)
+
+	client, err := snmp.NewClient("127.0.0.1", port, 2, 5*time.Second, &config.Authentication{ProtocolVersion: snmp.ProtocolVersion2c, Community: "public"}, logger)
+	require.NoError(t, err)
+	require.NoError(t, client.Connect())
+	defer func() { _ = client.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	time.AfterFunc(200*time.Millisecond, cancel)
+	start := time.Now()
+	_, err = client.Walk(ctx, "1.3.6.1.2.1.2.2.1.2", 1)
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 2*time.Second, "a cancellation interrupts the read in flight")
+}

--- a/orb-discovery/snmp-discovery/snmp/snmp_test.go
+++ b/orb-discovery/snmp-discovery/snmp/snmp_test.go
@@ -866,3 +866,21 @@ func TestSNMPHostKeepsATruncatedTable(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "3", oids[big+".1"].Value)
 }
+
+// Once the policy's context has ended, the host starts no further table:
+// the runner has stopped waiting, and every request from here would be
+// spent on a target nobody is listening for.
+func TestSNMPHostStartsNoTableAfterTheContextEnds(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	mockWalker := &MockSNMP{}
+	mockWalker.On("Connect").Return(nil)
+	mockWalker.On("Close").Return(nil)
+	host := snmp.NewHost("192.0.2.1", 161, 1, time.Second, nil, logger, func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
+		return mockWalker, nil
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := host.Walk(ctx, map[string]int{"1.3.6.1.2.1.2.2.1.2": 1})
+	require.ErrorIs(t, err, context.Canceled)
+	mockWalker.AssertNotCalled(t, "Walk", mock.Anything, mock.Anything, mock.Anything)
+}

--- a/orb-discovery/snmp-discovery/snmp/walk_internal_test.go
+++ b/orb-discovery/snmp-discovery/snmp/walk_internal_test.go
@@ -1,6 +1,7 @@
 package snmp
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -26,7 +27,7 @@ func feed(names ...string) func(fn gosnmp.WalkFunc) error {
 // refused them ended the table and, with it, the target, for a quirk no
 // operator can correct from our side.
 func TestCollectWalkKeepsRowsOutOfOrder(t *testing.T) {
-	rows, err := collectWalk(feed(".1.3.6.1.2.1.17.7.1.4.5.1.1.18", ".1.3.6.1.2.1.17.7.1.4.5.1.1.48", ".1.3.6.1.2.1.17.7.1.4.5.1.1.19"), 1)
+	rows, err := collectWalk(context.Background(), feed(".1.3.6.1.2.1.17.7.1.4.5.1.1.18", ".1.3.6.1.2.1.17.7.1.4.5.1.1.48", ".1.3.6.1.2.1.17.7.1.4.5.1.1.19"), 1)
 	require.NoError(t, err)
 	assert.Len(t, rows, 3)
 	assert.Equal(t, 1, rows[".1.3.6.1.2.1.17.7.1.4.5.1.1.48"].IdentifierSize)
@@ -35,7 +36,7 @@ func TestCollectWalkKeepsRowsOutOfOrder(t *testing.T) {
 // A repeated OID is the one way a walk without the ordering check can loop,
 // so it ends the table with the rows collected before it.
 func TestCollectWalkEndsTheTableOnARepeatedOID(t *testing.T) {
-	rows, err := collectWalk(feed(".1.3.6.1.2.1.2.2.1.2.1", ".1.3.6.1.2.1.2.2.1.2.2", ".1.3.6.1.2.1.2.2.1.2.1", ".1.3.6.1.2.1.2.2.1.2.3"), 1)
+	rows, err := collectWalk(context.Background(), feed(".1.3.6.1.2.1.2.2.1.2.1", ".1.3.6.1.2.1.2.2.1.2.2", ".1.3.6.1.2.1.2.2.1.2.1", ".1.3.6.1.2.1.2.2.1.2.3"), 1)
 	require.NoError(t, err)
 	assert.Len(t, rows, 2, "the walk stops at the repeat; nothing after it is read")
 }
@@ -43,7 +44,7 @@ func TestCollectWalkEndsTheTableOnARepeatedOID(t *testing.T) {
 // Any other error the walk reports still fails the table.
 func TestCollectWalkReportsOtherErrors(t *testing.T) {
 	boom := errors.New("request timeout")
-	_, err := collectWalk(func(fn gosnmp.WalkFunc) error {
+	_, err := collectWalk(context.Background(), func(fn gosnmp.WalkFunc) error {
 		_ = fn(gosnmp.SnmpPDU{Name: ".1.3.6.1.2.1.2.2.1.2.1", Type: gosnmp.Integer, Value: 1})
 		return boom
 	}, 1)
@@ -64,7 +65,30 @@ func TestCollectWalkEndsTheTableAtTheRowCap(t *testing.T) {
 			}
 		}
 	}
-	rows, err := collectWalk(endless, 1)
+	rows, err := collectWalk(context.Background(), endless, 1)
 	require.ErrorIs(t, err, ErrWalkTruncated)
 	assert.Len(t, rows, maxWalkRows, "the rows collected before the cap are kept")
+}
+
+// The policy's context reaches the walk and ends it: a row delivered after
+// the context ended is not collected, and the table reports the context's
+// error, so a runaway agent costs at most the policy's timeout plus one
+// request, and the runner's timeout actually stops the walker.
+func TestCollectWalkStopsWhenTheContextEnds(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	delivered := 0
+	endless := func(fn gosnmp.WalkFunc) error {
+		for i := 2_000_000_000; ; i-- {
+			delivered++
+			if delivered == 3 {
+				cancel()
+			}
+			if err := fn(gosnmp.SnmpPDU{Name: fmt.Sprintf(".1.3.6.1.2.1.2.2.1.2.%d", i), Type: gosnmp.Integer, Value: 1}); err != nil {
+				return err
+			}
+		}
+	}
+	_, err := collectWalk(ctx, endless, 1)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 3, delivered, "the walk ends on the first row after the context ended")
 }

--- a/orb-discovery/snmp-discovery/snmp/walk_internal_test.go
+++ b/orb-discovery/snmp-discovery/snmp/walk_internal_test.go
@@ -92,3 +92,13 @@ func TestCollectWalkStopsWhenTheContextEnds(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	assert.Equal(t, 3, delivered, "the walk ends on the first row after the context ended")
 }
+
+// A walk that delivers no rows never reaches the row callback, so the
+// context is checked once the walk returns as well: a table that ended
+// empty after the deadline reports the context's error, not success.
+func TestCollectWalkChecksTheContextAfterAnEmptyWalk(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := collectWalk(ctx, func(gosnmp.WalkFunc) error { return nil }, 1)
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/orb-discovery/snmp-discovery/snmp/walk_internal_test.go
+++ b/orb-discovery/snmp-discovery/snmp/walk_internal_test.go
@@ -34,10 +34,11 @@ func TestCollectWalkKeepsRowsOutOfOrder(t *testing.T) {
 }
 
 // A repeated OID is the one way a walk without the ordering check can loop,
-// so it ends the table with the rows collected before it.
+// so it ends the table with the rows collected before it, reported the way a
+// truncation is: the table may be incomplete, and the caller should say so.
 func TestCollectWalkEndsTheTableOnARepeatedOID(t *testing.T) {
 	rows, err := collectWalk(context.Background(), feed(".1.3.6.1.2.1.2.2.1.2.1", ".1.3.6.1.2.1.2.2.1.2.2", ".1.3.6.1.2.1.2.2.1.2.1", ".1.3.6.1.2.1.2.2.1.2.3"), 1)
-	require.NoError(t, err)
+	assert.ErrorIs(t, err, ErrWalkRepeated)
 	assert.Len(t, rows, 2, "the walk stops at the repeat; nothing after it is read")
 }
 

--- a/orb-discovery/snmp-discovery/snmp/walk_internal_test.go
+++ b/orb-discovery/snmp-discovery/snmp/walk_internal_test.go
@@ -2,6 +2,7 @@ package snmp
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/gosnmp/gosnmp"
@@ -47,4 +48,23 @@ func TestCollectWalkReportsOtherErrors(t *testing.T) {
 		return boom
 	}, 1)
 	assert.ErrorIs(t, err, boom)
+}
+
+// A repeated OID is not the only shape of a runaway walk: an agent can hand
+// back a new, non-increasing OID on every request, and the ordering check
+// that would have ended it is off. A table therefore ends at a hard row cap,
+// with what was collected and the truncation reported, never failing.
+func TestCollectWalkEndsTheTableAtTheRowCap(t *testing.T) {
+	endless := func(fn gosnmp.WalkFunc) error {
+		// Every row a new OID, each below the one before, none repeated.
+		for i := 2_000_000_000; ; i-- {
+			name := fmt.Sprintf(".1.3.6.1.2.1.17.1.4.1.2.%d", i)
+			if err := fn(gosnmp.SnmpPDU{Name: name, Type: gosnmp.Integer, Value: 1}); err != nil {
+				return err
+			}
+		}
+	}
+	rows, err := collectWalk(endless, 1)
+	require.ErrorIs(t, err, ErrWalkTruncated)
+	assert.Len(t, rows, maxWalkRows, "the rows collected before the cap are kept")
 }

--- a/orb-discovery/snmp-discovery/snmp/walk_internal_test.go
+++ b/orb-discovery/snmp-discovery/snmp/walk_internal_test.go
@@ -1,0 +1,50 @@
+package snmp
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// feed builds a walk function that delivers the given rows in order.
+func feed(names ...string) func(fn gosnmp.WalkFunc) error {
+	return func(fn gosnmp.WalkFunc) error {
+		for _, n := range names {
+			if err := fn(gosnmp.SnmpPDU{Name: n, Type: gosnmp.Integer, Value: 1}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// Rows an agent returns out of index order are all kept: the check that
+// refused them ended the table and, with it, the target, for a quirk no
+// operator can correct from our side.
+func TestCollectWalkKeepsRowsOutOfOrder(t *testing.T) {
+	rows, err := collectWalk(feed(".1.3.6.1.2.1.17.7.1.4.5.1.1.18", ".1.3.6.1.2.1.17.7.1.4.5.1.1.48", ".1.3.6.1.2.1.17.7.1.4.5.1.1.19"), 1)
+	require.NoError(t, err)
+	assert.Len(t, rows, 3)
+	assert.Equal(t, 1, rows[".1.3.6.1.2.1.17.7.1.4.5.1.1.48"].IdentifierSize)
+}
+
+// A repeated OID is the one way a walk without the ordering check can loop,
+// so it ends the table with the rows collected before it.
+func TestCollectWalkEndsTheTableOnARepeatedOID(t *testing.T) {
+	rows, err := collectWalk(feed(".1.3.6.1.2.1.2.2.1.2.1", ".1.3.6.1.2.1.2.2.1.2.2", ".1.3.6.1.2.1.2.2.1.2.1", ".1.3.6.1.2.1.2.2.1.2.3"), 1)
+	require.NoError(t, err)
+	assert.Len(t, rows, 2, "the walk stops at the repeat; nothing after it is read")
+}
+
+// Any other error the walk reports still fails the table.
+func TestCollectWalkReportsOtherErrors(t *testing.T) {
+	boom := errors.New("request timeout")
+	_, err := collectWalk(func(fn gosnmp.WalkFunc) error {
+		_ = fn(gosnmp.SnmpPDU{Name: ".1.3.6.1.2.1.2.2.1.2.1", Type: gosnmp.Integer, Value: 1})
+		return boom
+	}, 1)
+	assert.ErrorIs(t, err, boom)
+}


### PR DESCRIPTION
## Summary

A MikroTik RouterOS agent returns Q-BRIDGE and BRIDGE-MIB rows out of index order, and gosnmp's default ordering check failed the walk, so the device produced no entities at all (#590).

- **Out-of-order rows are accepted.** Every client is built with gosnmp's ordering check off, the opt-out the reporter identified. Because gosnmp documents that a walk without the check can loop forever against a misbehaving agent, the client collects rows through its own callback and bounds the table two ways: it ends at an OID it already holds, the one way such a walk can loop, and at 500,000 rows. Both keep the rows collected before them and log a warning naming the table. Rows are keyed by OID, so their order never mattered downstream.
- **The policy's context bounds every request.** The walk checks the context before each table and each row, gosnmp puts its deadline on the socket, and a cancellation moves the socket deadline to now so a read in flight returns at once.
- **A table the walk cannot finish still fails the target.** An earlier revision skipped such a table and returned the rest; that was reverted. An SNMP error status already ends a table without an error, so the skip only ever caught transport and decode failures, where a device missing the tables it lost is not a discovered device.

## Testing

- Collector: out-of-order rows all kept; a repeated OID and the row cap end the table with the rows before them and report it; any other error fails the table; the context ends a walk between rows and is checked after an empty one.
- Client: a context deadline and a plain cancellation each return a request blocked on a silent socket well inside the SNMP timeout.
- Constructors: v1, v2c and v3 clients all carry the opt-out.
- Host walk: a failed table fails the target; a timeout fails it at once; truncated and repeated tables are kept; no table starts after the context ends.
- Every assertion paired with a killed mutant; snmp-discovery suite with the race detector green; `make lint`, 0 issues.
- orb-test-lab dry-run comparison against develop: a RouterOS recording replayed as recorded, with its bridge port tables out of order, with one table answering garbage, silence or genErr, plus the four healthy simulators. Results posted in the PR conversation.

Refs #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)
