### PR TITLE
fix(network-discovery): keep reverse hostnames within the characters NetBox accepts

### DIFF
--- a/docs/backends/network_discovery.md
+++ b/docs/backends/network_discovery.md
@@ -8,6 +8,24 @@ The network discovery backend uses [Diode Go SDK](https://github.com/netboxlabs/
 
 IP addresses support VRF, Tenant, Role, Description, Comments and Tags via `defaults`.
 
+The name a reverse lookup returns for an address becomes the IP's `dns_name`,
+lowercased. NetBox accepts only letters, digits, hyphens and underscores in a
+label. nmap, which does the lookup, prints an asterisk in place of any
+character it will not pass, a space inside a DNS label for instance, and lets
+a few others through that NetBox rejects; every such character becomes a
+hyphen, so a name nmap printed as `abc1234-vendor*model*unit.example.net`
+arrives as `abc1234-vendor-model-unit.example.net`. A name with no form
+NetBox accepts, one with an empty label, longer than 255 characters or left
+with no letter or digit, is left off; the address is still sent, and a
+`dns_name` NetBox already holds for it stays as it is. In either case the
+name as nmap gave it is kept under `hostnames` in the IP's comments, unless
+the policy sets `defaults.comments`, which the backend does not add to. A
+name that needed no change is not recorded, so this changes nothing in the
+comments of an IP whose name was already acceptable. Each run logs how many
+names it replaced or left off. A name that was already accepted with an
+asterisk, which NetBox allows as a leading wildcard label, changes on the
+next run, since nmap's asterisk never marks a wildcard.
+
 ## Configuration
 The `network_discovery` backend does not require any special configuration, though overriding `host` and `port` values can be specified. The backend will use the `diode` settings specified in the `common` subsection to forward discovery results.
 

--- a/orb-discovery/network-discovery/policy/dnsname.go
+++ b/orb-discovery/network-discovery/policy/dnsname.go
@@ -1,0 +1,107 @@
+package policy
+
+import (
+	"strings"
+
+	"github.com/Ullaakut/nmap/v3"
+	"github.com/netboxlabs/diode-sdk-go/diode"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/config"
+)
+
+// maxDNSNameLength is the length of NetBox's dns_name field.
+const maxDNSNameLength = 255
+
+// dnsName returns the form of a reverse-lookup name that NetBox accepts as
+// an IP address's dns_name, and false when the name has none.
+//
+// NetBox allows letters, digits, hyphens and underscores in a label. nmap,
+// which does the lookup, prints an asterisk in place of any character it
+// will not pass, a space in a DNS label for one, and lets a few others
+// through that NetBox does not, so every such character becomes a hyphen.
+// nmap's asterisk never means a wildcard, so it is not kept as one. The name
+// is lowercased, as it always was. A name with an empty label, longer than
+// the field with its trailing dot, or left with no letter or digit is
+// refused rather than guessed at.
+// nmap passes only ASCII, so an internationalised label never arrives.
+func dnsName(name string) (string, bool) {
+	name = strings.ToLower(name)
+	trailingDot := strings.HasSuffix(name, ".") && len(name) > 1
+	if trailingDot {
+		name = strings.TrimSuffix(name, ".")
+	}
+	if name == "" {
+		return "", false
+	}
+	labels := strings.Split(name, ".")
+	for i, label := range labels {
+		if label == "" {
+			return "", false
+		}
+		labels[i] = strings.Map(func(r rune) rune {
+			if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '-' || r == '_' {
+				return r
+			}
+			return '-'
+		}, label)
+	}
+	out := strings.Join(labels, ".")
+	if trailingDot {
+		out += "."
+	}
+	if len(out) > maxDNSNameLength || !strings.ContainsFunc(out, func(r rune) bool { return r >= 'a' && r <= 'z' || r >= '0' && r <= '9' }) {
+		return "", false
+	}
+	return out, true
+}
+
+// hostnameOutcome says what became of a host's reverse-lookup name.
+type hostnameOutcome int
+
+const (
+	hostnameNone      hostnameOutcome = iota // the host had no name
+	hostnameUnchanged                        // the name went out as nmap gave it, lowercased
+	hostnameReplaced                         // characters NetBox rejects became hyphens
+	hostnameRefused                          // the name had no acceptable form and was left off
+)
+
+// applyHostname sets the IP's dns_name from the host's reverse lookup,
+// preferring a PTR record and otherwise the last name nmap listed. When the
+// name used had to change or could not be used, and the comments are the
+// backend's to write, it returns that name as nmap gave it for the IP's
+// comments, so the original is not lost; a name that needed no change
+// returns nothing, and the comments of every IP already in NetBox stay as
+// they are.
+func (r *Runner) applyHostname(ip *diode.IPAddress, hostnames []nmap.Hostname, addr, policyName string, canRecord bool) (hostnameOutcome, []config.Hostname) {
+	var chosen nmap.Hostname
+	for _, hostname := range hostnames {
+		chosen = hostname
+		if hostname.Type == "PTR" {
+			break
+		}
+	}
+	if chosen.Name == "" {
+		return hostnameNone, nil
+	}
+	name, ok := dnsName(chosen.Name)
+	outcome := hostnameRefused
+	if ok {
+		ip.DnsName = diode.String(name)
+		if name == strings.ToLower(chosen.Name) {
+			return hostnameUnchanged, nil
+		}
+		outcome = hostnameReplaced
+	}
+	switch {
+	case !ok:
+		r.logger.Warn("reverse hostname has no form NetBox accepts as dns_name; left off", "hostname", chosen.Name, "ip_address", addr, "policy", policyName)
+	case canRecord:
+		r.logger.Debug("reverse hostname carried characters NetBox does not accept as dns_name; replaced, original kept in comments", "hostname", chosen.Name, "dns_name", name, "ip_address", addr, "policy", policyName)
+	default:
+		r.logger.Warn("reverse hostname carried characters NetBox does not accept as dns_name; replaced, and the policy's comments leave no room for the original", "hostname", chosen.Name, "dns_name", name, "ip_address", addr, "policy", policyName)
+	}
+	if !canRecord {
+		return outcome, nil
+	}
+	return outcome, []config.Hostname{{Name: chosen.Name, Type: chosen.Type}}
+}

--- a/orb-discovery/network-discovery/policy/dnsname_internal_test.go
+++ b/orb-discovery/network-discovery/policy/dnsname_internal_test.go
@@ -1,0 +1,110 @@
+package policy
+
+import (
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/Ullaakut/nmap/v3"
+	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nmap prints an asterisk for any character it will not pass, a space in a
+// DNS label for one, and NetBox accepts an asterisk only as a leading
+// wildcard label, so every character NetBox rejects becomes a hyphen, an
+// asterisk included wherever it stands: nmap's asterisk never means a
+// wildcard.
+func TestDNSNameReplacesCharactersNetBoxRejects(t *testing.T) {
+	cases := []struct{ raw, want string }{
+		{"ABC1234-Vendor*Model*Unit.example.net", "abc1234-vendor-model-unit.example.net"},
+		{"host+name:with~odd=chars.example.net", "host-name-with-odd-chars.example.net"},
+		{"host.*.example.net", "host.-.example.net"},
+		{"*.example.net", "-.example.net"},
+		{"**.example.net", "--.example.net"},
+		{"plain_name-01.example.net.", "plain_name-01.example.net."},
+	}
+	for _, tc := range cases {
+		got, ok := dnsName(tc.raw)
+		require.True(t, ok, tc.raw)
+		assert.Equal(t, tc.want, got, tc.raw)
+	}
+}
+
+// A name with no form NetBox accepts is refused rather than guessed at: an
+// empty label cannot be filled in, NetBox's field holds 255 characters, a
+// trailing dot included, and a name left with no letter or digit is no
+// name.
+func TestDNSNameRefusesNamesWithNoAcceptableForm(t *testing.T) {
+	longest := strings.Repeat("a", 243) + ".example.net" // 255 characters
+	got, ok := dnsName(longest)
+	require.True(t, ok)
+	assert.Len(t, got, 255)
+	for _, raw := range []string{"", "a..b", ".example.net", longest + "a", longest + ".", "*", "*.*", "-_-"} {
+		_, ok := dnsName(raw)
+		assert.False(t, ok, raw)
+	}
+}
+
+func testRunner() *Runner {
+	return &Runner{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+}
+
+// The PTR name wins. A replaced name is recorded as nmap gave it so the
+// original is not lost, and only that name; a name that needed no change
+// records nothing, so the comments of every IP already in NetBox stay as
+// they are.
+func TestApplyHostnamePrefersThePTRAndRecordsOnlyAnAlteredName(t *testing.T) {
+	r := testRunner()
+	ip := &diode.IPAddress{}
+	outcome, recorded := r.applyHostname(ip, []nmap.Hostname{
+		{Name: "abc1234-vendor*model*unit.example.net", Type: "PTR"},
+		{Name: "other.example.net", Type: "user"},
+	}, "192.0.2.10", "p", true)
+	assert.Equal(t, hostnameReplaced, outcome)
+	require.NotNil(t, ip.DnsName)
+	assert.Equal(t, "abc1234-vendor-model-unit.example.net", *ip.DnsName)
+	require.Len(t, recorded, 1)
+	assert.Equal(t, "abc1234-vendor*model*unit.example.net", recorded[0].Name)
+	assert.Equal(t, "PTR", recorded[0].Type)
+
+	ip = &diode.IPAddress{}
+	outcome, recorded = r.applyHostname(ip, []nmap.Hostname{{Name: "Clean-01.example.net", Type: "PTR"}}, "192.0.2.11", "p", true)
+	assert.Equal(t, hostnameUnchanged, outcome)
+	require.NotNil(t, ip.DnsName)
+	assert.Equal(t, "clean-01.example.net", *ip.DnsName)
+	assert.Empty(t, recorded)
+}
+
+// Without a PTR the last name nmap listed is used, as before.
+func TestApplyHostnameFallsBackToTheLastName(t *testing.T) {
+	ip := &diode.IPAddress{}
+	testRunner().applyHostname(ip, []nmap.Hostname{{Name: "first.example.net", Type: "user"}, {Name: "Second.example.net", Type: "user"}}, "192.0.2.12", "p", true)
+	require.NotNil(t, ip.DnsName)
+	assert.Equal(t, "second.example.net", *ip.DnsName)
+}
+
+// A name with no acceptable form leaves dns_name off and is recorded; the
+// address itself is still ingested.
+func TestApplyHostnameLeavesAnUnusableNameOff(t *testing.T) {
+	ip := &diode.IPAddress{}
+	outcome, recorded := testRunner().applyHostname(ip, []nmap.Hostname{{Name: "bad..name.example.net", Type: "PTR"}}, "192.0.2.13", "p", true)
+	assert.Equal(t, hostnameRefused, outcome)
+	assert.Nil(t, ip.DnsName)
+	require.Len(t, recorded, 1)
+	assert.Equal(t, "bad..name.example.net", recorded[0].Name)
+}
+
+// When the policy sets its own comments there is nowhere to keep the raw
+// name: nothing is recorded, and the outcome still says what happened so
+// the run can report it.
+func TestApplyHostnameRecordsNothingWhenCommentsAreThePolicys(t *testing.T) {
+	ip := &diode.IPAddress{}
+	outcome, recorded := testRunner().applyHostname(ip, []nmap.Hostname{{Name: "abc*unit.example.net", Type: "PTR"}}, "192.0.2.14", "p", false)
+	assert.Equal(t, hostnameReplaced, outcome)
+	require.NotNil(t, ip.DnsName)
+	assert.Equal(t, "abc-unit.example.net", *ip.DnsName)
+	assert.Nil(t, recorded)
+}

--- a/orb-discovery/network-discovery/policy/entity_internal_test.go
+++ b/orb-discovery/network-discovery/policy/entity_internal_test.go
@@ -1,0 +1,59 @@
+package policy
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/Ullaakut/nmap/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/orb-discovery/network-discovery/config"
+)
+
+func scannedHost(name string) nmap.Host {
+	return nmap.Host{
+		Hostnames: []nmap.Hostname{{Name: name, Type: "PTR"}},
+		Ports:     []nmap.Port{{ID: 22, Protocol: "tcp", Service: nmap.Service{Name: "ssh"}, State: nmap.State{State: "open"}}},
+	}
+}
+
+func commentsOf(t *testing.T, comments *string) config.HostMetadata {
+	t.Helper()
+	require.NotNil(t, comments)
+	var metadata config.HostMetadata
+	require.NoError(t, json.Unmarshal([]byte(*comments), &metadata))
+	return metadata
+}
+
+// When the comments are the backend's to write, a replaced name is kept in
+// them as nmap gave it, next to the ports, and a clean name leaves the
+// hostnames list empty as it always was.
+func TestIPAddressEntityKeepsAReplacedNameInTheComments(t *testing.T) {
+	r := &Runner{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	ip, outcome := r.ipAddressEntity(scannedHost("abc1234-vendor*model*unit.example.net"), "192.0.2.10/24", "192.0.2.10", "p")
+	assert.Equal(t, hostnameReplaced, outcome)
+	assert.Equal(t, "abc1234-vendor-model-unit.example.net", *ip.DnsName)
+	metadata := commentsOf(t, ip.Comments)
+	require.Len(t, metadata.Hostnames, 1)
+	assert.Equal(t, "abc1234-vendor*model*unit.example.net", metadata.Hostnames[0].Name)
+	require.Len(t, metadata.Ports, 1)
+	assert.Equal(t, 22, metadata.Ports[0].Number)
+
+	ip, outcome = r.ipAddressEntity(scannedHost("clean.example.net"), "192.0.2.11/24", "192.0.2.11", "p")
+	assert.Equal(t, hostnameUnchanged, outcome)
+	assert.Nil(t, commentsOf(t, ip.Comments).Hostnames)
+}
+
+// When the policy sets its own comments they go out untouched, and the
+// replaced name is not recorded anywhere in the entity.
+func TestIPAddressEntityLeavesThePolicysCommentsAlone(t *testing.T) {
+	r := &Runner{logger: slog.New(slog.NewTextHandler(io.Discard, nil)), config: config.PolicyConfig{Defaults: config.Defaults{Comments: "owned by the policy"}}}
+	ip, outcome := r.ipAddressEntity(scannedHost("abc*unit.example.net"), "192.0.2.12/24", "192.0.2.12", "p")
+	assert.Equal(t, hostnameReplaced, outcome)
+	assert.Equal(t, "abc-unit.example.net", *ip.DnsName)
+	require.NotNil(t, ip.Comments)
+	assert.Equal(t, "owned by the policy", *ip.Comments)
+}

--- a/orb-discovery/network-discovery/policy/runner.go
+++ b/orb-discovery/network-discovery/policy/runner.go
@@ -333,6 +333,7 @@ func (r *Runner) run() {
 
 	// Track discovered hosts
 	processedEntries := make(map[string]bool)
+	var replacedHostnames, refusedHostnames int
 
 	defaultMask := "/32"
 	if r.config.Defaults.NetworkMask != nil && *r.config.Defaults.NetworkMask > 0 {
@@ -360,86 +361,18 @@ func (r *Runner) run() {
 		}
 		processedEntries[addr] = true
 
-		ip := &diode.IPAddress{
-			Address: diode.String(ipAddr),
+		ip, outcome := r.ipAddressEntity(host, ipAddr, addr, policyName)
+		switch outcome {
+		case hostnameReplaced:
+			replacedHostnames++
+		case hostnameRefused:
+			refusedHostnames++
 		}
-		if r.config.Defaults.Description != "" {
-			ip.Description = diode.String(r.config.Defaults.Description)
-		}
-		hasComments := false
-		if r.config.Defaults.Comments != "" {
-			hasComments = true
-			ip.Comments = diode.String(r.config.Defaults.Comments)
-		}
-		if r.config.Defaults.Vrf != "" {
-			vrf := &diode.VRF{Name: diode.String(r.config.Defaults.Vrf)}
-			if r.config.Defaults.Rd != "" {
-				vrf.Rd = diode.String(r.config.Defaults.Rd)
-			}
-			ip.Vrf = vrf
-		}
-		if r.config.Defaults.Tenant != "" {
-			ip.Tenant = &diode.Tenant{
-				Name: diode.String(r.config.Defaults.Tenant),
-			}
-		}
-		if r.config.Defaults.Role != "" {
-			ip.Role = diode.String(r.config.Defaults.Role)
-		}
-		if len(r.config.Defaults.Tags) > 0 {
-			var tags []*diode.Tag
-			for _, tag := range r.config.Defaults.Tags {
-				tags = append(tags, &diode.Tag{Name: diode.String(tag)})
-			}
-			ip.Tags = tags
-		}
-
-		if host.Hostnames != nil {
-			var fallbackHostname string
-			for _, hostname := range host.Hostnames {
-				fallbackHostname = strings.ToLower(hostname.Name)
-				if hostname.Type == "PTR" {
-					ip.DnsName = diode.String(strings.ToLower(hostname.Name))
-					break
-				}
-			}
-			if ip.DnsName == nil && fallbackHostname != "" {
-				ip.DnsName = diode.String(fallbackHostname)
-			}
-		}
-
-		if !hasComments {
-			var metadata config.HostMetadata
-
-			if host.ExtraPorts != nil {
-				metadata.ExtraPorts = make([]config.ExtraPort, len(host.ExtraPorts))
-				for i, extraPort := range host.ExtraPorts {
-					metadata.ExtraPorts[i] = config.ExtraPort{
-						State: extraPort.State,
-						Count: extraPort.Count,
-					}
-				}
-			}
-			if host.Ports != nil {
-				metadata.Ports = make([]config.Port, len(host.Ports))
-				for i, port := range host.Ports {
-					metadata.Ports[i] = config.Port{
-						Number:   int(port.ID),
-						Protocol: port.Protocol,
-						Service:  port.Service.Name,
-						State:    port.State.State,
-					}
-				}
-			}
-			data, err := json.Marshal(&metadata)
-			if err != nil {
-				r.logger.Error("error marshalling metadata", "error", err, "policy", policyName)
-			} else {
-				ip.Comments = diode.String(string(data))
-			}
-		}
-
 		entities = append(entities, ip)
+	}
+
+	if replacedHostnames > 0 || refusedHostnames > 0 {
+		r.logger.Info("reverse hostnames NetBox would not accept as dns_name", "replaced", replacedHostnames, "refused", refusedHostnames, "policy", policyName)
 	}
 
 	annotateEntitiesWithRunID(entities, run.ID)
@@ -478,4 +411,76 @@ func (r *Runner) Stop() error {
 		rMetric.Add(r.ctx, -1)
 	}
 	return r.scheduler.Shutdown()
+}
+
+// ipAddressEntity builds the IP address entity for one scanned host.
+func (r *Runner) ipAddressEntity(host nmap.Host, ipAddr, addr, policyName string) (*diode.IPAddress, hostnameOutcome) {
+	ip := &diode.IPAddress{
+		Address: diode.String(ipAddr),
+	}
+	if r.config.Defaults.Description != "" {
+		ip.Description = diode.String(r.config.Defaults.Description)
+	}
+	hasComments := false
+	if r.config.Defaults.Comments != "" {
+		hasComments = true
+		ip.Comments = diode.String(r.config.Defaults.Comments)
+	}
+	if r.config.Defaults.Vrf != "" {
+		vrf := &diode.VRF{Name: diode.String(r.config.Defaults.Vrf)}
+		if r.config.Defaults.Rd != "" {
+			vrf.Rd = diode.String(r.config.Defaults.Rd)
+		}
+		ip.Vrf = vrf
+	}
+	if r.config.Defaults.Tenant != "" {
+		ip.Tenant = &diode.Tenant{
+			Name: diode.String(r.config.Defaults.Tenant),
+		}
+	}
+	if r.config.Defaults.Role != "" {
+		ip.Role = diode.String(r.config.Defaults.Role)
+	}
+	if len(r.config.Defaults.Tags) > 0 {
+		var tags []*diode.Tag
+		for _, tag := range r.config.Defaults.Tags {
+			tags = append(tags, &diode.Tag{Name: diode.String(tag)})
+		}
+		ip.Tags = tags
+	}
+
+	canRecord := !hasComments
+	outcome, recordedHostnames := r.applyHostname(ip, host.Hostnames, addr, policyName, canRecord)
+
+	if !hasComments {
+		metadata := config.HostMetadata{Hostnames: recordedHostnames}
+
+		if host.ExtraPorts != nil {
+			metadata.ExtraPorts = make([]config.ExtraPort, len(host.ExtraPorts))
+			for i, extraPort := range host.ExtraPorts {
+				metadata.ExtraPorts[i] = config.ExtraPort{
+					State: extraPort.State,
+					Count: extraPort.Count,
+				}
+			}
+		}
+		if host.Ports != nil {
+			metadata.Ports = make([]config.Port, len(host.Ports))
+			for i, port := range host.Ports {
+				metadata.Ports[i] = config.Port{
+					Number:   int(port.ID),
+					Protocol: port.Protocol,
+					Service:  port.Service.Name,
+					State:    port.State.State,
+				}
+			}
+		}
+		data, err := json.Marshal(&metadata)
+		if err != nil {
+			r.logger.Error("error marshalling metadata", "error", err, "policy", policyName)
+		} else {
+			ip.Comments = diode.String(string(data))
+		}
+	}
+	return ip, outcome
 }


### PR DESCRIPTION
## Summary

nmap prints an asterisk in place of any character it will not pass in a reverse-lookup name, a space inside a DNS label for instance, and lets a few others through (`+ = : ~`). The backend set that name as the IP's `dns_name` unchanged, and NetBox, which accepts only letters, digits, hyphens and underscores in a label and an asterisk only as a leading wildcard label, rejected the IP when the change was applied. Diode's server has no rule for the field, so nothing stopped the value on the way. ENGHLP-1668.

- **Every character NetBox rejects becomes a hyphen.** `abc1234-vendor*model*unit.example.net` arrives as `abc1234-vendor-model-unit.example.net`. nmap's asterisk never marks a wildcard, so it is not kept as one; a name NetBox already held with a leading asterisk changes on the next run.
- **A name with no acceptable form is left off** rather than guessed at: an empty label, more than 255 characters with the trailing dot, or nothing but hyphens after replacement. The address is still sent, and Diode's patch leaves a `dns_name` NetBox already holds.
- **The original is kept.** When a name was replaced or left off, and the comments are the backend's to write, the name as nmap gave it goes under the `hostnames` key of the IP's comments, a key that was always present and null. A name that needed no change records nothing, so existing IPs see no comment change. When the policy sets `defaults.comments` the backend does not add to them and logs the replacement at warning level instead.
- **Each run logs** how many names it replaced or left off.

The per-host entity build moved out of the run loop into `ipAddressEntity` so the wiring is testable.

Follow-up worth its own ticket: Diode's server validates nothing about `dns_name`, so every producer has to know NetBox's rule; a server-side rule would catch the next one.

## Testing

- `dnsName`: replacement in every label position, trailing dot kept, the 255-character boundary with and without the dot, refusals for empty labels and hyphen-only names. Fuzzed in review over nmap's output alphabet against NetBox's validator regex: no accepted output NetBox rejects.
- `applyHostname`: PTR preferred over the last name, only the used name recorded, nothing recorded when the policy owns the comments, an unusable name left off.
- `ipAddressEntity`: the recorded name lands in the comments JSON next to the ports; the policy's own comments go out untouched.
- Eleven killed mutants across the helper, the hook and the call site, including an inverted `canRecord` at the call site. Two adversarial review passes.
- `go test ./...` green apart from `TestRunStore_UpdateRun`, which compares two nanosecond timestamps and fails on develop the same way; `make lint`, 0 issues.
- No customer data in tests or docs: `example.net`, TEST-NET-1 addresses, invented names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)