### PR TITLE
feat(agent): wire gnmi-telemetry into the agent and ship it in the image

### DIFF
--- a/.github/actions/resolve-backend-versions/action.yml
+++ b/.github/actions/resolve-backend-versions/action.yml
@@ -25,6 +25,9 @@ outputs:
   telemetry:
     description: 'Latest released snmp-telemetry version (X.Y.Z, or 0.0.0).'
     value: ${{ steps.resolve.outputs.telemetry }}
+  gnmi-telemetry:
+    description: 'Latest released gnmi-telemetry version (X.Y.Z, or 0.0.0).'
+    value: ${{ steps.resolve.outputs.gnmi-telemetry }}
 
 runs:
   using: composite
@@ -48,6 +51,7 @@ runs:
         dd=$(backend_version device-discovery)
         wk=$(backend_version worker)
         st=$(backend_version snmp-telemetry)
+        gt=$(backend_version gnmi-telemetry)
         {
           echo "network=${nd:-0.0.0}"
           echo "snmp=${sd:-0.0.0}"
@@ -55,4 +59,5 @@ runs:
           echo "device=${dd:-0.0.0}"
           echo "worker=${wk:-0.0.0}"
           echo "telemetry=${st:-0.0.0}"
+          echo "gnmi-telemetry=${gt:-0.0.0}"
         } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/_agent-release.yaml
+++ b/.github/workflows/_agent-release.yaml
@@ -31,6 +31,10 @@ on:
         description: 'snmp-telemetry version to bundle (X.Y.Z).'
         required: true
         type: string
+      gnmi-telemetry-version:
+        description: 'gnmi-telemetry version to bundle (X.Y.Z).'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -129,7 +133,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,scope=${{ matrix.platform }},mode=max
-          no-cache-filters: python-builder,network-discovery,snmp-discovery,snmp-telemetry,pktvisor,otlpinf,final
+          no-cache-filters: python-builder,network-discovery,snmp-discovery,snmp-telemetry,gnmi-telemetry,pktvisor,otlpinf,final
           pull: true
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
@@ -141,6 +145,7 @@ jobs:
             DEVICE_DISCOVERY_VERSION=${{ inputs.device-version }}
             WORKER_VERSION=${{ inputs.worker-version }}
             SNMP_TELEMETRY_VERSION=${{ inputs.telemetry-version }}
+            GNMI_TELEMETRY_VERSION=${{ inputs.gnmi-telemetry-version }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,6 +74,7 @@ jobs:
             DEVICE_DISCOVERY_VERSION=${{ steps.backend-versions.outputs.device }}
             WORKER_VERSION=${{ steps.backend-versions.outputs.worker }}
             SNMP_TELEMETRY_VERSION=${{ steps.backend-versions.outputs.telemetry }}
+            GNMI_TELEMETRY_VERSION=${{ steps.backend-versions.outputs.gnmi-telemetry }}
           tags: orb-agent:scan
 
       - name: Scan image for vulnerabilities

--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -92,6 +92,7 @@ jobs:
             DEVICE_DISCOVERY_VERSION=${{ steps.backend-versions.outputs.device }}
             WORKER_VERSION=${{ steps.backend-versions.outputs.worker }}
             SNMP_TELEMETRY_VERSION=${{ steps.backend-versions.outputs.telemetry }}
+            GNMI_TELEMETRY_VERSION=${{ steps.backend-versions.outputs.gnmi-telemetry }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,7 @@ jobs:
       snmp: ${{ steps.detect.outputs.snmp }}
       gnmi: ${{ steps.detect.outputs.gnmi }}
       telemetry: ${{ steps.detect.outputs.telemetry }}
+      gnmi-telemetry: ${{ steps.detect.outputs.gnmi-telemetry }}
       agent: ${{ steps.detect.outputs.agent }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -73,6 +74,7 @@ jobs:
               echo "snmp=true"
               echo "gnmi=true"
               echo "telemetry=true"
+              echo "gnmi-telemetry=true"
               echo "agent=true"
             } >> "$GITHUB_OUTPUT"
             exit 0
@@ -104,6 +106,7 @@ jobs:
             echo "snmp=$(detect '^orb-discovery/snmp-discovery/' '^orb-discovery/snmp-discovery/docker/')"
             echo "gnmi=$(detect '^orb-discovery/gnmi-discovery/' '^orb-discovery/gnmi-discovery/docker/')"
             echo "telemetry=$(detect '^orb-telemetry/snmp-telemetry/' '^orb-telemetry/snmp-telemetry/docker/')"
+            echo "gnmi-telemetry=$(detect '^orb-telemetry/gnmi-telemetry/' '^orb-telemetry/gnmi-telemetry/docker/')"
             echo "agent=$(detect '^(agent/|cmd/|go\.mod$|go\.sum$)' '^agent/docker/')"
           } >> "$GITHUB_OUTPUT"
 
@@ -119,7 +122,8 @@ jobs:
       ${{ github.event_name == 'push' && needs.changes.outputs.agent == 'true' &&
           (needs.changes.outputs.device == 'true' || needs.changes.outputs.worker == 'true' ||
            needs.changes.outputs.network == 'true' || needs.changes.outputs.snmp == 'true' ||
-           needs.changes.outputs.gnmi == 'true' || needs.changes.outputs.telemetry == 'true') }}
+           needs.changes.outputs.gnmi == 'true' || needs.changes.outputs.telemetry == 'true' ||
+           needs.changes.outputs.gnmi-telemetry == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 35
     permissions:
@@ -134,6 +138,7 @@ jobs:
       SNMP: ${{ needs.changes.outputs.snmp }}
       GNMI: ${{ needs.changes.outputs.gnmi }}
       TELEMETRY: ${{ needs.changes.outputs.telemetry }}
+      GNMI_TELEMETRY: ${{ needs.changes.outputs.gnmi-telemetry }}
     steps:
       - name: Wait for changed backend release runs
         run: |
@@ -171,6 +176,7 @@ jobs:
           if [ "$SNMP" = "true" ];      then wait_for snmp-discovery-release.yaml;    fi
           if [ "$GNMI" = "true" ];      then wait_for gnmi-discovery-release.yaml;    fi
           if [ "$TELEMETRY" = "true" ]; then wait_for snmp-telemetry-release.yaml;    fi
+          if [ "$GNMI_TELEMETRY" = "true" ]; then wait_for gnmi-telemetry-release.yaml; fi
           echo "all changed backend releases complete"
 
   resolve-versions:
@@ -186,6 +192,7 @@ jobs:
       device: ${{ steps.versions.outputs.device }}
       worker: ${{ steps.versions.outputs.worker }}
       telemetry: ${{ steps.versions.outputs.telemetry }}
+      gnmi-telemetry: ${{ steps.versions.outputs.gnmi-telemetry }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       # wait-for-backend-releases has ensured any changed backend already tagged
@@ -205,4 +212,5 @@ jobs:
       device-version: ${{ needs.resolve-versions.outputs.device }}
       worker-version: ${{ needs.resolve-versions.outputs.worker }}
       telemetry-version: ${{ needs.resolve-versions.outputs.telemetry }}
+      gnmi-telemetry-version: ${{ needs.resolve-versions.outputs.gnmi-telemetry }}
     secrets: inherit

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ DD_VERSION ?= $(shell v=$$(git tag -l 'device-discovery/v[0-9]*' | sed 's|.*/v||
 WK_VERSION ?= $(shell v=$$(git tag -l 'worker/v[0-9]*' | sed 's|.*/v||' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1); echo $${v:-0.0.0})
 GD_VERSION ?= $(shell v=$$(git tag -l 'gnmi-discovery/v[0-9]*' | sed 's|.*/v||' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1); echo $${v:-0.0.0})
 ST_VERSION ?= $(shell v=$$(git tag -l 'snmp-telemetry/v[0-9]*' | sed 's|.*/v||' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1); echo $${v:-0.0.0})
-BACKEND_VERSION_ARGS = --build-arg NETWORK_DISCOVERY_VERSION=$(ND_VERSION) --build-arg SNMP_DISCOVERY_VERSION=$(SD_VERSION) --build-arg GNMI_DISCOVERY_VERSION=$(GD_VERSION) --build-arg SNMP_TELEMETRY_VERSION=$(ST_VERSION) --build-arg DEVICE_DISCOVERY_VERSION=$(DD_VERSION) --build-arg WORKER_VERSION=$(WK_VERSION) --build-arg BUILD_COMMIT=$(COMMIT_HASH) --build-arg BUILD_TRACK=$(COMMIT_BRANCH)
+GT_VERSION ?= $(shell v=$$(git tag -l 'gnmi-telemetry/v[0-9]*' | sed 's|.*/v||' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1); echo $${v:-0.0.0})
+BACKEND_VERSION_ARGS = --build-arg NETWORK_DISCOVERY_VERSION=$(ND_VERSION) --build-arg SNMP_DISCOVERY_VERSION=$(SD_VERSION) --build-arg GNMI_DISCOVERY_VERSION=$(GD_VERSION) --build-arg SNMP_TELEMETRY_VERSION=$(ST_VERSION) --build-arg GNMI_TELEMETRY_VERSION=$(GT_VERSION) --build-arg DEVICE_DISCOVERY_VERSION=$(DD_VERSION) --build-arg WORKER_VERSION=$(WK_VERSION) --build-arg BUILD_COMMIT=$(COMMIT_HASH) --build-arg BUILD_TRACK=$(COMMIT_BRANCH)
 
 # Make targets operate on the agent (a single module), so never use a local
 # go.work — workspace mode is incompatible with the -mod=mod build flow. The

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Observability backends focus on collecting and exporting rich telemetry from net
 - [pktvisor](./docs/backends/pktvisor.md)
 - [OpenTelemetry Infinity](./docs/backends/opentelemetry_infinity.md)
 - [SNMP Telemetry](./docs/backends/snmp_telemetry.md)
+- [gNMI Telemetry](./docs/backends/gnmi_telemetry.md)
 
 #### Common
 A special `common` subsection under `backends` defines configuration settings that are shared with all backends. Currently, it supports passing [diode](https://github.com/netboxlabs/diode) server settings and OpenTelemetry configuration to all backends.
@@ -131,6 +132,9 @@ orb:
     snmp_telemetry:
       snmp_telemetry_policy_1:
        # see docs/backends/snmp_telemetry.md
+    gnmi_telemetry:
+      gnmi_telemetry_policy_1:
+       # see docs/backends/gnmi_telemetry.md
  ```
 
 ## System Requirements

--- a/agent/backend/gnmitelemetry/args_test.go
+++ b/agent/backend/gnmitelemetry/args_test.go
@@ -1,0 +1,394 @@
+package gnmitelemetry
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/backend/mocks"
+	"github.com/netboxlabs/orb-agent/agent/config"
+)
+
+func quietLogger(level slog.Level) *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: level}))
+}
+
+func commonsWithOTLP(endpoint string) config.BackendCommons {
+	var c config.BackendCommons
+	c.Otlp.Grpc = endpoint
+	return c
+}
+
+// debugCommons is what the agent hands a backend when run with its debug
+// flag; the flag arrives through the commons, not the config map.
+func debugCommons(endpoint string) config.BackendCommons {
+	c := commonsWithOTLP(endpoint)
+	c.Debug = true
+	return c
+}
+
+func TestConfigureBuildsArgs(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     map[string]any
+		commons config.BackendCommons
+		logger  *slog.Logger
+		want    []string
+		wantErr string
+	}{
+		{
+			name:    "defaults pass only host, port and the endpoint",
+			cfg:     map[string]any{},
+			commons: commonsWithOTLP("grpc://collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8079", "--otel-endpoint", "grpc://collector:4317"},
+		},
+		{
+			name: "every key is forwarded as its flag",
+			cfg: map[string]any{
+				"host":               "127.0.0.1",
+				"port":               9078,
+				"otel_export_period": 30,
+				"log_level":          "warn",
+				"log_format":         "JSON",
+				"policy_env_vars":    "GNMI_USERNAME,GNMI_PASSWORD",
+				"profiles_root":      "/opt/orb/profiles",
+				"profiles_dir":       "/opt/orb/overrides",
+			},
+			commons: commonsWithOTLP("collector:4317"),
+			want: []string{
+				"--host", "127.0.0.1", "--port", "9078", "--otel-endpoint", "collector:4317",
+				"--otel-export-period", "30", "--log-level", "warn", "--log-format", "JSON",
+				"--policy-env-vars", "GNMI_USERNAME,GNMI_PASSWORD",
+				"--profiles-root", "/opt/orb/profiles", "--profiles-dir", "/opt/orb/overrides",
+			},
+		},
+		{
+			name:    "policy_env_vars as a list is joined with commas",
+			cfg:     map[string]any{"policy_env_vars": []any{"A", "B"}},
+			commons: commonsWithOTLP("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8079", "--otel-endpoint", "collector:4317", "--policy-env-vars", "A,B"},
+		},
+		{
+			name:    "empty strings are unset",
+			cfg:     map[string]any{"log_format": "", "policy_env_vars": "", "profiles_root": "", "profiles_dir": ""},
+			commons: commonsWithOTLP("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8079", "--otel-endpoint", "collector:4317"},
+		},
+		{
+			name:    "debug true selects DEBUG",
+			cfg:     map[string]any{"debug": true},
+			commons: commonsWithOTLP("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8079", "--otel-endpoint", "collector:4317", "--log-level", "DEBUG"},
+		},
+		{
+			name:    "the agent's debug flag selects DEBUG",
+			cfg:     map[string]any{},
+			commons: debugCommons("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8079", "--otel-endpoint", "collector:4317", "--log-level", "DEBUG"},
+		},
+		{
+			name:    "a debug-enabled logger alone does not select DEBUG",
+			cfg:     map[string]any{},
+			commons: commonsWithOTLP("collector:4317"),
+			logger:  quietLogger(slog.LevelDebug),
+			want:    []string{"--host", "localhost", "--port", "8079", "--otel-endpoint", "collector:4317"},
+		},
+		{
+			name:    "an explicit log_level wins over debug",
+			cfg:     map[string]any{"debug": true, "log_level": "ERROR"},
+			commons: debugCommons("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8079", "--otel-endpoint", "collector:4317", "--log-level", "ERROR"},
+		},
+		{
+			name:    "export period accepts a whole float",
+			cfg:     map[string]any{"otel_export_period": 15.0},
+			commons: commonsWithOTLP("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8079", "--otel-endpoint", "collector:4317", "--otel-export-period", "15"},
+		},
+		{
+			name:    "export period accepts a numeric string",
+			cfg:     map[string]any{"otel_export_period": "20"},
+			commons: commonsWithOTLP("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8079", "--otel-endpoint", "collector:4317", "--otel-export-period", "20"},
+		},
+		{
+			name:    "a nil map, the documented bare gnmi_telemetry key, uses the defaults",
+			cfg:     nil,
+			commons: commonsWithOTLP("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8079", "--otel-endpoint", "collector:4317"},
+		},
+		{
+			name:    "an empty host or port stays on the default rather than binding everywhere",
+			cfg:     map[string]any{"host": "", "port": ""},
+			commons: commonsWithOTLP("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8079", "--otel-endpoint", "collector:4317"},
+		},
+		{
+			name:    "a null host or port, a key left blank in YAML, keeps the default",
+			cfg:     map[string]any{"host": nil, "port": nil},
+			commons: commonsWithOTLP("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8079", "--otel-endpoint", "collector:4317"},
+		},
+		{
+			name:    "port accepts a whole float and a numeric string",
+			cfg:     map[string]any{"port": 9078.0},
+			commons: commonsWithOTLP("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "9078", "--otel-endpoint", "collector:4317"},
+		},
+		{
+			name:    "a non-string host is refused",
+			cfg:     map[string]any{"host": 7},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "gnmi_telemetry: host must be a string, got int",
+		},
+		{
+			name:    "a fractional port is refused",
+			cfg:     map[string]any{"port": 8079.5},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "gnmi_telemetry: port must be an integer from 1 to 65535, got 8079.5",
+		},
+		{
+			name:    "a port out of range is refused",
+			cfg:     map[string]any{"port": 70000},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "gnmi_telemetry: port must be an integer from 1 to 65535, got 70000",
+		},
+		{
+			name:    "a port that is not a number is refused",
+			cfg:     map[string]any{"port": "eight"},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: `gnmi_telemetry: port must be an integer from 1 to 65535, got "eight"`,
+		},
+		{
+			name:    "an unrecognised log_level is refused rather than run at DEBUG",
+			cfg:     map[string]any{"log_level": "verbose"},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: `gnmi_telemetry: log_level must be one of DEBUG, INFO, WARN, ERROR, got "verbose"`,
+		},
+		{
+			name:    "an unrecognised log_format is refused rather than fall to JSON",
+			cfg:     map[string]any{"log_format": "yaml"},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: `gnmi_telemetry: log_format must be one of TEXT, JSON, got "yaml"`,
+		},
+		{
+			name:    "policy_env_vars entries are trimmed and joined",
+			cfg:     map[string]any{"policy_env_vars": "A, B"},
+			commons: commonsWithOTLP("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8079", "--otel-endpoint", "collector:4317", "--policy-env-vars", "A,B"},
+		},
+		{
+			name:    "a resolved secret in policy_env_vars is refused",
+			cfg:     map[string]any{"policy_env_vars": []any{"GNMI_USERNAME", "s3cr3t-value"}},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: `gnmi_telemetry: policy_env_vars takes environment variable names, not "s3cr3t-value"`,
+		},
+		{
+			name:    "an empty log_level still follows the debug rule",
+			cfg:     map[string]any{"log_level": "", "debug": true},
+			commons: commonsWithOTLP("collector:4317"),
+			want:    []string{"--host", "localhost", "--port", "8079", "--otel-endpoint", "collector:4317", "--log-level", "DEBUG"},
+		},
+		{
+			name:    "a non-string log_level is refused",
+			cfg:     map[string]any{"log_level": false},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "gnmi_telemetry: log_level must be a string, got bool",
+		},
+		{
+			name:    "a non-string log_format is refused",
+			cfg:     map[string]any{"log_format": 7},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "gnmi_telemetry: log_format must be a string, got int",
+		},
+		{
+			name:    "a non-string profiles path is refused",
+			cfg:     map[string]any{"profiles_root": true},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "gnmi_telemetry: profiles_root must be a string, got bool",
+		},
+		{
+			name:    "missing OTLP endpoint is refused",
+			cfg:     map[string]any{},
+			commons: config.BackendCommons{},
+			wantErr: "gnmi_telemetry: common.otlp.grpc is required, the backend exports its metrics over OTLP",
+		},
+		{
+			name:    "export period zero is refused",
+			cfg:     map[string]any{"otel_export_period": 0},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "gnmi_telemetry: otel_export_period must be >= 1, got 0",
+		},
+		{
+			name:    "export period above one year is refused",
+			cfg:     map[string]any{"otel_export_period": 31536001},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "gnmi_telemetry: otel_export_period must be <= 31536000, got 31536001",
+		},
+		{
+			name:    "export period fractional is refused",
+			cfg:     map[string]any{"otel_export_period": 1.5},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "gnmi_telemetry: otel_export_period must be a whole number, got 1.5",
+		},
+		{
+			name:    "export period text is refused",
+			cfg:     map[string]any{"otel_export_period": "soon"},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: `gnmi_telemetry: otel_export_period: invalid integer "soon"`,
+		},
+		{
+			name:    "export period bool is refused",
+			cfg:     map[string]any{"otel_export_period": true},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "gnmi_telemetry: otel_export_period must be an integer, got bool",
+		},
+		{
+			name:    "policy_env_vars with a non-string entry is refused",
+			cfg:     map[string]any{"policy_env_vars": []any{"A", 2}},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "gnmi_telemetry: policy_env_vars entries must be strings, got int",
+		},
+		{
+			name:    "policy_env_vars of another type is refused",
+			cfg:     map[string]any{"policy_env_vars": 7},
+			commons: commonsWithOTLP("collector:4317"),
+			wantErr: "gnmi_telemetry: policy_env_vars must be a string or a list of strings, got int",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := tc.logger
+			if logger == nil {
+				logger = quietLogger(slog.LevelInfo)
+			}
+			b := &gnmiTelemetryBackend{apiProtocol: "http", exec: defaultExec}
+			err := b.Configure(logger, nil, tc.cfg, tc.commons, nil)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, b.buildArgs())
+		})
+	}
+}
+
+// A second Configure on the same backend must not carry an optional flag over
+// from the first: the agent reconfigures a registered backend in place.
+func TestConfigureResetsOptionalFlags(t *testing.T) {
+	b := &gnmiTelemetryBackend{apiProtocol: "http", exec: defaultExec}
+	logger := quietLogger(slog.LevelInfo)
+	require.NoError(t, b.Configure(logger, nil, map[string]any{
+		"otel_export_period": 5, "log_level": "ERROR", "log_format": "JSON",
+		"policy_env_vars": "A", "profiles_root": "/r", "profiles_dir": "/d",
+	}, commonsWithOTLP("collector:4317"), nil))
+	require.NoError(t, b.Configure(logger, nil, map[string]any{}, commonsWithOTLP("collector:4317"), nil))
+	assert.Equal(t, []string{"--host", "localhost", "--port", "8079", "--otel-endpoint", "collector:4317"}, b.buildArgs())
+}
+
+// The binary sizes its shutdown, subscriptions closed and then the final
+// OTLP flush, to the agent's default stop grace. Stop must hand it exactly
+// that grace; a shorter one would SIGKILL it with the last export unsent.
+func TestStopPassesTheAgentGrace(t *testing.T) {
+	var gotGrace time.Duration
+	var gotName string
+	original := stopProcess
+	stopProcess = func(_ *slog.Logger, _ backend.Commander, _ <-chan backend.CmdStatus, grace time.Duration, name string) {
+		gotGrace = grace
+		gotName = name
+	}
+	t.Cleanup(func() { stopProcess = original })
+
+	b := &gnmiTelemetryBackend{apiProtocol: "http", exec: defaultExec}
+	require.NoError(t, b.Configure(quietLogger(slog.LevelInfo), nil, map[string]any{}, commonsWithOTLP("collector:4317"), nil))
+	_, cancel := context.WithCancel(context.Background())
+	b.cancelFunc = cancel
+	b.proc = &mocks.MockCmd{}
+
+	require.NoError(t, b.Stop(context.Background()))
+
+	assert.Equal(t, backend.DefaultStopGracePeriod, gotGrace)
+	assert.Equal(t, "gnmi_telemetry", gotName)
+}
+
+// A backend that never started has no process to stop; Stop is a no-op
+// rather than a nil dereference.
+func TestStopBeforeStartIsANoOp(t *testing.T) {
+	calls := 0
+	original := stopProcess
+	stopProcess = func(*slog.Logger, backend.Commander, <-chan backend.CmdStatus, time.Duration, string) { calls++ }
+	t.Cleanup(func() { stopProcess = original })
+
+	b := &gnmiTelemetryBackend{apiProtocol: "http", exec: defaultExec}
+	require.NoError(t, b.Stop(context.Background()))
+	assert.Equal(t, 0, calls)
+}
+
+// A fleet full reset walks the whole registry, reaching a backend the agent
+// never configured. It must refuse rather than start a process on empty
+// arguments through a nil logger.
+func TestStartAndResetBeforeConfigureAreRefused(t *testing.T) {
+	b := &gnmiTelemetryBackend{apiProtocol: "http", exec: defaultExec}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	assert.EqualError(t, b.Start(ctx, cancel), "gnmi_telemetry: started before it was configured")
+	assert.EqualError(t, b.FullReset(ctx), "gnmi_telemetry: reset before it was configured")
+}
+
+// A refused reconfiguration must not move the address the agent polls the
+// running process on, or every status check would miss it until a restart.
+func TestConfigureFailureLeavesTheBackendUnchanged(t *testing.T) {
+	b := &gnmiTelemetryBackend{apiProtocol: "http", exec: defaultExec}
+	logger := quietLogger(slog.LevelInfo)
+	require.NoError(t, b.Configure(logger, nil, map[string]any{"port": 9078, "log_format": "JSON"}, commonsWithOTLP("collector:4317"), nil))
+	before := b.buildArgs()
+
+	err := b.Configure(logger, nil, map[string]any{"port": 9079, "otel_export_period": 0}, commonsWithOTLP("other:4317"), nil)
+	require.Error(t, err)
+
+	assert.Equal(t, before, b.buildArgs())
+	assert.Equal(t, "http://localhost:9078/api/v1/status", b.apiURL("status"))
+}
+
+// The binary brackets an IPv6 host when it binds; the agent must do the same
+// when it dials, or readiness never passes.
+func TestAPIURLBracketsAnIPv6Host(t *testing.T) {
+	b := &gnmiTelemetryBackend{apiProtocol: "http", exec: defaultExec}
+	require.NoError(t, b.Configure(quietLogger(slog.LevelInfo), nil, map[string]any{"host": "::1"}, commonsWithOTLP("collector:4317"), nil))
+	assert.Equal(t, "http://[::1]:8079/api/v1/status", b.apiURL("status"))
+	assert.Equal(t, "http://[::1]:8079/api/v1/policies/a%20b", b.apiURL("policies/a%20b"))
+}
+
+// The binary's log lines are re-logged by the agent. A JSON record, the
+// binary's output under log_format JSON, must keep its severity and
+// attributes rather than arrive as one INFO string.
+func TestLogLineAdapterKeepsSeverityForBothFormats(t *testing.T) {
+	var out bytes.Buffer
+	b := &gnmiTelemetryBackend{apiProtocol: "http", exec: defaultExec}
+	require.NoError(t, b.Configure(slog.New(slog.NewTextHandler(&out, &slog.HandlerOptions{Level: slog.LevelDebug})), nil, map[string]any{}, commonsWithOTLP("collector:4317"), nil))
+
+	b.logLineAdapter(`{"time":"2026-09-04T12:00:00Z","level":"ERROR","msg":"subscription failed","target":"192.0.2.1:57400"}`, false)
+	b.logLineAdapter(`time=2026-09-04T12:00:00Z level=WARN msg="update dropped" reason=unmatched_path`, false)
+	b.logLineAdapter(`plain text from the child`, true)
+
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	require.Len(t, lines, 4, "configure line plus the three forwarded lines")
+	assert.Contains(t, lines[1], "level=ERROR")
+	assert.Contains(t, lines[1], `msg="subscription failed"`)
+	assert.Contains(t, lines[1], "target=192.0.2.1:57400")
+	assert.Contains(t, lines[2], "level=WARN")
+	assert.Contains(t, lines[2], "reason=unmatched_path")
+	assert.Contains(t, lines[3], "level=ERROR", "stderr keeps the error fallback")
+	assert.Contains(t, lines[3], `msg="plain text from the child"`)
+}

--- a/agent/backend/gnmitelemetry/gnmi_telemetry.go
+++ b/agent/backend/gnmitelemetry/gnmi_telemetry.go
@@ -1,0 +1,587 @@
+package gnmitelemetry
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/config"
+	"github.com/netboxlabs/orb-agent/agent/filesmgr"
+	"github.com/netboxlabs/orb-agent/agent/policies"
+	"github.com/netboxlabs/orb-agent/agent/redact"
+)
+
+var _ backend.Backend = (*gnmiTelemetryBackend)(nil)
+
+const (
+	versionTimeout      = 2
+	capabilitiesTimeout = 5
+	// The binary's DELETE waits for the policy's runners to unwind, and a
+	// sweep in flight notices the stop between addresses, so the wait is
+	// bounded by one probe timeout: three seconds by default, or the
+	// policy's own probe_timeout_ms. A POST for a name still stopping waits
+	// on that same unwinding. Both timeouts clear the default many times
+	// over; a policy that sets a probe timeout beyond them can make its own
+	// remove time out, which the agent reports rather than hangs on.
+	applyPolicyTimeout  = 30
+	removePolicyTimeout = 30
+	maxPort             = 65535
+	defaultExec         = "gnmi-telemetry"
+	defaultAPIHost      = "localhost"
+	defaultAPIPort      = "8079"
+
+	// maxExportPeriodSeconds is the binary's own cap on --otel-export-period,
+	// one year. The binary exits on a larger value, which the agent would
+	// then restart in a loop, so the agent refuses it at configuration.
+	maxExportPeriodSeconds = 365 * 24 * 60 * 60
+)
+
+// stopProcess is backend.StopProcess behind a seam so a test can observe the
+// grace Stop hands the process.
+var stopProcess = backend.StopProcess
+
+// gnmiTelemetryBackend runs the gnmi-telemetry binary, which subscribes to
+// gNMI streaming telemetry from network devices under policies and exports
+// what arrives as OTLP metrics. Every metric leaves over OTLP, so the backend
+// refuses to configure without common.otlp.grpc rather than start a process
+// with nowhere to export.
+//
+// It does not implement backend.PolicyStatusProvider. The agent uses that
+// provider only to feed each policy's runs into the policy repo, and a
+// telemetry policy is a continuous collector with no runs to report: its
+// status carries a name, a state and a last error. Implementing the provider
+// would poll the status endpoint every cycle to update nothing.
+type gnmiTelemetryBackend struct {
+	logger     *slog.Logger
+	policyRepo policies.PolicyRepo
+	exec       string
+
+	apiHost     string
+	apiPort     string
+	apiProtocol string
+
+	otelEndpoint string
+
+	// Optional flags, passed only when non-empty. Reset on every Configure
+	// so a reconfiguration cannot carry a value over.
+	otelExportPeriod string
+	logLevel         string
+	logFormat        string
+	policyEnvVars    string
+	profilesRoot     string
+	profilesDir      string
+
+	startTime  time.Time
+	proc       backend.Commander
+	statusChan <-chan backend.CmdStatus
+	cancelFunc context.CancelFunc
+	ctx        context.Context
+}
+
+type info struct {
+	Version string `json:"version"`
+}
+
+// Register registers the gnmi telemetry backend
+func Register() bool {
+	backend.Register("gnmi_telemetry", &gnmiTelemetryBackend{
+		apiProtocol: "http",
+		exec:        defaultExec,
+	})
+	return true
+}
+
+// envVarName is what --policy-env-vars accepts: variable names. A value that
+// is not a name, such as a secrets-manager reference the agent has resolved
+// into a secret, must not reach the command line.
+var envVarName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// readHost reads the API host. Absent, null or empty keeps the loopback
+// default: the binary joins an empty host with the port and binds every
+// interface, and its API has no authentication.
+func readHost(cfg map[string]any) (string, error) {
+	v, prs := cfg["host"]
+	if !prs || v == nil {
+		return defaultAPIHost, nil
+	}
+	host, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("host must be a string, got %T", v)
+	}
+	if host == "" {
+		return defaultAPIHost, nil
+	}
+	return host, nil
+}
+
+// readPort reads the API port as the binary's integer flag takes it. Absent,
+// null or empty keeps the default; anything the flag would reject is refused
+// here rather than at the binary's startup, which the agent would repeat.
+func readPort(cfg map[string]any) (string, error) {
+	v, prs := cfg["port"]
+	if !prs || v == nil || v == "" {
+		return defaultAPIPort, nil
+	}
+	var n int
+	switch val := v.(type) {
+	case int:
+		n = val
+	case int64:
+		n = int(val)
+	case float64:
+		if val != float64(int64(val)) {
+			return "", fmt.Errorf("port must be an integer from 1 to %d, got %v", maxPort, val)
+		}
+		n = int(val)
+	case string:
+		parsed, err := strconv.Atoi(val)
+		if err != nil {
+			return "", fmt.Errorf("port must be an integer from 1 to %d, got %q", maxPort, val)
+		}
+		n = parsed
+	default:
+		return "", fmt.Errorf("port must be an integer from 1 to %d, got %T", maxPort, v)
+	}
+	if n < 1 || n > maxPort {
+		return "", fmt.Errorf("port must be an integer from 1 to %d, got %d", maxPort, n)
+	}
+	return strconv.Itoa(n), nil
+}
+
+// readChoice reads an optional key whose value the binary matches
+// case-insensitively against a fixed set. An unrecognised value is refused
+// here because the binary falls back silently: any other level runs at
+// DEBUG and any other format is JSON.
+func readChoice(cfg map[string]any, key string, choices ...string) (string, error) {
+	value, err := optionalString(cfg, key)
+	if err != nil || value == "" {
+		return value, err
+	}
+	for _, choice := range choices {
+		if strings.EqualFold(value, choice) {
+			return value, nil
+		}
+	}
+	return "", fmt.Errorf("%s must be one of %s, got %q", key, strings.Join(choices, ", "), value)
+}
+
+func parseExportPeriod(v any) (int, error) {
+	var n int
+
+	switch val := v.(type) {
+	case int:
+		n = val
+	case int64:
+		n = int(val)
+	case float64:
+		if val != float64(int64(val)) {
+			return 0, fmt.Errorf("otel_export_period must be a whole number, got %v", val)
+		}
+		n = int(val)
+	case string:
+		parsed, err := strconv.Atoi(val)
+		if err != nil {
+			return 0, fmt.Errorf("otel_export_period: invalid integer %q: %w", val, err)
+		}
+		n = parsed
+	default:
+		return 0, fmt.Errorf("otel_export_period must be an integer, got %T", v)
+	}
+
+	if n < 1 {
+		return 0, fmt.Errorf("otel_export_period must be >= 1, got %d", n)
+	}
+	if n > maxExportPeriodSeconds {
+		return 0, fmt.Errorf("otel_export_period must be <= %d, got %d", maxExportPeriodSeconds, n)
+	}
+
+	return n, nil
+}
+
+// optionalString reads a key that is either absent, or a string passed to the
+// binary verbatim. Any other type is refused rather than coerced, so a stray
+// YAML boolean does not reach a flag the binary would silently reinterpret.
+func optionalString(cfg map[string]any, key string) (string, error) {
+	v, prs := cfg[key]
+	if !prs {
+		return "", nil
+	}
+	str, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("%s must be a string, got %T", key, v)
+	}
+	return str, nil
+}
+
+// parsePolicyEnvVars accepts the flag's own comma-separated string, or a YAML
+// list of names so an operator does not have to write the comma form by hand.
+func parsePolicyEnvVars(v any) (string, error) {
+	var names []string
+	switch val := v.(type) {
+	case string:
+		if val == "" {
+			return "", nil
+		}
+		names = strings.Split(val, ",")
+	case []string:
+		names = val
+	case []any:
+		for _, item := range val {
+			name, ok := item.(string)
+			if !ok {
+				return "", fmt.Errorf("policy_env_vars entries must be strings, got %T", item)
+			}
+			names = append(names, name)
+		}
+	default:
+		return "", fmt.Errorf("policy_env_vars must be a string or a list of strings, got %T", v)
+	}
+	for i, name := range names {
+		names[i] = strings.TrimSpace(name)
+		if !envVarName.MatchString(names[i]) {
+			return "", fmt.Errorf("policy_env_vars takes environment variable names, not %q", name)
+		}
+	}
+	return strings.Join(names, ","), nil
+}
+
+// settings is what Configure derives from the backend map. It is applied to
+// the backend only once every key has been read, so a refused reconfiguration
+// leaves the running backend, and the address the agent polls it on, as they
+// were.
+type settings struct {
+	apiHost, apiPort, otelEndpoint           string
+	otelExportPeriod, logLevel, logFormat    string
+	policyEnvVars, profilesRoot, profilesDir string
+}
+
+func (d *gnmiTelemetryBackend) Configure(logger *slog.Logger, repo policies.PolicyRepo,
+	cfg map[string]any, common config.BackendCommons, _ filesmgr.Manager,
+) error {
+	st, err := readSettings(cfg, common)
+	if err != nil {
+		return fmt.Errorf("gnmi_telemetry: %w", err)
+	}
+
+	d.logger = logger.With("backend", "gnmi_telemetry")
+	d.policyRepo = repo
+	d.apiHost = st.apiHost
+	d.apiPort = st.apiPort
+	d.otelEndpoint = st.otelEndpoint
+	d.otelExportPeriod = st.otelExportPeriod
+	d.logLevel = st.logLevel
+	d.logFormat = st.logFormat
+	d.policyEnvVars = st.policyEnvVars
+	d.profilesRoot = st.profilesRoot
+	d.profilesDir = st.profilesDir
+
+	d.logger.Info("gnmi-telemetry using OTLP endpoint", "endpoint", d.otelEndpoint)
+
+	return nil
+}
+
+func readSettings(cfg map[string]any, common config.BackendCommons) (settings, error) {
+	var st settings
+	var err error
+
+	if common.Otlp.Grpc == "" {
+		return st, errors.New("common.otlp.grpc is required, the backend exports its metrics over OTLP")
+	}
+	st.otelEndpoint = common.Otlp.Grpc
+
+	if st.apiHost, err = readHost(cfg); err != nil {
+		return st, err
+	}
+	if st.apiPort, err = readPort(cfg); err != nil {
+		return st, err
+	}
+
+	if v, prs := cfg["otel_export_period"]; prs {
+		period, err := parseExportPeriod(v)
+		if err != nil {
+			return st, err
+		}
+		st.otelExportPeriod = strconv.Itoa(period)
+	}
+
+	if st.logLevel, err = readChoice(cfg, "log_level", "DEBUG", "INFO", "WARN", "ERROR"); err != nil {
+		return st, err
+	}
+	// The agent's debug flag comes through the commons. The logger is not
+	// consulted: when OTLP log export is on, the agent wraps it in a handler
+	// that accepts debug records whatever the console level, so asking the
+	// logger would put every OTLP-exporting agent's backend at DEBUG.
+	if st.logLevel == "" {
+		if debug, prs := cfg["debug"].(bool); prs && debug {
+			st.logLevel = "DEBUG"
+		} else if common.Debug {
+			st.logLevel = "DEBUG"
+		}
+	}
+
+	if st.logFormat, err = readChoice(cfg, "log_format", "TEXT", "JSON"); err != nil {
+		return st, err
+	}
+
+	if v, prs := cfg["policy_env_vars"]; prs {
+		if st.policyEnvVars, err = parsePolicyEnvVars(v); err != nil {
+			return st, err
+		}
+	}
+
+	if st.profilesRoot, err = optionalString(cfg, "profiles_root"); err != nil {
+		return st, err
+	}
+	if st.profilesDir, err = optionalString(cfg, "profiles_dir"); err != nil {
+		return st, err
+	}
+
+	return st, nil
+}
+
+// apiURL joins the API address the way the binary binds it, so an IPv6 host
+// is bracketed.
+func (d *gnmiTelemetryBackend) apiURL(path string) string {
+	return fmt.Sprintf("%s://%s/api/v1/%s", d.apiProtocol, net.JoinHostPort(d.apiHost, d.apiPort), path)
+}
+
+func (d *gnmiTelemetryBackend) Version() (string, error) {
+	var info info
+	url := d.apiURL("status")
+	err := backend.CommonRequest("gnmi-telemetry", d.proc, d.logger, url, &info, http.MethodGet,
+		http.NoBody, "application/json", versionTimeout, "detail")
+	if err != nil {
+		return "", err
+	}
+	return info.Version, nil
+}
+
+// buildArgs lists the required flags first, then every optional flag that has
+// a value. An optional flag left out leaves the binary on its own default.
+func (d *gnmiTelemetryBackend) buildArgs() []string {
+	args := []string{
+		"--host", d.apiHost,
+		"--port", d.apiPort,
+		"--otel-endpoint", d.otelEndpoint,
+	}
+	optional := []struct{ flag, value string }{
+		{"--otel-export-period", d.otelExportPeriod},
+		{"--log-level", d.logLevel},
+		{"--log-format", d.logFormat},
+		{"--policy-env-vars", d.policyEnvVars},
+		{"--profiles-root", d.profilesRoot},
+		{"--profiles-dir", d.profilesDir},
+	}
+	for _, opt := range optional {
+		if opt.value != "" {
+			args = append(args, opt.flag, opt.value)
+		}
+	}
+	return args
+}
+
+func (d *gnmiTelemetryBackend) Start(ctx context.Context, cancelFunc context.CancelFunc) error {
+	// A registered backend the agent never configured has no logger and no
+	// arguments; a fleet full reset walks the whole registry and would reach
+	// it, so refuse rather than start a process on empty flags.
+	if d.logger == nil {
+		return errors.New("gnmi_telemetry: started before it was configured")
+	}
+	d.startTime = time.Now()
+	d.cancelFunc = cancelFunc
+	d.ctx = ctx
+
+	args := d.buildArgs()
+
+	d.logger.Info("gnmi-telemetry startup", "arguments", redact.Args(args))
+
+	return backend.StartProcess(backend.StartSpec{
+		Logger:         d.logger,
+		NameDisplay:    "gnmi-telemetry",
+		NameUnderscore: "gnmi_telemetry",
+		Exec:           d.exec,
+		Args:           args,
+		LogLine:        d.logLineAdapter,
+		SetProc: func(p backend.Commander, ch <-chan backend.CmdStatus) {
+			d.proc = p
+			d.statusChan = ch
+		},
+		ReadinessCheck: d.Version,
+	})
+}
+
+// logLineAdapter routes a streamed stdout/stderr line to the agent's logger
+// with the level matching the source stream. The binary writes logfmt under
+// its TEXT format and one JSON object per line under JSON; both are parsed,
+// so a WARN or ERROR record keeps its severity and attributes either way.
+func (d *gnmiTelemetryBackend) logLineAdapter(line string, isStderr bool) {
+	fallback := slog.LevelInfo
+	if isStderr {
+		fallback = slog.LevelError
+	}
+
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return
+	}
+
+	msg := trimmed
+	attrs := []slog.Attr(nil)
+	level := fallback
+
+	if parsedMsg, parsedAttrs, parsedLevel, ok := backend.NormalizeLogfmtLine(trimmed, fallback); ok {
+		msg = parsedMsg
+		attrs = parsedAttrs
+		level = parsedLevel
+	} else if parsedMsg, parsedAttrs, parsedLevel, ok := backend.NormalizeJSONLine(trimmed, fallback); ok {
+		msg = parsedMsg
+		attrs = parsedAttrs
+		level = parsedLevel
+	}
+
+	ctx := d.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	d.logger.LogAttrs(ctx, level, msg, attrs...)
+}
+
+// Stop hands the process the agent's default grace. The binary sizes its
+// whole shutdown to exactly that grace: it flushes the last OTLP export
+// within half of it, then cancels its subscriptions, then stops its API
+// under what is left, in that order so the flush does not race the
+// withdrawal of the series it is exporting. A shorter grace would SIGKILL
+// it with the final export unsent; a kill after the flush costs nothing but
+// a warning in the log.
+func (d *gnmiTelemetryBackend) Stop(ctx context.Context) error {
+	if d.cancelFunc != nil {
+		defer d.cancelFunc()
+	}
+	if d.proc == nil {
+		return nil
+	}
+	d.logger.Info("routine call to stop gnmi-telemetry", "routine", ctx.Value(config.ContextKey("routine")))
+	stopProcess(d.logger, d.proc, d.statusChan, backend.DefaultStopGracePeriod, "gnmi_telemetry")
+	return nil
+}
+
+func (d *gnmiTelemetryBackend) FullReset(ctx context.Context) error {
+	if d.logger == nil {
+		return errors.New("gnmi_telemetry: reset before it was configured")
+	}
+	if state, _, _ := backend.GetRunningStatus(d.proc); state == backend.Running {
+		if err := d.Stop(ctx); err != nil {
+			d.logger.Error("failed to stop backend on restart procedure", "error", err)
+			return err
+		}
+	}
+	backendCtx, cancelFunc := context.WithCancel(context.WithValue(ctx, config.ContextKey("routine"), "gnmi-telemetry"))
+	if err := d.Start(backendCtx, cancelFunc); err != nil {
+		d.logger.Error("failed to start backend on restart procedure", "error", err)
+		return err
+	}
+	return nil
+}
+
+func (d *gnmiTelemetryBackend) GetStartTime() time.Time {
+	return d.startTime
+}
+
+func (d *gnmiTelemetryBackend) GetCapabilities() (map[string]any, error) {
+	caps := make(map[string]any)
+	url := d.apiURL("capabilities")
+	err := backend.CommonRequest("gnmi-telemetry", d.proc, d.logger, url, &caps, http.MethodGet,
+		http.NoBody, "application/json", capabilitiesTimeout, "detail")
+	if err != nil {
+		return nil, err
+	}
+	return caps, nil
+}
+
+func (d *gnmiTelemetryBackend) GetRunningStatus() (backend.RunningStatus, string, error) {
+	runningStatus, errMsg, err := backend.GetRunningStatus(d.proc)
+	if runningStatus != backend.Running {
+		return runningStatus, errMsg, err
+	}
+	if _, aiErr := d.Version(); aiErr != nil {
+		return backend.BackendError, "process running, REST API unavailable", aiErr
+	}
+	return runningStatus, "", nil
+}
+
+func (d *gnmiTelemetryBackend) GetInitialState() backend.RunningStatus {
+	return backend.Unknown
+}
+
+func (d *gnmiTelemetryBackend) ApplyPolicy(data policies.PolicyData, updatePolicy bool) error {
+	if updatePolicy {
+		// The binary answers 409 for a name already running, so an update is a
+		// remove followed by a fresh apply.
+		if err := d.RemovePolicy(data); err != nil {
+			d.logger.Warn("policy failed to remove", "policy_id", data.ID,
+				"policy_name", data.Name, "error", err)
+		}
+	}
+
+	// The body carries solved secrets (username, password, TLS key paths),
+	// and a debug record reaches the OTLP log collector when export is on, so
+	// only the policy's identity is logged.
+	d.logger.Debug("gnmi-telemetry policy apply", "policy_id", data.ID, "policy_name", data.Name)
+
+	fullPolicy := map[string]any{
+		"policies": map[string]any{
+			data.Name: data.Data,
+		},
+	}
+
+	policyYaml, err := yaml.Marshal(fullPolicy)
+	if err != nil {
+		d.logger.Warn("policy yaml marshal failure", "policy_id", data.ID, "policy_name", data.Name)
+		return err
+	}
+
+	var resp map[string]any
+	url := d.apiURL("policies")
+	err = backend.CommonRequest("gnmi-telemetry", d.proc, d.logger, url, &resp, http.MethodPost,
+		bytes.NewBuffer(policyYaml), "application/x-yaml", applyPolicyTimeout, "detail")
+	if err != nil {
+		d.logger.Warn("policy application failure", "policy_id", data.ID, "policy_name", data.Name)
+		return err
+	}
+
+	return nil
+}
+
+func (d *gnmiTelemetryBackend) RemovePolicy(data policies.PolicyData) error {
+	d.logger.Debug("gnmi-telemetry policy remove", "policy_id", data.ID)
+	var resp any
+	name := data.Name
+	// Policies are removed by name, so a renamed policy is removed under the
+	// name the binary knows it by.
+	if data.PreviousPolicyData != nil && data.PreviousPolicyData.Name != data.Name {
+		name = data.PreviousPolicyData.Name
+	}
+	segment, err := backend.PolicyPathSegment(name)
+	if err != nil {
+		return err
+	}
+	url := d.apiURL("policies/" + segment)
+	err = backend.CommonRequest("gnmi-telemetry", d.proc, d.logger, url, &resp, http.MethodDelete,
+		http.NoBody, "application/json", removePolicyTimeout, "detail")
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/agent/backend/gnmitelemetry/gnmi_telemetry_test.go
+++ b/agent/backend/gnmitelemetry/gnmi_telemetry_test.go
@@ -1,0 +1,328 @@
+package gnmitelemetry_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/backend/gnmitelemetry"
+	"github.com/netboxlabs/orb-agent/agent/backend/mocks"
+	"github.com/netboxlabs/orb-agent/agent/config"
+	"github.com/netboxlabs/orb-agent/agent/policies"
+)
+
+type statusResponse struct {
+	Version       string `json:"version"`
+	StartTime     string `json:"start_time"`
+	UpTimeSeconds int64  `json:"up_time_seconds"`
+}
+
+// apiRecorder answers the binary's API and records every policy request.
+// Handlers run on the server's goroutines, so failures are reported with
+// t.Error rather than require, which must not leave the test goroutine.
+type apiRecorder struct {
+	mu       sync.Mutex
+	requests []recorded
+}
+
+type recorded struct {
+	method      string
+	path        string
+	contentType string
+	body        string
+}
+
+func (a *apiRecorder) handler(t *testing.T) http.HandlerFunc {
+	encode := func(w http.ResponseWriter, v any) {
+		w.WriteHeader(http.StatusOK)
+		if err := json.NewEncoder(w).Encode(v); err != nil {
+			t.Error(err)
+		}
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/status":
+			encode(w, statusResponse{Version: "1.0.0", StartTime: "2026-09-04T12:00:00Z", UpTimeSeconds: 42})
+		case r.URL.Path == "/api/v1/capabilities":
+			// The binary's body: the target kind and the three delivery rungs.
+			encode(w, map[string]any{"capabilities": []string{"targets", "on_change", "sample", "get"}})
+		case strings.HasPrefix(r.URL.Path, "/api/v1/policies"):
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Error(err)
+			}
+			a.mu.Lock()
+			a.requests = append(a.requests, recorded{
+				method: r.Method, path: r.URL.EscapedPath(),
+				contentType: r.Header.Get("Content-Type"), body: string(body),
+			})
+			a.mu.Unlock()
+			encode(w, map[string]any{"message": "ok"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}
+}
+
+func (a *apiRecorder) policyRequests() []recorded {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return append([]recorded(nil), a.requests...)
+}
+
+func TestGnmiTelemetryBackendStart(t *testing.T) {
+	rec := &apiRecorder{}
+	server := httptest.NewServer(rec.handler(t))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	// PID 0: a stray Stop on the mock's single status would wait out the
+	// grace, but StopProcess skips the SIGKILL escalation for an invalid pid.
+	mocks.SetupSuccessfulProcess(mockCmd, 0)
+
+	overrideNewCmdOptions(t, mockCmd, func(options backend.CmdOptions, name string, args []string) {
+		assert.Equal(t, "gnmi-telemetry", name)
+		assert.False(t, options.Buffered)
+		assert.True(t, options.Streaming)
+		assert.Equal(t, []string{
+			"--host", serverURL.Hostname(),
+			"--port", serverURL.Port(),
+			"--otel-endpoint", "grpc://collector:4317",
+			"--log-level", "INFO",
+		}, args)
+	})
+
+	assert.True(t, gnmitelemetry.Register())
+	assert.True(t, backend.HaveBackend("gnmi_telemetry"))
+
+	be := backend.GetBackend("gnmi_telemetry")
+	assert.Equal(t, backend.Unknown, be.GetInitialState())
+
+	var commons config.BackendCommons
+	commons.Otlp.Grpc = "grpc://collector:4317"
+
+	require.NoError(t, be.Configure(logger, repo, map[string]any{
+		"host":      serverURL.Hostname(),
+		"port":      serverURL.Port(),
+		"log_level": "INFO",
+	}, commons, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, be.Start(ctx, cancel))
+
+	version, err := be.Version()
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.0", version)
+
+	caps, err := be.GetCapabilities()
+	require.NoError(t, err)
+	assert.Equal(t, []any{"targets", "on_change", "sample", "get"}, caps["capabilities"])
+
+	status, msg, err := be.GetRunningStatus()
+	require.NoError(t, err)
+	assert.Equal(t, backend.Running, status)
+	assert.Empty(t, msg)
+
+	// A name the binary accepts (one path segment) that still needs escaping.
+	policy := policies.PolicyData{
+		ID:   "id-1",
+		Name: "core metrics",
+		Data: map[string]any{
+			"config": map[string]any{"metrics_interval": 30},
+			"scope":  map[string]any{"targets": []any{map[string]any{"host": "10.0.0.1"}}},
+		},
+	}
+	require.NoError(t, be.ApplyPolicy(policy, false))
+
+	renamed := policies.PolicyData{ID: "id-1", Name: "core", Data: policy.Data, PreviousPolicyData: &policy}
+	require.NoError(t, be.ApplyPolicy(renamed, true))
+
+	require.NoError(t, be.RemovePolicy(policies.PolicyData{ID: "id-1", Name: "core"}))
+
+	reqs := rec.policyRequests()
+	require.Len(t, reqs, 4, "apply, then remove-and-apply for the update, then remove")
+
+	assert.Equal(t, http.MethodPost, reqs[0].method)
+	assert.Equal(t, "/api/v1/policies", reqs[0].path)
+	assert.Equal(t, "application/x-yaml", reqs[0].contentType)
+	assert.Contains(t, reqs[0].body, "policies:\n    core metrics:\n")
+	assert.Contains(t, reqs[0].body, "metrics_interval: 30")
+
+	assert.Equal(t, http.MethodDelete, reqs[1].method)
+	assert.Equal(t, "/api/v1/policies/core%20metrics", reqs[1].path, "an update removes the previous name first, escaped")
+
+	assert.Equal(t, http.MethodPost, reqs[2].method)
+	assert.Contains(t, reqs[2].body, "policies:\n    core:\n")
+
+	assert.Equal(t, http.MethodDelete, reqs[3].method)
+	assert.Equal(t, "/api/v1/policies/core", reqs[3].path, "a remove without rename history uses the current name")
+
+	require.NoError(t, be.FullReset(ctx))
+
+	// With the API gone the process still runs, and the backend says so.
+	server.Close()
+	status, msg, err = be.GetRunningStatus()
+	assert.Error(t, err)
+	assert.Equal(t, backend.BackendError, status)
+	assert.Equal(t, "process running, REST API unavailable", msg)
+
+	// No trailing Stop: the mock delivers exactly one process status, which
+	// FullReset's Stop consumed; a second Stop would wait out the whole grace.
+	mockCmd.AssertExpectations(t)
+}
+
+// A policy body reaches the agent with its secrets solved, and a debug record
+// reaches the OTLP log collector when export is on, so the apply log must not
+// carry the body.
+func TestGnmiTelemetryBackendDoesNotLogPolicyCredentials(t *testing.T) {
+	rec := &apiRecorder{}
+	server := httptest.NewServer(rec.handler(t))
+	defer server.Close()
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 0)
+	overrideNewCmdOptions(t, mockCmd, nil)
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	assert.True(t, gnmitelemetry.Register())
+	be := backend.GetBackend("gnmi_telemetry")
+	var commons config.BackendCommons
+	commons.Otlp.Grpc = "collector:4317"
+	require.NoError(t, be.Configure(logger, nil, map[string]any{
+		"host": serverURL.Hostname(), "port": serverURL.Port(),
+	}, commons, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, be.Start(ctx, cancel))
+
+	require.NoError(t, be.ApplyPolicy(policies.PolicyData{ID: "id-3", Name: "core", Data: map[string]any{
+		"config": map[string]any{"metrics_interval": 30},
+		"scope": map[string]any{
+			"username": "gnmi-user", "password": "p4ssw0rd-secret",
+			"tls":     map[string]any{"cert": "/opt/orb/keys/client.pem", "key": "/opt/orb/keys/client-secret.key"},
+			"targets": []any{map[string]any{"host": "10.0.0.1"}},
+		},
+	}}, false))
+	require.NoError(t, be.Stop(ctx))
+
+	out := logs.String()
+	assert.Contains(t, out, "gnmi-telemetry policy apply", "the apply is still logged")
+	for _, secret := range []string{"p4ssw0rd-secret", "client-secret.key"} {
+		assert.NotContains(t, out, secret)
+	}
+}
+
+// The binary validates policy names and bodies itself and answers 400 with a
+// detail; that detail is the error the agent surfaces.
+func TestGnmiTelemetryBackendSurfacesTheServersRejection(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/status" {
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(statusResponse{Version: "1.0.0"})
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"detail": `policy name must be a single path segment, so it may not contain "/": "core/metrics"`})
+	}))
+	defer server.Close()
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 0)
+	overrideNewCmdOptions(t, mockCmd, nil)
+
+	assert.True(t, gnmitelemetry.Register())
+	be := backend.GetBackend("gnmi_telemetry")
+	var commons config.BackendCommons
+	commons.Otlp.Grpc = "collector:4317"
+	require.NoError(t, be.Configure(slog.New(slog.NewTextHandler(os.Stdout, nil)), nil, map[string]any{
+		"host": serverURL.Hostname(), "port": serverURL.Port(),
+	}, commons, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, be.Start(ctx, cancel))
+
+	err = be.ApplyPolicy(policies.PolicyData{ID: "id-2", Name: "core/metrics", Data: map[string]any{}}, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "policy name must be a single path segment")
+
+	require.NoError(t, be.Stop(ctx))
+}
+
+func TestGnmiTelemetryBackendCompleted(t *testing.T) {
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupCompletedProcess(mockCmd, 0, nil)
+
+	overrideNewCmdOptions(t, mockCmd, nil)
+
+	assert.True(t, gnmitelemetry.Register())
+	be := backend.GetBackend("gnmi_telemetry")
+
+	var commons config.BackendCommons
+	commons.Otlp.Grpc = "collector:4317"
+	require.NoError(t, be.Configure(slog.Default(), nil, map[string]any{"host": "invalid-host"}, commons, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	assert.Error(t, be.Start(ctx, cancel))
+
+	mockCmd.AssertExpectations(t)
+}
+
+func TestGnmiTelemetryBackendRefusesToConfigureWithoutOTLP(t *testing.T) {
+	assert.True(t, gnmitelemetry.Register())
+	be := backend.GetBackend("gnmi_telemetry")
+
+	err := be.Configure(slog.Default(), nil, map[string]any{}, config.BackendCommons{}, nil)
+	require.Error(t, err)
+	assert.Equal(t, "gnmi_telemetry: common.otlp.grpc is required, the backend exports its metrics over OTLP", err.Error())
+}
+
+func overrideNewCmdOptions(t *testing.T, cmd backend.Commander, assertFn func(options backend.CmdOptions, name string, args []string)) {
+	t.Helper()
+
+	original := backend.NewCmdOptions
+	backend.NewCmdOptions = func(options backend.CmdOptions, name string, args ...string) backend.Commander {
+		if assertFn != nil {
+			assertFn(options, name, args)
+		}
+		return cmd
+	}
+
+	t.Cleanup(func() {
+		backend.NewCmdOptions = original
+	})
+}

--- a/agent/docker/Dockerfile
+++ b/agent/docker/Dockerfile
@@ -102,6 +102,25 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     go build -ldflags="-s -w" -trimpath -o /usr/local/bin/snmp-telemetry ./cmd/main.go
 
 ########################################################################
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-trixie AS gnmi-telemetry
+
+WORKDIR /src/gnmi-telemetry
+
+COPY orb-telemetry/gnmi-telemetry/ .
+
+ARG TARGETOS TARGETARCH
+# Stamp the backend version: its version package go:embeds version/BUILD_*.txt.
+ARG GNMI_TELEMETRY_VERSION=0.0.0
+ARG BUILD_COMMIT=unknown
+
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    echo "${GNMI_TELEMETRY_VERSION}" > version/BUILD_VERSION.txt && \
+    echo "${BUILD_COMMIT}" > version/BUILD_COMMIT.txt && \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -ldflags="-s -w" -trimpath -o /usr/local/bin/gnmi-telemetry ./cmd/main.go
+
+########################################################################
 FROM netboxlabs/pktvisor:${PKTVISOR_TAG} AS pktvisor
 
 ########################################################################
@@ -188,6 +207,8 @@ COPY --from=snmp-discovery /usr/local/bin/snmp-discovery /usr/local/bin/snmp-dis
 COPY --from=gnmi-discovery /usr/local/bin/gnmi-discovery /usr/local/bin/gnmi-discovery
 
 COPY --from=snmp-telemetry /usr/local/bin/snmp-telemetry /usr/local/bin/snmp-telemetry
+
+COPY --from=gnmi-telemetry /usr/local/bin/gnmi-telemetry /usr/local/bin/gnmi-telemetry
 
 COPY --from=builder /build/orb-agent /usr/local/bin/orb-agent
 COPY --from=builder /src/orb-agent/agent/docker/orb-agent-entry.sh /usr/local/bin/orb-agent-entry.sh

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/netboxlabs/orb-agent/agent"
 	"github.com/netboxlabs/orb-agent/agent/backend/devicediscovery"
 	"github.com/netboxlabs/orb-agent/agent/backend/gnmidiscovery"
+	"github.com/netboxlabs/orb-agent/agent/backend/gnmitelemetry"
 	"github.com/netboxlabs/orb-agent/agent/backend/networkdiscovery"
 	"github.com/netboxlabs/orb-agent/agent/backend/opentelemetryinfinity"
 	"github.com/netboxlabs/orb-agent/agent/backend/pktvisor"
@@ -41,6 +42,7 @@ func init() {
 	opentelemetryinfinity.Register()
 	snmpdiscovery.Register()
 	snmptelemetry.Register()
+	gnmitelemetry.Register()
 	pktvisor.Register()
 	worker.Register()
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -83,3 +83,8 @@ func TestApplyConfigDebug_BothOnNoDuplicateAnnounce(t *testing.T) {
 func TestInitRegistersSnmpTelemetry(t *testing.T) {
 	assert.True(t, backend.HaveBackend("snmp_telemetry"))
 }
+
+// gnmi_telemetry ships in the image and is registered the same way.
+func TestInitRegistersGnmiTelemetry(t *testing.T) {
+	assert.True(t, backend.HaveBackend("gnmi_telemetry"))
+}

--- a/docs/backends/gnmi_telemetry.md
+++ b/docs/backends/gnmi_telemetry.md
@@ -1,0 +1,74 @@
+# gNMI Telemetry
+The gNMI telemetry backend subscribes to gNMI streaming telemetry from network devices under policies and exports what arrives as metrics over OTLP through the agent's `common.otlp` settings. It ingests nothing into Diode.
+
+The backend's own [README](../../orb-telemetry/gnmi-telemetry/README.md) is the reference for the subscription model, the bundled metric profiles, the security posture and the delivery-mode ladder. This page covers how to reach the backend through the agent.
+
+## Configuration
+`common.otlp.grpc` is required: every metric the backend produces leaves over OTLP. With `gnmi_telemetry` enabled and no endpoint, the agent reports the missing setting and refuses to start, the way it does for any backend that fails to configure. Every other key is optional.
+
+```yaml
+orb:
+  backends:
+    common:
+      otlp:
+        grpc: "grpc://otel-collector:4317"
+    gnmi_telemetry:
+      host: 127.0.0.1                    # default localhost
+      port: 8079                         # default 8079
+      log_level: INFO                    # default INFO (DEBUG, INFO, WARN, ERROR)
+      log_format: TEXT                   # default TEXT (TEXT, JSON)
+      otel_export_period: 10             # seconds between exports, default 10
+      policy_env_vars: [GNMI_PASSWORD]   # unset by default: every ${NAME} reference in a policy is refused
+      # Both directories must exist; the image creates neither, so they are shown commented out.
+      # profiles_root: /opt/orb/profiles   # unset by default: every per-policy profiles_dir is refused
+      # profiles_dir: /opt/orb/overrides   # unset by default: only the bundled profiles are used
+```
+
+| Parameter | Type | Default | Description |
+|:---------:|:----:|:-------:|:------------|
+| host | str | `localhost` | Address the backend's API binds. The agent reaches it on loopback; the API has no authentication, so widen it only behind your own access control. |
+| port | int | 8079 | Port of the backend's API, 1 to 65535. |
+| log_level | str | `INFO` | `DEBUG`, `INFO`, `WARN` or `ERROR`; any other value is refused. The agent passes `DEBUG` when the backend has `debug: true` or the agent runs with its debug flag. |
+| log_format | str | `TEXT` | `TEXT` or `JSON`; any other value is refused. |
+| otel_export_period | int | 10 | Seconds between OTLP exports, 1 to 31536000. |
+| policy_env_vars | str or list | unset | Environment variable names a policy may read through `${NAME}` in `username`, `password` or a `tls` file path. A comma-separated string or a list of names, never `${...}` references. Unset refuses every reference. |
+| profiles_root | str | unset | Directory a policy's own `profiles_dir` must resolve inside. Unset refuses every per-policy `profiles_dir`. |
+| profiles_dir | str | unset | Directory of metric profile YAML files overlaid on the bundled profiles; a file replaces the bundled profile of the same name. |
+
+The environment variables `policy_env_vars` names must be present in the agent's environment; the backend inherits it.
+
+## Policy
+A policy names the targets to subscribe to and the credentials to reach them with. `metrics_interval` is the SAMPLE cadence asked of the device in seconds, the Get polling interval when a device falls to polling, and the basis of the staleness window. Everything under `scope` is inherited by every target, and a target may override a field with its own value.
+
+```yaml
+orb:
+  policies:
+    gnmi_telemetry:
+      core_metrics:
+        config:
+          metrics_interval: 30
+        scope:
+          username: "admin"
+          password: "${GNMI_PASSWORD}"     # allowed only when policy_env_vars names it
+          port: 57400                      # the binary dials 9339 unless told otherwise
+          tls:
+            ca: /opt/orb/ca.pem            # verify the devices against this bundle
+          targets:
+            - host: "192.168.1.1"
+            - host: "192.168.1.2"
+              id: "42"                     # exported as netbox_id
+```
+
+A credential or a TLS file path may be read from the agent's environment as `${NAME}` only when `policy_env_vars` in the backend configuration names it; otherwise the policy is refused. A CIDR or range target may carry a credential only when TLS verifies the server, or when the policy sets `send_credentials_to_unverified_targets: true`.
+
+### Delivery modes
+For each target the backend selects a metric profile from the vendor and network OS the device reports, and asks for the profile's paths in the mode the profile names: counters at the `metrics_interval` SAMPLE cadence, states ON_CHANGE. A device that refuses that request is asked for SAMPLE on every path, and one that refuses that too is polled with Get at the same interval. `config.mode` narrows the ladder: `on_change` keeps the profile's own modes and skips the all-SAMPLE rung, `sample` asks for SAMPLE on every path from the start; both still fall to Get. A target may set its own `mode`, and `profile` pins a metric profile instead of matching it from the device's Capabilities.
+
+The full parameter tables are in the backend README under [Policy Configuration](../../orb-telemetry/gnmi-telemetry/README.md#policy-configuration).
+
+## Metrics
+Every metric name comes from the profile: a profile metric named `if_in_octets` is exported as `gnmi.if_in_octets`, so the names a policy produces are known before it runs. Every series carries `device_ip` and `policy`, plus `netbox_id` when the target sets `id`, and whatever path keys the profile promotes, such as `interface_name`. A profile metric of type `counter` is exported as a cumulative total and one of type `gauge` as a gauge; an enumerated or boolean leaf is mapped to the integer the profile names.
+
+Export runs on `otel_export_period`, independently of the sample cadence, and carries the last value of each series. A SAMPLE or Get series that receives no update for three `metrics_interval`s is withheld and dropped until the device sends the leaf again; an ON_CHANGE series keeps its last value until the device deletes the element, the stream's next initial dump omits it, or the policy stops.
+
+Seven metrics describe the backend itself, among them `gnmi.target_up{device_ip, policy, mode}`, `gnmi.updates_dropped_total{reason}` and `gnmi.mode_fallback_total`; they are listed under [Metrics](../../orb-telemetry/gnmi-telemetry/README.md#metrics), and the profile format under [Metric Profiles](../../orb-telemetry/gnmi-telemetry/README.md#metric-profiles).

--- a/docs/backends/gnmi_telemetry.md
+++ b/docs/backends/gnmi_telemetry.md
@@ -57,9 +57,11 @@ orb:
             - host: "192.168.1.1"
             - host: "192.168.1.2"
               id: "42"                     # exported as netbox_id
+            - host: "192.168.2.0/24"       # a CIDR prefix: every address that answers is subscribed
+            - host: "192.168.3.10-20"      # a range over the last octet
 ```
 
-A credential or a TLS file path may be read from the agent's environment as `${NAME}` only when `policy_env_vars` in the backend configuration names it; otherwise the policy is refused. A CIDR or range target may carry a credential only when TLS verifies the server, or when the policy sets `send_credentials_to_unverified_targets: true`.
+A target's `host` is one address or hostname, a CIDR prefix, or a range over the last octet; a prefix or range is swept, and each address that answers Capabilities gets a subscription of its own, while the ones that do not are probed again only when `config.rescan_interval_ms` is set. A credential or a TLS file path may be read from the agent's environment as `${NAME}` only when `policy_env_vars` in the backend configuration names it; otherwise the policy is refused. A CIDR or range target may carry a credential only when TLS verifies the server, as `tls.ca` does above, or when the policy sets `send_credentials_to_unverified_targets: true`.
 
 ### Delivery modes
 For each target the backend selects a metric profile from the vendor and network OS the device reports, and asks for the profile's paths in the mode the profile names: counters at the `metrics_interval` SAMPLE cadence, states ON_CHANGE. A device that refuses that request is asked for SAMPLE on every path, and one that refuses that too is polled with Get at the same interval. `config.mode` narrows the ladder: `on_change` keeps the profile's own modes and skips the all-SAMPLE rung, `sample` asks for SAMPLE on every path from the start; both still fall to Get. A target may set its own `mode`, and `profile` pins a metric profile instead of matching it from the device's Capabilities.

--- a/docs/config_samples.md
+++ b/docs/config_samples.md
@@ -655,6 +655,51 @@ docker run -p 162:162/udp \
     run -c "/opt/orb/snmp-telemetry-config.yaml"
 ```
 
+## gNMI Telemetry Backend
+
+The gNMI telemetry backend subscribes to streaming telemetry from network devices and exports the metrics over OTLP to the collector named in `common.otlp`. It ingests nothing into Diode. See the [backend documentation](backends/gnmi_telemetry.md) for every parameter.
+
+### Basic Configuration
+```yaml
+orb:
+  config_manager:
+    active: local
+  backends:
+    common:
+      otlp:
+        grpc: "grpc://otel-collector:4317"
+    gnmi_telemetry:
+      policy_env_vars: [GNMI_PASSWORD]
+  policies:
+    gnmi_telemetry:
+      core_metrics:
+        config:
+          metrics_interval: 30 # seconds, the SAMPLE cadence asked of the devices
+          # A CIDR target carries the credential to every address that answers,
+          # so with TLS not verifying the server the policy has to say so.
+          send_credentials_to_unverified_targets: true
+        scope:
+          username: "admin"
+          password: "${GNMI_PASSWORD}"
+          port: 57400
+          tls:
+            skip_verify: true # lab devices with self-signed certificates
+          targets:
+            - host: "192.168.1.0/24"
+```
+
+### Running the gNMI Telemetry Backend
+
+The backend opens no listener of its own toward the devices, so no port needs publishing; pass the environment variable the policy reads:
+
+```bash
+docker run \
+    -e GNMI_PASSWORD=admin-pass \
+    -v "/local/orb:/opt/orb/" \
+    netboxlabs/orb-agent:latest \
+    run -c "/opt/orb/gnmi-telemetry-config.yaml"
+```
+
 ## Diode Dry Run Mode
 
 The Orb Agent supports a diode dry run mode that allows you to test your configuration without sending data to the Diode server. This is useful for debugging and validating your configuration.

--- a/docs/configs/agent_yaml.md
+++ b/docs/configs/agent_yaml.md
@@ -148,7 +148,7 @@ Optional OpenTelemetry export for backend metrics.
 
 ### Backend keys
 
-Each backend key enables that backend. An empty value (no sub-keys) uses all defaults. All discovery backends and `snmp_telemetry` accept optional `host` and `port` overrides.
+Each backend key enables that backend. An empty value (no sub-keys) uses all defaults. All discovery backends, `snmp_telemetry` and `gnmi_telemetry` accept optional `host` and `port` overrides.
 
 | Key | Backend | Default port | Notes |
 |-----|---------|-------------|-------|
@@ -159,6 +159,7 @@ Each backend key enables that backend. An empty value (no sub-keys) uses all def
 | `pktvisor` | pktvisor packet analytics | — | See [pktvisor docs](../backends/pktvisor.md) |
 | `opentelemetry_infinity` | OpenTelemetry Infinity | — | See [OTel Infinity docs](../backends/opentelemetry_infinity.md) |
 | `snmp_telemetry` | SNMP metrics and traps | 8078 | Optional `host`/`port` overrides; requires `common.otlp.grpc`. See [SNMP Telemetry docs](../backends/snmp_telemetry.md) |
+| `gnmi_telemetry` | gNMI streaming telemetry metrics | 8079 | Optional `host`/`port` overrides; requires `common.otlp.grpc`. See [gNMI Telemetry docs](../backends/gnmi_telemetry.md) |
 
 ---
 
@@ -204,6 +205,7 @@ For the full list of parameters per backend, see:
 - [Network Discovery](../backends/network_discovery.md)
 - [Worker](../backends/worker.md)
 - [SNMP Telemetry](../backends/snmp_telemetry.md)
+- [gNMI Telemetry](../backends/gnmi_telemetry.md)
 
 ---
 
@@ -357,6 +359,7 @@ Values can reference environment variables using `${VAR_NAME}` syntax. Resolutio
 | `device_discovery` policy (all fields) | Any string value in `scope` and `defaults` | Python backend at policy execution |
 | `snmp_discovery` policy authentication | `community`, `username`, `auth_passphrase`, `priv_passphrase`, `context_name` | Go SNMP backend at policy execution |
 | `snmp_telemetry` policy authentication | `community`, `username`, `auth_passphrase`, `priv_passphrase`, only for variables named in `backends.snmp_telemetry.policy_env_vars`; unset refuses every reference | Go SNMP telemetry backend at policy execution |
+| `gnmi_telemetry` policy credentials | `username`, `password`, `tls.ca`, `tls.cert`, `tls.key`, only for variables named in `backends.gnmi_telemetry.policy_env_vars`; unset refuses every reference | Go gNMI telemetry backend at policy execution |
 
 ```yaml
 # Git config (resolved by Go agent)


### PR DESCRIPTION
## Summary

The glue for the `gnmi-telemetry` backend, in the shape of #584 for `snmp-telemetry`. MON-356.

- **Backend package** `agent/backend/gnmitelemetry`: registry name `gnmi_telemetry`, exec `gnmi-telemetry`, API on `localhost:8079`. `common.otlp.grpc` is required and passed to `--otel-endpoint`; an agent that enables the backend without it refuses to start. `host`, `port`, `log_level`, `log_format`, `otel_export_period`, `policy_env_vars`, `profiles_root` and `profiles_dir` are each passed only when set with a non-empty value, an absent or null `host` or `port` keeps the default, non-string log keys are refused, the port is validated 1 to 65535. Stop hands the process the agent's default grace, which the binary sizes its whole shutdown to. No `PolicyStatusProvider`. The apply log carries only the policy's identity. The child's logfmt and JSON records are re-logged with their severity.
- **Registration** in `cmd/main.go`, with a test.
- **Image**: a `gnmi-telemetry` build stage stamping `GNMI_TELEMETRY_VERSION` and `BUILD_COMMIT`, copied into the final stage. No `USER` change.
- **Release parity**: `resolve-backend-versions` resolves `gnmi-telemetry/v*` tags; `release.yaml` detects changes under `orb-telemetry/gnmi-telemetry/`, waits on `gnmi-telemetry-release.yaml` and passes the version through; `_agent-release.yaml` gains the input, build arg and no-cache filter; `develop.yaml`, `build.yaml` and the Makefile pass the build arg. Until the first `gnmi-telemetry/v*` tag exists the image stamps `0.0.0`.
- **Docs**: `docs/backends/gnmi_telemetry.md`, the root README list and policies example, rows in `docs/configs/agent_yaml.md` including the env-var substitution table, and a section in `docs/config_samples.md`. Off by default: nothing is added to `default_config.yaml`.

Two things the adversarial review of this diff surfaced that stay for follow-ups: the package is a rename of `snmptelemetry` with the readers duplicated, which the ticket asked for file for file and which a shared set of plain reader functions in `agent/backend` should replace before a third telemetry backend; and the binary's own comments in `policy/sweep.go` and `server/server.go` say the agent's policy POST times out at 10 s where both telemetry backends use 30 s, a stale claim in the backend module left out of an agent-scoped PR.

## Testing

- Backend package tests: the args table, optional-flag reset, refused reconfiguration leaving the backend unchanged, IPv6 bracketing, stop grace, start and reset before configure refused, both log formats re-logged, an end-to-end apply, rename and remove against a recorded API, the server's rejection surfaced, and no policy secret in the log. Six killed mutants: OTLP endpoint defaulted instead of refused, `profiles_dir` under the snmp flag name, port above 65535 accepted, half the stop grace, policy body logged, default port 8078.
- Both documented policy samples parsed and validated by the binary's own `ParsePolicies` with the env var allowed, in a throwaway test run in the backend module.
- Under the race detector, with `make lint` at 0 issues.
- The `gnmi-telemetry` stage builds and `--help` runs. Full image: develop 940 MB, this branch 977 MB (the binary is 27 MB).
- End to end with the branch image on orb-test-lab: a `gnmi_telemetry` policy in a local agent config, credential through `policy_env_vars`, against the lab's gnmi-sim. The agent started the backend on 8079, applied the policy, and the collector received `gnmi.if_admin_status{device_ip, interface_name, netbox_id, policy}` plus `gnmi.target_up{mode=on_change}`, `gnmi.targets_active`, `gnmi.notifications_total` and `gnmi.updates_dropped_total`. The MON-354 containerlab topology is down, so the sim stood in.
- One adversarial review pass; its findings (a sample the binary rejected, three comments and a fixture inherited from the snmp package) are fixed in this revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)