### PR TITLE
fix(agent): survive a fleet reset, a remove and a restart that reach a backend the agent did not start

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -611,8 +611,11 @@ func (a *orbAgent) shutdownOTLP() {
 }
 
 func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason string) error {
-	if !backend.HaveBackend(name) {
-		return errors.New("specified backend does not exist: " + name)
+	// Every bundled backend is registered; only the ones this agent started
+	// are in a.backends, and only those have a process to restart.
+	be, ok := a.backends[name]
+	if !ok {
+		return errors.New("backend is not started by this agent: " + name)
 	}
 
 	// Serialize concurrent Stop+Start sequences for the same backend across
@@ -621,11 +624,10 @@ func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason strin
 	restartMu.Lock()
 	defer restartMu.Unlock()
 
-	be := a.backends[name]
 	a.logger.Info("restarting backend", "backend", name, "reason", reason)
 	a.backendStateManager.RegisterRestart(name, reason)
 	a.logger.Info("removing policies", "backend", name)
-	if err := a.policyManager.RemoveBackendPolicies(be, true); err != nil {
+	if err := a.policyManager.RemoveBackendPolicies(name, be, true); err != nil {
 		a.logger.Error("failed to remove policies", "backend", name, "error", err)
 	}
 	var beConfig map[string]any

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/backend/snmptelemetry"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/configmgr"
 	"github.com/netboxlabs/orb-agent/agent/filesmgr"
@@ -35,6 +36,29 @@ func (m *mockConfigManager) Stop(_ context.Context) error {
 	}
 	m.stopCalled = true
 	return nil
+}
+
+// Every bundled backend is registered; only the ones this agent started are
+// in its backends map. A restart asked for a registered backend the agent
+// never started, which has no process, logger or arguments, is refused
+// rather than reached for.
+func TestRestartBackendRefusesABackendTheAgentDidNotStart(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	snmptelemetry.Register()
+	require.True(t, backend.HaveBackend("snmp_telemetry"))
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{},
+		policyManager:       &mockPolicyManager{repo: repo},
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), repo),
+	}
+
+	var restartErr error
+	require.NotPanics(t, func() { restartErr = a.RestartBackend(context.Background(), "snmp_telemetry", "test") })
+	require.Error(t, restartErr)
+	assert.Contains(t, restartErr.Error(), "not started by this agent")
 }
 
 func TestAgentStop_DelegatesToConfigManagerStop(t *testing.T) {
@@ -113,7 +137,7 @@ func (m *mockPolicyManager) ApplyBackendPolicies(_ backend.Backend) error {
 	return nil
 }
 
-func (m *mockPolicyManager) RemoveBackendPolicies(_ backend.Backend, _ bool) error {
+func (m *mockPolicyManager) RemoveBackendPolicies(_ string, _ backend.Backend, _ bool) error {
 	return nil
 }
 

--- a/agent/backend/backend.go
+++ b/agent/backend/backend.go
@@ -145,7 +145,6 @@ func GetBackend(name string) Backend {
 	return registry[name]
 }
 
-// RestartAll restarts all backends
 // RestartAll resets every backend the agent has started. Every bundled
 // backend is registered, but only the ones the agent's configuration names
 // are configured and started; one that was never started has no process,

--- a/agent/backend/backend.go
+++ b/agent/backend/backend.go
@@ -96,6 +96,10 @@ type Backend interface {
 
 	GetStartTime() time.Time
 	GetCapabilities() (map[string]any, error)
+	// GetRunningStatus reports Unknown only for a backend the agent never
+	// started: every bundled backend is registered, but only the ones the
+	// configuration names are configured and started, and a full reset or
+	// a policy removal treats Unknown as nothing to talk to.
 	GetRunningStatus() (RunningStatus, string, error)
 	GetInitialState() RunningStatus
 
@@ -142,9 +146,16 @@ func GetBackend(name string) Backend {
 }
 
 // RestartAll restarts all backends
+// RestartAll resets every backend the agent has started. Every bundled
+// backend is registered, but only the ones the agent's configuration names
+// are configured and started; one that was never started has no process,
+// logger or arguments to reset with, reports Unknown, and is left alone.
 func RestartAll(ctx context.Context) error {
 	errs := make([]error, 0)
 	for _, be := range registry {
+		if state, _, _ := be.GetRunningStatus(); state == Unknown {
+			continue
+		}
 		err := be.FullReset(ctx)
 		if err != nil {
 			errs = append(errs, err)

--- a/agent/backend/backend_state.go
+++ b/agent/backend/backend_state.go
@@ -139,6 +139,10 @@ func (manager *stateManager) RegisterError(name string, errMessage string) {
 func (manager *stateManager) RegisterRestart(name string, reason string) {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
+	// A restart can be asked for before the monitor registered the backend.
+	if manager.backendState[name] == nil {
+		manager.backendState[name] = &State{Status: Unknown}
+	}
 	manager.backendState[name].RestartCount++
 	manager.backendState[name].LastRestartTS = time.Now()
 	manager.backendState[name].LastRestartReason = reason

--- a/agent/backend/backend_state_test.go
+++ b/agent/backend/backend_state_test.go
@@ -87,6 +87,23 @@ func TestBackendStateManager_RegisterRestart(t *testing.T) {
 	assert.False(t, state[backendName].LastRestartTS.IsZero())
 }
 
+// A restart can be requested for a backend the monitor never registered, a
+// backend the agent restarts before its monitor ran; the record is created
+// rather than dereferenced.
+func TestBackendStateManager_RegisterRestart_UnmonitoredBackend(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	manager := backend.NewStateManager("fleet", logger, make(chan string, 5), repo)
+
+	require.NotPanics(t, func() { manager.RegisterRestart("never-monitored", "operator request") })
+
+	state := manager.Get()
+	require.Contains(t, state, "never-monitored")
+	assert.Equal(t, int64(1), state["never-monitored"].RestartCount)
+	assert.Equal(t, "operator request", state["never-monitored"].LastRestartReason)
+}
+
 func TestBackendStateManager_RegisterRestart_MultipleRestarts(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))

--- a/agent/backend/backend_test.go
+++ b/agent/backend/backend_test.go
@@ -110,8 +110,11 @@ func TestRestartAll_MultipleBackendsSuccess(t *testing.T) {
 
 	// Register test backends
 	backend.Register("test_backend_restart_1", mockBe1)
+	mockBe1.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 	backend.Register("test_backend_restart_2", mockBe2)
+	mockBe2.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 	backend.Register("test_backend_restart_3", mockBe3)
+	mockBe3.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 
 	// Setup expectations - all succeed
 	mockBe1.On("FullReset", ctx).Return(nil)
@@ -138,8 +141,11 @@ func TestRestartAll_OneBackendFails(t *testing.T) {
 
 	// Register test backends
 	backend.Register("test_backend_fail_1", mockBe1)
+	mockBe1.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 	backend.Register("test_backend_fail_2", mockBe2)
+	mockBe2.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 	backend.Register("test_backend_fail_3", mockBe3)
+	mockBe3.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 
 	expectedErr := errors.New("backend reset failed")
 
@@ -169,8 +175,11 @@ func TestRestartAll_MultipleBackendsFail(t *testing.T) {
 
 	// Register test backends
 	backend.Register("test_backend_multifail_1", mockBe1)
+	mockBe1.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 	backend.Register("test_backend_multifail_2", mockBe2)
+	mockBe2.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 	backend.Register("test_backend_multifail_3", mockBe3)
+	mockBe3.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 
 	err1 := errors.New("backend 1 reset failed")
 	err2 := errors.New("backend 2 reset failed")
@@ -193,6 +202,27 @@ func TestRestartAll_MultipleBackendsFail(t *testing.T) {
 	mockBe3.AssertExpectations(t)
 }
 
+// A registered backend the agent never started, one absent from its
+// configuration, has no process, logger or arguments; a fleet full reset
+// walks the whole registry and must leave it alone rather than start it.
+func TestRestartAll_SkipsABackendTheAgentNeverStarted(t *testing.T) {
+	ctx := context.Background()
+	started := &mockBackend{}
+	cold := &mockBackend{}
+	backend.Register("test_backend_started", started)
+	backend.Register("test_backend_cold", cold)
+	started.On("GetRunningStatus").Return(backend.Running, "", nil)
+	started.On("FullReset", ctx).Return(nil)
+	cold.On("GetRunningStatus").Return(backend.Unknown, "backend not started yet", nil)
+
+	// The registry is shared with the other tests' mocks, some of which fail
+	// their reset on purpose, so only these two are asserted on.
+	_ = backend.RestartAll(ctx)
+
+	started.AssertExpectations(t)
+	cold.AssertNotCalled(t, "FullReset", ctx)
+}
+
 func TestBackendRegistry_GetList(t *testing.T) {
 	// Test that GetList returns registered backends
 	list := backend.GetList()
@@ -205,6 +235,7 @@ func TestBackendRegistry_HaveBackend(t *testing.T) {
 	// Arrange
 	mockBe := &mockBackend{}
 	backend.Register("test_backend_exists", mockBe)
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 
 	// Act & Assert
 	assert.True(t, backend.HaveBackend("test_backend_exists"))
@@ -215,6 +246,7 @@ func TestBackendRegistry_GetBackend(t *testing.T) {
 	// Arrange
 	mockBe := &mockBackend{}
 	backend.Register("test_backend_get", mockBe)
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 
 	// Act
 	retrievedBackend := backend.GetBackend("test_backend_get")

--- a/agent/configmgr/fleet/connection_hooks_test.go
+++ b/agent/configmgr/fleet/connection_hooks_test.go
@@ -17,13 +17,13 @@ import (
 // minimal policy manager impl for constructor
 type noopPM struct{}
 
-func (noopPM) ManagePolicy(_ config.PolicyPayload)                       {}
-func (noopPM) RemovePolicyDataset(_ string, _ string, _ backend.Backend) {}
-func (noopPM) GetPolicyState() ([]policies.PolicyData, error)            { return nil, nil }
-func (noopPM) GetRepo() policies.PolicyRepo                              { return nil }
-func (noopPM) ApplyBackendPolicies(_ backend.Backend) error              { return nil }
-func (noopPM) RemoveBackendPolicies(_ backend.Backend, _ bool) error     { return nil }
-func (noopPM) RemovePolicy(_ string, _ string, _ string) error           { return nil }
+func (noopPM) ManagePolicy(_ config.PolicyPayload)                             {}
+func (noopPM) RemovePolicyDataset(_ string, _ string, _ backend.Backend)       {}
+func (noopPM) GetPolicyState() ([]policies.PolicyData, error)                  { return nil, nil }
+func (noopPM) GetRepo() policies.PolicyRepo                                    { return nil }
+func (noopPM) ApplyBackendPolicies(_ backend.Backend) error                    { return nil }
+func (noopPM) RemoveBackendPolicies(_ string, _ backend.Backend, _ bool) error { return nil }
+func (noopPM) RemovePolicy(_ string, _ string, _ string) error                 { return nil }
 
 type noopBackendState struct{}
 

--- a/agent/configmgr/fleet/connection_test.go
+++ b/agent/configmgr/fleet/connection_test.go
@@ -46,7 +46,7 @@ func (m *mockPolicyManagerForFleet) ApplyBackendPolicies(be backend.Backend) err
 	return args.Error(0)
 }
 
-func (m *mockPolicyManagerForFleet) RemoveBackendPolicies(be backend.Backend, permanently bool) error {
+func (m *mockPolicyManagerForFleet) RemoveBackendPolicies(_ string, be backend.Backend, permanently bool) error {
 	args := m.Called(be, permanently)
 	return args.Error(0)
 }

--- a/agent/configmgr/fleet/from_rpc_test.go
+++ b/agent/configmgr/fleet/from_rpc_test.go
@@ -49,7 +49,7 @@ func (m *mockPolicyManager) ApplyBackendPolicies(be backend.Backend) error {
 	return args.Error(0)
 }
 
-func (m *mockPolicyManager) RemoveBackendPolicies(be backend.Backend, permanently bool) error {
+func (m *mockPolicyManager) RemoveBackendPolicies(_ string, be backend.Backend, permanently bool) error {
 	args := m.Called(be, permanently)
 	return args.Error(0)
 }

--- a/agent/configmgr/fleet/heartbeats_test.go
+++ b/agent/configmgr/fleet/heartbeats_test.go
@@ -53,7 +53,7 @@ func (t *testPolicyManagerWithRepo) GetRepo() policies.PolicyRepo { return t.rep
 
 func (t *testPolicyManagerWithRepo) ApplyBackendPolicies(_ backend.Backend) error { return nil }
 
-func (t *testPolicyManagerWithRepo) RemoveBackendPolicies(_ backend.Backend, _ bool) error {
+func (t *testPolicyManagerWithRepo) RemoveBackendPolicies(_ string, _ backend.Backend, _ bool) error {
 	return nil
 }
 
@@ -99,7 +99,7 @@ func (m *mockPolicyManagerForHeartbeat) ApplyBackendPolicies(be backend.Backend)
 	return args.Error(0)
 }
 
-func (m *mockPolicyManagerForHeartbeat) RemoveBackendPolicies(be backend.Backend, permanently bool) error {
+func (m *mockPolicyManagerForHeartbeat) RemoveBackendPolicies(_ string, be backend.Backend, permanently bool) error {
 	args := m.Called(be, permanently)
 	return args.Error(0)
 }

--- a/agent/configmgr/fleet/to_rpc_test.go
+++ b/agent/configmgr/fleet/to_rpc_test.go
@@ -47,7 +47,7 @@ func (m *mockPolicyManagerForToRPC) ApplyBackendPolicies(be backend.Backend) err
 	return args.Error(0)
 }
 
-func (m *mockPolicyManagerForToRPC) RemoveBackendPolicies(be backend.Backend, permanently bool) error {
+func (m *mockPolicyManagerForToRPC) RemoveBackendPolicies(_ string, be backend.Backend, permanently bool) error {
 	args := m.Called(be, permanently)
 	return args.Error(0)
 }

--- a/agent/configmgr/fleet_test.go
+++ b/agent/configmgr/fleet_test.go
@@ -58,7 +58,7 @@ func (m *mockPolicyManagerForFleet) ApplyBackendPolicies(be backend.Backend) err
 	return args.Error(0)
 }
 
-func (m *mockPolicyManagerForFleet) RemoveBackendPolicies(be backend.Backend, permanently bool) error {
+func (m *mockPolicyManagerForFleet) RemoveBackendPolicies(_ string, be backend.Backend, permanently bool) error {
 	args := m.Called(be, permanently)
 	return args.Error(0)
 }

--- a/agent/configmgr/manager_test.go
+++ b/agent/configmgr/manager_test.go
@@ -46,7 +46,7 @@ func (m *mockPolicyManager) ApplyBackendPolicies(be backend.Backend) error {
 	return args.Error(0)
 }
 
-func (m *mockPolicyManager) RemoveBackendPolicies(be backend.Backend, permanently bool) error {
+func (m *mockPolicyManager) RemoveBackendPolicies(_ string, be backend.Backend, permanently bool) error {
 	args := m.Called(be, permanently)
 	return args.Error(0)
 }

--- a/agent/policymgr/manager.go
+++ b/agent/policymgr/manager.go
@@ -19,7 +19,7 @@ type PolicyManager interface {
 	GetPolicyState() ([]policies.PolicyData, error)
 	GetRepo() policies.PolicyRepo
 	ApplyBackendPolicies(be backend.Backend) error
-	RemoveBackendPolicies(be backend.Backend, permanently bool) error
+	RemoveBackendPolicies(name string, be backend.Backend, permanently bool) error
 	RemovePolicy(policyID string, policyName string, beName string) error
 }
 
@@ -192,10 +192,11 @@ func (a *policyManager) RemovePolicy(policyID string, policyName string, beName 
 		return errors.New("policy remove for a backend we do not have, ignoring")
 	}
 	be := backend.GetBackend(beName)
-	err := be.RemovePolicy(pd)
+	err := removeFromBackend(be, pd)
 	if err != nil {
 		var httpErr *backend.HTTPError
-		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+		switch {
+		case errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound:
 			// Expected for run-once policies the backend already dropped after
 			// completion: the desired state (policy absent) is reached, so this
 			// is a no-op. Kept at WARN (not DEBUG) because a 404 here can also
@@ -203,7 +204,12 @@ func (a *policyManager) RemovePolicy(policyID string, policyName string, beName 
 			// under another name on the backend.
 			a.logger.Warn("policy not present on backend at removal; treating as already removed",
 				"policy_id", policyID, "policy_name", pd.Name, "error", err)
-		} else {
+		case errors.Is(err, errBackendNeverStarted):
+			// The agent never started the backend, so nothing runs the policy:
+			// the desired state is reached the same way.
+			a.logger.Warn("backend never started; treating policy as already removed",
+				"policy_id", policyID, "policy_name", pd.Name, "backend", beName)
+		default:
 			a.logger.Error("backend remove policy failed: will still remove from PolicyManager", "policy_id", policyID, "error", err)
 		}
 	}
@@ -228,7 +234,7 @@ func (a *policyManager) RemovePolicyDataset(policyID string, datasetID string, b
 	}
 	if removePolicy {
 		// Remove policy via http request
-		err := be.RemovePolicy(policyData)
+		err := removeFromBackend(be, policyData)
 		if err != nil {
 			a.logger.Warn("policy failed to remove", "policy_id", policyID, "policy_name", policyData.Name, "error", err)
 		}
@@ -294,7 +300,29 @@ func (a *policyManager) applyPolicy(payload config.PolicyPayload, be backend.Bac
 	}
 }
 
-func (a *policyManager) RemoveBackendPolicies(be backend.Backend, permanently bool) error {
+// errBackendNeverStarted stands in for a call to a backend the agent never
+// started; callers treat it like a backend that answered the policy is not
+// there.
+var errBackendNeverStarted = errors.New("backend never started; nothing to remove from")
+
+// removeFromBackend asks the backend to remove a policy, unless the agent
+// never started it. Every bundled backend is registered, but only the ones
+// the configuration names are configured and started; one never started has
+// no process to ask and no logger to log the call with. A backend that was
+// started is asked whatever its state, since a live process whose status
+// probe timed out may still hold the policy, and the request's own timeout
+// bounds the wait.
+func removeFromBackend(be backend.Backend, pd policies.PolicyData) error {
+	if state, _, _ := be.GetRunningStatus(); state == backend.Unknown {
+		return errBackendNeverStarted
+	}
+	return be.RemovePolicy(pd)
+}
+
+// RemoveBackendPolicies removes the named backend's policies, and only its
+// own: the repo holds every backend's policies, and a restart of one backend
+// must not take the others' with it.
+func (a *policyManager) RemoveBackendPolicies(name string, be backend.Backend, permanently bool) error {
 	plcies, err := a.repo.GetAll()
 	if err != nil {
 		a.logger.Error("failed to retrieve list of policies", "error", err)
@@ -302,7 +330,10 @@ func (a *policyManager) RemoveBackendPolicies(be backend.Backend, permanently bo
 	}
 
 	for _, plcy := range plcies {
-		err := be.RemovePolicy(plcy)
+		if plcy.Backend != name {
+			continue
+		}
+		err := removeFromBackend(be, plcy)
 		if err != nil {
 			a.logger.Error("failed to remove policy from backend", "policy_id", plcy.ID, "policy_name", plcy.Name, "error", err)
 			// note we continue here: even if the backend failed to remove, we update our policy repo to remove it

--- a/agent/policymgr/manager_test.go
+++ b/agent/policymgr/manager_test.go
@@ -459,7 +459,7 @@ func TestRemoveBackendPolicies(t *testing.T) {
 	mockBe.On("RemovePolicy", mock.Anything).Return(nil).Times(3)
 
 	// Test non-permanent removal (only marks policies as unknown)
-	err = mgr.RemoveBackendPolicies(mockBe, false)
+	err = mgr.RemoveBackendPolicies("testbackend", mockBe, false)
 	require.NoError(t, err)
 
 	// Verify policies are still there but with state Unknown
@@ -472,7 +472,7 @@ func TestRemoveBackendPolicies(t *testing.T) {
 
 	// Test permanent removal
 	mockBe.On("RemovePolicy", mock.Anything).Return(nil).Times(3)
-	err = mgr.RemoveBackendPolicies(mockBe, true)
+	err = mgr.RemoveBackendPolicies("testbackend", mockBe, true)
 	require.NoError(t, err)
 
 	// Verify policies are gone
@@ -732,6 +732,7 @@ func TestRemovePolicy_BackendRemoveError(t *testing.T) {
 	cfg := config.Config{}
 
 	mockBe := &mockBackend{name: "be_remove_err"}
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 	backend.Register("be_remove_err", mockBe)
 
 	mgr, err := policymgr.New(logger, secretsMgr, cfg)
@@ -772,6 +773,7 @@ func TestRemovePolicyDataset_GetError(t *testing.T) {
 	cfg := config.Config{}
 
 	mockBe := &mockBackend{name: "be_dataset_get_err"}
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 	backend.Register("be_dataset_get_err", mockBe)
 
 	mgr, err := policymgr.New(logger, secretsMgr, cfg)
@@ -789,6 +791,7 @@ func TestRemovePolicyDataset_RemovePolicyError(t *testing.T) {
 	cfg := config.Config{}
 
 	mockBe := &mockBackend{name: "be_dataset_rm_err"}
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 	backend.Register("be_dataset_rm_err", mockBe)
 
 	mgr, err := policymgr.New(logger, secretsMgr, cfg)
@@ -819,6 +822,131 @@ func TestRemovePolicyDataset_RemovePolicyError(t *testing.T) {
 	assert.Empty(t, state)
 }
 
+// A restart removes the policies of the backend being restarted and no
+// other's: the repo holds every backend's policies, and removing them all
+// left the agent with nothing applied until the next full list from fleet.
+func TestRemoveBackendPoliciesLeavesOtherBackendsAlone(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	restarted := &mockBackend{name: "restarted_backend"}
+	restarted.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	other := &mockBackend{name: "other_backend"}
+	other.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	backend.Register("restarted_backend", restarted)
+	backend.Register("other_backend", other)
+
+	restarted.On("ApplyPolicy", mock.Anything, false).Return(nil)
+	other.On("ApplyPolicy", mock.Anything, false).Return(nil)
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	for _, be := range []string{"restarted_backend", "other_backend"} {
+		payload := config.PolicyPayload{Action: "manage", ID: "policy-" + be, Name: "Policy " + be, Backend: be, Version: 1, Data: map[string]any{}, DatasetID: "ds-" + be}
+		secretsMgr.On("SolvePolicySecrets", payload).Return(payload, nil)
+		mgr.ManagePolicy(payload)
+	}
+	restarted.On("RemovePolicy", mock.MatchedBy(func(pd policies.PolicyData) bool { return pd.ID == "policy-restarted_backend" })).Return(nil).Once()
+
+	require.NoError(t, mgr.RemoveBackendPolicies("restarted_backend", restarted, true))
+
+	other.AssertNotCalled(t, "RemovePolicy", mock.Anything)
+	restarted.AssertExpectations(t)
+	state, err := mgr.GetPolicyState()
+	require.NoError(t, err)
+	require.Len(t, state, 1)
+	assert.Equal(t, "policy-other_backend", state[0].ID)
+}
+
+func policyIDs(state []policies.PolicyData) []string {
+	ids := make([]string, 0, len(state))
+	for _, p := range state {
+		ids = append(ids, p.ID)
+	}
+	return ids
+}
+
+// A remove for a backend the agent never started has no process to ask and
+// no logger to log the call with, so the policy leaves the agent's repo
+// without the call, as an expected condition rather than an error.
+func TestRemovePolicyDoesNotCallABackendThatIsNotRunning(t *testing.T) {
+	var logs strings.Builder
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	secretsMgr := new(mockSecretsManager)
+	cold := &mockBackend{name: "cold_backend"}
+	cold.On("GetRunningStatus").Return(backend.Unknown, "backend not started yet", nil)
+	backend.Register("cold_backend", cold)
+
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	payload := config.PolicyPayload{Action: "manage", ID: "policy-cold", Name: "Cold Policy", Backend: "cold_backend", Version: 1, Data: map[string]any{}, DatasetID: "ds-cold"}
+	secretsMgr.On("SolvePolicySecrets", payload).Return(payload, nil)
+	mgr.ManagePolicy(payload)
+	state, err := mgr.GetPolicyState()
+	require.NoError(t, err)
+	require.Contains(t, policyIDs(state), "policy-cold", "the policy is kept as failed to apply")
+
+	require.NoError(t, mgr.RemovePolicy("policy-cold", "Cold Policy", "cold_backend"))
+
+	cold.AssertNotCalled(t, "RemovePolicy", mock.Anything)
+	state, err = mgr.GetPolicyState()
+	require.NoError(t, err)
+	assert.NotContains(t, policyIDs(state), "policy-cold")
+	assert.NotContains(t, logs.String(), "level=ERROR", "an expected condition is not an error")
+	assert.Contains(t, logs.String(), "treating policy as already removed")
+
+	// The dataset path removes through the same gate.
+	mgr.ManagePolicy(payload)
+	mgr.RemovePolicyDataset("policy-cold", "ds-cold", cold)
+	cold.AssertNotCalled(t, "RemovePolicy", mock.Anything)
+	state, err = mgr.GetPolicyState()
+	require.NoError(t, err)
+	assert.NotContains(t, policyIDs(state), "policy-cold")
+}
+
+// A backend that was started is asked whatever its state: a live process
+// whose status probe timed out may still hold the policy, and skipping it
+// would drop the agent's record while the policy kept running.
+func TestRemovePolicyStillAsksABackendWhoseStatusProbeFailed(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	flaky := &mockBackend{name: "flaky_backend"}
+	flaky.On("GetRunningStatus").Return(backend.BackendError, "process running, REST API unavailable", errors.New("timeout"))
+	backend.Register("flaky_backend", flaky)
+	flaky.On("RemovePolicy", mock.MatchedBy(func(pd policies.PolicyData) bool { return pd.ID == "policy-flaky" })).Return(nil).Once()
+
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	payload := config.PolicyPayload{Action: "manage", ID: "policy-flaky", Name: "Flaky Policy", Backend: "flaky_backend", Version: 1, Data: map[string]any{}, DatasetID: "ds-flaky"}
+	secretsMgr.On("SolvePolicySecrets", payload).Return(payload, nil)
+	mgr.ManagePolicy(payload)
+
+	require.NoError(t, mgr.RemovePolicy("policy-flaky", "Flaky Policy", "flaky_backend"))
+
+	flaky.AssertExpectations(t)
+}
+
+// A restart's removals go through the same gate as a single remove: a
+// backend the agent never started is not asked, and its records still leave.
+func TestRemoveBackendPoliciesDoesNotCallABackendThatWasNeverStarted(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	cold := &mockBackend{name: "cold_restart_backend"}
+	cold.On("GetRunningStatus").Return(backend.Unknown, "backend not started yet", nil)
+	backend.Register("cold_restart_backend", cold)
+
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	payload := config.PolicyPayload{Action: "manage", ID: "policy-cold-restart", Name: "Cold Restart Policy", Backend: "cold_restart_backend", Version: 1, Data: map[string]any{}, DatasetID: "ds-cold-restart"}
+	secretsMgr.On("SolvePolicySecrets", payload).Return(payload, nil)
+	mgr.ManagePolicy(payload)
+
+	require.NoError(t, mgr.RemoveBackendPolicies("cold_restart_backend", cold, true))
+
+	cold.AssertNotCalled(t, "RemovePolicy", mock.Anything)
+	state, err := mgr.GetPolicyState()
+	require.NoError(t, err)
+	assert.NotContains(t, policyIDs(state), "policy-cold-restart")
+}
+
 func TestRemoveBackendPolicies_Permanently(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	secretsMgr := new(mockSecretsManager)
@@ -826,6 +954,7 @@ func TestRemoveBackendPolicies_Permanently(t *testing.T) {
 	cfg := config.Config{}
 
 	mockBe := &mockBackend{name: "be_perm_remove"}
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 	backend.Register("be_perm_remove", mockBe)
 
 	mgr, err := policymgr.New(logger, secretsMgr, cfg)
@@ -843,7 +972,7 @@ func TestRemoveBackendPolicies_Permanently(t *testing.T) {
 
 	mockBe.On("RemovePolicy", mock.Anything).Return(nil)
 
-	err = mgr.RemoveBackendPolicies(mockBe, true)
+	err = mgr.RemoveBackendPolicies("be_perm_remove", mockBe, true)
 	require.NoError(t, err)
 
 	state, err := mgr.GetPolicyState()
@@ -858,6 +987,7 @@ func TestRemoveBackendPolicies_NotPermanently(t *testing.T) {
 	cfg := config.Config{}
 
 	mockBe := &mockBackend{name: "be_nonperm_remove"}
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 	backend.Register("be_nonperm_remove", mockBe)
 
 	mgr, err := policymgr.New(logger, secretsMgr, cfg)
@@ -875,7 +1005,7 @@ func TestRemoveBackendPolicies_NotPermanently(t *testing.T) {
 
 	mockBe.On("RemovePolicy", mock.Anything).Return(nil)
 
-	err = mgr.RemoveBackendPolicies(mockBe, false)
+	err = mgr.RemoveBackendPolicies("be_nonperm_remove", mockBe, false)
 	require.NoError(t, err)
 
 	// Policies still exist but state is Unknown
@@ -1249,6 +1379,7 @@ func TestRemoveBackendPolicies_BackendError_Permanently(t *testing.T) {
 	cfg := config.Config{}
 
 	mockBe := &mockBackend{name: "be_perm_err"}
+	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 	backend.Register("be_perm_err", mockBe)
 
 	mgr, err := policymgr.New(logger, secretsMgr, cfg)
@@ -1265,7 +1396,7 @@ func TestRemoveBackendPolicies_BackendError_Permanently(t *testing.T) {
 	// Backend errors on remove — should still proceed
 	mockBe.On("RemovePolicy", mock.Anything).Return(errors.New("backend error"))
 
-	err = mgr.RemoveBackendPolicies(mockBe, true)
+	err = mgr.RemoveBackendPolicies("be_perm_err", mockBe, true)
 	require.NoError(t, err)
 
 	state, err := mgr.GetPolicyState()


### PR DESCRIPTION
## Summary

Every bundled backend is registered in `cmd/main.go`, but only the ones the agent's configuration names are configured and started, so on the image's default config five registered backends never receive a logger or a process. Three paths reached them and dereferenced that logger; all three are reachable from fleet RPCs on any agent running the shipped default config.

- **Fleet full reset.** The reset RPC walked the whole registry and called `FullReset` on every backend; pktvisor, opentelemetry_infinity and gnmi_discovery log before their process guard and panicked the agent. `backend.RestartAll` now leaves alone a backend that reports it was never started, which is the one meaning of `Unknown` (documented on the interface).
- **Policy remove.** `RemovePolicy` and the dataset removal behind it had no counterpart to the running check the apply path has, and called the backend with the nil logger; reachable from the remove action, the full-list reconciliation, a group removal and a dataset removal. Both now go through one helper that skips only a backend the agent never started, still removing the policy from the agent's repo as an expected condition logged at warning level. A backend that was started is asked whatever its state, since a live process whose status probe timed out may still hold the policy and the request's own timeout bounds the wait.
- **Restart wiping every policy.** `RemoveBackendPolicies` removed every policy of every backend from the repo when one backend restarted, so the others were gone until the next full list from fleet. It now takes the backend's name and removes only that backend's, through the same helper. `RestartBackend` also looks the backend up in the started set rather than the registry, so a restart requested for a registered but unstarted backend is refused instead of dereferencing a nil entry, and the restart counter tolerates a backend the monitor never registered.

Not in this PR, noted for a follow-up: after a restart the backend's own policies are not re-applied (`ApplyBackendPolicies` has no caller), so they come back only on fleet's next full list, on git's next scheduled refresh, or never under the local manager.

## Testing

- Six new tests, each paired with a killed mutant: a never-started backend skipped by the full reset, a restart counter for an unmonitored backend, a remove that does not call a never-started backend and logs no error, a remove that still asks a started backend whose status probe failed, a restart removing only its own backend's policies and going through the same gate, and a restart refused for a registered but unstarted backend.
- The three original crashes reproduced by an independent review against develop with the full nine-backend registry unconfigured, and confirmed gone on this branch by rerunning the same reproductions.
- Agent module suite green under the race detector; `make lint`, 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)