### PR TITLE
fix(agent): cancellable backend start and a monitor that never blocks the state lock

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -335,6 +335,10 @@ func (a *orbAgent) restartBackendWithFilesmgrRollback(ctx context.Context, backe
 		a.logger.Info("filesmgr: backend restarted with upgraded binary", "backend", backendName, "binary", binaryName)
 		return
 	}
+	if errors.Is(startErr, context.Canceled) || ctx.Err() != nil {
+		a.logger.Info("filesmgr: backend start cancelled during restart, leaving the binary as it is", "backend", backendName, "error", startErr)
+		return
+	}
 	a.logger.Warn("filesmgr: backend Start failed after upgrade, rolling back", "backend", backendName, "error", startErr)
 
 	if binaryName == "" {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"testing"
@@ -145,8 +146,12 @@ func (m *mockPolicyManager) RemovePolicy(_ string, _ string, _ string) error {
 	return nil
 }
 
-// mockFilesManager implements filesmgr.Manager for testing (no-op)
-type mockFilesManager struct{}
+// mockFilesManager implements filesmgr.Manager for testing (no-op), and
+// records every Rollback call so a test can assert one was, or was not, made.
+type mockFilesManager struct {
+	rollbackCalls int
+	rollbackNames []string
+}
 
 func (m *mockFilesManager) Start(_ context.Context) error { return nil }
 func (m *mockFilesManager) Stop(_ context.Context) error  { return nil }
@@ -158,10 +163,14 @@ func (m *mockFilesManager) Get(_ string) (filesmgr.FileEntry, bool) {
 	return filesmgr.FileEntry{}, false
 }
 
-func (m *mockFilesManager) List() []filesmgr.FileEntry                  { return nil }
-func (m *mockFilesManager) ListPending() []filesmgr.FileEntry           { return nil }
-func (m *mockFilesManager) Remove(_ context.Context, _ string) error    { return nil }
-func (m *mockFilesManager) Rollback(_ context.Context, _ string) error  { return nil }
+func (m *mockFilesManager) List() []filesmgr.FileEntry               { return nil }
+func (m *mockFilesManager) ListPending() []filesmgr.FileEntry        { return nil }
+func (m *mockFilesManager) Remove(_ context.Context, _ string) error { return nil }
+func (m *mockFilesManager) Rollback(_ context.Context, name string) error {
+	m.rollbackCalls++
+	m.rollbackNames = append(m.rollbackNames, name)
+	return nil
+}
 func (m *mockFilesManager) Subscribe(_ func(filesmgr.FileEvent)) func() { return func() {} }
 
 // mockSecretsManager implements secretsmgr.Manager for testing
@@ -382,4 +391,58 @@ func TestStart_FleetConfig_UsesConfiguredGRPCPort(t *testing.T) {
 	// into backendsCommon and then deletes the "common" key from the map.
 	// Verify the extracted config has the custom port.
 	assert.Equal(t, "grpc://localhost:9999", orbAgent.backendsCommon.Otlp.Grpc, "grpc URL should use configured port")
+}
+
+// stubCancelledStartBackend is a minimal backend.Backend and backend.ManagedBinary
+// whose Start always fails as if the agent's own shutdown had already cancelled
+// the context it was given, for testing that filesmgr's rollback gate treats
+// that as distinct from a bad binary.
+type stubCancelledStartBackend struct {
+	startCalls int
+}
+
+func (s *stubCancelledStartBackend) Configure(*slog.Logger, policies.PolicyRepo, map[string]any, config.BackendCommons, filesmgr.Manager) error {
+	return nil
+}
+func (s *stubCancelledStartBackend) Version() (string, error) { return "", nil }
+func (s *stubCancelledStartBackend) Start(context.Context, context.CancelFunc) error {
+	s.startCalls++
+	return fmt.Errorf("stub start cancelled: %w", context.Canceled)
+}
+func (s *stubCancelledStartBackend) Stop(context.Context) error      { return nil }
+func (s *stubCancelledStartBackend) FullReset(context.Context) error { return nil }
+func (s *stubCancelledStartBackend) GetStartTime() time.Time         { return time.Time{} }
+func (s *stubCancelledStartBackend) GetCapabilities() (map[string]any, error) {
+	return nil, nil
+}
+
+func (s *stubCancelledStartBackend) GetRunningStatus() (backend.RunningStatus, string, error) {
+	return backend.Unknown, "", nil
+}
+func (s *stubCancelledStartBackend) GetInitialState() backend.RunningStatus      { return backend.Unknown }
+func (s *stubCancelledStartBackend) ApplyPolicy(policies.PolicyData, bool) error { return nil }
+func (s *stubCancelledStartBackend) RemovePolicy(policies.PolicyData) error      { return nil }
+func (s *stubCancelledStartBackend) ManagedBinaryName() string                   { return "stub-binary" }
+
+// A start the agent itself gave up on (its context was already cancelled,
+// typically by shutdown) is not evidence the managed binary is bad, so it
+// must not trigger a rollback to the previous version.
+func TestFilesmgrRestartDoesNotRollBackACancelledStart(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	be := &stubCancelledStartBackend{}
+	fm := &mockFilesManager{}
+
+	a := &orbAgent{
+		logger:       logger,
+		backends:     map[string]backend.Backend{"stub": be},
+		filesManager: fm,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	a.restartBackendWithFilesmgrRollback(ctx, "stub")
+
+	assert.Equal(t, 1, be.startCalls, "Start should be attempted exactly once")
+	assert.Equal(t, 0, fm.rollbackCalls, "a cancelled start must not trigger a rollback")
 }

--- a/agent/backend/backend_state.go
+++ b/agent/backend/backend_state.go
@@ -16,6 +16,13 @@ const MinRestartTime = 5 * time.Minute
 // BackendMonitorInterval is the interval at which to monitor backends
 const BackendMonitorInterval = 10 * time.Second
 
+// newMonitorTicker is a seam for tests: production code gets a real ticker,
+// tests install a function that hands back a channel they control.
+var newMonitorTicker = func(interval time.Duration) (<-chan time.Time, func()) {
+	t := time.NewTicker(interval)
+	return t.C, t.Stop
+}
+
 // StateRetriever provides an interface for accessing backend state information
 type StateRetriever interface {
 	Get() map[string]*State
@@ -33,7 +40,6 @@ type StateManager interface {
 type stateManager struct {
 	backendState       map[string]*State
 	mu                 sync.RWMutex
-	ticker             *time.Ticker
 	logger             *slog.Logger
 	restartBackendChan chan string
 	policyRepo         policies.PolicyRepo
@@ -44,7 +50,6 @@ func NewStateManager(activeConfigMgr string, logger *slog.Logger, restartBackend
 	if configMgrSupportsStateMonitoring(activeConfigMgr) {
 		return &stateManager{
 			backendState:       make(map[string]*State),
-			ticker:             time.NewTicker(BackendMonitorInterval),
 			logger:             logger,
 			restartBackendChan: restartBackendChan,
 			policyRepo:         policyRepo,
@@ -80,10 +85,16 @@ func (manager *stateManager) StartBackendMonitor(name string, be Backend) {
 	}
 	manager.mu.Unlock()
 
+	ticks, stop := newMonitorTicker(BackendMonitorInterval)
 	go func() {
-		for range manager.ticker.C {
-			manager.mu.Lock()
+		defer stop()
+		for range ticks {
+			// The status call is an HTTP request for several backends, so it runs
+			// outside the lock; a RegisterError landing between this read and the
+			// write below is overwritten until the next tick, which is accepted.
 			backendStatus, errMsg, err := be.GetRunningStatus()
+			restart := false
+			manager.mu.Lock()
 			manager.backendState[name].Status = backendStatus
 			if backendStatus != Running {
 				if err != nil {
@@ -91,19 +102,28 @@ func (manager *stateManager) StartBackendMonitor(name string, be Backend) {
 				} else if errMsg != "" {
 					manager.backendState[name].LastError = errMsg
 				}
-
 				// status is not running so we have a current error
 				if time.Since(be.GetStartTime()) >= MinRestartTime {
-					manager.restartBackendChan <- name
-					if err != nil {
-						manager.logger.Error("failed to restart backend", "error", err, "backend", name)
-					}
+					restart = true
 				} else {
 					remainingSecondsUntilRestart := MinRestartTime - time.Since(be.GetStartTime())
-					manager.logger.Info("waiting to attempt backend restart due to failed status", "remaining_secs", remainingSecondsUntilRestart)
+					manager.logger.Info("waiting to attempt backend restart due to failed status", "remaining_secs", remainingSecondsUntilRestart, "backend", name)
 				}
 			}
 			manager.mu.Unlock()
+
+			if restart {
+				// Outside the lock, and never blocking: a consumer that has
+				// fallen behind must not freeze every reader of the state.
+				select {
+				case manager.restartBackendChan <- name:
+				default:
+					manager.logger.Debug("restart already queued for this backend, request dropped until the next tick", "backend", name)
+				}
+				if err != nil {
+					manager.logger.Error("failed to read backend status", "error", err, "backend", name)
+				}
+			}
 
 			// Poll policy status if backend supports it
 			if provider, ok := be.(PolicyStatusProvider); ok && manager.policyRepo != nil {
@@ -123,16 +143,22 @@ func (manager *stateManager) StartBackendMonitor(name string, be Backend) {
 	}()
 }
 
-// RegisterError registers an error for a backend and updates its state
+// RegisterError records a failure on a backend's entry. A new entry is
+// stamped with the time, as before, since the failure is the first thing
+// known about the backend; an existing one keeps its restart count, time
+// and reason, which belong to RegisterRestart, so a failed retry does not
+// erase the restarts before it.
 func (manager *stateManager) RegisterError(name string, errMessage string) {
 	manager.logger.Error(errMessage, "backend", name)
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
-	manager.backendState[name] = &State{
-		Status:        BackendError,
-		LastError:     errMessage,
-		LastRestartTS: time.Now(),
+	state, ok := manager.backendState[name]
+	if !ok {
+		state = &State{LastRestartTS: time.Now()}
+		manager.backendState[name] = state
 	}
+	state.Status = BackendError
+	state.LastError = errMessage
 }
 
 // RegisterRestart registers a restart event for a backend

--- a/agent/backend/backend_state.go
+++ b/agent/backend/backend_state.go
@@ -53,6 +53,12 @@ type stateManager struct {
 	restartBackendChan chan string
 	policyRepo         policies.PolicyRepo
 	tick               TickSource
+	// queued tracks, per backend, whether a restart request for it is
+	// currently sitting in restartBackendChan. It caps each backend at one
+	// slot: without it, repeated ticks from a handful of unhealthy backends
+	// could fill every slot with the same names and starve a backend whose
+	// request never fits.
+	queued map[string]bool
 }
 
 // NewStateManager creates a new StateManager with the given logger and restart channel.
@@ -65,6 +71,7 @@ func NewStateManager(activeConfigMgr string, logger *slog.Logger, restartBackend
 			logger:             logger,
 			restartBackendChan: restartBackendChan,
 			policyRepo:         policyRepo,
+			queued:             make(map[string]bool),
 			tick: func(d time.Duration) (<-chan time.Time, func()) {
 				t := time.NewTicker(d)
 				return t.C, t.Stop
@@ -133,12 +140,24 @@ func (manager *stateManager) StartBackendMonitor(name string, be Backend) {
 			manager.mu.Unlock()
 
 			if restart {
-				// Outside the lock, and never blocking: a consumer that has
-				// fallen behind must not freeze every reader of the state.
-				select {
-				case manager.restartBackendChan <- name:
-				default:
-					manager.logger.Debug("restart already queued for this backend, request dropped until the next tick", "backend", name)
+				manager.mu.Lock()
+				alreadyQueued := manager.queued[name]
+				if !alreadyQueued {
+					manager.queued[name] = true
+				}
+				manager.mu.Unlock()
+
+				if !alreadyQueued {
+					// Outside the lock, and never blocking: a consumer that has
+					// fallen behind must not freeze every reader of the state.
+					select {
+					case manager.restartBackendChan <- name:
+					default:
+						manager.mu.Lock()
+						manager.queued[name] = false
+						manager.mu.Unlock()
+						manager.logger.Warn("restart queue full, request kept for the next tick", "backend", name)
+					}
 				}
 				if err != nil {
 					manager.logger.Error("failed to read backend status", "error", err, "backend", name)
@@ -181,10 +200,13 @@ func (manager *stateManager) RegisterError(name string, errMessage string) {
 	state.LastError = errMessage
 }
 
-// RegisterRestart registers a restart event for a backend
+// RegisterRestart registers a restart event for a backend. It is the first
+// thing RestartBackend calls, so clearing the queue slot here marks the
+// request as taken: the monitor may queue another one on its next tick.
 func (manager *stateManager) RegisterRestart(name string, reason string) {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
+	manager.queued[name] = false
 	// A restart can be asked for before the monitor registered the backend.
 	if manager.backendState[name] == nil {
 		manager.backendState[name] = &State{Status: Unknown}

--- a/agent/backend/backend_state.go
+++ b/agent/backend/backend_state.go
@@ -16,11 +16,20 @@ const MinRestartTime = 5 * time.Minute
 // BackendMonitorInterval is the interval at which to monitor backends
 const BackendMonitorInterval = 10 * time.Second
 
-// newMonitorTicker is a seam for tests: production code gets a real ticker,
-// tests install a function that hands back a channel they control.
-var newMonitorTicker = func(interval time.Duration) (<-chan time.Time, func()) {
-	t := time.NewTicker(interval)
-	return t.C, t.Stop
+// TickSource creates the channel a monitor reads ticks from, and a function
+// to stop it. Production code is given a real ticker; tests inject one that
+// hands back a channel they control.
+type TickSource func(interval time.Duration) (<-chan time.Time, func())
+
+// StateManagerOption configures a stateManager built by NewStateManager.
+type StateManagerOption func(*stateManager)
+
+// WithTickSource overrides the tick source a stateManager's monitors use,
+// for tests that need to drive ticks by hand instead of waiting on a timer.
+func WithTickSource(tick TickSource) StateManagerOption {
+	return func(manager *stateManager) {
+		manager.tick = tick
+	}
 }
 
 // StateRetriever provides an interface for accessing backend state information
@@ -43,17 +52,28 @@ type stateManager struct {
 	logger             *slog.Logger
 	restartBackendChan chan string
 	policyRepo         policies.PolicyRepo
+	tick               TickSource
 }
 
-// NewStateManager creates a new StateManager with the given logger and restart channel
-func NewStateManager(activeConfigMgr string, logger *slog.Logger, restartBackendChan chan string, policyRepo policies.PolicyRepo) StateManager {
+// NewStateManager creates a new StateManager with the given logger and restart channel.
+// The tick source each monitor uses defaults to a real ticker; pass WithTickSource to
+// override it.
+func NewStateManager(activeConfigMgr string, logger *slog.Logger, restartBackendChan chan string, policyRepo policies.PolicyRepo, opts ...StateManagerOption) StateManager {
 	if configMgrSupportsStateMonitoring(activeConfigMgr) {
-		return &stateManager{
+		manager := &stateManager{
 			backendState:       make(map[string]*State),
 			logger:             logger,
 			restartBackendChan: restartBackendChan,
 			policyRepo:         policyRepo,
+			tick: func(d time.Duration) (<-chan time.Time, func()) {
+				t := time.NewTicker(d)
+				return t.C, t.Stop
+			},
 		}
+		for _, opt := range opts {
+			opt(manager)
+		}
+		return manager
 	}
 	return nullStateManager{}
 }
@@ -85,7 +105,7 @@ func (manager *stateManager) StartBackendMonitor(name string, be Backend) {
 	}
 	manager.mu.Unlock()
 
-	ticks, stop := newMonitorTicker(BackendMonitorInterval)
+	ticks, stop := manager.tick(BackendMonitorInterval)
 	go func() {
 		defer stop()
 		for range ticks {

--- a/agent/backend/backend_state.go
+++ b/agent/backend/backend_state.go
@@ -32,6 +32,15 @@ func WithTickSource(tick TickSource) StateManagerOption {
 	}
 }
 
+// WithClock overrides the clock a stateManager uses to age an in-flight
+// restart request, for tests that need to advance time deterministically
+// instead of sleeping.
+func WithClock(now func() time.Time) StateManagerOption {
+	return func(manager *stateManager) {
+		manager.now = now
+	}
+}
+
 // StateRetriever provides an interface for accessing backend state information
 type StateRetriever interface {
 	Get() map[string]*State
@@ -53,12 +62,16 @@ type stateManager struct {
 	restartBackendChan chan string
 	policyRepo         policies.PolicyRepo
 	tick               TickSource
-	// queued tracks, per backend, whether a restart request for it is
-	// currently sitting in restartBackendChan. It caps each backend at one
-	// slot: without it, repeated ticks from a handful of unhealthy backends
-	// could fill every slot with the same names and starve a backend whose
-	// request never fits.
-	queued map[string]bool
+	now                func() time.Time
+	// queued tracks, per backend, whether a restart request for it holds a
+	// slot: a zero time means the request is waiting in restartBackendChan,
+	// a non-zero time means RegisterRestart took it and it is in flight. It
+	// caps each backend at one slot: without it, repeated ticks from a
+	// handful of unhealthy backends could fill every slot with the same
+	// names and starve a backend whose request never fits, and a monitor
+	// tick during the restart's stop would see the same old start time and
+	// queue the same backend again right behind the restart it already took.
+	queued map[string]time.Time
 }
 
 // NewStateManager creates a new StateManager with the given logger and restart channel.
@@ -71,7 +84,8 @@ func NewStateManager(activeConfigMgr string, logger *slog.Logger, restartBackend
 			logger:             logger,
 			restartBackendChan: restartBackendChan,
 			policyRepo:         policyRepo,
-			queued:             make(map[string]bool),
+			queued:             make(map[string]time.Time),
+			now:                time.Now,
 			tick: func(d time.Duration) (<-chan time.Time, func()) {
 				t := time.NewTicker(d)
 				return t.C, t.Stop
@@ -121,9 +135,14 @@ func (manager *stateManager) StartBackendMonitor(name string, be Backend) {
 			// write below is overwritten until the next tick, which is accepted.
 			backendStatus, errMsg, err := be.GetRunningStatus()
 			restart := false
+			shouldSend := false
 			manager.mu.Lock()
 			manager.backendState[name].Status = backendStatus
-			if backendStatus != Running {
+			if backendStatus == Running {
+				// The restart worked, or nothing was wrong: release any slot
+				// this backend was holding.
+				delete(manager.queued, name)
+			} else {
 				if err != nil {
 					manager.backendState[name].LastError = fmt.Sprintf("failed to retrieve backend status: %v", err)
 				} else if errMsg != "" {
@@ -132,6 +151,17 @@ func (manager *stateManager) StartBackendMonitor(name string, be Backend) {
 				// status is not running so we have a current error
 				if time.Since(be.GetStartTime()) >= MinRestartTime {
 					restart = true
+					if ts, ok := manager.queued[name]; ok && !ts.IsZero() && manager.now().Sub(ts) >= MinRestartTime {
+						// A restart that never brought the backend back
+						// releases its slot so the next tick may queue
+						// another one, keeping today's retry cadence for a
+						// permanently failing backend.
+						delete(manager.queued, name)
+					}
+					if _, stillQueued := manager.queued[name]; !stillQueued {
+						manager.queued[name] = time.Time{}
+						shouldSend = true
+					}
 				} else {
 					remainingSecondsUntilRestart := MinRestartTime - time.Since(be.GetStartTime())
 					manager.logger.Info("waiting to attempt backend restart due to failed status", "remaining_secs", remainingSecondsUntilRestart, "backend", name)
@@ -139,29 +169,20 @@ func (manager *stateManager) StartBackendMonitor(name string, be Backend) {
 			}
 			manager.mu.Unlock()
 
-			if restart {
-				manager.mu.Lock()
-				alreadyQueued := manager.queued[name]
-				if !alreadyQueued {
-					manager.queued[name] = true
+			if shouldSend {
+				// Outside the lock, and never blocking: a consumer that has
+				// fallen behind must not freeze every reader of the state.
+				select {
+				case manager.restartBackendChan <- name:
+				default:
+					manager.mu.Lock()
+					delete(manager.queued, name)
+					manager.mu.Unlock()
+					manager.logger.Warn("restart queue full, request kept for the next tick", "backend", name)
 				}
-				manager.mu.Unlock()
-
-				if !alreadyQueued {
-					// Outside the lock, and never blocking: a consumer that has
-					// fallen behind must not freeze every reader of the state.
-					select {
-					case manager.restartBackendChan <- name:
-					default:
-						manager.mu.Lock()
-						manager.queued[name] = false
-						manager.mu.Unlock()
-						manager.logger.Warn("restart queue full, request kept for the next tick", "backend", name)
-					}
-				}
-				if err != nil {
-					manager.logger.Error("failed to read backend status", "error", err, "backend", name)
-				}
+			}
+			if restart && err != nil {
+				manager.logger.Error("failed to read backend status", "error", err, "backend", name)
 			}
 
 			// Poll policy status if backend supports it
@@ -201,12 +222,15 @@ func (manager *stateManager) RegisterError(name string, errMessage string) {
 }
 
 // RegisterRestart registers a restart event for a backend. It is the first
-// thing RestartBackend calls, so clearing the queue slot here marks the
-// request as taken: the monitor may queue another one on its next tick.
+// thing RestartBackend calls, so stamping the queue slot with the current
+// time here marks the request as taken and in flight: a monitor tick during
+// the restart's stop still sees the slot held and will not queue the same
+// backend again, until the backend is seen running again or this restart
+// itself is older than MinRestartTime.
 func (manager *stateManager) RegisterRestart(name string, reason string) {
 	manager.mu.Lock()
 	defer manager.mu.Unlock()
-	manager.queued[name] = false
+	manager.queued[name] = manager.now()
 	// A restart can be asked for before the monitor registered the backend.
 	if manager.backendState[name] == nil {
 		manager.backendState[name] = &State{Status: Unknown}

--- a/agent/backend/backend_state_internal_test.go
+++ b/agent/backend/backend_state_internal_test.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"log/slog"
 	"os"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -13,25 +14,72 @@ import (
 )
 
 // countingBackend reports a fixed status and counts how often it is asked.
+// status and started are guarded by mu so a test can flip them between
+// ticks without racing the monitor goroutine's reads.
 type countingBackend struct {
 	Backend
+	mu      sync.Mutex
 	status  RunningStatus
 	started time.Time
 	polls   atomic.Int32
 }
 
 func (c *countingBackend) GetInitialState() RunningStatus { return Running }
-func (c *countingBackend) GetStartTime() time.Time        { return c.started }
+
+func (c *countingBackend) GetStartTime() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.started
+}
+
 func (c *countingBackend) GetRunningStatus() (RunningStatus, string, error) {
 	c.polls.Add(1)
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.status, "", nil
+}
+
+func (c *countingBackend) setStatus(status RunningStatus) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.status = status
+}
+
+func (c *countingBackend) setStarted(started time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.started = started
+}
+
+// mutableClock is a manually advanced clock for tests that need to age a
+// queued restart request deterministically instead of sleeping.
+type mutableClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newMutableClock(start time.Time) *mutableClock {
+	return &mutableClock{now: start}
+}
+
+func (c *mutableClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *mutableClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
 }
 
 // newTestManager builds a stateManager whose tick source hands each call its
 // own unbuffered channel, recorded in order, so a test can drive ticks by
 // hand instead of waiting on a real ticker. Injected through WithTickSource,
-// so there is no package variable to restore.
-func newTestManager(t *testing.T, restartChan chan string) (*stateManager, *[]chan time.Time) {
+// so there is no package variable to restore. Extra options, such as
+// WithClock, are applied after it.
+func newTestManager(t *testing.T, restartChan chan string, extraOpts ...StateManagerOption) (*stateManager, *[]chan time.Time) {
 	t.Helper()
 	channels := make([]chan time.Time, 0)
 	tick := func(_ time.Duration) (<-chan time.Time, func()) {
@@ -42,7 +90,8 @@ func newTestManager(t *testing.T, restartChan chan string) (*stateManager, *[]ch
 	repo, err := policies.NewMemRepo()
 	require.NoError(t, err)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	manager := NewStateManager("fleet", logger, restartChan, repo, WithTickSource(tick)).(*stateManager)
+	opts := append([]StateManagerOption{WithTickSource(tick)}, extraOpts...)
+	manager := NewStateManager("fleet", logger, restartChan, repo, opts...).(*stateManager)
 	return manager, &channels
 }
 
@@ -86,9 +135,11 @@ func TestMonitorDoesNotHoldTheLockOnAFullRestartChannel(t *testing.T) {
 }
 
 // A backend holds at most one slot in the restart queue: repeated ticks
-// while a request is still pending must not enqueue it again, since a name
-// with no dedup would let a handful of unhealthy backends fill every slot
-// and starve one whose request never fits.
+// while a request is still pending, or still in flight after RegisterRestart
+// took it, must not enqueue it again, since a name with no dedup would let a
+// handful of unhealthy backends fill every slot and starve one whose request
+// never fits. Once the backend is seen running again, or fails again after a
+// fresh restart, the slot is free for another request.
 func TestMonitorQueuesOneRestartPerBackendUntilItIsTaken(t *testing.T) {
 	restartChan := make(chan string, 5)
 	manager, channels := newTestManager(t, restartChan)
@@ -98,14 +149,55 @@ func TestMonitorQueuesOneRestartPerBackendUntilItIsTaken(t *testing.T) {
 	tick := (*channels)[0]
 
 	sendTick(t, tick)
-	sendTick(t, tick)
-	sendTick(t, tick)
-	require.Len(t, restartChan, 1)
+	require.Eventually(t, func() bool { return len(restartChan) == 1 }, time.Second, time.Millisecond)
 
 	manager.RegisterRestart("unhealthy", "taken")
 	sendTick(t, tick)
+	// The next tick only arrives once the previous one's iteration is fully
+	// done, which is what proves it really did skip instead of just not
+	// having gotten to the send yet.
+	sendTick(t, tick)
+	require.Len(t, restartChan, 1, "a request already taken and in flight must not be queued again")
+
+	be.setStatus(Running)
+	sendTick(t, tick)
+	// Wait for the Running tick's iteration to actually clear the slot
+	// before flipping the backend again, so that iteration's own read of
+	// status and start time cannot race the mutation below.
+	require.Eventually(t, func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		_, ok := manager.queued["unhealthy"]
+		return !ok
+	}, time.Second, time.Millisecond, "seeing the backend running again must release the slot")
+
+	be.setStatus(BackendError)
+	be.setStarted(time.Now().Add(-2 * MinRestartTime))
+	sendTick(t, tick)
 	require.Eventually(t, func() bool { return len(restartChan) == 2 }, time.Second, time.Millisecond,
-		"RegisterRestart must release the slot so the next tick can queue again")
+		"a later failure after the slot was released must be able to queue again")
+}
+
+// A restart in flight for longer than MinRestartTime never brought the
+// backend back, so its slot is released and the next tick may queue another
+// one, keeping today's retry cadence for a permanently failing backend.
+func TestMonitorReleasesAnInFlightRestartOlderThanMinRestartTime(t *testing.T) {
+	clock := newMutableClock(time.Now())
+	restartChan := make(chan string, 5)
+	manager, channels := newTestManager(t, restartChan, WithClock(clock.Now))
+	be := &countingBackend{status: BackendError, started: time.Now().Add(-2 * MinRestartTime)}
+	manager.StartBackendMonitor("unhealthy", be)
+	require.Len(t, *channels, 1)
+	tick := (*channels)[0]
+
+	sendTick(t, tick)
+	require.Eventually(t, func() bool { return len(restartChan) == 1 }, time.Second, time.Millisecond)
+
+	manager.RegisterRestart("unhealthy", "taken")
+	clock.Advance(MinRestartTime)
+	sendTick(t, tick)
+	require.Eventually(t, func() bool { return len(restartChan) == 2 }, time.Second, time.Millisecond,
+		"an in-flight restart older than MinRestartTime must release its slot")
 }
 
 // A restart request that did not fit in a full queue must not be considered
@@ -124,7 +216,8 @@ func TestMonitorKeepsARequestThatDidNotFit(t *testing.T) {
 	require.Eventually(t, func() bool {
 		manager.mu.Lock()
 		defer manager.mu.Unlock()
-		return !manager.queued["unhealthy"]
+		_, ok := manager.queued["unhealthy"]
+		return !ok
 	}, time.Second, time.Millisecond, "a request that did not fit must be released so the next tick retries it")
 	require.Len(t, restartChan, 1)
 	require.Equal(t, "other", <-restartChan)

--- a/agent/backend/backend_state_internal_test.go
+++ b/agent/backend/backend_state_internal_test.go
@@ -85,6 +85,55 @@ func TestMonitorDoesNotHoldTheLockOnAFullRestartChannel(t *testing.T) {
 	}
 }
 
+// A backend holds at most one slot in the restart queue: repeated ticks
+// while a request is still pending must not enqueue it again, since a name
+// with no dedup would let a handful of unhealthy backends fill every slot
+// and starve one whose request never fits.
+func TestMonitorQueuesOneRestartPerBackendUntilItIsTaken(t *testing.T) {
+	restartChan := make(chan string, 5)
+	manager, channels := newTestManager(t, restartChan)
+	be := &countingBackend{status: BackendError, started: time.Now().Add(-2 * MinRestartTime)}
+	manager.StartBackendMonitor("unhealthy", be)
+	require.Len(t, *channels, 1)
+	tick := (*channels)[0]
+
+	sendTick(t, tick)
+	sendTick(t, tick)
+	sendTick(t, tick)
+	require.Len(t, restartChan, 1)
+
+	manager.RegisterRestart("unhealthy", "taken")
+	sendTick(t, tick)
+	require.Eventually(t, func() bool { return len(restartChan) == 2 }, time.Second, time.Millisecond,
+		"RegisterRestart must release the slot so the next tick can queue again")
+}
+
+// A restart request that did not fit in a full queue must not be considered
+// queued: the monitor has to retry it on a later tick instead of dropping it
+// for good.
+func TestMonitorKeepsARequestThatDidNotFit(t *testing.T) {
+	restartChan := make(chan string, 1)
+	restartChan <- "other"
+	manager, channels := newTestManager(t, restartChan)
+	be := &countingBackend{status: BackendError, started: time.Now().Add(-2 * MinRestartTime)}
+	manager.StartBackendMonitor("unhealthy", be)
+	require.Len(t, *channels, 1)
+	tick := (*channels)[0]
+
+	sendTick(t, tick)
+	require.Eventually(t, func() bool {
+		manager.mu.Lock()
+		defer manager.mu.Unlock()
+		return !manager.queued["unhealthy"]
+	}, time.Second, time.Millisecond, "a request that did not fit must be released so the next tick retries it")
+	require.Len(t, restartChan, 1)
+	require.Equal(t, "other", <-restartChan)
+
+	sendTick(t, tick)
+	require.Eventually(t, func() bool { return len(restartChan) == 1 }, time.Second, time.Millisecond)
+	require.Equal(t, "unhealthy", <-restartChan)
+}
+
 // Each monitor gets its own tick source, so adding a backend does not slow
 // the polling of the others.
 func TestEachMonitorHasItsOwnTickSource(t *testing.T) {

--- a/agent/backend/backend_state_internal_test.go
+++ b/agent/backend/backend_state_internal_test.go
@@ -27,29 +27,23 @@ func (c *countingBackend) GetRunningStatus() (RunningStatus, string, error) {
 	return c.status, "", nil
 }
 
-// installTickSeam replaces newMonitorTicker with a fake that hands each call
-// its own unbuffered channel, recorded in order, so a test can drive ticks by
-// hand instead of waiting on a real ticker. The real seam is restored in
-// t.Cleanup; the returned pointer reflects channels recorded after the call.
-func installTickSeam(t *testing.T) *[]chan time.Time {
+// newTestManager builds a stateManager whose tick source hands each call its
+// own unbuffered channel, recorded in order, so a test can drive ticks by
+// hand instead of waiting on a real ticker. Injected through WithTickSource,
+// so there is no package variable to restore.
+func newTestManager(t *testing.T, restartChan chan string) (*stateManager, *[]chan time.Time) {
 	t.Helper()
-	orig := newMonitorTicker
 	channels := make([]chan time.Time, 0)
-	newMonitorTicker = func(_ time.Duration) (<-chan time.Time, func()) {
+	tick := func(_ time.Duration) (<-chan time.Time, func()) {
 		ch := make(chan time.Time)
 		channels = append(channels, ch)
 		return ch, func() {}
 	}
-	t.Cleanup(func() { newMonitorTicker = orig })
-	return &channels
-}
-
-func newTestManager(t *testing.T, restartChan chan string) *stateManager {
-	t.Helper()
 	repo, err := policies.NewMemRepo()
 	require.NoError(t, err)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	return NewStateManager("fleet", logger, restartChan, repo).(*stateManager)
+	manager := NewStateManager("fleet", logger, restartChan, repo, WithTickSource(tick)).(*stateManager)
+	return manager, &channels
 }
 
 // sendTick delivers one tick on ch, failing the test if the monitor is not
@@ -67,10 +61,9 @@ func sendTick(t *testing.T, ch chan time.Time) {
 // state lock while it waits: heartbeats read that lock, and a full channel
 // would freeze them. The request is dropped and logged instead.
 func TestMonitorDoesNotHoldTheLockOnAFullRestartChannel(t *testing.T) {
-	channels := installTickSeam(t)
 	restartChan := make(chan string, 1)
 	restartChan <- "already-queued"
-	manager := newTestManager(t, restartChan)
+	manager, channels := newTestManager(t, restartChan)
 	be := &countingBackend{status: BackendError, started: time.Now().Add(-2 * MinRestartTime)}
 	manager.StartBackendMonitor("unhealthy", be)
 	require.Len(t, *channels, 1)
@@ -92,17 +85,16 @@ func TestMonitorDoesNotHoldTheLockOnAFullRestartChannel(t *testing.T) {
 	}
 }
 
-// Each monitor gets its own tick source from newMonitorTicker, so adding a
-// backend does not slow the polling of the others.
+// Each monitor gets its own tick source, so adding a backend does not slow
+// the polling of the others.
 func TestEachMonitorHasItsOwnTickSource(t *testing.T) {
-	channels := installTickSeam(t)
-	manager := newTestManager(t, make(chan string, 10))
+	manager, channels := newTestManager(t, make(chan string, 10))
 	first := &countingBackend{status: Running, started: time.Now()}
 	second := &countingBackend{status: Running, started: time.Now()}
 	manager.StartBackendMonitor("first", first)
 	manager.StartBackendMonitor("second", second)
 
-	require.Len(t, *channels, 2, "each monitor must call newMonitorTicker for its own channel")
+	require.Len(t, *channels, 2, "each monitor must call the tick source for its own channel")
 	firstTicks, secondTicks := (*channels)[0], (*channels)[1]
 
 	for i := 0; i < 3; i++ {

--- a/agent/backend/backend_state_internal_test.go
+++ b/agent/backend/backend_state_internal_test.go
@@ -1,0 +1,115 @@
+package backend
+
+import (
+	"log/slog"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/policies"
+)
+
+// countingBackend reports a fixed status and counts how often it is asked.
+type countingBackend struct {
+	Backend
+	status  RunningStatus
+	started time.Time
+	polls   atomic.Int32
+}
+
+func (c *countingBackend) GetInitialState() RunningStatus { return Running }
+func (c *countingBackend) GetStartTime() time.Time        { return c.started }
+func (c *countingBackend) GetRunningStatus() (RunningStatus, string, error) {
+	c.polls.Add(1)
+	return c.status, "", nil
+}
+
+// installTickSeam replaces newMonitorTicker with a fake that hands each call
+// its own unbuffered channel, recorded in order, so a test can drive ticks by
+// hand instead of waiting on a real ticker. The real seam is restored in
+// t.Cleanup; the returned pointer reflects channels recorded after the call.
+func installTickSeam(t *testing.T) *[]chan time.Time {
+	t.Helper()
+	orig := newMonitorTicker
+	channels := make([]chan time.Time, 0)
+	newMonitorTicker = func(_ time.Duration) (<-chan time.Time, func()) {
+		ch := make(chan time.Time)
+		channels = append(channels, ch)
+		return ch, func() {}
+	}
+	t.Cleanup(func() { newMonitorTicker = orig })
+	return &channels
+}
+
+func newTestManager(t *testing.T, restartChan chan string) *stateManager {
+	t.Helper()
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	return NewStateManager("fleet", logger, restartChan, repo).(*stateManager)
+}
+
+// sendTick delivers one tick on ch, failing the test if the monitor is not
+// ready to receive it.
+func sendTick(t *testing.T, ch chan time.Time) {
+	t.Helper()
+	select {
+	case ch <- time.Now():
+	case <-time.After(time.Second):
+		t.Fatal("monitor did not receive the tick in time")
+	}
+}
+
+// A monitor whose restart request cannot be delivered must not hold the
+// state lock while it waits: heartbeats read that lock, and a full channel
+// would freeze them. The request is dropped and logged instead.
+func TestMonitorDoesNotHoldTheLockOnAFullRestartChannel(t *testing.T) {
+	channels := installTickSeam(t)
+	restartChan := make(chan string, 1)
+	restartChan <- "already-queued"
+	manager := newTestManager(t, restartChan)
+	be := &countingBackend{status: BackendError, started: time.Now().Add(-2 * MinRestartTime)}
+	manager.StartBackendMonitor("unhealthy", be)
+	require.Len(t, *channels, 1)
+	tick := (*channels)[0]
+
+	sendTick(t, tick)
+	// The second tick only arrives once the monitor has looped back to wait
+	// for it, which requires the first iteration's restart attempt to have
+	// returned; a monitor stuck holding the lock on the full channel would
+	// never get here.
+	sendTick(t, tick)
+
+	done := make(chan struct{})
+	go func() { manager.Get(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Get() blocked behind a monitor waiting on the restart channel")
+	}
+}
+
+// Each monitor gets its own tick source from newMonitorTicker, so adding a
+// backend does not slow the polling of the others.
+func TestEachMonitorHasItsOwnTickSource(t *testing.T) {
+	channels := installTickSeam(t)
+	manager := newTestManager(t, make(chan string, 10))
+	first := &countingBackend{status: Running, started: time.Now()}
+	second := &countingBackend{status: Running, started: time.Now()}
+	manager.StartBackendMonitor("first", first)
+	manager.StartBackendMonitor("second", second)
+
+	require.Len(t, *channels, 2, "each monitor must call newMonitorTicker for its own channel")
+	firstTicks, secondTicks := (*channels)[0], (*channels)[1]
+
+	for i := 0; i < 3; i++ {
+		sendTick(t, firstTicks)
+	}
+	sendTick(t, secondTicks)
+
+	require.Eventually(t, func() bool { return first.polls.Load() == 3 }, time.Second, time.Millisecond)
+	require.Eventually(t, func() bool { return second.polls.Load() == 1 }, time.Second, time.Millisecond)
+}

--- a/agent/backend/backend_state_test.go
+++ b/agent/backend/backend_state_test.go
@@ -411,7 +411,7 @@ func TestBackendStateManager_Interface_Implementation(t *testing.T) {
 	assert.NotNil(t, state)
 }
 
-func TestBackendStateManager_RegisterError_OverwritesExistingState(t *testing.T) {
+func TestBackendStateManager_RegisterError_UpdatesStatusAndErrorInPlace(t *testing.T) {
 	// Arrange
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	restartChan := make(chan string, 5)
@@ -433,7 +433,8 @@ func TestBackendStateManager_RegisterError_OverwritesExistingState(t *testing.T)
 
 	initialRestartCount := manager.Get()[backendName].RestartCount
 
-	// Act - RegisterError should overwrite the state
+	// Act - RegisterError updates only the status and error, in place, and
+	// keeps the restart record
 	errorMsg := "critical error"
 	manager.RegisterError(backendName, errorMsg)
 
@@ -442,9 +443,10 @@ func TestBackendStateManager_RegisterError_OverwritesExistingState(t *testing.T)
 	require.Contains(t, state, backendName)
 	assert.Equal(t, backend.BackendError, state[backendName].Status)
 	assert.Equal(t, errorMsg, state[backendName].LastError)
-	// RestartCount should be reset to 0 because RegisterError creates a new State
-	assert.Equal(t, int64(0), state[backendName].RestartCount)
-	assert.NotEqual(t, initialRestartCount, state[backendName].RestartCount)
+	// RestartCount is preserved: RegisterError updates the entry in place
+	// rather than replacing it, so a failed retry does not erase the
+	// restarts recorded before it.
+	assert.Equal(t, initialRestartCount, state[backendName].RestartCount)
 }
 
 func TestBackendStateManager_MinRestartTime_Constant(t *testing.T) {
@@ -712,6 +714,29 @@ func TestBackendStateManager_PolicyStatusPolling_WithoutEntityCount(t *testing.T
 	assert.Zero(t, retrievedPolicy.Runs[0].EntityCount, "Expected entity_count to be zero when not provided")
 
 	mockBe.AssertExpectations(t)
+}
+
+// A failed start after restarts must not erase the restarts: RegisterError
+// creates an entry when there is none, and on an existing one updates the
+// status and error and leaves the restart record alone.
+func TestBackendStateManager_RegisterError_KeepsTheRestartRecord(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	manager := backend.NewStateManager("fleet", logger, make(chan string, 5), repo)
+	manager.RegisterError("flaky", "first failure")
+	manager.RegisterRestart("flaky", "first")
+	manager.RegisterRestart("flaky", "second")
+	before := manager.Get()["flaky"]
+
+	manager.RegisterError("flaky", "binary not found")
+
+	state := manager.Get()["flaky"]
+	assert.Equal(t, backend.BackendError, state.Status)
+	assert.Equal(t, "binary not found", state.LastError)
+	assert.Equal(t, int64(2), state.RestartCount)
+	assert.Equal(t, "second", state.LastRestartReason)
+	assert.Equal(t, before.LastRestartTS, state.LastRestartTS)
 }
 
 func TestBackendStateManager_PolicyStatusPolling_NonProviderBackend(t *testing.T) {

--- a/agent/backend/backend_test.go
+++ b/agent/backend/backend_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
+	"github.com/netboxlabs/orb-agent/agent/backend/mocks"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/filesmgr"
 	"github.com/netboxlabs/orb-agent/agent/policies"
@@ -307,4 +308,29 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 
 	os.Exit(code)
+}
+
+// A second StopProcess call against a mock whose one status was already
+// delivered must return at once: SetupSuccessfulProcess closes its status
+// channel after sending, mirroring CmdWrapper.Start, so a stale receive
+// never makes a caller wait out the real grace period or attempt to SIGKILL
+// a fabricated PID.
+func TestStopProcessReturnsAtOnceOnASecondCallAgainstAClosedMockChannel(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	mockCmd := &mocks.MockCmd{}
+	mocks.SetupSuccessfulProcess(mockCmd, 12345)
+	statusCh := mockCmd.Start()
+
+	backend.StopProcess(logger, mockCmd, statusCh, 5*time.Second, "test-backend")
+
+	done := make(chan struct{})
+	go func() {
+		backend.StopProcess(logger, mockCmd, statusCh, 5*time.Second, "test-backend")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("second StopProcess call did not return within 100ms; the mock's status channel is still open")
+	}
 }

--- a/agent/backend/devicediscovery/device_discovery.go
+++ b/agent/backend/devicediscovery/device_discovery.go
@@ -188,6 +188,7 @@ func (d *deviceDiscoveryBackend) Start(ctx context.Context, cancelFunc context.C
 
 	return backend.StartProcess(backend.StartSpec{
 		Logger:         d.logger,
+		Ctx:            d.ctx,
 		NameDisplay:    "device-discovery",
 		NameUnderscore: "device_discovery",
 		Exec:           d.exec,

--- a/agent/backend/devicediscovery/device_discovery_test.go
+++ b/agent/backend/devicediscovery/device_discovery_test.go
@@ -159,7 +159,7 @@ func TestDeviceDiscoveryBackendStart(t *testing.T) {
 	}
 	require.NoError(t, be.ApplyPolicy(updatedData, true))
 
-	require.NoError(t, be.FullReset(ctx))
+	require.NoError(t, be.FullReset(context.Background()))
 
 	mockCmd.AssertExpectations(t)
 }

--- a/agent/backend/gnmidiscovery/gnmi_discovery.go
+++ b/agent/backend/gnmidiscovery/gnmi_discovery.go
@@ -198,6 +198,7 @@ func (d *gnmiDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 
 	return backend.StartProcess(backend.StartSpec{
 		Logger:         d.logger,
+		Ctx:            d.ctx,
 		NameDisplay:    "gnmi-discovery",
 		NameUnderscore: "gnmi_discovery",
 		Exec:           d.exec,

--- a/agent/backend/gnmidiscovery/gnmi_discovery_test.go
+++ b/agent/backend/gnmidiscovery/gnmi_discovery_test.go
@@ -206,7 +206,7 @@ func TestGnmiDiscoveryBackendStart(t *testing.T) {
 	assert.NotContains(t, lastDelete, "dummy-policy-updated",
 		"update must not DELETE the new policy name")
 
-	require.NoError(t, be.FullReset(ctx))
+	require.NoError(t, be.FullReset(context.Background()))
 
 	mockCmd.AssertExpectations(t)
 }

--- a/agent/backend/gnmitelemetry/gnmi_telemetry.go
+++ b/agent/backend/gnmitelemetry/gnmi_telemetry.go
@@ -408,6 +408,7 @@ func (d *gnmiTelemetryBackend) Start(ctx context.Context, cancelFunc context.Can
 
 	return backend.StartProcess(backend.StartSpec{
 		Logger:         d.logger,
+		Ctx:            d.ctx,
 		NameDisplay:    "gnmi-telemetry",
 		NameUnderscore: "gnmi_telemetry",
 		Exec:           d.exec,

--- a/agent/backend/gnmitelemetry/gnmi_telemetry_test.go
+++ b/agent/backend/gnmitelemetry/gnmi_telemetry_test.go
@@ -181,7 +181,7 @@ func TestGnmiTelemetryBackendStart(t *testing.T) {
 	assert.Equal(t, http.MethodDelete, reqs[3].method)
 	assert.Equal(t, "/api/v1/policies/core", reqs[3].path, "a remove without rename history uses the current name")
 
-	require.NoError(t, be.FullReset(ctx))
+	require.NoError(t, be.FullReset(context.Background()))
 
 	// With the API gone the process still runs, and the backend says so.
 	server.Close()
@@ -325,4 +325,25 @@ func overrideNewCmdOptions(t *testing.T, cmd backend.Commander, assertFn func(op
 	t.Cleanup(func() {
 		backend.NewCmdOptions = original
 	})
+}
+
+// The context the agent hands Start reaches the process start, so a start
+// the agent has already given up on spawns nothing.
+func TestGnmiTelemetryBackendStartHonoursACancelledContext(t *testing.T) {
+	mockCmd := &mocks.MockCmd{}
+	spawned := false
+	overrideNewCmdOptions(t, mockCmd, func(backend.CmdOptions, string, []string) { spawned = true })
+
+	assert.True(t, gnmitelemetry.Register())
+	be := backend.GetBackend("gnmi_telemetry")
+	var commons config.BackendCommons
+	commons.Otlp.Grpc = "collector:4317"
+	require.NoError(t, be.Configure(slog.New(slog.NewTextHandler(os.Stdout, nil)), nil, map[string]any{}, commons, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := be.Start(ctx, cancel)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.False(t, spawned, "no process is spawned for a start that was cancelled before it began")
 }

--- a/agent/backend/mocks/mocks.go
+++ b/agent/backend/mocks/mocks.go
@@ -78,6 +78,11 @@ func SetupSuccessfulProcess(mockCmd *MockCmd, pid int) (<-chan string, <-chan st
 		// Delay before sending to simulate process startup
 		time.Sleep(10 * time.Millisecond)
 		statusCh <- status
+		// Mirrors CmdWrapper.Start in agent/backend/cmd.go: close the status
+		// channel once its one value is sent, so a second StopProcess call
+		// against this mock receives immediately instead of waiting out the
+		// real grace period.
+		close(statusCh)
 		// Simulate some output
 		stdoutCh <- "success"
 		stderrCh <- "error"
@@ -121,9 +126,12 @@ func SetupCompletedProcess(mockCmd *MockCmd, exitCode int, err error) {
 	close(stdoutCh)
 	close(stderrCh)
 
-	// Send status immediately
+	// Send status immediately, then close: mirrors CmdWrapper.Start in
+	// agent/backend/cmd.go, so a second StopProcess call against this mock
+	// receives immediately instead of waiting out the real grace period.
 	go func() {
 		statusCh <- status
+		close(statusCh)
 	}()
 }
 

--- a/agent/backend/networkdiscovery/network_discovery.go
+++ b/agent/backend/networkdiscovery/network_discovery.go
@@ -170,6 +170,7 @@ func (d *networkDiscoveryBackend) Start(ctx context.Context, cancelFunc context.
 
 	return backend.StartProcess(backend.StartSpec{
 		Logger:         d.logger,
+		Ctx:            d.ctx,
 		NameDisplay:    "network-discovery",
 		NameUnderscore: "network_discovery",
 		Exec:           d.exec,

--- a/agent/backend/networkdiscovery/network_discovery_test.go
+++ b/agent/backend/networkdiscovery/network_discovery_test.go
@@ -159,7 +159,7 @@ func TestNetworkDiscoveryBackendStart(t *testing.T) {
 	}
 	require.NoError(t, be.ApplyPolicy(updatedData, true))
 
-	require.NoError(t, be.FullReset(ctx))
+	require.NoError(t, be.FullReset(context.Background()))
 
 	mockCmd.AssertExpectations(t)
 }

--- a/agent/backend/opentelemetryinfinity/opentelemetry_infinity.go
+++ b/agent/backend/opentelemetryinfinity/opentelemetry_infinity.go
@@ -109,6 +109,7 @@ func (o *openTelemetryBackend) Start(ctx context.Context, cancelFunc context.Can
 
 	return backend.StartProcess(backend.StartSpec{
 		Logger:         o.logger,
+		Ctx:            o.ctx,
 		NameDisplay:    "opentelemetry infinity",
 		NameUnderscore: "opentelemetry_infinity",
 		Exec:           o.exec,

--- a/agent/backend/opentelemetryinfinity/opentelemetry_infinity_test.go
+++ b/agent/backend/opentelemetryinfinity/opentelemetry_infinity_test.go
@@ -160,7 +160,7 @@ func TestOpenTelemetryBackendStart(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Assert restart
-	err = be.FullReset(ctx)
+	err = be.FullReset(context.Background())
 	assert.NoError(t, err)
 
 	// Verify expectations

--- a/agent/backend/pktvisor/pktvisor.go
+++ b/agent/backend/pktvisor/pktvisor.go
@@ -127,6 +127,7 @@ func (p *pktvisorBackend) Start(ctx context.Context, cancelFunc context.CancelFu
 
 	return backend.StartProcess(backend.StartSpec{
 		Logger:         p.logger,
+		Ctx:            p.ctx,
 		NameDisplay:    "pktvisor",
 		NameUnderscore: "pktvisor",
 		Exec:           p.binary,

--- a/agent/backend/pktvisor/pktvisor_test.go
+++ b/agent/backend/pktvisor/pktvisor_test.go
@@ -138,7 +138,7 @@ func TestPktvisorBackendStart(t *testing.T) {
 	}
 	require.NoError(t, be.ApplyPolicy(updatedData, true))
 
-	require.NoError(t, be.FullReset(ctx))
+	require.NoError(t, be.FullReset(context.Background()))
 
 	mockCmd.AssertExpectations(t)
 }

--- a/agent/backend/process.go
+++ b/agent/backend/process.go
@@ -53,7 +53,9 @@ type StartSpec struct {
 	// and one that ends during the startup wait or a readiness backoff stops
 	// the child and returns the cancellation. A readiness check in flight is
 	// not interrupted, so a cancellation returns within one check's own
-	// timeout. Nil means the start cannot be cancelled, as before.
+	// timeout; the result of a check that completes after the cancellation is
+	// discarded and the child is stopped. Nil means the start cannot be
+	// cancelled, as before.
 	Ctx context.Context
 	// ReadinessBudget bounds the readiness phase after the startup wait: the
 	// loop never sleeps past it and gives up when it is spent, overshooting by
@@ -184,6 +186,9 @@ func StartProcess(spec StartSpec) error {
 		}
 		version, readinessErr = spec.ReadinessCheck()
 		if readinessErr == nil {
+			if ctx.Err() != nil {
+				return cancelled()
+			}
 			spec.Logger.Info(spec.NameDisplay+" readiness ok, got version", "version", version)
 			break
 		}

--- a/agent/backend/process.go
+++ b/agent/backend/process.go
@@ -1,7 +1,9 @@
 package backend
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"time"
 )
@@ -12,12 +14,30 @@ import (
 const readinessBackoffCount = 10
 
 // startProcessStartupWait is the one-shot post-spawn wait; startProcessSleep is
-// the per-iteration readiness backoff. Both are package vars so success and
-// timeout paths are unit-testable without multi-second waits.
+// the context-aware sleep used for it and for every readiness backoff. Both are
+// package vars so success and timeout paths are unit-testable without
+// multi-second waits.
 var (
 	startProcessStartupWait = time.Second
-	startProcessSleep       = time.Sleep
+	startProcessSleep       = sleepUnlessDone
 )
+
+// sleepUnlessDone sleeps for d and reports true, or reports false as soon as
+// ctx ends. A non-positive d does not sleep and reports whether ctx is still
+// live.
+func sleepUnlessDone(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return ctx.Err() == nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
 
 // StartSpec describes how to launch and validate a backend subprocess.
 type StartSpec struct {
@@ -29,6 +49,17 @@ type StartSpec struct {
 	LogLine        func(line string, isStderr bool)  // per-backend normalizer adapter
 	SetProc        func(Commander, <-chan CmdStatus) // publishes proc+statusChan to the backend BEFORE the readiness loop (see CRITICAL below)
 	ReadinessCheck func() (string, error)            // returns the version string + err; d.Version fits directly; pktvisor wraps an inline /metrics/app probe returning appMetrics.App.Version
+	// Ctx, when set, ends the start: a context already done spawns nothing,
+	// and one that ends during the startup wait or a readiness backoff stops
+	// the child and returns the cancellation. A readiness check in flight is
+	// not interrupted, so a cancellation returns within one check's own
+	// timeout. Nil means the start cannot be cancelled, as before.
+	Ctx context.Context
+	// ReadinessBudget bounds the readiness phase after the startup wait: the
+	// loop never sleeps past it and gives up when it is spent, overshooting by
+	// at most one check. It never adds attempts. Zero keeps the ten-attempt
+	// loop as it is.
+	ReadinessBudget time.Duration
 }
 
 // StartProcess launches the process, streams stdout/stderr to LogLine, then:
@@ -62,12 +93,21 @@ type StartSpec struct {
 // "<name> startup / arguments" line — each backend keeps its own (it owns the
 // per-backend redaction). Returns only error — proc/statusChan are published via
 // SetProc, not the return (one source of truth). It owns ONLY the Start path;
-// callers keep their own Stop. The startup wait and readiness backoff are not
-// cancellable (preserving the pre-refactor per-backend behavior), so it takes no
-// context.
+// callers keep their own Stop. The startup wait and readiness backoff end with
+// spec.Ctx when it is set, and the readiness phase is bounded by
+// spec.ReadinessBudget; both are optional and their zero values keep the
+// historical behaviour.
 func StartProcess(spec StartSpec) error {
 	if spec.Logger == nil || spec.SetProc == nil || spec.LogLine == nil || spec.ReadinessCheck == nil {
 		return errors.New("StartProcess: Logger, SetProc, LogLine, and ReadinessCheck are required")
+	}
+
+	ctx := spec.Ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("%s start cancelled: %w", spec.NameDisplay, err)
 	}
 
 	proc := NewCmdOptions(CmdOptions{
@@ -102,8 +142,20 @@ func StartProcess(spec StartSpec) error {
 		}
 	}()
 
+	cancelled := func() error {
+		spec.Logger.Info(spec.NameDisplay + " start cancelled")
+		StopProcess(spec.Logger, proc, statusChan, DefaultStopGracePeriod, spec.NameUnderscore)
+		cause := ctx.Err()
+		if cause == nil {
+			cause = context.Canceled
+		}
+		return fmt.Errorf("%s start cancelled: %w", spec.NameDisplay, cause)
+	}
+
 	// wait for simple startup errors
-	time.Sleep(startProcessStartupWait)
+	if !startProcessSleep(ctx, startProcessStartupWait) {
+		return cancelled()
+	}
 
 	status := proc.Status()
 
@@ -119,6 +171,10 @@ func StartProcess(spec StartSpec) error {
 
 	spec.Logger.Info(spec.NameDisplay+" process started", "pid", status.PID)
 
+	var deadline time.Time
+	if spec.ReadinessBudget > 0 {
+		deadline = time.Now().Add(spec.ReadinessBudget)
+	}
 	var version string
 	var readinessErr error
 	for backoff := range readinessBackoffCount {
@@ -132,9 +188,21 @@ func StartProcess(spec StartSpec) error {
 			break
 		}
 		backoffDuration := time.Duration(backoff) * time.Second
+		if !deadline.IsZero() {
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				readinessErr = fmt.Errorf("%s not ready within %s: %w", spec.NameDisplay, spec.ReadinessBudget, readinessErr)
+				break
+			}
+			if backoffDuration > remaining {
+				backoffDuration = remaining
+			}
+		}
 		spec.Logger.Info(spec.NameDisplay+" is not ready, trying again with backoff",
 			"backoff_duration", backoffDuration.String())
-		startProcessSleep(backoffDuration)
+		if !startProcessSleep(ctx, backoffDuration) {
+			return cancelled()
+		}
 	}
 
 	if readinessErr != nil {

--- a/agent/backend/process_test.go
+++ b/agent/backend/process_test.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"os"
@@ -66,12 +67,14 @@ func (f *fakeCommander) GetStderr() <-chan string { return f.stderrCh }
 // stubProcessTimers stubs the package-level startup wait + readiness sleep to
 // no-ops so tests run instantly. NOT t.Parallel-safe — these are package vars,
 // which -race would flag under parallel mutation; callers must not parallelize.
+// The sleep stub ignores its context and always reports true, so a test that
+// needs cancellation during a sleep must not use this helper.
 func stubProcessTimers(t *testing.T) {
 	t.Helper()
 	origWait := startProcessStartupWait
 	origSleep := startProcessSleep
 	startProcessStartupWait = 0
-	startProcessSleep = func(time.Duration) {}
+	startProcessSleep = func(context.Context, time.Duration) bool { return true }
 	t.Cleanup(func() {
 		startProcessStartupWait = origWait
 		startProcessSleep = origSleep
@@ -404,4 +407,106 @@ func TestStartProcess_PassesExecAndArgs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "my-binary", captured.exec)
 	assert.Equal(t, []string{"run", "--flag", "value"}, captured.args)
+}
+
+// A context that is already done spawns nothing: the caller has moved on,
+// and a child it never sees would run until something else killed it.
+func TestStartProcess_ReturnsBeforeSpawningWhenTheContextIsDone(t *testing.T) {
+	stubProcessTimers(t)
+	fake := newFakeCommander(1)
+	captured := stubNewCmdOptions(t, fake)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := StartProcess(StartSpec{
+		Logger: testProcessLogger(), NameDisplay: "test-backend", NameUnderscore: "test_backend", Exec: "test-exec",
+		LogLine: func(string, bool) {}, SetProc: func(Commander, <-chan CmdStatus) {},
+		ReadinessCheck: func() (string, error) { return "1", nil },
+		Ctx:            ctx,
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Empty(t, captured.exec, "no command is built for a start that was cancelled before it began")
+	assert.Equal(t, int32(0), fake.stopCalls.Load())
+}
+
+// A cancellation during the startup wait stops the child and returns at
+// once, with the cancellation as the cause.
+func TestStartProcess_CancelledDuringTheStartupWait(t *testing.T) {
+	origWait := startProcessStartupWait
+	startProcessStartupWait = 5 * time.Second
+	t.Cleanup(func() { startProcessStartupWait = origWait })
+	fake := newFakeCommander(4242)
+	stubNewCmdOptions(t, fake)
+	ctx, cancel := context.WithCancel(context.Background())
+	time.AfterFunc(20*time.Millisecond, cancel)
+	start := time.Now()
+
+	err := StartProcess(StartSpec{
+		Logger: testProcessLogger(), NameDisplay: "test-backend", NameUnderscore: "test_backend", Exec: "test-exec",
+		LogLine: func(string, bool) {}, SetProc: func(Commander, <-chan CmdStatus) {},
+		ReadinessCheck: func() (string, error) { return "1", nil },
+		Ctx:            ctx,
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Contains(t, err.Error(), "test-backend start cancelled")
+	assert.Less(t, time.Since(start), time.Second, "the startup wait ends with the context")
+	assert.Equal(t, int32(1), fake.stopCalls.Load(), "the child is stopped")
+}
+
+// A cancellation during a readiness backoff does the same; the readiness
+// check itself is not interrupted, so the return is bounded by one check.
+func TestStartProcess_CancelledDuringAReadinessBackoff(t *testing.T) {
+	origWait := startProcessStartupWait
+	startProcessStartupWait = 0
+	t.Cleanup(func() { startProcessStartupWait = origWait })
+	fake := newFakeCommander(4242)
+	stubNewCmdOptions(t, fake)
+	ctx, cancel := context.WithCancel(context.Background())
+	var checks atomic.Int32
+	start := time.Now()
+
+	err := StartProcess(StartSpec{
+		Logger: testProcessLogger(), NameDisplay: "test-backend", NameUnderscore: "test_backend", Exec: "test-exec",
+		LogLine: func(string, bool) {}, SetProc: func(Commander, <-chan CmdStatus) {},
+		ReadinessCheck: func() (string, error) {
+			if checks.Add(1) == 2 {
+				cancel() // the second attempt's backoff is one second; cancel lands inside it
+			}
+			return "", errors.New("not yet")
+		},
+		Ctx: ctx,
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Less(t, time.Since(start), time.Second, "the backoff sleep ends with the context")
+	assert.Equal(t, int32(2), checks.Load(), "no readiness check after the cancellation")
+	assert.Equal(t, int32(1), fake.stopCalls.Load())
+}
+
+// A readiness budget bounds the whole readiness phase: the loop never sleeps
+// past it and gives up when it is spent, naming the budget.
+func TestStartProcess_GivesUpWhenTheReadinessBudgetIsSpent(t *testing.T) {
+	origWait := startProcessStartupWait
+	startProcessStartupWait = 0
+	t.Cleanup(func() { startProcessStartupWait = origWait })
+	fake := newFakeCommander(4242)
+	stubNewCmdOptions(t, fake)
+	var checks atomic.Int32
+	start := time.Now()
+
+	err := StartProcess(StartSpec{
+		Logger: testProcessLogger(), NameDisplay: "test-backend", NameUnderscore: "test_backend", Exec: "test-exec",
+		LogLine: func(string, bool) {}, SetProc: func(Commander, <-chan CmdStatus) {},
+		ReadinessCheck:  func() (string, error) { checks.Add(1); return "", errors.New("not yet") },
+		ReadinessBudget: 40 * time.Millisecond,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "test-backend not ready within 40ms")
+	assert.Contains(t, err.Error(), "not yet", "the last readiness error is kept as the cause")
+	assert.Less(t, time.Since(start), time.Second, "the one-second backoff was cut to the budget")
+	assert.LessOrEqual(t, checks.Load(), int32(3), "attempt 0 sleeps nothing, attempt 1 sleeps the clamped budget, attempt 2 finds it spent")
+	assert.Equal(t, int32(1), fake.stopCalls.Load())
 }

--- a/agent/backend/process_test.go
+++ b/agent/backend/process_test.go
@@ -510,3 +510,32 @@ func TestStartProcess_GivesUpWhenTheReadinessBudgetIsSpent(t *testing.T) {
 	assert.LessOrEqual(t, checks.Load(), int32(3), "attempt 0 sleeps nothing, attempt 1 sleeps the clamped budget, attempt 2 finds it spent")
 	assert.Equal(t, int32(1), fake.stopCalls.Load())
 }
+
+// A readiness check that completes successfully after the context was
+// cancelled must still stop the child: the check itself is not interrupted,
+// but its result arrives too late to matter, and the start must not report
+// success while leaving an unwanted process running.
+func TestStartProcess_StopsTheChildWhenCancelledDuringASuccessfulReadinessCheck(t *testing.T) {
+	origWait := startProcessStartupWait
+	startProcessStartupWait = 0
+	t.Cleanup(func() { startProcessStartupWait = origWait })
+	fake := newFakeCommander(4242)
+	stubNewCmdOptions(t, fake)
+	ctx, cancel := context.WithCancel(context.Background())
+	var checks atomic.Int32
+
+	err := StartProcess(StartSpec{
+		Logger: testProcessLogger(), NameDisplay: "test-backend", NameUnderscore: "test_backend", Exec: "test-exec",
+		LogLine: func(string, bool) {}, SetProc: func(Commander, <-chan CmdStatus) {},
+		ReadinessCheck: func() (string, error) {
+			checks.Add(1)
+			cancel()
+			return "1.2.3", nil
+		},
+		Ctx: ctx,
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, int32(1), checks.Load(), "the readiness check ran once")
+	assert.Equal(t, int32(1), fake.stopCalls.Load())
+}

--- a/agent/backend/snmpdiscovery/snmp_discovery.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery.go
@@ -213,6 +213,7 @@ func (d *snmpDiscoveryBackend) Start(ctx context.Context, cancelFunc context.Can
 
 	return backend.StartProcess(backend.StartSpec{
 		Logger:         d.logger,
+		Ctx:            d.ctx,
 		NameDisplay:    "snmp-discovery",
 		NameUnderscore: "snmp_discovery",
 		Exec:           d.exec,

--- a/agent/backend/snmpdiscovery/snmp_discovery_test.go
+++ b/agent/backend/snmpdiscovery/snmp_discovery_test.go
@@ -160,7 +160,7 @@ func TestSnmpDiscoveryBackendStart(t *testing.T) {
 	}
 	require.NoError(t, be.ApplyPolicy(updatedData, true))
 
-	require.NoError(t, be.FullReset(ctx))
+	require.NoError(t, be.FullReset(context.Background()))
 
 	mockCmd.AssertExpectations(t)
 }

--- a/agent/backend/snmptelemetry/snmp_telemetry.go
+++ b/agent/backend/snmptelemetry/snmp_telemetry.go
@@ -403,6 +403,7 @@ func (d *snmpTelemetryBackend) Start(ctx context.Context, cancelFunc context.Can
 
 	return backend.StartProcess(backend.StartSpec{
 		Logger:         d.logger,
+		Ctx:            d.ctx,
 		NameDisplay:    "snmp-telemetry",
 		NameUnderscore: "snmp_telemetry",
 		Exec:           d.exec,

--- a/agent/backend/snmptelemetry/snmp_telemetry_test.go
+++ b/agent/backend/snmptelemetry/snmp_telemetry_test.go
@@ -181,7 +181,7 @@ func TestSnmpTelemetryBackendStart(t *testing.T) {
 	assert.Equal(t, http.MethodDelete, reqs[3].method)
 	assert.Equal(t, "/api/v1/policies/core", reqs[3].path, "a remove without rename history uses the current name")
 
-	require.NoError(t, be.FullReset(ctx))
+	require.NoError(t, be.FullReset(context.Background()))
 
 	// With the API gone the process still runs, and the backend says so.
 	server.Close()
@@ -322,4 +322,25 @@ func overrideNewCmdOptions(t *testing.T, cmd backend.Commander, assertFn func(op
 	t.Cleanup(func() {
 		backend.NewCmdOptions = original
 	})
+}
+
+// The context the agent hands Start reaches the process start, so a start
+// the agent has already given up on spawns nothing.
+func TestSnmpTelemetryBackendStartHonoursACancelledContext(t *testing.T) {
+	mockCmd := &mocks.MockCmd{}
+	spawned := false
+	overrideNewCmdOptions(t, mockCmd, func(backend.CmdOptions, string, []string) { spawned = true })
+
+	assert.True(t, snmptelemetry.Register())
+	be := backend.GetBackend("snmp_telemetry")
+	var commons config.BackendCommons
+	commons.Otlp.Grpc = "collector:4317"
+	require.NoError(t, be.Configure(slog.New(slog.NewTextHandler(os.Stdout, nil)), nil, map[string]any{}, commons, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := be.Start(ctx, cancel)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.False(t, spawned, "no process is spawned for a start that was cancelled before it began")
 }

--- a/agent/backend/worker/worker.go
+++ b/agent/backend/worker/worker.go
@@ -189,6 +189,7 @@ func (d *workerBackend) Start(ctx context.Context, cancelFunc context.CancelFunc
 
 	return backend.StartProcess(backend.StartSpec{
 		Logger:         d.logger,
+		Ctx:            d.ctx,
 		NameDisplay:    "worker",
 		NameUnderscore: "worker",
 		Exec:           d.resolveExecPath(),

--- a/agent/backend/worker/worker_test.go
+++ b/agent/backend/worker/worker_test.go
@@ -150,7 +150,7 @@ func TestWorkerBackendStart(t *testing.T) {
 	}
 	require.NoError(t, be.ApplyPolicy(updatedData, true))
 
-	require.NoError(t, be.FullReset(ctx))
+	require.NoError(t, be.FullReset(context.Background()))
 
 	mockCmd.AssertExpectations(t)
 }


### PR DESCRIPTION
## Summary

A backend start could not be stopped. `StartProcess` slept through a one-second startup wait and up to ten readiness backoffs with `time.Sleep` and no context, so anything that started a backend held its goroutine for 66 s, 96 s for opentelemetry_infinity or 146 s for pktvisor, and a shutdown waited it out. This is the first of the supervisor series (MON-356 follow-up): the change every later step needs, plus three defects in the state manager it exposed.

- **`StartSpec` gains `Ctx` and `ReadinessBudget`.** A context already done spawns nothing; one that ends during the startup wait or a readiness backoff stops the child with the default grace and returns the cancellation wrapped, and the result of a readiness check that completes after the cancellation is discarded and the child stopped. The budget bounds the readiness phase, never adds attempts, and overshoots by at most one check. Both are optional: a nil context and a zero budget keep the ten-attempt loop, the index-scaled backoff and every error string exactly as they are. `ReadinessBudget` has no caller yet; on-demand starts will set it.
- **All nine backends pass the run context they already stored**, one line each. The backend tests that reset a backend with the context their own stop had cancelled now use a fresh one, as the agent's restart paths do.
- **A cancelled start is not a bad binary.** `restartBackendWithFilesmgrRollback` treated any start failure as a reason to roll the managed binary back; a start the agent itself gave up on, typically because shutdown cancelled the dispatcher context, now logs and leaves the binary on disk instead of rolling back and retrying against a context that cannot succeed. The mock process also closes its status channel after its single status, as the real one does, so a second stop on it returns at once instead of signalling a fabricated PID.
- **Three state-manager defects, fleet only.** The monitor decided under the state lock and sent on the restart channel while holding it, so a full channel froze every reader of the state, heartbeats included; it now decides under the lock and sends outside it without blocking. Each backend holds one restart request in the queue at a time: a request that did not fit releases its slot and is retried on the next tick, and `RegisterRestart`, the first thing the restart path calls, marks it taken, so repeats from other unhealthy backends cannot starve one. Every monitor ranged over one shared ticker, so each backend was polled every 10 s times the backend count; each now has its own tick source, injected through `WithTickSource` on the constructor. `RegisterError` replaced the whole entry, erasing the restart count on a failed retry; it now creates an entry with a timestamp or updates status and error only.

## Fleet-visible timing changes

Each backend is now polled every 10 s rather than every 10 s times the backend count, for both the health check and the run polling, so every backend answers more requests. A restart request that cannot be queued is kept for the next tick with a warning. A failed retry keeps the restart record instead of resetting the count to zero.

## Not in this PR

- `agent.Stop` still does not cancel the health-driven restart path, so a shutdown landing inside a fleet-requested restart waits it out; the supervisor's `StopAll` owns that in the next PRs.
- `RegisterRestart` on a backend the monitor never registered is guarded by #603, which this branch is rebased onto.
- The monitor goroutines still never exit after `agent.Stop`, as before.

## Container validation

The branch image and a develop image built from the same base, each run on orb-test-lab with a local config enabling all nine backends (Diode in dry-run mode, the OTLP endpoint on a debug collector, one gnmi_telemetry policy against gnmi-sim):

| Scenario | develop | this branch |
|---|---|---|
| start, wait for readiness | 9 of 9 backends ready | 9 of 9 backends ready |
| `docker stop` with everything running | 686 ms, exit 0, every backend stopped gracefully | 582 ms, exit 0, the same lines |
| `docker stop` two seconds into startup | 45.6 s, one backend's readiness loop waited out | 142 ms, "worker start cancelled", the child stopped |

Both images exit 1 with "agent startup error" in the last scenario, since a stop during startup is a start that did not complete; the difference is that the branch returns at once.

## Testing

- New tests, each paired with a killed mutant: a done context spawns nothing; cancellation during the startup wait, during a readiness backoff and during a readiness check that then succeeds all stop the child; a spent budget gives up naming the budget; the two telemetry backends honour a cancelled context; a cancelled start during a file-driven restart rolls nothing back; a second stop on the mock returns at once; the monitor survives a full restart channel without blocking `Get()`; each monitor has its own tick source, driven by hand; one request per backend until it is taken and a request that did not fit is kept for the next tick; `RegisterError` keeps the restart record. Sixteen mutants killed in total.
- `GOWORK=off go test -count=1 -race ./...` green across the agent module; `make lint`, 0 issues. Every commit builds and passes the backend package on its own.
- Four adversarial passes on the design spec, one on the plan, a task review per commit, a whole-branch review and five Codex rounds shaped this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
