### PR TITLE
feat(agent): include last_restart_ts on heartbeats

### DIFF
--- a/agent/configmgr/fleet/heartbeat_reconnect_test.go
+++ b/agent/configmgr/fleet/heartbeat_reconnect_test.go
@@ -2,6 +2,7 @@ package fleet
 
 import (
 	"context"
+	"encoding/json"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -10,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-agent/agent/configmgr/fleet/messages"
 )
 
 // TestHeartbeater_MultipleStopStartCycles_OBS2315 exercises repeated disconnect/reconnect style
@@ -67,5 +70,63 @@ func TestHeartbeater_AtMostOnePublishAtATime(t *testing.T) {
 	hb.stop(testTopic, publish)
 
 	assert.LessOrEqual(t, maxConcurrent, 1, "heartbeats should not publish concurrently")
+	mockPublish.AssertExpectations(t)
+}
+
+// TestHeartbeater_StartHeartbeats_LastRestartTSUnchangedAfterReconnect verifies that
+// replacing the heartbeat session (MQTT reconnect) does not reset process-level last_restart_ts.
+func TestHeartbeater_StartHeartbeats_LastRestartTSUnchangedAfterReconnect(t *testing.T) {
+	hb := createTestHeartbeater()
+	mockPublish := &mockPublishFunc{}
+	ctx := context.Background()
+	testTopic := "test/heartbeat"
+
+	var mu sync.Mutex
+	var payloads [][]byte
+	publish := func(_ context.Context, _ string, payload []byte) error {
+		payloadCopy := make([]byte, len(payload))
+		copy(payloadCopy, payload)
+		mu.Lock()
+		payloads = append(payloads, payloadCopy)
+		mu.Unlock()
+		return mockPublish.Publish(ctx, testTopic, payload)
+	}
+	mockPublish.On("Publish", mock.Anything, testTopic, mock.AnythingOfType("[]uint8")).Return(nil).Maybe()
+
+	hb.StartHeartbeats(ctx, testTopic, "test-agent-id", publish, nil)
+	time.Sleep(80 * time.Millisecond)
+	hb.stop(testTopic, publish)
+
+	payloadCountAfterFirstSession := len(payloads)
+
+	hb.StartHeartbeats(ctx, testTopic, "test-agent-id", publish, nil)
+	time.Sleep(80 * time.Millisecond)
+	hb.stop(testTopic, publish)
+
+	mu.Lock()
+	allPayloads := append([][]byte(nil), payloads...)
+	mu.Unlock()
+
+	require.Greater(t, len(allPayloads), payloadCountAfterFirstSession)
+
+	var firstOnline, secondOnline messages.Heartbeat
+	for _, payload := range allPayloads {
+		var hbMsg messages.Heartbeat
+		require.NoError(t, json.Unmarshal(payload, &hbMsg))
+		if hbMsg.State != messages.State(messages.Online) {
+			continue
+		}
+		if firstOnline.LastRestartTS.IsZero() {
+			firstOnline = hbMsg
+			continue
+		}
+		secondOnline = hbMsg
+		break
+	}
+
+	require.False(t, firstOnline.LastRestartTS.IsZero())
+	require.False(t, secondOnline.LastRestartTS.IsZero())
+	assert.True(t, testFixedLastRestartTS.Equal(firstOnline.LastRestartTS))
+	assert.True(t, firstOnline.LastRestartTS.Equal(secondOnline.LastRestartTS))
 	mockPublish.AssertExpectations(t)
 }

--- a/agent/configmgr/fleet/heartbeats.go
+++ b/agent/configmgr/fleet/heartbeats.go
@@ -37,6 +37,7 @@ type heartbeater struct {
 	policyManager   policymgr.PolicyManager
 	groupRetriever  GroupRetriever
 	bundleRetriever BundleStateRetriever
+	lastRestartTS   time.Time
 
 	mu            sync.Mutex
 	sessionCancel context.CancelFunc
@@ -50,6 +51,7 @@ func newHeartbeater(logger *slog.Logger, backendState backend.StateRetriever, po
 		policyManager:   policyManager,
 		groupRetriever:  groupRetriever,
 		bundleRetriever: bundleRetriever,
+		lastRestartTS:   time.Now().UTC(),
 	}
 }
 
@@ -117,6 +119,7 @@ func (hb *heartbeater) sendSingleHeartbeat(ctx context.Context, heartbeatTopic s
 		SchemaVersion: messages.CurrentHeartbeatSchemaVersion,
 		TimeStamp:     time.Now().UTC(),
 		State:         messages.State(state),
+		LastRestartTS: hb.lastRestartTS,
 		BackendState:  hb.getBackendState(),
 		PolicyState:   hb.getPolicyState(),
 		GroupState:    hb.getGroupState(),

--- a/agent/configmgr/fleet/heartbeats_test.go
+++ b/agent/configmgr/fleet/heartbeats_test.go
@@ -31,6 +31,8 @@ type stubBundleRetriever struct {
 func (s stubBundleRetriever) List() []filesmgr.FileEntry        { return s.entries }
 func (s stubBundleRetriever) ListPending() []filesmgr.FileEntry { return s.pending }
 
+var testFixedLastRestartTS = time.Date(2026, 3, 19, 13, 0, 0, 0, time.UTC)
+
 func init() {
 	heartbeatTickInterval = 50 * time.Millisecond
 }
@@ -120,6 +122,7 @@ func createTestHeartbeater() *heartbeater {
 		backendState:   &mockBackendState{},
 		policyManager:  mockPMgr,
 		groupRetriever: &groupManager,
+		lastRestartTS:  testFixedLastRestartTS,
 	}
 }
 
@@ -133,6 +136,7 @@ func createTestHeartbeaterWithBackendState(backendState *mockBackendState) *hear
 		backendState:   backendState,
 		policyManager:  mockPMgr,
 		groupRetriever: &groupManager,
+		lastRestartTS:  testFixedLastRestartTS,
 	}
 }
 
@@ -144,6 +148,7 @@ func createTestHeartbeaterWithPolicyManager(backendState *mockBackendState, poli
 		backendState:   backendState,
 		policyManager:  policyManager,
 		groupRetriever: &groupManager,
+		lastRestartTS:  testFixedLastRestartTS,
 	}
 }
 
@@ -183,6 +188,7 @@ func TestHeartbeater_SendSingleHeartbeat_Success(t *testing.T) {
 	assert.Equal(t, messages.CurrentHeartbeatSchemaVersion, hbMsg.SchemaVersion)
 	assert.Equal(t, messages.State(messages.Online), hbMsg.State)
 	assert.False(t, hbMsg.TimeStamp.IsZero())
+	assert.True(t, testFixedLastRestartTS.Equal(hbMsg.LastRestartTS))
 }
 
 func TestHeartbeater_SendSingleHeartbeat_OfflineState(t *testing.T) {
@@ -236,6 +242,7 @@ func TestHeartbeater_OfflineHeartbeat_IncludesFailedRunsAfterFailNonTerminalRuns
 		backendState:   &mockBackendState{},
 		policyManager:  pm,
 		groupRetriever: &groupManager,
+		lastRestartTS:  testFixedLastRestartTS,
 	}
 
 	var captured []byte
@@ -316,6 +323,55 @@ func TestHeartbeater_SendSingleHeartbeat_HeartbeatContent(t *testing.T) {
 	assert.Equal(t, messages.CurrentHeartbeatSchemaVersion, heartbeat.SchemaVersion)
 	assert.Equal(t, messages.State(1), heartbeat.State)
 	assert.False(t, heartbeat.TimeStamp.IsZero())
+}
+
+func TestHeartbeater_SendSingleHeartbeat_IncludesLastRestartTS(t *testing.T) {
+	hb := createTestHeartbeater()
+
+	var capturedPayload []byte
+	publishFunc := func(_ context.Context, _ string, payload []byte) error {
+		capturedPayload = payload
+		return nil
+	}
+
+	hb.sendSingleHeartbeat(context.Background(), "test/heartbeat", publishFunc, "test-agent-id", time.Now(), messages.Online, nil)
+
+	require.NotNil(t, capturedPayload)
+
+	var heartbeat messages.Heartbeat
+	require.NoError(t, json.Unmarshal(capturedPayload, &heartbeat))
+
+	assert.Equal(t, "1.3", heartbeat.SchemaVersion)
+	assert.True(t, testFixedLastRestartTS.Equal(heartbeat.LastRestartTS))
+	assert.Contains(t, string(capturedPayload), `"last_restart_ts":"2026-03-19T13:00:00Z"`)
+}
+
+func TestHeartbeater_SendSingleHeartbeat_LastRestartTSStableAcrossPublishes(t *testing.T) {
+	hb := createTestHeartbeater()
+
+	var payloads [][]byte
+	publishFunc := func(_ context.Context, _ string, payload []byte) error {
+		payloadCopy := make([]byte, len(payload))
+		copy(payloadCopy, payload)
+		payloads = append(payloads, payloadCopy)
+		return nil
+	}
+
+	ctx := context.Background()
+	hb.sendSingleHeartbeat(ctx, "test/heartbeat", publishFunc, "test-agent-id", time.Now(), messages.Online, nil)
+	time.Sleep(2 * time.Millisecond)
+	hb.sendSingleHeartbeat(ctx, "test/heartbeat", publishFunc, "test-agent-id", time.Now(), messages.Online, nil)
+
+	require.Len(t, payloads, 2)
+
+	var hb1, hb2 messages.Heartbeat
+	require.NoError(t, json.Unmarshal(payloads[0], &hb1))
+	require.NoError(t, json.Unmarshal(payloads[1], &hb2))
+
+	assert.True(t, testFixedLastRestartTS.Equal(hb1.LastRestartTS))
+	assert.True(t, testFixedLastRestartTS.Equal(hb2.LastRestartTS))
+	assert.True(t, hb1.LastRestartTS.Equal(hb2.LastRestartTS))
+	assert.NotEqual(t, hb1.TimeStamp, hb2.TimeStamp)
 }
 
 func TestHeartbeater_SendHeartbeats_InitialHeartbeat(t *testing.T) {
@@ -1149,6 +1205,7 @@ func createTestHeartbeaterWithGroupManager(groupManager *GroupManager) *heartbea
 		backendState:   &mockBackendState{},
 		policyManager:  mockPMgr,
 		groupRetriever: groupManager,
+		lastRestartTS:  testFixedLastRestartTS,
 	}
 }
 
@@ -1276,6 +1333,7 @@ func TestHeartbeater_SendSingleHeartbeat_WithCompleteState(t *testing.T) {
 		backendState:   backendState,
 		policyManager:  mockPMgr,
 		groupRetriever: &gm,
+		lastRestartTS:  testFixedLastRestartTS,
 	}
 
 	var capturedPayload []byte
@@ -1854,6 +1912,7 @@ func TestHeartbeater_SendSingleHeartbeat_SerializesBundleState(t *testing.T) {
 		backendState:   &mockBackendState{},
 		policyManager:  &mockPolicyManagerForHeartbeat{},
 		groupRetriever: &groupManager,
+		lastRestartTS:  testFixedLastRestartTS,
 		bundleRetriever: stubBundleRetriever{entries: []filesmgr.FileEntry{
 			{
 				Name:        "nbl_cisco_meraki",
@@ -1906,6 +1965,7 @@ func TestHeartbeater_SendSingleHeartbeat_SerializesFailedBundleState(t *testing.
 		backendState:   &mockBackendState{},
 		policyManager:  &mockPolicyManagerForHeartbeat{},
 		groupRetriever: &groupManager,
+		lastRestartTS:  testFixedLastRestartTS,
 		bundleRetriever: stubBundleRetriever{
 			entries: []filesmgr.FileEntry{
 				{

--- a/agent/configmgr/fleet/messages/fleet_messages.go
+++ b/agent/configmgr/fleet/messages/fleet_messages.go
@@ -103,6 +103,7 @@ type Heartbeat struct {
 	SchemaVersion string                      `json:"schema_version"`
 	TimeStamp     time.Time                   `json:"ts"`
 	State         State                       `json:"state"`
+	LastRestartTS time.Time                   `json:"last_restart_ts,omitempty"`
 	BackendState  map[string]BackendStateInfo `json:"backend_state"`
 	PolicyState   map[string]PolicyStateInfo  `json:"policy_state"`
 	GroupState    map[string]GroupStateInfo   `json:"group_state"`


### PR DESCRIPTION
## Summary

Agent heartbeats now include a top-level `last_restart_ts` field at schema version 1.3. The value represents when the orb-agent process started, not when an individual backend or MQTT session restarted.

## What changed

- Added `LastRestartTS` to the `Heartbeat` message struct (`fleet_messages.go`).
- The heartbeater captures `time.Now().UTC()` once in `newHeartbeater` and includes it on every heartbeat publish.
- Backend-level `backend_state.*.last_restart_ts` is unchanged.
- Added tests for field presence, stability across consecutive publishes, and unchanged value after a reconnect-style `StartHeartbeats` cycle.

## How tested

- `make fix-lint`
- `go test -race -count=1 -run 'TestHeartbeater|TestCurrentHeartbeatSchemaVersion' ./agent/configmgr/fleet/...`

## Follow-ups (out of scope)

- **orb-pro**: persist `last_restart_ts` from heartbeat JSON into agent `lastHbData` in Fleet AMQP.
- **UI (ASUR-627)**: use agent-level restart time for uptime once Fleet exposes it.

## Linear

ASUR-628 — https://linear.app/netboxlabs/issue/ASUR-628/agent-response-does-not-include-last-restart-timestamp

Made with [Cursor](https://cursor.com)