### PR TITLE
feat(snmp-discovery): let vlan.group choose the NetBox scope of the VLAN group

### DIFF
--- a/docs/backends/snmp_discovery/README.md
+++ b/docs/backends/snmp_discovery/README.md
@@ -139,7 +139,7 @@ SNMP discovery policies are broken down into two subsections: `config` and `scop
 | vlan    | map  | VLAN-specific defaults  |
 | ├─ description | string  | VLAN description |
 | ├─ tags | list | Per-VLAN tags. Merged with the top-level `tags` list on each emitted VLAN entity, mirroring the `device`/`interface`/`ip_address` defaults pattern. |
-| ├─ group | string | VLAN group name. When set, every emitted VLAN is attached to an `ipam.vlangroup` scoped to `defaults.site`: the group's `scope_site` is populated from `defaults.site` |
+| ├─ group | string \| map | VLAN group. A bare name attaches every emitted VLAN to an `ipam.vlangroup` scoped to `defaults.site`. The map form takes `name` plus one optional scope: `scope_site`, `scope_site_group`, `scope_region` or `scope_location` (see the [VLAN group map](#vlan-group-map) below). In a per-target `override_defaults`, the group replaces the policy value as a whole |
 | ├─ tenant | string | VLAN tenant |
 | ├─ status | string | VLAN status override (`active`, `reserved`, `deprecated`). When unset, status is derived from `dot1qVlanStaticRowStatus`: `active(1)` → `active`, `notInService(2)` → `reserved`. |
 
@@ -153,6 +153,28 @@ The top-level `tenant` default accepts either a bare string (tenant name) or a m
 | description | string  | Tenant description |
 | comments | string  | Tenant comments |
 | tags | list  | Tenant tags |
+
+##### VLAN Group Map
+Diode matches a VLAN group on its name and scope, so the group must be scoped the way it is in NetBox. With a bare name the group is scoped to `defaults.site`. When VLANs are shared across several sites, scope the group to the site group, region or location that holds them instead:
+
+```yaml
+defaults:
+  site: "mysite01"
+  vlan:
+    group:
+      name: "Brussels VLAN Group"
+      scope_site_group: "Brussels"
+```
+
+| Parameter | Type | Description |
+|---------|----|-----------|
+| name | string | VLAN group name (required in the map form) |
+| scope_site | string | Scope the group to this site instead of `defaults.site` |
+| scope_site_group | string | Scope the group to a site group |
+| scope_region | string | Scope the group to a region |
+| scope_location | string | Scope the group to a location. Locations are unique per site in NetBox, so `defaults.site` is sent with it |
+
+Only one `scope_*` may be set; a map with none behaves like the bare name. Rack and cluster scopes are not supported.
 
 ### Scope Section
 | Parameter | Type | Required | Description |

--- a/orb-discovery/snmp-discovery/config/config.go
+++ b/orb-discovery/snmp-discovery/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -255,13 +256,60 @@ type DeviceDefaults struct {
 	Platform     string   `yaml:"platform,omitempty"`
 }
 
+// VLANGroupParameters names the VLAN group discovered VLANs are attached
+// to and the NetBox object the group is scoped to. A bare string is the
+// group name; the mapping form adds at most one scope_* field. With no
+// scope the group is scoped to defaults.site, as the string form is.
+type VLANGroupParameters struct {
+	Name           string `yaml:"name,omitempty"`
+	ScopeSite      string `yaml:"scope_site,omitempty"`
+	ScopeSiteGroup string `yaml:"scope_site_group,omitempty"`
+	ScopeRegion    string `yaml:"scope_region,omitempty"`
+	ScopeLocation  string `yaml:"scope_location,omitempty"`
+}
+
+// UnmarshalYAML accepts a scalar group name or a mapping.
+func (g *VLANGroupParameters) UnmarshalYAML(node *yaml.Node) error {
+	*g = VLANGroupParameters{}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if node.Tag == "!!null" {
+			return nil
+		}
+		g.Name = node.Value
+		return nil
+	case yaml.MappingNode:
+		type alias VLANGroupParameters
+		var a alias
+		if err := node.Decode(&a); err != nil {
+			return err
+		}
+		if a.Name == "" {
+			return errors.New("vlan.group: name is required")
+		}
+		scopes := 0
+		for _, v := range []string{a.ScopeSite, a.ScopeSiteGroup, a.ScopeRegion, a.ScopeLocation} {
+			if v != "" {
+				scopes++
+			}
+		}
+		if scopes > 1 {
+			return errors.New("vlan.group: only one scope may be set (scope_site, scope_site_group, scope_region, scope_location)")
+		}
+		*g = VLANGroupParameters(a)
+		return nil
+	default:
+		return fmt.Errorf("vlan.group: expected string or mapping, got node kind %d", node.Kind)
+	}
+}
+
 // VLANDefaults represents default values applied to discovered VLAN entities.
 type VLANDefaults struct {
-	Description string   `yaml:"description,omitempty"`
-	Tags        []string `yaml:"tags,omitempty"`
-	Group       string   `yaml:"group,omitempty"`
-	Tenant      string   `yaml:"tenant,omitempty"`
-	Status      string   `yaml:"status,omitempty"`
+	Description string              `yaml:"description,omitempty"`
+	Tags        []string            `yaml:"tags,omitempty"`
+	Group       VLANGroupParameters `yaml:"group,omitempty"`
+	Tenant      string              `yaml:"tenant,omitempty"`
+	Status      string              `yaml:"status,omitempty"`
 }
 
 // Defaults represents the supported default values for a policy
@@ -424,7 +472,7 @@ func MergeDefaults(policyDefaults, overrideDefaults *Defaults) *Defaults {
 	if len(overrideDefaults.VLAN.Tags) > 0 {
 		merged.VLAN.Tags = overrideDefaults.VLAN.Tags
 	}
-	if overrideDefaults.VLAN.Group != "" {
+	if overrideDefaults.VLAN.Group.Name != "" {
 		merged.VLAN.Group = overrideDefaults.VLAN.Group
 	}
 	if overrideDefaults.VLAN.Tenant != "" {

--- a/orb-discovery/snmp-discovery/config/config.go
+++ b/orb-discovery/snmp-discovery/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -269,6 +270,11 @@ type VLANGroupParameters struct {
 }
 
 // UnmarshalYAML accepts a scalar group name or a mapping.
+//
+// An unknown key in the mapping is an error rather than the warning the
+// rest of the policy gets: the warning pass cannot see inside a custom
+// decoder, and a misspelled scope would otherwise fall back to a
+// site-scoped group that then persists in NetBox.
 func (g *VLANGroupParameters) UnmarshalYAML(node *yaml.Node) error {
 	*g = VLANGroupParameters{}
 	switch node.Kind {
@@ -279,6 +285,12 @@ func (g *VLANGroupParameters) UnmarshalYAML(node *yaml.Node) error {
 		g.Name = node.Value
 		return nil
 	case yaml.MappingNode:
+		known := yamlFieldNames(reflect.TypeFor[VLANGroupParameters]())
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			if key := node.Content[i].Value; !known[key] {
+				return fmt.Errorf("vlan.group: unknown key %s", key)
+			}
+		}
 		type alias VLANGroupParameters
 		var a alias
 		if err := node.Decode(&a); err != nil {

--- a/orb-discovery/snmp-discovery/config/config_test.go
+++ b/orb-discovery/snmp-discovery/config/config_test.go
@@ -507,7 +507,7 @@ func TestMergeDefaults_VLAN(t *testing.T) {
 		VLAN: VLANDefaults{
 			Description: "policy desc",
 			Tags:        []string{"policy-tag"},
-			Group:       "policy-group",
+			Group:       VLANGroupParameters{Name: "policy-group", ScopeSiteGroup: "policy-sg"},
 			Tenant:      "policy-tenant",
 			Status:      "active",
 		},
@@ -523,7 +523,7 @@ func TestMergeDefaults_VLAN(t *testing.T) {
 
 	assert.Equal(t, "override desc", merged.VLAN.Description)
 	assert.Equal(t, []string{"override-tag"}, merged.VLAN.Tags)
-	assert.Equal(t, "policy-group", merged.VLAN.Group, "Group should be preserved from policy")
+	assert.Equal(t, VLANGroupParameters{Name: "policy-group", ScopeSiteGroup: "policy-sg"}, merged.VLAN.Group, "Group should be preserved from policy")
 	assert.Equal(t, "override-tenant", merged.VLAN.Tenant)
 	assert.Equal(t, "active", merged.VLAN.Status, "Status should be preserved from policy")
 }
@@ -932,4 +932,77 @@ func TestPrefixVlanMode(t *testing.T) {
 	nonsense := "nonsense"
 	assert.Equal(t, "off", (&Options{EmitPrefixVlan: &nonsense}).PrefixVlanMode(),
 		"an unrecognised value must fail closed, never guess")
+}
+
+func TestMergeDefaults_VLANGroupReplacedWhole(t *testing.T) {
+	policy := &Defaults{
+		VLAN: VLANDefaults{Group: VLANGroupParameters{Name: "policy-group", ScopeSiteGroup: "policy-sg"}},
+	}
+	override := &Defaults{
+		VLAN: VLANDefaults{Group: VLANGroupParameters{Name: "override-group"}},
+	}
+	merged := MergeDefaults(policy, override)
+
+	assert.Equal(t, VLANGroupParameters{Name: "override-group"}, merged.VLAN.Group,
+		"an override group replaces the whole value; the policy scope must not leak in")
+}
+
+func TestVLANGroupParameters_UnmarshalScalar(t *testing.T) {
+	var d VLANDefaults
+	require.NoError(t, yaml.Unmarshal([]byte("group: campus-vlans\n"), &d))
+	assert.Equal(t, VLANGroupParameters{Name: "campus-vlans"}, d.Group)
+}
+
+func TestVLANGroupParameters_UnmarshalMapping(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want VLANGroupParameters
+	}{
+		{
+			"site group", "group:\n  name: Brussels VLAN Group\n  scope_site_group: Brussels\n",
+			VLANGroupParameters{Name: "Brussels VLAN Group", ScopeSiteGroup: "Brussels"},
+		},
+		{"site", "group:\n  name: g\n  scope_site: s\n", VLANGroupParameters{Name: "g", ScopeSite: "s"}},
+		{"region", "group:\n  name: g\n  scope_region: r\n", VLANGroupParameters{Name: "g", ScopeRegion: "r"}},
+		{"location", "group:\n  name: g\n  scope_location: l\n", VLANGroupParameters{Name: "g", ScopeLocation: "l"}},
+		{"no scope", "group:\n  name: g\n", VLANGroupParameters{Name: "g"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var d VLANDefaults
+			require.NoError(t, yaml.Unmarshal([]byte(tt.yaml), &d))
+			assert.Equal(t, tt.want, d.Group)
+		})
+	}
+}
+
+func TestVLANGroupParameters_UnmarshalErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{"two scopes", "group:\n  name: g\n  scope_site: s\n  scope_site_group: sg\n", "only one scope"},
+		{"missing name", "group:\n  scope_site_group: sg\n", "name is required"},
+		{"bad kind", "group:\n  - g\n", "expected string or mapping"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var d VLANDefaults
+			err := yaml.Unmarshal([]byte(tt.yaml), &d)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestVLANGroupParameters_UnmarshalNullAndReceiverReset(t *testing.T) {
+	d := VLANDefaults{Group: VLANGroupParameters{Name: "stale", ScopeRegion: "stale"}}
+	require.NoError(t, yaml.Unmarshal([]byte("group: fresh\n"), &d))
+	assert.Equal(t, VLANGroupParameters{Name: "fresh"}, d.Group, "scalar form must clear a stale scope")
+
+	var fresh VLANDefaults
+	require.NoError(t, yaml.Unmarshal([]byte("group: null\n"), &fresh))
+	assert.Equal(t, VLANGroupParameters{}, fresh.Group)
 }

--- a/orb-discovery/snmp-discovery/config/config_test.go
+++ b/orb-discovery/snmp-discovery/config/config_test.go
@@ -985,6 +985,7 @@ func TestVLANGroupParameters_UnmarshalErrors(t *testing.T) {
 	}{
 		{"two scopes", "group:\n  name: g\n  scope_site: s\n  scope_site_group: sg\n", "only one scope"},
 		{"missing name", "group:\n  scope_site_group: sg\n", "name is required"},
+		{"unknown key", "group:\n  name: g\n  scope_regoin: r\n", "unknown key scope_regoin"},
 		{"bad kind", "group:\n  - g\n", "expected string or mapping"},
 	}
 	for _, tt := range tests {

--- a/orb-discovery/snmp-discovery/mapping/vlan_mapper.go
+++ b/orb-discovery/snmp-discovery/mapping/vlan_mapper.go
@@ -272,16 +272,37 @@ func applyVLANDefaults(v *diode.VLAN, defaults *config.Defaults) {
 	if vd.Tenant != "" {
 		v.Tenant = &diode.Tenant{Name: StringPtr(vd.Tenant)}
 	}
-	if vd.Group != "" {
-		name := vd.Group
+	if vd.Group.Name != "" {
+		name := vd.Group.Name
 		group := &diode.VLANGroup{Name: &name, Slug: toSlug(&name)}
-		if defaults.Site != "" {
-			group.Scope = &diode.Site{Name: StringPtr(defaults.Site)}
-		}
+		setVLANGroupScope(group, vd.Group, defaults.Site)
 		v.Group = group
 	}
 	if vd.Status != "" {
 		v.Status = StringPtr(vd.Status)
+	}
+}
+
+// setVLANGroupScope attaches the configured scope to a VLAN group. An
+// explicit scope_* wins; otherwise defaults.site applies, so the string
+// form of vlan.group keeps its site scope. NetBox Locations are unique
+// within their site, so a Location scope carries defaults.site when set.
+func setVLANGroupScope(group *diode.VLANGroup, g config.VLANGroupParameters, defaultSite string) {
+	switch {
+	case g.ScopeSiteGroup != "":
+		group.Scope = &diode.SiteGroup{Name: StringPtr(g.ScopeSiteGroup)}
+	case g.ScopeRegion != "":
+		group.Scope = &diode.Region{Name: StringPtr(g.ScopeRegion)}
+	case g.ScopeLocation != "":
+		loc := &diode.Location{Name: StringPtr(g.ScopeLocation)}
+		if defaultSite != "" {
+			loc.Site = &diode.Site{Name: StringPtr(defaultSite)}
+		}
+		group.Scope = loc
+	case g.ScopeSite != "":
+		group.Scope = &diode.Site{Name: StringPtr(g.ScopeSite)}
+	case defaultSite != "":
+		group.Scope = &diode.Site{Name: StringPtr(defaultSite)}
 	}
 }
 

--- a/orb-discovery/snmp-discovery/mapping/vlan_mapper_test.go
+++ b/orb-discovery/snmp-discovery/mapping/vlan_mapper_test.go
@@ -319,7 +319,7 @@ func TestVlanMapper_EmitVLANs_AppliesDefaults(t *testing.T) {
 			Description: "auto-discovered",
 			Tags:        []string{"vlan-tag"},
 			Tenant:      "NetOps",
-			Group:       "campus-vlans",
+			Group:       config.VLANGroupParameters{Name: "campus-vlans"},
 		},
 	}
 
@@ -460,7 +460,7 @@ func TestApplyVLANDefaults_GroupScopeSite_WhenSiteDefined(t *testing.T) {
 	v := &diode.VLAN{}
 	defaults := &config.Defaults{
 		Site: "NYC",
-		VLAN: config.VLANDefaults{Group: "Lab VLAN Group"},
+		VLAN: config.VLANDefaults{Group: config.VLANGroupParameters{Name: "Lab VLAN Group"}},
 	}
 
 	applyVLANDefaults(v, defaults)
@@ -490,7 +490,7 @@ func TestApplyVLANDefaults_GroupScopeSite_WhenSiteUndefined(t *testing.T) {
 	v := &diode.VLAN{}
 	defaults := &config.Defaults{
 		Site: "undefined",
-		VLAN: config.VLANDefaults{Group: "campus-vlans"},
+		VLAN: config.VLANDefaults{Group: config.VLANGroupParameters{Name: "campus-vlans"}},
 	}
 
 	applyVLANDefaults(v, defaults)
@@ -515,7 +515,7 @@ func TestApplyVLANDefaults_GroupScopeSite_WhenSiteUndefined(t *testing.T) {
 func TestApplyVLANDefaults_GroupNoScopeSite_WhenSiteEmpty(t *testing.T) {
 	v := &diode.VLAN{}
 	defaults := &config.Defaults{
-		VLAN: config.VLANDefaults{Group: "campus-vlans"},
+		VLAN: config.VLANDefaults{Group: config.VLANGroupParameters{Name: "campus-vlans"}},
 	}
 
 	applyVLANDefaults(v, defaults)
@@ -824,4 +824,91 @@ func TestEmitVLANs_Dot1qWinsOverVtpForTheSameVid(t *testing.T) {
 	ents := m.emitVLANs(oids, nil)
 	require.Len(t, ents, 1)
 	assert.Equal(t, "from-dot1q", *ents[0].(*diode.VLAN).Name)
+}
+
+// applyVLANDefaults: the map form of vlan.group picks the scope NetBox
+// attaches the group to. An explicit scope wins over defaults.site; a map
+// without one falls back to defaults.site like the string form.
+func TestApplyVLANDefaults_GroupExplicitScope(t *testing.T) {
+	tests := []struct {
+		name  string
+		group config.VLANGroupParameters
+		check func(t *testing.T, scope any)
+	}{
+		{"site group", config.VLANGroupParameters{Name: "g", ScopeSiteGroup: "Brussels"}, func(t *testing.T, scope any) {
+			sg, ok := scope.(*diode.SiteGroup)
+			if !ok {
+				t.Fatalf("scope: got %T, want *diode.SiteGroup", scope)
+			}
+			if sg.Name == nil || *sg.Name != "Brussels" {
+				t.Errorf("SiteGroup.Name: got %v, want Brussels", sg.Name)
+			}
+		}},
+		{"region", config.VLANGroupParameters{Name: "g", ScopeRegion: "Benelux"}, func(t *testing.T, scope any) {
+			r, ok := scope.(*diode.Region)
+			if !ok {
+				t.Fatalf("scope: got %T, want *diode.Region", scope)
+			}
+			if r.Name == nil || *r.Name != "Benelux" {
+				t.Errorf("Region.Name: got %v, want Benelux", r.Name)
+			}
+		}},
+		{"explicit site overrides defaults.site", config.VLANGroupParameters{Name: "g", ScopeSite: "other"}, func(t *testing.T, scope any) {
+			s, ok := scope.(*diode.Site)
+			if !ok {
+				t.Fatalf("scope: got %T, want *diode.Site", scope)
+			}
+			if s.Name == nil || *s.Name != "other" {
+				t.Errorf("Site.Name: got %v, want other", s.Name)
+			}
+		}},
+		{"location carries defaults.site", config.VLANGroupParameters{Name: "g", ScopeLocation: "Floor 2"}, func(t *testing.T, scope any) {
+			l, ok := scope.(*diode.Location)
+			if !ok {
+				t.Fatalf("scope: got %T, want *diode.Location", scope)
+			}
+			if l.Name == nil || *l.Name != "Floor 2" {
+				t.Errorf("Location.Name: got %v, want Floor 2", l.Name)
+			}
+			if l.Site == nil || l.Site.Name == nil || *l.Site.Name != "NYC" {
+				t.Errorf("Location.Site: got %v, want NYC", l.Site)
+			}
+		}},
+		{"map without scope falls back to defaults.site", config.VLANGroupParameters{Name: "g"}, func(t *testing.T, scope any) {
+			s, ok := scope.(*diode.Site)
+			if !ok {
+				t.Fatalf("scope: got %T, want *diode.Site", scope)
+			}
+			if s.Name == nil || *s.Name != "NYC" {
+				t.Errorf("Site.Name: got %v, want NYC", s.Name)
+			}
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &diode.VLAN{}
+			applyVLANDefaults(v, &config.Defaults{Site: "NYC", VLAN: config.VLANDefaults{Group: tt.group}})
+			if v.Group == nil {
+				t.Fatal("Group: got nil, want non-nil")
+			}
+			if v.Group.Slug == nil || *v.Group.Slug != "g" {
+				t.Errorf("Group.Slug: got %v, want g", v.Group.Slug)
+			}
+			tt.check(t, v.Group.Scope)
+		})
+	}
+}
+
+// A location scope with no site anywhere is still emitted; NetBox rejects
+// it rather than the agent guessing a site.
+func TestApplyVLANDefaults_GroupLocationWithoutSite(t *testing.T) {
+	v := &diode.VLAN{}
+	applyVLANDefaults(v, &config.Defaults{VLAN: config.VLANDefaults{Group: config.VLANGroupParameters{Name: "g", ScopeLocation: "Floor 2"}}})
+	l, ok := v.Group.Scope.(*diode.Location)
+	if !ok {
+		t.Fatalf("scope: got %T, want *diode.Location", v.Group.Scope)
+	}
+	if l.Site != nil {
+		t.Errorf("Location.Site: got %v, want nil", l.Site)
+	}
 }


### PR DESCRIPTION
## Summary

Fixes the snmp-discovery half of #607.

- `vlan.group` keeps accepting a bare name, scoped to `defaults.site` as before.
- It also accepts a map with `name` and one of `scope_site`, `scope_site_group`, `scope_region` or `scope_location`. A location scope carries `defaults.site`, as prefix `scope_location` already does.
- A map with no scope behaves like the bare name. Two scopes at once, or a map without a name, fails policy parsing with a clear message.
- In a per-target `override_defaults`, the group replaces the policy value as a whole so a scope cannot leak between forms.

Diode matches VLAN groups on name plus scope, so a group that exists in NetBox with a site-group scope could never be matched by the site-scoped group the agent sent, and a duplicate was created.

## Config

```yaml
defaults:
  site: "mysite01"
  vlan:
    group:
      name: "Brussels VLAN Group"
      scope_site_group: "Brussels"
```

## Testing

- Config decoding tests for the string form, each scope, no scope, two scopes, missing name, bad node kind and receiver reset.
- Mapper tests for each emitted scope type, explicit site overriding `defaults.site`, location carrying the site, and the map-without-scope fallback.
- `go test ./...` and `golangci-lint` pass on the module.

Device-discovery and gnmi-discovery follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
