### PR TITLE
feat(device-discovery): let vlan.group choose the NetBox scope of the VLAN group

### DIFF
--- a/docs/backends/device_discovery/README.md
+++ b/docs/backends/device_discovery/README.md
@@ -233,13 +233,34 @@ Current supported defaults:
 | ├─ comments | str | VRF comments |
 | ├─ tags | list | VRF tags |
 | vlan       | map  | VLAN-specific defaults        |
-| ├─ group   | str  | VLAN group name. When set, every emitted VLAN is attached to an `ipam.vlangroup` scoped to `defaults.site`: the group's `scope_site` is populated from `defaults.site` |
+| ├─ group   | str/map  | VLAN group. A bare name attaches every emitted VLAN to an `ipam.vlangroup` scoped to `defaults.site`. The map form takes `name` plus one optional scope: `scope_site`, `scope_site_group`, `scope_region` or `scope_location` (see [VLAN group](#vlan-group) below). In a per-device `override_defaults`, the group replaces the policy value as a whole |
 | ├─ tenant   | str  | VLAN tenant                  |
 | ├─ role   | str  | VLAN role                      |
 | ├─ description | str  | VLAN description          |
 | ├─ comments   | str  | VLAN comments              |
 | ├─ tags       | list | VLAN tags                  |
 
+##### VLAN group
+Diode matches a VLAN group on its name and scope, so the group must be scoped the way it is in NetBox. With a bare name the group is scoped to `defaults.site`. When VLANs are shared across several sites, scope the group to the site group, region or location that holds them instead:
+
+```yaml
+defaults:
+  site: "mysite01"
+  vlan:
+    group:
+      name: "Brussels VLAN Group"
+      scope_site_group: "Brussels"
+```
+
+| Parameter | Type | Description |
+|---------|----|-----------|
+| name | str | VLAN group name (required in the map form) |
+| scope_site | str | Scope the group to this site instead of `defaults.site` |
+| scope_site_group | str | Scope the group to a site group |
+| scope_region | str | Scope the group to a region |
+| scope_location | str | Scope the group to a location. Locations are unique per site in NetBox, so `defaults.site` is sent with it |
+
+Only one `scope_*` may be set; a map with none behaves like the bare name. Rack and cluster scopes are not supported.
 
 ### Scope
 The scope defines a list of devices that can be accessed and pulled data. 

--- a/orb-discovery/device-discovery/device_discovery/policy/models.py
+++ b/orb-discovery/device-discovery/device_discovery/policy/models.py
@@ -105,10 +105,45 @@ class VrfParameters(ObjectParameters):
     rd: str | None = Field(default=None, description="Route distinguisher, optional")
 
 
+class VlanGroupParameters(BaseModel):
+    """
+    VLAN group discovered VLANs are attached to, and the NetBox object it is scoped to.
+
+    At most one ``scope_*`` may be set. With none, the group is scoped to
+    ``defaults.site``, as a bare group name is.
+    """
+
+    name: str
+    scope_site: str | None = Field(default=None, description="Scope the group to this site")
+    scope_site_group: str | None = Field(default=None, description="Scope the group to a site group")
+    scope_region: str | None = Field(default=None, description="Scope the group to a region")
+    scope_location: str | None = Field(
+        default=None,
+        description="Scope the group to a location; ``defaults.site`` is sent with it",
+    )
+
+    @model_validator(mode="after")
+    def _single_scope(self) -> "VlanGroupParameters":
+        scopes = [
+            self.scope_site,
+            self.scope_site_group,
+            self.scope_region,
+            self.scope_location,
+        ]
+        if sum(1 for scope in scopes if scope) > 1:
+            raise ValueError(
+                "only one scope may be set (scope_site, scope_site_group, scope_region, scope_location)"
+            )
+        return self
+
+
 class VlanParameters(ObjectParameters):
     """Model for VLAN parameters."""
 
-    group: str | None = Field(default=None, description="VLAN group, optional")
+    group: str | VlanGroupParameters | None = Field(
+        default=None,
+        description="VLAN group: a bare name, or a map with name and one optional scope_*",
+    )
     tenant: str | TenantParameters | None = Field(
         default=None, description="VLAN tenant, optional"
     )

--- a/orb-discovery/device-discovery/device_discovery/policy/models.py
+++ b/orb-discovery/device-discovery/device_discovery/policy/models.py
@@ -10,7 +10,7 @@ from enum import Enum
 from typing import Any, Literal
 
 from croniter import CroniterBadCronError, croniter
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from device_discovery.policy.portscan import (
     MAX_EXPANDED_HOSTS as _MAX_EXPANDED_HOSTS,
@@ -110,8 +110,12 @@ class VlanGroupParameters(BaseModel):
     VLAN group discovered VLANs are attached to, and the NetBox object it is scoped to.
 
     At most one ``scope_*`` may be set. With none, the group is scoped to
-    ``defaults.site``, as a bare group name is.
+    ``defaults.site``, as a bare group name is. Unknown keys are rejected: a
+    misspelled scope would otherwise fall back to a site-scoped group that
+    then persists in NetBox.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     name: str
     scope_site: str | None = Field(default=None, description="Scope the group to this site")

--- a/orb-discovery/device-discovery/device_discovery/policy/runner.py
+++ b/orb-discovery/device-discovery/device_discovery/policy/runner.py
@@ -85,6 +85,22 @@ def _deep_merge(base: dict, override: dict) -> dict:
     return merged
 
 
+def merge_override_defaults(base: Defaults, override: Defaults) -> Defaults:
+    """
+    Overlay a target's ``override_defaults`` onto the policy defaults.
+
+    Fields merge recursively, except ``vlan.group``: an override group replaces
+    the policy group as a whole so a scope set on the policy cannot leak into
+    a group the override named without one.
+    """
+    override_dump = override.model_dump(exclude_unset=True, exclude_none=True)
+    merged = _deep_merge(base.model_dump(), override_dump)
+    override_group = override_dump.get("vlan", {}).get("group")
+    if override_group is not None:
+        merged["vlan"]["group"] = override_group
+    return Defaults.model_validate(merged)
+
+
 class PolicyRunner:
     """Policy Runner class."""
 
@@ -175,13 +191,9 @@ class PolicyRunner:
 
             config = self.config.model_copy(deep=True)
             if scope.override_defaults is not None:
-                merged = _deep_merge(
-                    config.defaults.model_dump(),
-                    scope.override_defaults.model_dump(
-                        exclude_unset=True, exclude_none=True
-                    ),
+                config.defaults = merge_override_defaults(
+                    config.defaults, scope.override_defaults
                 )
-                config.defaults = Defaults.model_validate(merged)
             hostnames, parsed_as_range = expand_hostnames(sanitized_hostname)
 
             if parsed_as_range:

--- a/orb-discovery/device-discovery/device_discovery/translate.py
+++ b/orb-discovery/device-discovery/device_discovery/translate.py
@@ -19,6 +19,9 @@ from netboxlabs.diode.sdk.ingester import (
     Location,
     Platform,
     Rack,
+    Region,
+    Site,
+    SiteGroup,
     Tenant,
     TenantGroup,
     VLANGroup,
@@ -32,6 +35,7 @@ from device_discovery.policy.models import (
     Defaults,
     Options,
     TenantParameters,
+    VlanGroupParameters,
     VrfParameters,
 )
 from device_discovery.proto_presence import blank_to_none
@@ -247,7 +251,7 @@ def translate_vlan(vid: str, vlan_name: str, defaults: Defaults) -> VLAN | None:
         tenant = translate_tenant(defaults.vlan.tenant)
         role = defaults.vlan.role
         if group:
-            group = VLANGroup(name=group, slug=slugify(group), scope_site=defaults.site)
+            group = translate_vlan_group(group, defaults.site)
 
     clean_name = " ".join(vlan_name.strip().split())
     vlan = VLAN(
@@ -262,6 +266,33 @@ def translate_vlan(vid: str, vlan_name: str, defaults: Defaults) -> VLAN | None:
     )
 
     return vlan
+
+
+def translate_vlan_group(
+    group: str | VlanGroupParameters, default_site: str | None
+) -> VLANGroup:
+    """
+    Build the VLAN group with the scope NetBox attaches it to.
+
+    An explicit ``scope_*`` wins; otherwise ``default_site`` applies, so a
+    bare group name keeps its site scope. NetBox locations are unique within
+    their site, so a location scope carries ``default_site`` when set.
+    """
+    if isinstance(group, str):
+        group = VlanGroupParameters(name=group)
+    scope: dict[str, Any] = {}
+    if group.scope_site_group:
+        scope["scope_site_group"] = SiteGroup(name=group.scope_site_group)
+    elif group.scope_region:
+        scope["scope_region"] = Region(name=group.scope_region)
+    elif group.scope_location:
+        site = Site(name=default_site) if default_site else None
+        scope["scope_location"] = Location(name=group.scope_location, site=site)
+    elif group.scope_site:
+        scope["scope_site"] = group.scope_site
+    elif default_site:
+        scope["scope_site"] = default_site
+    return VLANGroup(name=group.name, slug=slugify(group.name), **scope)
 
 
 def _build_vlan_cache(

--- a/orb-discovery/device-discovery/tests/test_vlan_group_scope.py
+++ b/orb-discovery/device-discovery/tests/test_vlan_group_scope.py
@@ -1,0 +1,111 @@
+"""Tests for the scope of the VLAN group that discovered VLANs are attached to."""
+
+import pytest
+from pydantic import ValidationError
+
+from device_discovery.policy.models import Defaults, VlanGroupParameters, VlanParameters
+from device_discovery.policy.runner import merge_override_defaults
+from device_discovery.translate import translate_vlan
+
+
+def test_group_accepts_bare_name():
+    """A bare string is the group name."""
+    assert VlanParameters(group="campus-vlans").group == "campus-vlans"
+
+
+def test_group_accepts_map_with_scope():
+    """The map form carries the name and one scope."""
+    params = VlanParameters.model_validate(
+        {"group": {"name": "Brussels VLAN Group", "scope_site_group": "Brussels"}}
+    )
+    assert params.group == VlanGroupParameters(
+        name="Brussels VLAN Group", scope_site_group="Brussels"
+    )
+
+
+def test_group_map_rejects_two_scopes():
+    """Two scopes at once is a validation error."""
+    with pytest.raises(ValidationError, match="only one scope"):
+        VlanParameters.model_validate(
+            {"group": {"name": "g", "scope_site": "s", "scope_site_group": "sg"}}
+        )
+
+
+def test_group_map_requires_name():
+    """The map form needs a name."""
+    with pytest.raises(ValidationError, match="name"):
+        VlanParameters.model_validate({"group": {"scope_site_group": "sg"}})
+
+
+def _defaults(group) -> Defaults:
+    return Defaults(site="NYC", vlan=VlanParameters(group=group))
+
+
+def test_translate_site_group_scope():
+    """scope_site_group is emitted as a SiteGroup scope, with no site."""
+    vlan = translate_vlan("10", "V10", _defaults(VlanGroupParameters(name="g", scope_site_group="Brussels")))
+
+    assert vlan.group.slug == "g"
+    assert vlan.group.scope_site_group.name == "Brussels"
+    assert vlan.group.scope_site.name == ""
+
+
+def test_translate_region_scope():
+    """scope_region is emitted as a Region scope, with no site."""
+    vlan = translate_vlan("10", "V10", _defaults(VlanGroupParameters(name="g", scope_region="Benelux")))
+
+    assert vlan.group.scope_region.name == "Benelux"
+    assert vlan.group.scope_site.name == ""
+
+
+def test_translate_explicit_site_wins_over_defaults_site():
+    """An explicit scope_site replaces defaults.site."""
+    vlan = translate_vlan("10", "V10", _defaults(VlanGroupParameters(name="g", scope_site="other")))
+
+    assert vlan.group.scope_site.name == "other"
+
+
+def test_translate_location_scope_carries_defaults_site():
+    """A location scope carries defaults.site, as NetBox locations are per site."""
+    vlan = translate_vlan("10", "V10", _defaults(VlanGroupParameters(name="g", scope_location="Floor 2")))
+
+    assert vlan.group.scope_location.name == "Floor 2"
+    assert vlan.group.scope_location.site.name == "NYC"
+    assert vlan.group.scope_site.name == ""
+
+
+def test_translate_location_scope_without_site():
+    """A location scope with no site anywhere is emitted without one."""
+    defaults = Defaults(site=None, vlan=VlanParameters(group=VlanGroupParameters(name="g", scope_location="Floor 2")))
+    vlan = translate_vlan("10", "V10", defaults)
+
+    assert vlan.group.scope_location.name == "Floor 2"
+    assert vlan.group.scope_location.site.name == ""
+
+
+def test_translate_map_without_scope_falls_back_to_defaults_site():
+    """A map with no scope behaves like the bare name."""
+    vlan = translate_vlan("10", "V10", _defaults(VlanGroupParameters(name="g")))
+
+    assert vlan.group.scope_site.name == "NYC"
+
+
+def test_override_replaces_group_as_a_whole():
+    """An override group replaces the policy group; the policy scope must not leak in."""
+    base = Defaults(vlan=VlanParameters(group=VlanGroupParameters(name="policy", scope_site_group="sg")))
+
+    as_name = merge_override_defaults(base, Defaults(vlan=VlanParameters(group="override")))
+    assert as_name.vlan.group == "override"
+
+    as_map = merge_override_defaults(base, Defaults(vlan=VlanParameters(group=VlanGroupParameters(name="override"))))
+    assert as_map.vlan.group == VlanGroupParameters(name="override")
+
+
+def test_override_without_group_keeps_policy_group():
+    """An override that does not name a group keeps the policy group intact."""
+    base = Defaults(vlan=VlanParameters(group=VlanGroupParameters(name="policy", scope_site_group="sg")))
+
+    merged = merge_override_defaults(base, Defaults(vlan=VlanParameters(tenant="t")))
+
+    assert merged.vlan.group == VlanGroupParameters(name="policy", scope_site_group="sg")
+    assert merged.vlan.tenant == "t"

--- a/orb-discovery/device-discovery/tests/test_vlan_group_scope.py
+++ b/orb-discovery/device-discovery/tests/test_vlan_group_scope.py
@@ -31,6 +31,12 @@ def test_group_map_rejects_two_scopes():
         )
 
 
+def test_group_map_rejects_unknown_key():
+    """A misspelled scope key is rejected instead of silently falling back to a site scope."""
+    with pytest.raises(ValidationError, match="scope_regoin"):
+        VlanParameters.model_validate({"group": {"name": "g", "scope_regoin": "r"}})
+
+
 def test_group_map_requires_name():
     """The map form needs a name."""
     with pytest.raises(ValidationError, match="name"):


### PR DESCRIPTION
## Summary

Device-discovery half of #607, same config shape as #609 for snmp-discovery.

- `vlan.group` keeps accepting a bare name, scoped to `defaults.site` as before.
- It also accepts a map with `name` and one of `scope_site`, `scope_site_group`, `scope_region` or `scope_location`. A location scope carries `defaults.site`, as prefix `scope_location` already does.
- A map with no scope behaves like the bare name. Two scopes at once, or a map without a name, fails policy validation with a clear message.
- A per-device `override_defaults.vlan.group` replaces the policy group as a whole. The generic deep merge would otherwise carry a policy `scope_site_group` into an override that only named a group.

## Config

```yaml
defaults:
  site: "mysite01"
  vlan:
    group:
      name: "Brussels VLAN Group"
      scope_site_group: "Brussels"
```

## Testing

- Model tests for the string form, the map form, two scopes and a missing name.
- Translate tests for each emitted scope type, explicit site over `defaults.site`, location carrying the site, location without a site, and the map-without-scope fallback.
- Override merge tests for replace-as-a-whole and for an override that leaves the group alone.
- `pytest` and `ruff check` pass on the module.

gnmi-discovery follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
