### PR TITLE
feat(gnmi-discovery): let vlan.group choose the NetBox scope of the VLAN group

### DIFF
--- a/docs/backends/gnmi_discovery.md
+++ b/docs/backends/gnmi_discovery.md
@@ -71,8 +71,31 @@ gNMI discovery policies are broken into two subsections: `config` and `scope`.
 | interface | map | Interface defaults: `if_type` (fallback type, default `other`), `description`, `tags` |
 | ip_address | map | IP address defaults: `role`, `tenant`, `description`, `comments`, `tags` |
 | vrf | map | VRF defaults: `tenant`, `description`, `comments`, `tags` (name/RD come from discovery) |
+| vlan | map | VLAN defaults: `group` (see [VLAN group](#vlan-group)), `tenant`, `role`, `description`, `tags` |
 | interface_patterns | list | Name-regex → NetBox type, highest precedence (first match wins). |
 | interface_exclude_patterns | list | Name-regex; matching interfaces are skipped entirely. |
+
+##### VLAN group
+`vlan.group` attaches every emitted VLAN to an `ipam.vlangroup`. Diode matches a VLAN group on its name and scope, so the group must be scoped the way it is in NetBox. A bare name scopes the group to the device's site. When VLANs are shared across several sites, scope the group to the site group, region or location that holds them instead:
+
+```yaml
+defaults:
+  site: "mysite01"
+  vlan:
+    group:
+      name: "Brussels VLAN Group"
+      scope_site_group: "Brussels"
+```
+
+| Key | Type | Description |
+|:---:|:----:|:-----------:|
+| name | str | VLAN group name (required in the map form) |
+| scope_site | str | Scope the group to this site instead of the device's site |
+| scope_site_group | str | Scope the group to a site group |
+| scope_region | str | Scope the group to a region |
+| scope_location | str | Scope the group to a location. Locations are unique per site in NetBox, so the device's site is sent with it |
+
+Only one `scope_*` may be set; a map with none behaves like the bare name. An unknown key in the map, two scopes, or a missing name rejects the policy rather than falling back to a site-scoped group. In a per-target `override_defaults`, the group replaces the policy value as a whole. Rack and cluster scopes are not supported.
 
 ### Scope
 `scope` defines the list of gNMI targets to discover.

--- a/orb-discovery/gnmi-discovery/config/config.go
+++ b/orb-discovery/gnmi-discovery/config/config.go
@@ -1,6 +1,13 @@
 package config
 
-import "time"
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
 
 // Delivery mode constants (spec §5).
 const (
@@ -167,13 +174,71 @@ type PrefixDefaults struct {
 	Description string   `yaml:"description,omitempty"`
 }
 
+// VlanGroupParameters names the VLAN group discovered VLANs are attached
+// to and the NetBox object the group is scoped to. A bare string is the
+// group name; the mapping form adds at most one scope_* field. With no
+// scope the group is scoped to the device's site, as the string form is.
+type VlanGroupParameters struct {
+	Name           string `yaml:"name,omitempty"`
+	ScopeSite      string `yaml:"scope_site,omitempty"`
+	ScopeSiteGroup string `yaml:"scope_site_group,omitempty"`
+	ScopeRegion    string `yaml:"scope_region,omitempty"`
+	ScopeLocation  string `yaml:"scope_location,omitempty"`
+}
+
+// UnmarshalYAML accepts a scalar group name or a mapping.
+//
+// An unknown key in the mapping is an error rather than the warning the
+// rest of the policy gets: the warning pass cannot see inside a custom
+// decoder, and a misspelled scope would otherwise fall back to a
+// site-scoped group that then persists in NetBox.
+func (g *VlanGroupParameters) UnmarshalYAML(node *yaml.Node) error {
+	*g = VlanGroupParameters{}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if node.Tag == "!!null" {
+			return nil
+		}
+		g.Name = node.Value
+		return nil
+	case yaml.MappingNode:
+		known := yamlFieldNames(reflect.TypeFor[VlanGroupParameters]())
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			if key := node.Content[i].Value; !known[key] {
+				return fmt.Errorf("vlan.group: unknown key %s", key)
+			}
+		}
+		type alias VlanGroupParameters
+		var a alias
+		if err := node.Decode(&a); err != nil {
+			return err
+		}
+		if a.Name == "" {
+			return errors.New("vlan.group: name is required")
+		}
+		scopes := 0
+		for _, v := range []string{a.ScopeSite, a.ScopeSiteGroup, a.ScopeRegion, a.ScopeLocation} {
+			if v != "" {
+				scopes++
+			}
+		}
+		if scopes > 1 {
+			return errors.New("vlan.group: only one scope may be set (scope_site, scope_site_group, scope_region, scope_location)")
+		}
+		*g = VlanGroupParameters(a)
+		return nil
+	default:
+		return fmt.Errorf("vlan.group: expected string or mapping, got node kind %d", node.Kind)
+	}
+}
+
 // VlanDefaults holds NetBox defaults applied to discovered VLANs.
 type VlanDefaults struct {
-	Group       string   `yaml:"group,omitempty"`
-	Tenant      string   `yaml:"tenant,omitempty"`
-	Role        string   `yaml:"role,omitempty"`
-	Tags        []string `yaml:"tags,omitempty"`
-	Description string   `yaml:"description,omitempty"`
+	Group       VlanGroupParameters `yaml:"group,omitempty"`
+	Tenant      string              `yaml:"tenant,omitempty"`
+	Role        string              `yaml:"role,omitempty"`
+	Tags        []string            `yaml:"tags,omitempty"`
+	Description string              `yaml:"description,omitempty"`
 }
 
 // IPAddressDefaults holds NetBox defaults applied to discovered IP addresses.
@@ -420,7 +485,7 @@ func MergeDefaults(policyDefaults, overrideDefaults *Defaults) *Defaults {
 	if len(overrideDefaults.InterfaceExcludePatterns) > 0 {
 		merged.InterfaceExcludePatterns = cloneStrings(overrideDefaults.InterfaceExcludePatterns)
 	}
-	if overrideDefaults.Vlan.Group != "" {
+	if overrideDefaults.Vlan.Group.Name != "" {
 		merged.Vlan.Group = overrideDefaults.Vlan.Group
 	}
 	if overrideDefaults.Vlan.Tenant != "" {

--- a/orb-discovery/gnmi-discovery/config/config_test.go
+++ b/orb-discovery/gnmi-discovery/config/config_test.go
@@ -233,18 +233,18 @@ func TestMergeDefaults(t *testing.T) {
 }
 
 func TestMergeDefaultsVlan(t *testing.T) {
-	policy := &Defaults{Site: "NYC", Vlan: VlanDefaults{Group: "g1", Tenant: "t1", Role: "r1", Tags: []string{"a"}, Description: "d1"}}
+	policy := &Defaults{Site: "NYC", Vlan: VlanDefaults{Group: VlanGroupParameters{Name: "g1", ScopeSiteGroup: "sg1"}, Tenant: "t1", Role: "r1", Tags: []string{"a"}, Description: "d1"}}
 	// nil override -> clone preserves vlan
 	got := MergeDefaults(policy, nil)
-	require.Equal(t, "g1", got.Vlan.Group)
+	require.Equal(t, VlanGroupParameters{Name: "g1", ScopeSiteGroup: "sg1"}, got.Vlan.Group)
 	require.Equal(t, "t1", got.Vlan.Tenant)
 	// override wins on non-empty fields, preserves the rest
-	override := &Defaults{Vlan: VlanDefaults{Group: "g2", Role: "r2"}}
+	override := &Defaults{Vlan: VlanDefaults{Group: VlanGroupParameters{Name: "g2"}, Role: "r2"}}
 	got = MergeDefaults(policy, override)
-	require.Equal(t, "g2", got.Vlan.Group)       // overridden
-	require.Equal(t, "r2", got.Vlan.Role)        // overridden
-	require.Equal(t, "t1", got.Vlan.Tenant)      // preserved
-	require.Equal(t, "d1", got.Vlan.Description) // preserved
+	require.Equal(t, VlanGroupParameters{Name: "g2"}, got.Vlan.Group) // replaced whole: no policy scope leaks in
+	require.Equal(t, "r2", got.Vlan.Role)                             // overridden
+	require.Equal(t, "t1", got.Vlan.Tenant)                           // preserved
+	require.Equal(t, "d1", got.Vlan.Description)                      // preserved
 
 	// no-alias contract: mutating the merged Vlan.Tags must not touch the source
 	// (mirrors the existing Device.Tags/Interface.Tags non-alias assertions).
@@ -319,4 +319,59 @@ func TestResolvedOrigin(t *testing.T) {
 	require.Equal(t, "", Target{Origin: &empty}.ResolvedOrigin(), "explicit empty stays origin-less")
 	oc := "oc"
 	require.Equal(t, "oc", Target{Origin: &oc}.ResolvedOrigin())
+}
+
+func TestVlanGroupParametersUnmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want VlanGroupParameters
+	}{
+		{"scalar", "group: campus-vlans\n", VlanGroupParameters{Name: "campus-vlans"}},
+		{
+			"site group", "group:\n  name: Brussels VLAN Group\n  scope_site_group: Brussels\n",
+			VlanGroupParameters{Name: "Brussels VLAN Group", ScopeSiteGroup: "Brussels"},
+		},
+		{"site", "group:\n  name: g\n  scope_site: s\n", VlanGroupParameters{Name: "g", ScopeSite: "s"}},
+		{"region", "group:\n  name: g\n  scope_region: r\n", VlanGroupParameters{Name: "g", ScopeRegion: "r"}},
+		{"location", "group:\n  name: g\n  scope_location: l\n", VlanGroupParameters{Name: "g", ScopeLocation: "l"}},
+		{"no scope", "group:\n  name: g\n", VlanGroupParameters{Name: "g"}},
+		{"null", "group: null\n", VlanGroupParameters{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var d VlanDefaults
+			require.NoError(t, yaml.Unmarshal([]byte(tt.yaml), &d))
+			require.Equal(t, tt.want, d.Group)
+		})
+	}
+}
+
+func TestVlanGroupParametersUnmarshalErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{"two scopes", "group:\n  name: g\n  scope_site: s\n  scope_site_group: sg\n", "only one scope"},
+		{"missing name", "group:\n  scope_site_group: sg\n", "name is required"},
+		{"unknown key", "group:\n  name: g\n  scope_sitegroup: sg\n", "unknown key scope_sitegroup"},
+		{"bad kind", "group:\n  - g\n", "expected string or mapping"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var d VlanDefaults
+			err := yaml.Unmarshal([]byte(tt.yaml), &d)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+// Re-decoding a scalar into a receiver that held the map form must drop the
+// old scope, or a target override would inherit a scope it never named.
+func TestVlanGroupParametersUnmarshalResetsReceiver(t *testing.T) {
+	d := VlanDefaults{Group: VlanGroupParameters{Name: "stale", ScopeRegion: "stale"}}
+	require.NoError(t, yaml.Unmarshal([]byte("group: fresh\n"), &d))
+	require.Equal(t, VlanGroupParameters{Name: "fresh"}, d.Group)
 }

--- a/orb-discovery/gnmi-discovery/mapping/translate_test.go
+++ b/orb-discovery/gnmi-discovery/mapping/translate_test.go
@@ -618,7 +618,7 @@ func TestTranslateVlanNamesAndInventory(t *testing.T) {
 		"/network-instances/network-instance[name=default]/vlans/vlan[vlan-id=99]/state/name":   "mgmt",
 		"/network-instances/network-instance[name=default]/vlans/vlan[vlan-id=99]/state/status": "SUSPENDED",
 	}
-	defaults := &config.Defaults{Site: "lab", Vlan: config.VlanDefaults{Group: "lab-vlans"}}
+	defaults := &config.Defaults{Site: "lab", Vlan: config.VlanDefaults{Group: config.VlanGroupParameters{Name: "lab-vlans"}}}
 	ents := Translate(base, snap, defaults, "")
 	vlans := map[int64]*diode.VLAN{}
 	for _, e := range ents {

--- a/orb-discovery/gnmi-discovery/mapping/vlan.go
+++ b/orb-discovery/gnmi-discovery/mapping/vlan.go
@@ -105,8 +105,33 @@ func translateVlanDefinitions(snap map[string]any) map[int64]vlanDef {
 	return out
 }
 
+// setVlanGroupScope attaches the configured scope to a VLAN group. An
+// explicit scope_* wins; otherwise the device site applies, so the string
+// form of vlan.group keeps its site scope. NetBox Locations are unique
+// within their site, so a Location scope carries the device site when
+// there is one. Scope is only assigned a real value: a typed-nil *diode.Site
+// would make the interface non-nil and serialize as an empty site.
+func setVlanGroupScope(g *diode.VLANGroup, p config.VlanGroupParameters, site *diode.Site) {
+	switch {
+	case p.ScopeSiteGroup != "":
+		g.Scope = &diode.SiteGroup{Name: strptr(p.ScopeSiteGroup)}
+	case p.ScopeRegion != "":
+		g.Scope = &diode.Region{Name: strptr(p.ScopeRegion)}
+	case p.ScopeLocation != "":
+		loc := &diode.Location{Name: strptr(p.ScopeLocation)}
+		if site != nil {
+			loc.Site = site
+		}
+		g.Scope = loc
+	case p.ScopeSite != "":
+		g.Scope = &diode.Site{Name: strptr(p.ScopeSite)}
+	case site != nil:
+		g.Scope = site
+	}
+}
+
 // vlanBuilder constructs deduped *diode.VLAN entities with real-or-placeholder
-// name/status and the policy vlan defaults (site-scoped group, tenant, role, tags,
+// name/status and the policy vlan defaults (scoped group, tenant, role, tags,
 // description). The same rich VLAN is shared between interface refs and the
 // top-level entity (VLAN has no back-ref to Interface/Device -> DAG, no cycle).
 type vlanBuilder struct {
@@ -132,14 +157,9 @@ func newVlanBuilder(dev *diode.Device, defaults *config.Defaults, defs map[int64
 		// requires VLANGroup.slug to be non-empty, so a name with no [a-z0-9] runes
 		// (slug == "") would make ingestion fail. Skip the group in that case (the
 		// VLANs are still emitted, just ungrouped).
-		if slug := slugify(v.Group); v.Group != "" && slug != "" {
-			g := &diode.VLANGroup{Name: strptr(v.Group), Slug: strptr(slug)}
-			// Only set Scope when we have a real site. Assigning a typed-nil
-			// *diode.Site to the Scope interface would make it non-nil, causing the
-			// SDK to emit a bogus empty-site scope.
-			if b.site != nil {
-				g.Scope = b.site
-			}
+		if slug := slugify(v.Group.Name); v.Group.Name != "" && slug != "" {
+			g := &diode.VLANGroup{Name: strptr(v.Group.Name), Slug: strptr(slug)}
+			setVlanGroupScope(g, v.Group, b.site)
 			b.group = g
 		}
 		if v.Tenant != "" {

--- a/orb-discovery/gnmi-discovery/mapping/vlan_test.go
+++ b/orb-discovery/gnmi-discovery/mapping/vlan_test.go
@@ -66,7 +66,7 @@ func TestTranslateVlanDefinitions(t *testing.T) {
 func TestVlanBuilder(t *testing.T) {
 	dev := &diode.Device{Name: strptr("r1"), Site: &diode.Site{Name: strptr("lab")}}
 	defs := map[int64]vlanDef{10: {name: "users", status: "ACTIVE"}, 20: {name: "voice", status: "SUSPENDED"}}
-	defaults := &config.Defaults{Tags: []string{"global"}, Vlan: config.VlanDefaults{Group: "Lab VLANs", Tenant: "acme", Role: "data", Tags: []string{"managed"}}}
+	defaults := &config.Defaults{Tags: []string{"global"}, Vlan: config.VlanDefaults{Group: config.VlanGroupParameters{Name: "Lab VLANs"}, Tenant: "acme", Role: "data", Tags: []string{"managed"}}}
 	b := newVlanBuilder(dev, defaults, defs)
 
 	v10 := b.get(10)
@@ -111,7 +111,7 @@ func TestVlanBuilder(t *testing.T) {
 // would serialize as a bogus empty-site scope).
 func TestVlanBuilderGroupNilSiteScope(t *testing.T) {
 	dev := &diode.Device{Name: strptr("r1")} // no Site
-	b := newVlanBuilder(dev, &config.Defaults{Vlan: config.VlanDefaults{Group: "g"}}, nil)
+	b := newVlanBuilder(dev, &config.Defaults{Vlan: config.VlanDefaults{Group: config.VlanGroupParameters{Name: "g"}}}, nil)
 	v := b.get(10)
 	require.NotNil(t, v.Group)
 	require.Nil(t, v.Group.Scope)
@@ -123,16 +123,62 @@ func TestVlanBuilderGroupNilSiteScope(t *testing.T) {
 // non-empty VLANGroup.slug, so no group must be created (VLANs stay ungrouped).
 func TestVlanBuilderGroupEmptySlugSkipped(t *testing.T) {
 	dev := &diode.Device{Name: strptr("r1"), Site: &diode.Site{Name: strptr("lab")}}
-	b := newVlanBuilder(dev, &config.Defaults{Vlan: config.VlanDefaults{Group: "!!!"}}, nil)
+	b := newVlanBuilder(dev, &config.Defaults{Vlan: config.VlanDefaults{Group: config.VlanGroupParameters{Name: "!!!"}}}, nil)
 	v := b.get(10)
 	require.Nil(t, v.Group, "group with empty slug must not be created")
 }
 
 func TestVlanGroupNoReferenceCycle(t *testing.T) {
 	dev := &diode.Device{Name: strptr("r1"), Site: &diode.Site{Name: strptr("lab")}}
-	b := newVlanBuilder(dev, &config.Defaults{Vlan: config.VlanDefaults{Group: "g"}}, nil)
+	b := newVlanBuilder(dev, &config.Defaults{Vlan: config.VlanDefaults{Group: config.VlanGroupParameters{Name: "g"}}}, nil)
 	v := b.get(10)
 	iface := &diode.Interface{Device: dev, Name: strptr("Ethernet1"), UntaggedVlan: v}
 	require.NotNil(t, iface.ConvertToProtoMessage())
+	require.NotNil(t, v.ConvertToProtoMessage())
+}
+
+// The map form of vlan.group picks the scope NetBox attaches the group to.
+// An explicit scope wins over the device site; a map without one keeps the
+// device site, like the string form.
+func TestVlanBuilderGroupExplicitScope(t *testing.T) {
+	dev := &diode.Device{Name: strptr("r1"), Site: &diode.Site{Name: strptr("lab")}}
+	build := func(g config.VlanGroupParameters) *diode.VLANGroup {
+		v := newVlanBuilder(dev, &config.Defaults{Vlan: config.VlanDefaults{Group: g}}, nil).get(10)
+		require.NotNil(t, v.Group)
+		require.Equal(t, "g", *v.Group.Slug)
+		return v.Group
+	}
+
+	sg, ok := build(config.VlanGroupParameters{Name: "g", ScopeSiteGroup: "Brussels"}).Scope.(*diode.SiteGroup)
+	require.True(t, ok)
+	require.Equal(t, "Brussels", *sg.Name)
+
+	region, ok := build(config.VlanGroupParameters{Name: "g", ScopeRegion: "Benelux"}).Scope.(*diode.Region)
+	require.True(t, ok)
+	require.Equal(t, "Benelux", *region.Name)
+
+	site, ok := build(config.VlanGroupParameters{Name: "g", ScopeSite: "other"}).Scope.(*diode.Site)
+	require.True(t, ok)
+	require.Equal(t, "other", *site.Name, "explicit scope_site wins over the device site")
+
+	loc, ok := build(config.VlanGroupParameters{Name: "g", ScopeLocation: "Floor 2"}).Scope.(*diode.Location)
+	require.True(t, ok)
+	require.Equal(t, "Floor 2", *loc.Name)
+	require.NotNil(t, loc.Site, "a location scope carries the device site")
+	require.Equal(t, "lab", *loc.Site.Name)
+
+	fallback, ok := build(config.VlanGroupParameters{Name: "g"}).Scope.(*diode.Site)
+	require.True(t, ok)
+	require.Equal(t, "lab", *fallback.Name)
+}
+
+// A location scope with no device site is emitted without one rather than
+// with a typed-nil site that would serialize as an empty site.
+func TestVlanBuilderGroupLocationScopeNilSite(t *testing.T) {
+	dev := &diode.Device{Name: strptr("r1")}
+	v := newVlanBuilder(dev, &config.Defaults{Vlan: config.VlanDefaults{Group: config.VlanGroupParameters{Name: "g", ScopeLocation: "Floor 2"}}}, nil).get(10)
+	loc, ok := v.Group.Scope.(*diode.Location)
+	require.True(t, ok)
+	require.Nil(t, loc.Site)
 	require.NotNil(t, v.ConvertToProtoMessage())
 }


### PR DESCRIPTION
## Summary

gnmi-discovery part of #607, same config shape as #609 (snmp-discovery) and #610 (device-discovery).

- `vlan.group` keeps accepting a bare name, scoped to the device's site as before.
- It also accepts a map with `name` and one of `scope_site`, `scope_site_group`, `scope_region` or `scope_location`. A location scope carries the device's site, as NetBox locations are unique per site.
- A map with no scope behaves like the bare name. A per-target `override_defaults.vlan.group` replaces the policy group as a whole so a policy scope cannot leak in.
- Two scopes at once, a missing name, or an unknown key inside the map fails policy parsing. The unknown key case is stricter than the warn-only pass the rest of the policy gets, on purpose: that pass cannot see inside a custom decoder, and a typo like `scope_sitegroup` would otherwise silently create a site-scoped group that persists in NetBox.
- The gnmi docs had no row for `vlan` defaults at all; this adds it along with the group section.

## Config

```yaml
defaults:
  site: "mysite01"
  vlan:
    group:
      name: "Brussels VLAN Group"
      scope_site_group: "Brussels"
```

## Testing

- Config decoding tests for the string form, each scope, no scope, null, two scopes, missing name, unknown key, bad node kind and receiver reset.
- Merge test updated to check the override replaces the group as a whole.
- Builder tests for each emitted scope type, explicit site over the device site, location carrying the device site, location with no device site, and the map-without-scope fallback.
- `go test ./...` and `golangci-lint` pass on the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
