### PR TITLE
ci(ci): install nmap for the agent tests with retries and an HTTPS fallback

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,6 +16,7 @@ on:
       - "go.mod"
       - "go.sum"
       - "!agent/docker/**"
+      - ".github/workflows/tests.yaml"
 
 concurrency:
   group: ${{ github.workflow }}
@@ -44,7 +45,22 @@ jobs:
       - name: Install additional dependencies
         run: |
           go install github.com/mfridman/tparse@v0.14.0
-          sudo apt-get -y install nmap
+          # The runner reaches its apt mirrors over plain HTTP, and that route
+          # has been down for hours at a time, failing every run before a test
+          # ran. Retry with a short timeout first, then fall back to the Ubuntu
+          # archive over HTTPS, which does not share the port 80 route.
+          install_nmap() {
+            sudo apt-get -y -o Acquire::Retries=3 -o Acquire::http::Timeout=20 install nmap
+          }
+          if ! install_nmap; then
+            echo "apt mirrors unreachable, falling back to the Ubuntu archive over HTTPS"
+            . /etc/os-release
+            fallback=/etc/apt/sources.list.d/zz-https-fallback.list
+            printf 'deb https://archive.ubuntu.com/ubuntu %s main universe\ndeb https://archive.ubuntu.com/ubuntu %s-updates main universe\ndeb https://security.ubuntu.com/ubuntu %s-security main universe\n' \
+              "$VERSION_CODENAME" "$VERSION_CODENAME" "$VERSION_CODENAME" | sudo tee "$fallback" >/dev/null
+            sudo apt-get update -o Dir::Etc::sourcelist="$fallback" -o Dir::Etc::sourceparts=- -o APT::Get::List-Cleanup=0
+            install_nmap
+          fi
       - name: Run go test
         id: go-test
         run: |


### PR DESCRIPTION
## Summary

The go-test job installs nmap with `apt-get` on every run, and the Blacksmith runner reaches its three apt mirrors over plain HTTP. When that route is down, as it has been for the last hours, every package cycles through the three mirrors and fails, the test step is skipped, and the job is red before a single test has run. PR #604 hit it four times in a row.

- The install now runs with apt retries and a short per-request timeout, then, if it still fails, writes a sources file naming the Ubuntu archive over HTTPS, refreshes only that list and installs again. HTTPS does not share the port 80 route that is failing.
- The workflow now also triggers on changes to its own file, so this PR runs the step it changes.

## Testing

This PR's own go-test run is the test. If the mirrors are still unreachable when it runs, the log should show "apt mirrors unreachable, falling back to the Ubuntu archive over HTTPS" followed by a successful install and the test step running; if they have recovered, the first install succeeds and nothing else changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)