### PR TITLE
fix(agent): a restart re-applies its policies and one mutex per backend serialises policy operations

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -306,8 +306,13 @@ func (a *orbAgent) backendRestartLock(name string) *sync.Mutex {
 
 // reapplyBackendPolicies hands the backend its own policies again after a
 // restart. A failure is logged, not returned: the policies stay marked unknown
-// for the next successful restart.
-func (a *orbAgent) reapplyBackendPolicies(name string, be backend.Backend) {
+// for the next successful restart. Once the context is done the agent is
+// shutting down and no new work is launched; the policies stay unknown.
+func (a *orbAgent) reapplyBackendPolicies(ctx context.Context, name string, be backend.Backend) {
+	if err := ctx.Err(); err != nil {
+		a.logger.Info("shutting down; backend policies left unknown", "backend", name, "error", err)
+		return
+	}
 	if err := a.policyManager.ApplyBackendPolicies(name, be); err != nil {
 		a.logger.Error("backend policies left unapplied after restart; they stay unknown until the next successful restart",
 			"backend", name, "error", err)
@@ -375,7 +380,7 @@ func (a *orbAgent) restartBackendWithFilesmgrRollback(ctx context.Context, backe
 	startErr := be.Start(runCtx, runCancel)
 	if startErr == nil {
 		a.logger.Info("filesmgr: backend restarted with upgraded binary", "backend", backendName, "binary", binaryName)
-		a.reapplyBackendPolicies(backendName, be)
+		a.reapplyBackendPolicies(ctx, backendName, be)
 		return
 	}
 	a.logger.Warn("filesmgr: backend Start failed after upgrade, rolling back", "backend", backendName, "error", startErr)
@@ -405,7 +410,7 @@ func (a *orbAgent) restartBackendWithFilesmgrRollback(ctx context.Context, backe
 		return
 	}
 	a.logger.Info("filesmgr: backend restarted with rolled-back binary", "backend", backendName, "binary", binaryName)
-	a.reapplyBackendPolicies(backendName, be)
+	a.reapplyBackendPolicies(ctx, backendName, be)
 }
 
 // restartDispatcher runs as a background goroutine and drains pendingRestarts
@@ -694,12 +699,12 @@ func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason strin
 			// The backend was never stopped, so it is still running with
 			// nothing applied; hand its policies back rather than leave
 			// them unknown for a restart that may not come again soon.
-			a.reapplyBackendPolicies(name, be)
+			a.reapplyBackendPolicies(ctx, name, be)
 			return errors.New("backend not found: " + name)
 		}
 	}
 	if err := be.Configure(a.logger, a.policyManager.GetRepo(), beConfig, a.backendsCommon, a.filesManager); err != nil {
-		a.reapplyBackendPolicies(name, be)
+		a.reapplyBackendPolicies(ctx, name, be)
 		return err
 	}
 	a.logger.Info("resetting backend", "backend", name)
@@ -712,7 +717,7 @@ func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason strin
 		// The policies stay marked unknown; the next successful restart applies them.
 		return nil
 	}
-	a.reapplyBackendPolicies(name, be)
+	a.reapplyBackendPolicies(ctx, name, be)
 	return nil
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -284,11 +284,27 @@ func (a *orbAgent) backendRestartLock(name string) *sync.Mutex {
 	return mu
 }
 
+// reapplyBackendPolicies hands the backend its own policies again after a
+// restart. A failure is logged, not returned: the policies stay marked unknown
+// for the next successful restart.
+func (a *orbAgent) reapplyBackendPolicies(name string, be backend.Backend) {
+	if err := a.policyManager.ApplyBackendPolicies(name, be); err != nil {
+		a.logger.Error("backend policies left unapplied after restart; they stay unknown until the next successful restart",
+			"backend", name, "error", err)
+	}
+}
+
 // restartBackendWithFilesmgrRollback performs a Stop + Start sequence for a
 // backend after a FilesManager event upgraded its managed binary. If Start
 // fails, asks FilesManager to roll back the binary to its previous version,
 // then retries Start once. On second failure, gives up and logs the error —
 // no infinite loop.
+//
+// Like RestartBackend, it marks the backend's policies unknown before Stop
+// and re-applies them after each Start that succeeds (the first attempt and
+// the rollback retry). The restart mutex is held across the whole function,
+// so the lock order RestartBackend documents (the restart mutex before the
+// policy manager's apply mutex) holds here too.
 func (a *orbAgent) restartBackendWithFilesmgrRollback(ctx context.Context, backendName string) {
 	// Serialize concurrent Stop+Start sequences for the same backend across
 	// both restart paths (file-driven and health/fleet-driven).
@@ -304,6 +320,12 @@ func (a *orbAgent) restartBackendWithFilesmgrRollback(ctx context.Context, backe
 	binaryName := ""
 	if mb, ok := be.(backend.ManagedBinary); ok {
 		binaryName = mb.ManagedBinaryName()
+	}
+
+	// The removal here is bookkeeping symmetry with RestartBackend, not
+	// because the process about to be stopped needs it.
+	if err := a.policyManager.RemoveBackendPolicies(backendName, be, false); err != nil {
+		a.logger.Error("filesmgr: failed to remove policies", "backend", backendName, "error", err)
 	}
 
 	if err := be.Stop(ctx); err != nil {
@@ -333,6 +355,7 @@ func (a *orbAgent) restartBackendWithFilesmgrRollback(ctx context.Context, backe
 	startErr := be.Start(runCtx, runCancel)
 	if startErr == nil {
 		a.logger.Info("filesmgr: backend restarted with upgraded binary", "backend", backendName, "binary", binaryName)
+		a.reapplyBackendPolicies(backendName, be)
 		return
 	}
 	a.logger.Warn("filesmgr: backend Start failed after upgrade, rolling back", "backend", backendName, "error", startErr)
@@ -362,6 +385,7 @@ func (a *orbAgent) restartBackendWithFilesmgrRollback(ctx context.Context, backe
 		return
 	}
 	a.logger.Info("filesmgr: backend restarted with rolled-back binary", "backend", backendName, "binary", binaryName)
+	a.reapplyBackendPolicies(backendName, be)
 }
 
 // restartDispatcher runs as a background goroutine and drains pendingRestarts
@@ -610,6 +634,18 @@ func (a *orbAgent) shutdownOTLP() {
 	})
 }
 
+// RestartBackend keeps the backend's policies and re-applies them once the
+// reset succeeds: they are marked unknown for the restart, not deleted, and
+// handed back to the backend after it is running again. Every stored policy
+// for the backend is handed back, including one whose run already finished,
+// so a one-shot policy runs again. Any return after the removal re-applies
+// immediately if the backend never stopped (a bad backend config, a
+// Configure failure), or leaves the policies marked unknown for the next
+// successful restart if the reset itself failed.
+//
+// The per-backend restart mutex is held across both policy manager calls
+// (the removal and the re-apply), so it is taken before the policy
+// manager's apply mutex, never after.
 func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason string) error {
 	// Every bundled backend is registered; only the ones this agent started
 	// are in a.backends, and only those have a process to restart.
@@ -626,8 +662,8 @@ func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason strin
 
 	a.logger.Info("restarting backend", "backend", name, "reason", reason)
 	a.backendStateManager.RegisterRestart(name, reason)
-	a.logger.Info("removing policies", "backend", name)
-	if err := a.policyManager.RemoveBackendPolicies(name, be, true); err != nil {
+	a.logger.Info("marking policies for re-apply", "backend", name)
+	if err := a.policyManager.RemoveBackendPolicies(name, be, false); err != nil {
 		a.logger.Error("failed to remove policies", "backend", name, "error", err)
 	}
 	var beConfig map[string]any
@@ -635,18 +671,28 @@ func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason strin
 		var ok bool
 		beConfig, ok = a.config.OrbAgent.Backends[name].(map[string]any)
 		if !ok {
+			// The backend was never stopped, so it is still running with
+			// nothing applied; hand its policies back rather than leave
+			// them unknown for a restart that may not come again soon.
+			a.reapplyBackendPolicies(name, be)
 			return errors.New("backend not found: " + name)
 		}
 	}
 	if err := be.Configure(a.logger, a.policyManager.GetRepo(), beConfig, a.backendsCommon, a.filesManager); err != nil {
+		a.reapplyBackendPolicies(name, be)
 		return err
 	}
 	a.logger.Info("resetting backend", "backend", name)
 
+	// The apply mutex is deliberately not held across the reset: a manage
+	// landing on this backend meanwhile may be stamped failed to apply, and
+	// the re-apply below heals it by re-applying every stored policy.
 	if err := be.FullReset(ctx); err != nil {
 		a.backendStateManager.RegisterError(name, fmt.Sprintf("failed to reset backend: %v", err))
+		// The policies stay marked unknown; the next successful restart applies them.
+		return nil
 	}
-
+	a.reapplyBackendPolicies(name, be)
 	return nil
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -109,6 +110,26 @@ type orbAgent struct {
 	// the backend is not yet answering its status probe. New sets it; tests
 	// shorten it.
 	reapplyRetryDelay time.Duration
+
+	// replayScheduled tracks, per backend name, whether a scheduleReplay
+	// goroutine is currently waiting or attempting for that backend: a
+	// sync.Map of *atomic.Bool, same rationale as backendRestartMu for never
+	// deleting entries.
+	replayScheduled sync.Map
+
+	// replayers tracks every goroutine scheduleReplay starts, so Stop can
+	// wait for all of them to exit before returning.
+	replayers sync.WaitGroup
+
+	// replayRetryInterval separates the attempts a scheduled replay makes
+	// after a restart's own replay gave up because the backend was still not
+	// answering. New sets it to time.Minute; tests shorten it.
+	replayRetryInterval time.Duration
+
+	// replayStarts counts how many scheduleReplay calls actually started a
+	// goroutine, for tests to assert a second call for a backend that
+	// already has one scheduled is a no-op.
+	replayStarts atomic.Int32
 }
 
 var _ Agent = (*orbAgent)(nil)
@@ -153,6 +174,7 @@ func New(logger *slog.Logger, c config.Config, debug bool) (Agent, error) {
 		stopCtx:             stopCtx,
 		stopCancel:          stopCancel,
 		reapplyRetryDelay:   10 * time.Second,
+		replayRetryInterval: time.Minute,
 	}
 	return a, nil
 }
@@ -313,17 +335,24 @@ func (a *orbAgent) backendRestartLock(name string) *sync.Mutex {
 // The replay retries that specific error, up to reapplyAttempts times,
 // reapplyRetryDelay apart, because nothing else would install the policies:
 // the health monitor sees a healthy backend and never asks for another
-// restart. Any other failure, and giving up after reapplyAttempts, is
-// logged, not returned: the policies stay marked unknown for the next
-// successful restart, and manages for the backend stay deferred until the
-// next successful restart, because the policy manager's own restarting
-// marker (set by the removal that precedes this replay) is cleared only by
-// an attempt whose gate confirms the backend is answering, which none of
-// these did. Once the context is done the agent is shutting down
-// and no new work is launched; the policies stay unknown. The policy manager
-// itself re-checks the context before every policy in its loop, so a
-// shutdown that begins mid-replay stops launching further HTTP calls instead
-// of running the whole backlog.
+// restart. Any other failure is logged, not returned: the policies stay
+// marked unknown for the next successful restart, and manages for the
+// backend stay deferred until the next successful restart, because the
+// policy manager's own restarting marker (set by the removal that precedes
+// this replay) is cleared only by an attempt whose gate confirms the backend
+// is answering, which none of these did. Once the context is done the agent
+// is shutting down and no new work is launched; the policies stay unknown.
+// The policy manager itself re-checks the context before every policy in its
+// loop, so a shutdown that begins mid-replay stops launching further HTTP
+// calls instead of running the whole backlog.
+//
+// Giving up after reapplyAttempts is different from every other failure:
+// the caller is told, through the returned retryable flag, to reschedule the
+// replay via scheduleReplay, which keeps attempting it, at
+// replayRetryInterval, until it completes. Without that, the restarting
+// marker set by the removal above would stay set forever and every later
+// manage for the backend would stay deferred, since a healthy backend never
+// asks for another restart on its own.
 //
 // The restart mutex stays held across the retries, which is intended: no
 // other restart for this backend may interleave with a replay in progress,
@@ -341,7 +370,13 @@ func (a *orbAgent) backendRestartLock(name string) *sync.Mutex {
 // context.AfterFunc, whose callback runs in its own goroutine, so it is
 // checked directly up front rather than relied on to interrupt a loop
 // already in flight.
-func (a *orbAgent) reapplyBackendPolicies(ctx context.Context, name string, be backend.Backend) {
+//
+// completed is true only when ApplyBackendPolicies returns nil. Otherwise
+// completed is false, and retryable tells the caller whether to reschedule:
+// true when every attempt answered ErrBackendNotRunning and reapplyAttempts
+// was reached, false for any other failure and for a replay that never ran
+// because the context was already done.
+func (a *orbAgent) reapplyBackendPolicies(ctx context.Context, name string, be backend.Backend) (completed, retryable bool) {
 	stopCtx := a.stopCtx
 	if stopCtx == nil {
 		stopCtx = context.Background()
@@ -351,31 +386,93 @@ func (a *orbAgent) reapplyBackendPolicies(ctx context.Context, name string, be b
 	defer context.AfterFunc(ctx, cancel)()
 	if err := ctx.Err(); err != nil {
 		a.logger.Info("shutting down; backend policies left unknown", "backend", name, "error", err)
-		return
+		return false, false
 	}
 	if err := applyCtx.Err(); err != nil {
 		a.logger.Info("shutting down; backend policies left unknown", "backend", name, "error", err)
-		return
+		return false, false
 	}
 	for attempt := 1; ; attempt++ {
 		err := a.policyManager.ApplyBackendPolicies(applyCtx, name, be)
 		if err == nil {
-			return
+			return true, false
 		}
-		if !errors.Is(err, policymgr.ErrBackendNotRunning) || attempt == reapplyAttempts {
+		if !errors.Is(err, policymgr.ErrBackendNotRunning) {
 			a.logger.Error("backend policies left unapplied after restart; they stay unknown until the next successful restart",
 				"backend", name, "attempts", attempt, "error", err)
-			return
+			return false, false
+		}
+		if attempt == reapplyAttempts {
+			a.logger.Error("backend policies left unapplied after restart; the replay will be rescheduled until it completes",
+				"backend", name, "attempts", attempt, "error", err)
+			return false, true
 		}
 		a.logger.Warn("backend not answering yet after restart; retrying the policy replay",
 			"backend", name, "attempt", attempt, "retry_in", a.reapplyRetryDelay)
 		select {
 		case <-applyCtx.Done():
 			a.logger.Info("shutting down; backend policies left unknown", "backend", name, "error", applyCtx.Err())
-			return
+			return false, false
 		case <-time.After(a.reapplyRetryDelay):
 		}
 	}
+}
+
+// scheduleReplay ensures a replay that gave up because the backend was still
+// not answering keeps being attempted until it completes. Nothing else would
+// ask for another one: the health monitor sees the backend as healthy once
+// it does answer and never requests another restart on its own, so a
+// give-up would otherwise leave the restarting marker set and every later
+// manage for the backend deferred indefinitely.
+//
+// One scheduled replay per backend runs at a time; a second call while one
+// is already scheduled for that backend is a no-op, since the loop already
+// running keeps retrying on its own.
+//
+// Each attempt takes the backend's restart mutex before calling
+// reapplyBackendPolicies, so it cannot interleave with a restart of the same
+// backend. The wait between attempts does not hold the mutex, so a restart
+// can run in between; that restart performs its own replay and clears the
+// restarting marker itself, and this loop's next attempt then completes at
+// once, because a replay with nothing left deferred is a no-op that returns
+// nil.
+func (a *orbAgent) scheduleReplay(name string, be backend.Backend) {
+	v, _ := a.replayScheduled.LoadOrStore(name, &atomic.Bool{})
+	scheduled, _ := v.(*atomic.Bool) // LoadOrStore stored an *atomic.Bool; assertion cannot fail.
+	if !scheduled.CompareAndSwap(false, true) {
+		return
+	}
+	a.replayStarts.Add(1)
+	a.replayers.Add(1)
+	go func() {
+		defer a.replayers.Done()
+		defer scheduled.Store(false)
+		stopCtx := a.stopCtx
+		if stopCtx == nil {
+			stopCtx = context.Background()
+		}
+		for attempt := 1; ; attempt++ {
+			select {
+			case <-stopCtx.Done():
+				return
+			case <-time.After(a.replayRetryInterval):
+			}
+			restartMu := a.backendRestartLock(name)
+			restartMu.Lock()
+			completed, retryable := a.reapplyBackendPolicies(stopCtx, name, be)
+			restartMu.Unlock()
+			if completed {
+				return
+			}
+			if !retryable {
+				a.logger.Error("scheduled policy replay failed and will not be retried",
+					"backend", name, "attempt", attempt)
+				return
+			}
+			a.logger.Warn("scheduled policy replay gave up again; retrying",
+				"backend", name, "attempt", attempt, "retry_in", a.replayRetryInterval)
+		}
+	}()
 }
 
 // restartBackendWithFilesmgrRollback performs a Stop + Start sequence for a
@@ -392,7 +489,10 @@ func (a *orbAgent) reapplyBackendPolicies(ctx context.Context, name string, be b
 // below sets it, and the re-apply's entry gate clears it once the backend
 // answers, so a manage arriving before the clear is stored as starting for
 // the re-apply to pick up, and one arriving after applies directly to the
-// backend, which is up by then.
+// backend, which is up by then. A re-apply that gives up because the
+// backend still is not answering is rescheduled the same way RestartBackend
+// reschedules one, and keeps retrying at replayRetryInterval until it
+// completes, so a manage stored as starting is not deferred forever.
 func (a *orbAgent) restartBackendWithFilesmgrRollback(ctx context.Context, backendName string) {
 	// Serialize concurrent Stop+Start sequences for the same backend across
 	// both restart paths (file-driven and health/fleet-driven).
@@ -443,7 +543,9 @@ func (a *orbAgent) restartBackendWithFilesmgrRollback(ctx context.Context, backe
 	startErr := be.Start(runCtx, runCancel)
 	if startErr == nil {
 		a.logger.Info("filesmgr: backend restarted with upgraded binary", "backend", backendName, "binary", binaryName)
-		a.reapplyBackendPolicies(ctx, backendName, be)
+		if completed, retryable := a.reapplyBackendPolicies(ctx, backendName, be); !completed && retryable {
+			a.scheduleReplay(backendName, be)
+		}
 		return
 	}
 	a.logger.Warn("filesmgr: backend Start failed after upgrade, rolling back", "backend", backendName, "error", startErr)
@@ -473,7 +575,9 @@ func (a *orbAgent) restartBackendWithFilesmgrRollback(ctx context.Context, backe
 		return
 	}
 	a.logger.Info("filesmgr: backend restarted with rolled-back binary", "backend", backendName, "binary", binaryName)
-	a.reapplyBackendPolicies(ctx, backendName, be)
+	if completed, retryable := a.reapplyBackendPolicies(ctx, backendName, be); !completed && retryable {
+		a.scheduleReplay(backendName, be)
+	}
 }
 
 // restartDispatcher runs as a background goroutine and drains pendingRestarts
@@ -709,6 +813,10 @@ func (a *orbAgent) Stop(ctx context.Context) {
 			a.cancelFunction()
 		}
 	}()
+	// stopCtx was cancelled first, above, so every scheduled replay goroutine
+	// either already exited or is about to, on its next check; wait for all
+	// of them so none outlives the agent.
+	a.replayers.Wait()
 }
 
 func (a *orbAgent) shutdownOTLP() {
@@ -746,7 +854,10 @@ func (a *orbAgent) shutdownOTLP() {
 // stored as starting for that re-apply to pick up, and one arriving after
 // applies directly to the backend, which is up by then; the re-apply itself
 // skips anything already Running, so neither path ever applies a policy
-// twice.
+// twice. A re-apply that gives up because the backend still is not
+// answering is rescheduled and keeps trying, at replayRetryInterval, until
+// it completes, so deferred manages are not stuck behind a marker nothing
+// else would ever clear.
 func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason string) error {
 	// Every bundled backend is registered; only the ones this agent started
 	// are in a.backends, and only those have a process to restart.
@@ -775,12 +886,16 @@ func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason strin
 			// The backend was never stopped, so it is still running with
 			// nothing applied; hand its policies back rather than leave
 			// them unknown for a restart that may not come again soon.
-			a.reapplyBackendPolicies(ctx, name, be)
+			if completed, retryable := a.reapplyBackendPolicies(ctx, name, be); !completed && retryable {
+				a.scheduleReplay(name, be)
+			}
 			return errors.New("backend not found: " + name)
 		}
 	}
 	if err := be.Configure(a.logger, a.policyManager.GetRepo(), beConfig, a.backendsCommon, a.filesManager); err != nil {
-		a.reapplyBackendPolicies(ctx, name, be)
+		if completed, retryable := a.reapplyBackendPolicies(ctx, name, be); !completed && retryable {
+			a.scheduleReplay(name, be)
+		}
 		return err
 	}
 	a.logger.Info("resetting backend", "backend", name)
@@ -793,7 +908,9 @@ func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason strin
 		// The policies stay marked unknown; the next successful restart applies them.
 		return nil
 	}
-	a.reapplyBackendPolicies(ctx, name, be)
+	if completed, retryable := a.reapplyBackendPolicies(ctx, name, be); !completed && retryable {
+		a.scheduleReplay(name, be)
+	}
 	return nil
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"runtime"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -99,14 +98,6 @@ type orbAgent struct {
 	// operations.
 	backendRestartMu sync.Map // name -> *sync.Mutex
 
-	// restarting marks, per backend name, a restart in flight: set after the
-	// restart mutex is taken and cleared right before the restart's replay,
-	// still under that mutex. restartStarter answers from it, so a manage
-	// arriving while it is set is stored as starting for the replay to apply,
-	// and one arriving after the clear applies directly to a backend that is
-	// up. Entries are never deleted, same rationale as backendRestartMu.
-	restarting sync.Map // name -> *atomic.Bool
-
 	// stopCancel is called as the first statement of Stop. The agent context
 	// is only cancelled at the end of Stop, after every backend is stopped,
 	// so a restart already holding a backend's restart mutex when Stop
@@ -121,23 +112,6 @@ type orbAgent struct {
 }
 
 var _ Agent = (*orbAgent)(nil)
-
-// restartStarter tells the policy manager whether a backend can take a
-// policy now. Every backend is started at agent start, so the only reason
-// to say no is a restart in flight: the restarting marker is set once the
-// restart mutex is taken, before the removal, and cleared right before the
-// restart's single replay, still under that mutex. A policy stored as
-// "backend starting" while the marker is set is applied exactly once by
-// that replay instead of landing on a process about to be reset or being
-// replayed after it.
-type restartStarter struct{ agent *orbAgent }
-
-func (s restartStarter) EnsureStarted(name string) (policymgr.StartState, error) {
-	if s.agent.restartingFlag(name).Load() {
-		return policymgr.StartStarting, nil
-	}
-	return policymgr.StartRunning, nil
-}
 
 // New creates a new agent
 func New(logger *slog.Logger, c config.Config, debug bool) (Agent, error) {
@@ -180,7 +154,6 @@ func New(logger *slog.Logger, c config.Config, debug bool) (Agent, error) {
 		stopCancel:          stopCancel,
 		reapplyRetryDelay:   10 * time.Second,
 	}
-	pm.SetStarter(restartStarter{agent: a})
 	return a, nil
 }
 
@@ -333,16 +306,6 @@ func (a *orbAgent) backendRestartLock(name string) *sync.Mutex {
 	return mu
 }
 
-// restartingFlag returns the per-backend marker restartStarter and a restart
-// each consult to tell whether a restart of that backend is currently in
-// flight. Entries are never deleted, same race rationale as
-// backendRestartLock.
-func (a *orbAgent) restartingFlag(name string) *atomic.Bool {
-	v, _ := a.restarting.LoadOrStore(name, &atomic.Bool{})
-	flag, _ := v.(*atomic.Bool) // LoadOrStore stored a *atomic.Bool; assertion cannot fail.
-	return flag
-}
-
 // reapplyBackendPolicies hands the backend its own policies again after a
 // restart. A backend that has just come back from a reset or a start may not
 // answer its first status probe or two, so ApplyBackendPolicies can return
@@ -352,7 +315,11 @@ func (a *orbAgent) restartingFlag(name string) *atomic.Bool {
 // the health monitor sees a healthy backend and never asks for another
 // restart. Any other failure, and giving up after reapplyAttempts, is
 // logged, not returned: the policies stay marked unknown for the next
-// successful restart. Once the context is done the agent is shutting down
+// successful restart, and manages for the backend stay deferred until the
+// next successful restart, because the policy manager's own restarting
+// marker (set by the removal that precedes this replay) is cleared only by
+// an attempt whose gate confirms the backend is answering, which none of
+// these did. Once the context is done the agent is shutting down
 // and no new work is launched; the policies stay unknown. The policy manager
 // itself re-checks the context before every policy in its loop, so a
 // shutdown that begins mid-replay stops launching further HTTP calls instead
@@ -419,22 +386,19 @@ func (a *orbAgent) reapplyBackendPolicies(ctx context.Context, name string, be b
 //
 // Like RestartBackend, it marks the backend's policies unknown before Stop
 // and re-applies them once, after whichever Start succeeds (the first
-// attempt or the rollback retry), under the same restart mutex and
-// restarting marker: the mutex is taken before the policy manager's apply
-// mutex, never after, and the marker clears right before that re-apply, so a
-// manage arriving before the clear is stored as starting for the re-apply to
-// pick up, and one arriving after applies directly to the backend, which is
-// up by then.
+// attempt or the rollback retry), under the same restart mutex the policy
+// manager's own apply mutex is taken after, never before. The policy
+// manager owns the restarting marker itself: its non-permanent removal
+// below sets it, and the re-apply's entry gate clears it once the backend
+// answers, so a manage arriving before the clear is stored as starting for
+// the re-apply to pick up, and one arriving after applies directly to the
+// backend, which is up by then.
 func (a *orbAgent) restartBackendWithFilesmgrRollback(ctx context.Context, backendName string) {
 	// Serialize concurrent Stop+Start sequences for the same backend across
 	// both restart paths (file-driven and health/fleet-driven).
 	restartMu := a.backendRestartLock(backendName)
 	restartMu.Lock()
 	defer restartMu.Unlock()
-
-	flag := a.restartingFlag(backendName)
-	flag.Store(true)
-	defer flag.Store(false) // every exit, so a failed restart does not leave manages deferred
 
 	be, ok := a.backends[backendName]
 	if !ok {
@@ -479,7 +443,6 @@ func (a *orbAgent) restartBackendWithFilesmgrRollback(ctx context.Context, backe
 	startErr := be.Start(runCtx, runCancel)
 	if startErr == nil {
 		a.logger.Info("filesmgr: backend restarted with upgraded binary", "backend", backendName, "binary", binaryName)
-		flag.Store(false)
 		a.reapplyBackendPolicies(ctx, backendName, be)
 		return
 	}
@@ -510,7 +473,6 @@ func (a *orbAgent) restartBackendWithFilesmgrRollback(ctx context.Context, backe
 		return
 	}
 	a.logger.Info("filesmgr: backend restarted with rolled-back binary", "backend", backendName, "binary", binaryName)
-	flag.Store(false)
 	a.reapplyBackendPolicies(ctx, backendName, be)
 }
 
@@ -777,13 +739,14 @@ func (a *orbAgent) shutdownOTLP() {
 // successful restart if the reset itself failed.
 //
 // The whole sequence runs under the backend's restart mutex, taken before
-// the policy manager's apply mutex, never after. The restarting marker is
-// set right after the mutex is taken and cleared right before the single
-// re-apply at the end, still under the mutex: a manage arriving before the
-// clear is stored as starting for that re-apply to pick up, and one arriving
-// after applies directly to the backend, which is up by then; the re-apply
-// itself skips anything already Running, so neither path ever applies a
-// policy twice.
+// the policy manager's apply mutex, never after. The policy manager's own
+// restarting marker is set by the removal below, the first thing it does
+// under its own mutex, and cleared by the re-apply's entry gate once it
+// confirms the backend answers: a manage arriving before the clear is
+// stored as starting for that re-apply to pick up, and one arriving after
+// applies directly to the backend, which is up by then; the re-apply itself
+// skips anything already Running, so neither path ever applies a policy
+// twice.
 func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason string) error {
 	// Every bundled backend is registered; only the ones this agent started
 	// are in a.backends, and only those have a process to restart.
@@ -797,10 +760,6 @@ func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason strin
 	restartMu := a.backendRestartLock(name)
 	restartMu.Lock()
 	defer restartMu.Unlock()
-
-	flag := a.restartingFlag(name)
-	flag.Store(true)
-	defer flag.Store(false) // every exit, so a failed restart does not leave manages deferred
 
 	a.logger.Info("restarting backend", "backend", name, "reason", reason)
 	a.backendStateManager.RegisterRestart(name, reason)
@@ -816,13 +775,11 @@ func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason strin
 			// The backend was never stopped, so it is still running with
 			// nothing applied; hand its policies back rather than leave
 			// them unknown for a restart that may not come again soon.
-			flag.Store(false)
 			a.reapplyBackendPolicies(ctx, name, be)
 			return errors.New("backend not found: " + name)
 		}
 	}
 	if err := be.Configure(a.logger, a.policyManager.GetRepo(), beConfig, a.backendsCommon, a.filesManager); err != nil {
-		flag.Store(false)
 		a.reapplyBackendPolicies(ctx, name, be)
 		return err
 	}
@@ -836,7 +793,6 @@ func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason strin
 		// The policies stay marked unknown; the next successful restart applies them.
 		return nil
 	}
-	flag.Store(false)
 	a.reapplyBackendPolicies(ctx, name, be)
 	return nil
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -96,6 +96,24 @@ type orbAgent struct {
 
 var _ Agent = (*orbAgent)(nil)
 
+// restartStarter tells the policy manager whether a backend can take a
+// policy now. Every backend is started at agent start, so the only reason
+// to say no is a restart in flight: the restart mutex is held across the
+// removal, the stop or reset, and the re-apply, and a policy stored as
+// "backend starting" meanwhile is applied exactly once by that re-apply
+// instead of landing on a process about to be reset or being replayed after
+// it. TryLock never blocks, so the restart-before-apply lock order holds.
+type restartStarter struct{ agent *orbAgent }
+
+func (s restartStarter) EnsureStarted(name string) (policymgr.StartState, error) {
+	mu := s.agent.backendRestartLock(name)
+	if !mu.TryLock() {
+		return policymgr.StartStarting, nil
+	}
+	mu.Unlock()
+	return policymgr.StartRunning, nil
+}
+
 // New creates a new agent
 func New(logger *slog.Logger, c config.Config, debug bool) (Agent, error) {
 	sm, err := secretsmgr.New(logger, c.OrbAgent.SecretsManager)
@@ -122,7 +140,7 @@ func New(logger *slog.Logger, c config.Config, debug bool) (Agent, error) {
 	// runtime context supplied in Agent.Start.
 	cm := configmgr.New(logger, pm, c.OrbAgent.ConfigManager.Active, backendStateManager, fm)
 
-	return &orbAgent{
+	a := &orbAgent{
 		logger:              logger,
 		config:              c,
 		debug:               debug,
@@ -132,7 +150,9 @@ func New(logger *slog.Logger, c config.Config, debug bool) (Agent, error) {
 		backendStateManager: backendStateManager,
 		filesManager:        fm,
 		restartBackendChan:  restartBackendChan,
-	}, nil
+	}
+	pm.SetStarter(restartStarter{agent: a})
+	return a, nil
 }
 
 func (a *orbAgent) startBackends(agentCtx context.Context, cfgBackends map[string]any, labels map[string]string) (err error) {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -28,6 +28,11 @@ const (
 	routineKey             config.ContextKey = "routine"
 	otlpShutdownTimeout    time.Duration     = 5 * time.Second
 	restartBackendChanSize int               = 5
+
+	// reapplyAttempts bounds how many times reapplyBackendPolicies calls
+	// ApplyBackendPolicies for a single restart while it keeps answering
+	// ErrBackendNotRunning.
+	reapplyAttempts int = 3
 )
 
 // Agent is the interface that all agents must implement
@@ -108,6 +113,11 @@ type orbAgent struct {
 	// begins still sees a live context; stopCtx is what it observes instead.
 	stopCtx    context.Context
 	stopCancel context.CancelFunc
+
+	// reapplyRetryDelay separates the attempts a restart's replay makes while
+	// the backend is not yet answering its status probe. New sets it; tests
+	// shorten it.
+	reapplyRetryDelay time.Duration
 }
 
 var _ Agent = (*orbAgent)(nil)
@@ -168,6 +178,7 @@ func New(logger *slog.Logger, c config.Config, debug bool) (Agent, error) {
 		restartBackendChan:  restartBackendChan,
 		stopCtx:             stopCtx,
 		stopCancel:          stopCancel,
+		reapplyRetryDelay:   10 * time.Second,
 	}
 	pm.SetStarter(restartStarter{agent: a})
 	return a, nil
@@ -333,12 +344,23 @@ func (a *orbAgent) restartingFlag(name string) *atomic.Bool {
 }
 
 // reapplyBackendPolicies hands the backend its own policies again after a
-// restart. A failure is logged, not returned: the policies stay marked unknown
-// for the next successful restart. Once the context is done the agent is
-// shutting down and no new work is launched; the policies stay unknown. The
-// policy manager itself re-checks the context before every policy in its
-// loop, so a shutdown that begins mid-replay stops launching further HTTP
-// calls instead of running the whole backlog.
+// restart. A backend that has just come back from a reset or a start may not
+// answer its first status probe or two, so ApplyBackendPolicies can return
+// ErrBackendNotRunning transiently even though the backend is on its way up.
+// The replay retries that specific error, up to reapplyAttempts times,
+// reapplyRetryDelay apart, because nothing else would install the policies:
+// the health monitor sees a healthy backend and never asks for another
+// restart. Any other failure, and giving up after reapplyAttempts, is
+// logged, not returned: the policies stay marked unknown for the next
+// successful restart. Once the context is done the agent is shutting down
+// and no new work is launched; the policies stay unknown. The policy manager
+// itself re-checks the context before every policy in its loop, so a
+// shutdown that begins mid-replay stops launching further HTTP calls instead
+// of running the whole backlog.
+//
+// The restart mutex stays held across the retries, which is intended: no
+// other restart for this backend may interleave with a replay in progress,
+// and a shutdown cancels the wait rather than blocking it.
 //
 // The apply context is cancelled by whichever of the caller's context or the
 // agent's stop context is cancelled first, since the agent context (unlike
@@ -368,9 +390,24 @@ func (a *orbAgent) reapplyBackendPolicies(ctx context.Context, name string, be b
 		a.logger.Info("shutting down; backend policies left unknown", "backend", name, "error", err)
 		return
 	}
-	if err := a.policyManager.ApplyBackendPolicies(applyCtx, name, be); err != nil {
-		a.logger.Error("backend policies left unapplied after restart; they stay unknown until the next successful restart",
-			"backend", name, "error", err)
+	for attempt := 1; ; attempt++ {
+		err := a.policyManager.ApplyBackendPolicies(applyCtx, name, be)
+		if err == nil {
+			return
+		}
+		if !errors.Is(err, policymgr.ErrBackendNotRunning) || attempt == reapplyAttempts {
+			a.logger.Error("backend policies left unapplied after restart; they stay unknown until the next successful restart",
+				"backend", name, "attempts", attempt, "error", err)
+			return
+		}
+		a.logger.Warn("backend not answering yet after restart; retrying the policy replay",
+			"backend", name, "attempt", attempt, "retry_in", a.reapplyRetryDelay)
+		select {
+		case <-applyCtx.Done():
+			a.logger.Info("shutting down; backend policies left unknown", "backend", name, "error", applyCtx.Err())
+			return
+		case <-time.After(a.reapplyRetryDelay):
+		}
 	}
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"runtime"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -94,12 +93,12 @@ type orbAgent struct {
 	// operations.
 	backendRestartMu sync.Map // name -> *sync.Mutex
 
-	// stopping is set to true as the first statement of Stop. The agent
-	// context is only cancelled at the end of Stop, after every backend is
-	// stopped, so a restart already holding a backend's restart mutex when
-	// Stop begins still sees a live context; this flag is what it observes
-	// instead.
-	stopping atomic.Bool
+	// stopCancel is called as the first statement of Stop. The agent context
+	// is only cancelled at the end of Stop, after every backend is stopped,
+	// so a restart already holding a backend's restart mutex when Stop
+	// begins still sees a live context; stopCtx is what it observes instead.
+	stopCtx    context.Context
+	stopCancel context.CancelFunc
 }
 
 var _ Agent = (*orbAgent)(nil)
@@ -148,6 +147,7 @@ func New(logger *slog.Logger, c config.Config, debug bool) (Agent, error) {
 	// runtime context supplied in Agent.Start.
 	cm := configmgr.New(logger, pm, c.OrbAgent.ConfigManager.Active, backendStateManager, fm)
 
+	stopCtx, stopCancel := context.WithCancel(context.Background())
 	a := &orbAgent{
 		logger:              logger,
 		config:              c,
@@ -158,6 +158,8 @@ func New(logger *slog.Logger, c config.Config, debug bool) (Agent, error) {
 		backendStateManager: backendStateManager,
 		filesManager:        fm,
 		restartBackendChan:  restartBackendChan,
+		stopCtx:             stopCtx,
+		stopCancel:          stopCancel,
 	}
 	pm.SetStarter(restartStarter{agent: a})
 	return a, nil
@@ -315,18 +317,40 @@ func (a *orbAgent) backendRestartLock(name string) *sync.Mutex {
 // reapplyBackendPolicies hands the backend its own policies again after a
 // restart. A failure is logged, not returned: the policies stay marked unknown
 // for the next successful restart. Once the context is done the agent is
-// shutting down and no new work is launched; the policies stay unknown.
+// shutting down and no new work is launched; the policies stay unknown. The
+// policy manager itself re-checks the context before every policy in its
+// loop, so a shutdown that begins mid-replay stops launching further HTTP
+// calls instead of running the whole backlog.
 //
-// The agent context is cancelled only at the end of Stop, after every
-// backend has been stopped, so a restart that already holds a backend's
-// restart mutex when Stop begins still sees a live context here. The
-// stopping flag is what that in-flight restart observes instead.
+// The apply context is cancelled by whichever of the caller's context or the
+// agent's stop context is cancelled first, since the agent context (unlike
+// stopCtx) is only cancelled at the end of Stop, after every backend has
+// been stopped, so a restart that already holds a backend's restart mutex
+// when Stop begins still sees a live agent context here. The merge makes
+// stopCtx the direct parent of the apply context, so a cancellation of
+// stopCtx (Stop beginning, including mid-replay) is observed synchronously
+// by every check against the apply context, in this function and inside the
+// policy manager's loop alike; the caller's context is folded in through
+// context.AfterFunc, whose callback runs in its own goroutine, so it is
+// checked directly up front rather than relied on to interrupt a loop
+// already in flight.
 func (a *orbAgent) reapplyBackendPolicies(ctx context.Context, name string, be backend.Backend) {
-	if err := ctx.Err(); err != nil || a.stopping.Load() {
+	stopCtx := a.stopCtx
+	if stopCtx == nil {
+		stopCtx = context.Background()
+	}
+	applyCtx, cancel := context.WithCancel(stopCtx)
+	defer cancel()
+	defer context.AfterFunc(ctx, cancel)()
+	if err := ctx.Err(); err != nil {
 		a.logger.Info("shutting down; backend policies left unknown", "backend", name, "error", err)
 		return
 	}
-	if err := a.policyManager.ApplyBackendPolicies(name, be); err != nil {
+	if err := applyCtx.Err(); err != nil {
+		a.logger.Info("shutting down; backend policies left unknown", "backend", name, "error", err)
+		return
+	}
+	if err := a.policyManager.ApplyBackendPolicies(applyCtx, name, be); err != nil {
 		a.logger.Error("backend policies left unapplied after restart; they stay unknown until the next successful restart",
 			"backend", name, "error", err)
 	}
@@ -340,10 +364,29 @@ func (a *orbAgent) reapplyBackendPolicies(ctx context.Context, name string, be b
 //
 // Like RestartBackend, it marks the backend's policies unknown before Stop
 // and re-applies them after each Start that succeeds (the first attempt and
-// the rollback retry). The restart mutex is held across the whole function,
-// so the lock order RestartBackend documents (the restart mutex before the
-// policy manager's apply mutex) holds here too.
+// the rollback retry). restartBackendWithFilesmgrRollbackLocked does that
+// first pass while still holding the restart mutex, so the lock order
+// RestartBackend documents (the restart mutex before the policy manager's
+// apply mutex) holds here too; this function then takes a second pass, with
+// the mutex released, for whatever the policy manager's applier stored
+// failed to apply as "starting" in the window between that first pass and
+// the unlock (a manage that lands there sees the mutex still held, since
+// restartStarter answers from the same mutex). The applier itself skips
+// anything already Running, so a policy the first pass already applied is
+// never applied twice by the second.
 func (a *orbAgent) restartBackendWithFilesmgrRollback(ctx context.Context, backendName string) {
+	restarted, be := a.restartBackendWithFilesmgrRollbackLocked(ctx, backendName)
+	if restarted {
+		a.reapplyBackendPolicies(ctx, backendName, be)
+	}
+}
+
+// restartBackendWithFilesmgrRollbackLocked holds backendName's restart mutex
+// for the whole Stop, Start (and, on failure, rollback and retry) sequence,
+// including the first re-apply pass on a successful Start. It reports
+// whether Start came back up (either attempt), which is what tells the
+// caller a second re-apply pass, with the mutex released, is needed.
+func (a *orbAgent) restartBackendWithFilesmgrRollbackLocked(ctx context.Context, backendName string) (restarted bool, be backend.Backend) {
 	// Serialize concurrent Stop+Start sequences for the same backend across
 	// both restart paths (file-driven and health/fleet-driven).
 	restartMu := a.backendRestartLock(backendName)
@@ -353,7 +396,7 @@ func (a *orbAgent) restartBackendWithFilesmgrRollback(ctx context.Context, backe
 	be, ok := a.backends[backendName]
 	if !ok {
 		a.logger.Warn("filesmgr: backend not registered for restart", "backend", backendName)
-		return
+		return false, nil
 	}
 	binaryName := ""
 	if mb, ok := be.(backend.ManagedBinary); ok {
@@ -394,17 +437,17 @@ func (a *orbAgent) restartBackendWithFilesmgrRollback(ctx context.Context, backe
 	if startErr == nil {
 		a.logger.Info("filesmgr: backend restarted with upgraded binary", "backend", backendName, "binary", binaryName)
 		a.reapplyBackendPolicies(ctx, backendName, be)
-		return
+		return true, be
 	}
 	a.logger.Warn("filesmgr: backend Start failed after upgrade, rolling back", "backend", backendName, "error", startErr)
 
 	if binaryName == "" {
 		a.logger.Error("filesmgr: cannot roll back, backend declares no managed binary", "backend", backendName)
-		return
+		return false, be
 	}
 	if err := a.filesManager.Rollback(ctx, binaryName); err != nil {
 		a.logger.Error("filesmgr: rollback failed", "backend", backendName, "binary", binaryName, "error", err)
-		return
+		return false, be
 	}
 
 	// Retry Start with the rolled-back binary — fresh context derived from ctx again.
@@ -420,10 +463,11 @@ func (a *orbAgent) restartBackendWithFilesmgrRollback(ctx context.Context, backe
 
 	if err := be.Start(runCtx2, runCancel2); err != nil {
 		a.logger.Error("filesmgr: backend Start failed even after rollback", "backend", backendName, "error", err)
-		return
+		return false, be
 	}
 	a.logger.Info("filesmgr: backend restarted with rolled-back binary", "backend", backendName, "binary", binaryName)
 	a.reapplyBackendPolicies(ctx, backendName, be)
+	return true, be
 }
 
 // restartDispatcher runs as a background goroutine and drains pendingRestarts
@@ -589,7 +633,13 @@ func (a *orbAgent) Start(ctx context.Context, cancelFunc context.CancelFunc) err
 }
 
 func (a *orbAgent) Stop(ctx context.Context) {
-	a.stopping.Store(true)
+	// Cancelled first, ahead of every other teardown step, so an in-flight
+	// restart's replay observes shutdown as soon as it checks stopCtx. Guarded
+	// against nil for tests that build an orbAgent literal without going
+	// through New.
+	if a.stopCancel != nil {
+		a.stopCancel()
+	}
 	a.logger.Info("routine call for stop agent", "routine", ctx.Value(routineKey))
 	// Cancel the restart dispatcher first so it cannot fire a restart after we
 	// begin stopping backends. The dispatcher's select loop respects cancellation
@@ -682,9 +732,16 @@ func (a *orbAgent) shutdownOTLP() {
 // Configure failure), or leaves the policies marked unknown for the next
 // successful restart if the reset itself failed.
 //
-// The per-backend restart mutex is held across both policy manager calls
-// (the removal and the re-apply), so it is taken before the policy
-// manager's apply mutex, never after.
+// restartBackendLocked does all of that while holding the per-backend
+// restart mutex, so it is taken before the policy manager's apply mutex,
+// never after. Whenever it took a first re-apply pass (the backend is up,
+// after a successful reset or because it was never stopped), this function
+// takes a second pass with the mutex released, for whatever landed as
+// "starting" between the first pass and the unlock: a manage arriving in
+// that window still sees the mutex held, since restartStarter answers from
+// it too, and is stored failed to apply rather than running. The policy
+// manager's applier skips anything already Running, so the first pass's own
+// work is never repeated by the second.
 func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason string) error {
 	// Every bundled backend is registered; only the ones this agent started
 	// are in a.backends, and only those have a process to restart.
@@ -693,6 +750,21 @@ func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason strin
 		return errors.New("backend is not started by this agent: " + name)
 	}
 
+	replayed, err := a.restartBackendLocked(ctx, name, reason, be)
+	if replayed {
+		a.reapplyBackendPolicies(ctx, name, be)
+	}
+	return err
+}
+
+// restartBackendLocked holds name's restart mutex for the removal, Configure
+// and FullReset sequence, including the first re-apply pass whenever the
+// backend is up at the end: after a successful reset, or because it was
+// never stopped (Configure never reached, or itself failed) and still runs
+// its previous configuration. It reports whether that first pass ran, which
+// is what tells the caller a second pass, with the mutex released, is
+// needed; only a failed reset leaves the policies unknown with no pass.
+func (a *orbAgent) restartBackendLocked(ctx context.Context, name string, reason string, be backend.Backend) (replayed bool, err error) {
 	// Serialize concurrent Stop+Start sequences for the same backend across
 	// both restart paths (file-driven and health/fleet-driven).
 	restartMu := a.backendRestartLock(name)
@@ -714,12 +786,12 @@ func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason strin
 			// nothing applied; hand its policies back rather than leave
 			// them unknown for a restart that may not come again soon.
 			a.reapplyBackendPolicies(ctx, name, be)
-			return errors.New("backend not found: " + name)
+			return true, errors.New("backend not found: " + name)
 		}
 	}
 	if err := be.Configure(a.logger, a.policyManager.GetRepo(), beConfig, a.backendsCommon, a.filesManager); err != nil {
 		a.reapplyBackendPolicies(ctx, name, be)
-		return err
+		return true, err
 	}
 	a.logger.Info("resetting backend", "backend", name)
 
@@ -729,10 +801,10 @@ func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason strin
 	if err := be.FullReset(ctx); err != nil {
 		a.backendStateManager.RegisterError(name, fmt.Sprintf("failed to reset backend: %v", err))
 		// The policies stay marked unknown; the next successful restart applies them.
-		return nil
+		return false, nil
 	}
 	a.reapplyBackendPolicies(ctx, name, be)
-	return nil
+	return true, nil
 }
 
 func (a *orbAgent) RestartAll(ctx context.Context, reason string) error {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -446,7 +446,6 @@ func (a *orbAgent) scheduleReplay(name string, be backend.Backend) {
 	a.replayers.Add(1)
 	go func() {
 		defer a.replayers.Done()
-		defer scheduled.Store(false)
 		stopCtx := a.stopCtx
 		if stopCtx == nil {
 			stopCtx = context.Background()
@@ -454,12 +453,21 @@ func (a *orbAgent) scheduleReplay(name string, be backend.Backend) {
 		for attempt := 1; ; attempt++ {
 			select {
 			case <-stopCtx.Done():
+				scheduled.Store(false)
 				return
 			case <-time.After(a.replayRetryInterval):
 			}
 			restartMu := a.backendRestartLock(name)
 			restartMu.Lock()
 			completed, retryable := a.reapplyBackendPolicies(stopCtx, name, be)
+			done := completed || !retryable
+			if done {
+				// Cleared while the restart mutex is still held: a restart
+				// that takes the mutex next and gives up must be able to
+				// schedule its own replay rather than be told one is pending
+				// by a goroutine about to exit.
+				scheduled.Store(false)
+			}
 			restartMu.Unlock()
 			if completed {
 				return

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -93,6 +94,14 @@ type orbAgent struct {
 	// operations.
 	backendRestartMu sync.Map // name -> *sync.Mutex
 
+	// restarting marks, per backend name, a restart in flight: set after the
+	// restart mutex is taken and cleared right before the restart's replay,
+	// still under that mutex. restartStarter answers from it, so a manage
+	// arriving while it is set is stored as starting for the replay to apply,
+	// and one arriving after the clear applies directly to a backend that is
+	// up. Entries are never deleted, same rationale as backendRestartMu.
+	restarting sync.Map // name -> *atomic.Bool
+
 	// stopCancel is called as the first statement of Stop. The agent context
 	// is only cancelled at the end of Stop, after every backend is stopped,
 	// so a restart already holding a backend's restart mutex when Stop
@@ -105,19 +114,18 @@ var _ Agent = (*orbAgent)(nil)
 
 // restartStarter tells the policy manager whether a backend can take a
 // policy now. Every backend is started at agent start, so the only reason
-// to say no is a restart in flight: the restart mutex is held across the
-// removal, the stop or reset, and the re-apply, and a policy stored as
-// "backend starting" meanwhile is applied exactly once by that re-apply
-// instead of landing on a process about to be reset or being replayed after
-// it. TryLock never blocks, so the restart-before-apply lock order holds.
+// to say no is a restart in flight: the restarting marker is set once the
+// restart mutex is taken, before the removal, and cleared right before the
+// restart's single replay, still under that mutex. A policy stored as
+// "backend starting" while the marker is set is applied exactly once by
+// that replay instead of landing on a process about to be reset or being
+// replayed after it.
 type restartStarter struct{ agent *orbAgent }
 
 func (s restartStarter) EnsureStarted(name string) (policymgr.StartState, error) {
-	mu := s.agent.backendRestartLock(name)
-	if !mu.TryLock() {
+	if s.agent.restartingFlag(name).Load() {
 		return policymgr.StartStarting, nil
 	}
-	mu.Unlock()
 	return policymgr.StartRunning, nil
 }
 
@@ -314,6 +322,16 @@ func (a *orbAgent) backendRestartLock(name string) *sync.Mutex {
 	return mu
 }
 
+// restartingFlag returns the per-backend marker restartStarter and a restart
+// each consult to tell whether a restart of that backend is currently in
+// flight. Entries are never deleted, same race rationale as
+// backendRestartLock.
+func (a *orbAgent) restartingFlag(name string) *atomic.Bool {
+	v, _ := a.restarting.LoadOrStore(name, &atomic.Bool{})
+	flag, _ := v.(*atomic.Bool) // LoadOrStore stored a *atomic.Bool; assertion cannot fail.
+	return flag
+}
+
 // reapplyBackendPolicies hands the backend its own policies again after a
 // restart. A failure is logged, not returned: the policies stay marked unknown
 // for the next successful restart. Once the context is done the agent is
@@ -363,40 +381,28 @@ func (a *orbAgent) reapplyBackendPolicies(ctx context.Context, name string, be b
 // no infinite loop.
 //
 // Like RestartBackend, it marks the backend's policies unknown before Stop
-// and re-applies them after each Start that succeeds (the first attempt and
-// the rollback retry). restartBackendWithFilesmgrRollbackLocked does that
-// first pass while still holding the restart mutex, so the lock order
-// RestartBackend documents (the restart mutex before the policy manager's
-// apply mutex) holds here too; this function then takes a second pass, with
-// the mutex released, for whatever the policy manager's applier stored
-// failed to apply as "starting" in the window between that first pass and
-// the unlock (a manage that lands there sees the mutex still held, since
-// restartStarter answers from the same mutex). The applier itself skips
-// anything already Running, so a policy the first pass already applied is
-// never applied twice by the second.
+// and re-applies them once, after whichever Start succeeds (the first
+// attempt or the rollback retry), under the same restart mutex and
+// restarting marker: the mutex is taken before the policy manager's apply
+// mutex, never after, and the marker clears right before that re-apply, so a
+// manage arriving before the clear is stored as starting for the re-apply to
+// pick up, and one arriving after applies directly to the backend, which is
+// up by then.
 func (a *orbAgent) restartBackendWithFilesmgrRollback(ctx context.Context, backendName string) {
-	restarted, be := a.restartBackendWithFilesmgrRollbackLocked(ctx, backendName)
-	if restarted {
-		a.reapplyBackendPolicies(ctx, backendName, be)
-	}
-}
-
-// restartBackendWithFilesmgrRollbackLocked holds backendName's restart mutex
-// for the whole Stop, Start (and, on failure, rollback and retry) sequence,
-// including the first re-apply pass on a successful Start. It reports
-// whether Start came back up (either attempt), which is what tells the
-// caller a second re-apply pass, with the mutex released, is needed.
-func (a *orbAgent) restartBackendWithFilesmgrRollbackLocked(ctx context.Context, backendName string) (restarted bool, be backend.Backend) {
 	// Serialize concurrent Stop+Start sequences for the same backend across
 	// both restart paths (file-driven and health/fleet-driven).
 	restartMu := a.backendRestartLock(backendName)
 	restartMu.Lock()
 	defer restartMu.Unlock()
 
+	flag := a.restartingFlag(backendName)
+	flag.Store(true)
+	defer flag.Store(false) // every exit, so a failed restart does not leave manages deferred
+
 	be, ok := a.backends[backendName]
 	if !ok {
 		a.logger.Warn("filesmgr: backend not registered for restart", "backend", backendName)
-		return false, nil
+		return
 	}
 	binaryName := ""
 	if mb, ok := be.(backend.ManagedBinary); ok {
@@ -436,18 +442,19 @@ func (a *orbAgent) restartBackendWithFilesmgrRollbackLocked(ctx context.Context,
 	startErr := be.Start(runCtx, runCancel)
 	if startErr == nil {
 		a.logger.Info("filesmgr: backend restarted with upgraded binary", "backend", backendName, "binary", binaryName)
+		flag.Store(false)
 		a.reapplyBackendPolicies(ctx, backendName, be)
-		return true, be
+		return
 	}
 	a.logger.Warn("filesmgr: backend Start failed after upgrade, rolling back", "backend", backendName, "error", startErr)
 
 	if binaryName == "" {
 		a.logger.Error("filesmgr: cannot roll back, backend declares no managed binary", "backend", backendName)
-		return false, be
+		return
 	}
 	if err := a.filesManager.Rollback(ctx, binaryName); err != nil {
 		a.logger.Error("filesmgr: rollback failed", "backend", backendName, "binary", binaryName, "error", err)
-		return false, be
+		return
 	}
 
 	// Retry Start with the rolled-back binary — fresh context derived from ctx again.
@@ -463,11 +470,11 @@ func (a *orbAgent) restartBackendWithFilesmgrRollbackLocked(ctx context.Context,
 
 	if err := be.Start(runCtx2, runCancel2); err != nil {
 		a.logger.Error("filesmgr: backend Start failed even after rollback", "backend", backendName, "error", err)
-		return false, be
+		return
 	}
 	a.logger.Info("filesmgr: backend restarted with rolled-back binary", "backend", backendName, "binary", binaryName)
+	flag.Store(false)
 	a.reapplyBackendPolicies(ctx, backendName, be)
-	return true, be
 }
 
 // restartDispatcher runs as a background goroutine and drains pendingRestarts
@@ -732,16 +739,14 @@ func (a *orbAgent) shutdownOTLP() {
 // Configure failure), or leaves the policies marked unknown for the next
 // successful restart if the reset itself failed.
 //
-// restartBackendLocked does all of that while holding the per-backend
-// restart mutex, so it is taken before the policy manager's apply mutex,
-// never after. Whenever it took a first re-apply pass (the backend is up,
-// after a successful reset or because it was never stopped), this function
-// takes a second pass with the mutex released, for whatever landed as
-// "starting" between the first pass and the unlock: a manage arriving in
-// that window still sees the mutex held, since restartStarter answers from
-// it too, and is stored failed to apply rather than running. The policy
-// manager's applier skips anything already Running, so the first pass's own
-// work is never repeated by the second.
+// The whole sequence runs under the backend's restart mutex, taken before
+// the policy manager's apply mutex, never after. The restarting marker is
+// set right after the mutex is taken and cleared right before the single
+// re-apply at the end, still under the mutex: a manage arriving before the
+// clear is stored as starting for that re-apply to pick up, and one arriving
+// after applies directly to the backend, which is up by then; the re-apply
+// itself skips anything already Running, so neither path ever applies a
+// policy twice.
 func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason string) error {
 	// Every bundled backend is registered; only the ones this agent started
 	// are in a.backends, and only those have a process to restart.
@@ -750,26 +755,15 @@ func (a *orbAgent) RestartBackend(ctx context.Context, name string, reason strin
 		return errors.New("backend is not started by this agent: " + name)
 	}
 
-	replayed, err := a.restartBackendLocked(ctx, name, reason, be)
-	if replayed {
-		a.reapplyBackendPolicies(ctx, name, be)
-	}
-	return err
-}
-
-// restartBackendLocked holds name's restart mutex for the removal, Configure
-// and FullReset sequence, including the first re-apply pass whenever the
-// backend is up at the end: after a successful reset, or because it was
-// never stopped (Configure never reached, or itself failed) and still runs
-// its previous configuration. It reports whether that first pass ran, which
-// is what tells the caller a second pass, with the mutex released, is
-// needed; only a failed reset leaves the policies unknown with no pass.
-func (a *orbAgent) restartBackendLocked(ctx context.Context, name string, reason string, be backend.Backend) (replayed bool, err error) {
 	// Serialize concurrent Stop+Start sequences for the same backend across
 	// both restart paths (file-driven and health/fleet-driven).
 	restartMu := a.backendRestartLock(name)
 	restartMu.Lock()
 	defer restartMu.Unlock()
+
+	flag := a.restartingFlag(name)
+	flag.Store(true)
+	defer flag.Store(false) // every exit, so a failed restart does not leave manages deferred
 
 	a.logger.Info("restarting backend", "backend", name, "reason", reason)
 	a.backendStateManager.RegisterRestart(name, reason)
@@ -785,13 +779,15 @@ func (a *orbAgent) restartBackendLocked(ctx context.Context, name string, reason
 			// The backend was never stopped, so it is still running with
 			// nothing applied; hand its policies back rather than leave
 			// them unknown for a restart that may not come again soon.
+			flag.Store(false)
 			a.reapplyBackendPolicies(ctx, name, be)
-			return true, errors.New("backend not found: " + name)
+			return errors.New("backend not found: " + name)
 		}
 	}
 	if err := be.Configure(a.logger, a.policyManager.GetRepo(), beConfig, a.backendsCommon, a.filesManager); err != nil {
+		flag.Store(false)
 		a.reapplyBackendPolicies(ctx, name, be)
-		return true, err
+		return err
 	}
 	a.logger.Info("resetting backend", "backend", name)
 
@@ -801,10 +797,11 @@ func (a *orbAgent) restartBackendLocked(ctx context.Context, name string, reason
 	if err := be.FullReset(ctx); err != nil {
 		a.backendStateManager.RegisterError(name, fmt.Sprintf("failed to reset backend: %v", err))
 		// The policies stay marked unknown; the next successful restart applies them.
-		return false, nil
+		return nil
 	}
+	flag.Store(false)
 	a.reapplyBackendPolicies(ctx, name, be)
-	return true, nil
+	return nil
 }
 
 func (a *orbAgent) RestartAll(ctx context.Context, reason string) error {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -92,6 +93,13 @@ type orbAgent struct {
 	// health-driven restart for the same backend can interleave Stop/Start
 	// operations.
 	backendRestartMu sync.Map // name -> *sync.Mutex
+
+	// stopping is set to true as the first statement of Stop. The agent
+	// context is only cancelled at the end of Stop, after every backend is
+	// stopped, so a restart already holding a backend's restart mutex when
+	// Stop begins still sees a live context; this flag is what it observes
+	// instead.
+	stopping atomic.Bool
 }
 
 var _ Agent = (*orbAgent)(nil)
@@ -308,8 +316,13 @@ func (a *orbAgent) backendRestartLock(name string) *sync.Mutex {
 // restart. A failure is logged, not returned: the policies stay marked unknown
 // for the next successful restart. Once the context is done the agent is
 // shutting down and no new work is launched; the policies stay unknown.
+//
+// The agent context is cancelled only at the end of Stop, after every
+// backend has been stopped, so a restart that already holds a backend's
+// restart mutex when Stop begins still sees a live context here. The
+// stopping flag is what that in-flight restart observes instead.
 func (a *orbAgent) reapplyBackendPolicies(ctx context.Context, name string, be backend.Backend) {
-	if err := ctx.Err(); err != nil {
+	if err := ctx.Err(); err != nil || a.stopping.Load() {
 		a.logger.Info("shutting down; backend policies left unknown", "backend", name, "error", err)
 		return
 	}
@@ -576,6 +589,7 @@ func (a *orbAgent) Start(ctx context.Context, cancelFunc context.CancelFunc) err
 }
 
 func (a *orbAgent) Stop(ctx context.Context) {
+	a.stopping.Store(true)
 	a.logger.Info("routine call for stop agent", "routine", ctx.Value(routineKey))
 	// Cancel the restart dispatcher first so it cannot fire a restart after we
 	// begin stopping backends. The dispatcher's select loop respects cancellation

--- a/agent/agent_filesmgr_test.go
+++ b/agent/agent_filesmgr_test.go
@@ -89,6 +89,7 @@ func TestRestartBackendWithFilesmgrRollback_RetriesAfterFailure(t *testing.T) {
 	defer cancel()
 
 	a := &orbAgent{
+		policyManager:  &mockPolicyManager{},
 		logger:         slog.Default(),
 		backends:       map[string]backend.Backend{"worker": be},
 		filesManager:   fm,
@@ -241,6 +242,7 @@ func TestRestartDispatcher_StopsOnDispatcherCancel(t *testing.T) {
 	dispatcherCtx, dispatcherCancel := context.WithCancel(parentCtx)
 
 	a := &orbAgent{
+		policyManager:    &mockPolicyManager{},
 		logger:           slog.Default(),
 		backends:         map[string]backend.Backend{"worker": be},
 		filesManager:     &mockFilesManager{},
@@ -305,6 +307,7 @@ func TestRestartDispatcher_ProcessesRestartsSequentially(t *testing.T) {
 	defer cancel()
 
 	a := &orbAgent{
+		policyManager:  &mockPolicyManager{},
 		logger:         slog.Default(),
 		backends:       backends,
 		filesManager:   &mockFilesManager{},
@@ -364,6 +367,7 @@ func TestRestartDispatcher_CtxCancelMidDrain(t *testing.T) {
 	dispatcherCtx, dispatcherCancel := context.WithCancel(parentCtx)
 
 	a := &orbAgent{
+		policyManager:    &mockPolicyManager{},
 		logger:           slog.Default(),
 		backends:         backends,
 		filesManager:     &mockFilesManager{},
@@ -445,6 +449,7 @@ func TestSubscribeToFilesmgr_CoalescesAndDeliversReliably(t *testing.T) {
 	defer cancel()
 
 	a := &orbAgent{
+		policyManager:  &mockPolicyManager{},
 		logger:         slog.Default(),
 		backends:       map[string]backend.Backend{},
 		filesManager:   &mockFilesManager{},
@@ -562,6 +567,7 @@ func TestBackendRestartLock_SerializesConcurrentRestarts(t *testing.T) {
 	defer cancel()
 
 	a := &orbAgent{
+		policyManager:  &mockPolicyManager{},
 		logger:         slog.Default(),
 		backends:       map[string]backend.Backend{"worker": cbe},
 		filesManager:   &mockFilesManager{},
@@ -693,6 +699,7 @@ func TestRestartBackendWithFilesmgrRollback_FirstInstallFailureFallsBackToBaked(
 	defer cancel()
 
 	a := &orbAgent{
+		policyManager:  &mockPolicyManager{},
 		logger:         slog.Default(),
 		backends:       map[string]backend.Backend{"worker": be},
 		filesManager:   fm,
@@ -751,6 +758,7 @@ func TestRestartBackendWithFilesmgrRollback_NoCancelLeakOnRollbackRetry(t *testi
 	defer cancel()
 
 	a := &orbAgent{
+		policyManager:  &mockPolicyManager{},
 		logger:         slog.Default(),
 		backends:       map[string]backend.Backend{"worker": be},
 		filesManager:   fm,

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -123,8 +123,8 @@ type mockPolicyManager struct {
 	repo policies.PolicyRepo
 }
 
-func (m *mockPolicyManager) ManagePolicy(_ config.PolicyPayload)                       {}
-func (m *mockPolicyManager) RemovePolicyDataset(_ string, _ string, _ backend.Backend) {}
+func (m *mockPolicyManager) ManagePolicy(_ config.PolicyPayload)                                 {}
+func (m *mockPolicyManager) RemovePolicyDataset(_ string, _ string, _ string, _ backend.Backend) {}
 func (m *mockPolicyManager) GetPolicyState() ([]policies.PolicyData, error) {
 	return nil, nil
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -128,20 +128,52 @@ type mockPolicyManager struct {
 	repo   policies.PolicyRepo
 	events *[]string // shared with the backend stub so one slice records the order
 
+	// mu guards events, applyErrs, and lastErr against a scheduled replay
+	// goroutine calling ApplyBackendPolicies while a test concurrently reads
+	// the recorded events through snapshotEvents.
+	mu sync.Mutex
+
 	// applyErrs queues the errors ApplyBackendPolicies returns, one per call,
 	// popped in call order; once the queue is empty every further call
-	// returns nil.
+	// returns nil, unless repeatLastErr is set.
 	applyErrs []error
+
+	// repeatLastErr, when true, makes ApplyBackendPolicies keep returning the
+	// last popped error forever once applyErrs is exhausted, instead of nil.
+	repeatLastErr bool
+	lastErr       error
 
 	// onApply, when set, runs at the start of every ApplyBackendPolicies
 	// call, before the queued error is popped.
 	onApply func()
+
+	// agent, when set, makes ApplyBackendPolicies record whether the
+	// backend's restart mutex is held at call time (see ApplyBackendPolicies
+	// below), so a test can see a scheduled replay's attempt hold the
+	// mutex. Left nil, and so checked before use, by tests that do not care.
+	agent *orbAgent
 }
 
 func (m *mockPolicyManager) record(event string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.events != nil {
 		*m.events = append(*m.events, event)
 	}
+}
+
+// snapshotEvents returns a copy of the recorded events. Safe to call while a
+// scheduled replay goroutine may be recording concurrently, unlike reading
+// the shared slice directly.
+func (m *mockPolicyManager) snapshotEvents() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.events == nil {
+		return nil
+	}
+	out := make([]string, len(*m.events))
+	copy(out, *m.events)
+	return out
 }
 
 func (m *mockPolicyManager) ManagePolicy(_ config.PolicyPayload)                                 {}
@@ -154,18 +186,47 @@ func (m *mockPolicyManager) GetRepo() policies.PolicyRepo {
 	return m.repo
 }
 
-// ApplyBackendPolicies records a plain "apply:<name>" event.
+// nextErr pops the next queued error for ApplyBackendPolicies, in call
+// order; once the queue is empty it returns nil, unless repeatLastErr is
+// set, in which case it keeps returning the last popped error.
+func (m *mockPolicyManager) nextErr() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.applyErrs) > 0 {
+		m.lastErr = m.applyErrs[0]
+		m.applyErrs = m.applyErrs[1:]
+		return m.lastErr
+	}
+	if m.repeatLastErr {
+		return m.lastErr
+	}
+	return nil
+}
+
+// ApplyBackendPolicies records a plain "apply:<name>" event, unless agent is
+// set: then it records whether the backend's restart mutex is held at call
+// time, as "apply:<name>:locked" or "apply:<name>:unlocked", using a
+// non-blocking TryLock, so a test can see a scheduled replay's attempt hold
+// the mutex.
 func (m *mockPolicyManager) ApplyBackendPolicies(_ context.Context, name string, _ backend.Backend) error {
 	if m.onApply != nil {
 		m.onApply()
 	}
-	m.record("apply:" + name)
-	var err error
-	if len(m.applyErrs) > 0 {
-		err = m.applyErrs[0]
-		m.applyErrs = m.applyErrs[1:]
+	if m.agent == nil {
+		m.record("apply:" + name)
+	} else {
+		mu := m.agent.backendRestartLock(name)
+		held := !mu.TryLock()
+		if !held {
+			mu.Unlock()
+		}
+		state := "unlocked"
+		if held {
+			state = "locked"
+		}
+		m.record(fmt.Sprintf("apply:%s:%s", name, state))
 	}
-	return err
+	return m.nextErr()
 }
 
 func (m *mockPolicyManager) RemoveBackendPolicies(name string, _ backend.Backend, permanently bool) error {
@@ -290,6 +351,10 @@ func TestRestartBackendRetriesTheReplayWhileTheBackendIsNotAnsweringYet(t *testi
 // The replay is retried a bounded number of times: a backend that keeps
 // answering not-running must not be retried forever, since nothing else
 // would ever install its policies (the health monitor sees it as healthy).
+// The give-up schedules a replay (covered by
+// TestRestartBackendReschedulesAReplayThatGaveUp); replayRetryInterval is
+// set long here and torn down through Stop's own cancellation so that
+// background attempt cannot fire during this test and race its assertion.
 func TestRestartBackendGivesUpTheReplayAfterThreeAttempts(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	repo, err := policies.NewMemRepo()
@@ -299,6 +364,7 @@ func TestRestartBackendGivesUpTheReplayAfterThreeAttempts(t *testing.T) {
 		policymgr.ErrBackendNotRunning, policymgr.ErrBackendNotRunning, policymgr.ErrBackendNotRunning,
 	}}
 	be := &restartableBackend{events: &events}
+	stopCtx, stopCancel := context.WithCancel(context.Background())
 	a := &orbAgent{
 		logger:              logger,
 		backends:            map[string]backend.Backend{"snmp_discovery": be},
@@ -306,6 +372,9 @@ func TestRestartBackendGivesUpTheReplayAfterThreeAttempts(t *testing.T) {
 		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), repo),
 		config:              config.Config{},
 		reapplyRetryDelay:   time.Millisecond,
+		replayRetryInterval: time.Hour,
+		stopCtx:             stopCtx,
+		stopCancel:          stopCancel,
 	}
 
 	require.NoError(t, a.RestartBackend(context.Background(), "snmp_discovery", "test"))
@@ -318,6 +387,15 @@ func TestRestartBackendGivesUpTheReplayAfterThreeAttempts(t *testing.T) {
 		"apply:snmp_discovery",
 		"apply:snmp_discovery",
 	}, events, "the replay gives up after three attempts and leaves the policies unknown")
+
+	a.stopCancel()
+	waitDone := make(chan struct{})
+	go func() { a.replayers.Wait(); close(waitDone) }()
+	select {
+	case <-waitDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("replayers.Wait did not return within 5s of shutdown")
+	}
 }
 
 // A failure that is not ErrBackendNotRunning is not transient in the same
@@ -391,6 +469,170 @@ func TestRestartBackendStopsRetryingWhenStopBegins(t *testing.T) {
 		"reset",
 		"apply:snmp_discovery",
 	}, events, "the retry wait is cancelled the instant Stop begins, not slept out")
+}
+
+// countLockedApplies counts how many "apply:<name>:locked" events appear in
+// events, so a test can wait for a scheduled replay's own attempt (recorded
+// the same way as the restart's own attempts, since both hold the restart
+// mutex) without racing the goroutine that records it.
+func countLockedApplies(events []string, name string) int {
+	want := "apply:" + name + ":locked"
+	n := 0
+	for _, e := range events {
+		if e == want {
+			n++
+		}
+	}
+	return n
+}
+
+// A replay that gives up because the backend is still not answering must
+// not leave the restart marker set forever: nothing else asks for another
+// restart once the health monitor sees the backend running. The give-up is
+// rescheduled and keeps trying, at replayRetryInterval, until it completes.
+func TestRestartBackendReschedulesAReplayThatGaveUp(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	events := []string{}
+	pm := &mockPolicyManager{repo: repo, events: &events, applyErrs: []error{
+		policymgr.ErrBackendNotRunning, policymgr.ErrBackendNotRunning, policymgr.ErrBackendNotRunning, nil,
+	}}
+	be := &restartableBackend{events: &events}
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{"snmp_discovery": be},
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), repo),
+		config:              config.Config{},
+		reapplyRetryDelay:   time.Millisecond,
+		replayRetryInterval: time.Millisecond,
+	}
+	pm.agent = a
+
+	require.NoError(t, a.RestartBackend(context.Background(), "snmp_discovery", "test"))
+
+	require.Eventually(t, func() bool {
+		return countLockedApplies(pm.snapshotEvents(), "snmp_discovery") >= 4
+	}, 5*time.Second, time.Millisecond,
+		"the scheduled replay must make a fourth attempt, holding the restart mutex, and complete")
+
+	waitDone := make(chan struct{})
+	go func() { a.replayers.Wait(); close(waitDone) }()
+	select {
+	case <-waitDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("replayers.Wait did not return promptly once the scheduled replay completed")
+	}
+}
+
+// The wait between scheduled replay attempts is cancelled the instant Stop
+// begins, not slept out, even when the interval is long: the loop selects
+// on stopCtx rather than sleeping.
+func TestScheduledReplayStopsOnShutdown(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	events := []string{}
+	pm := &mockPolicyManager{repo: repo, events: &events, applyErrs: []error{
+		policymgr.ErrBackendNotRunning, policymgr.ErrBackendNotRunning, policymgr.ErrBackendNotRunning,
+	}, repeatLastErr: true}
+	be := &restartableBackend{events: &events}
+	stopCtx, stopCancel := context.WithCancel(context.Background())
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{"snmp_discovery": be},
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), repo),
+		config:              config.Config{},
+		reapplyRetryDelay:   time.Millisecond,
+		replayRetryInterval: time.Hour,
+		stopCtx:             stopCtx,
+		stopCancel:          stopCancel,
+	}
+	pm.agent = a
+
+	require.NoError(t, a.RestartBackend(context.Background(), "snmp_discovery", "test"))
+
+	a.stopCancel()
+
+	waitDone := make(chan struct{})
+	go func() { a.replayers.Wait(); close(waitDone) }()
+	select {
+	case <-waitDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("replayers.Wait did not return within 5s of shutdown")
+	}
+}
+
+// A second give-up for the same backend while a replay is already scheduled
+// must not start a second goroutine: the one already running keeps
+// retrying on its own.
+func TestScheduledReplayIsNotDuplicated(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	events := []string{}
+	pm := &mockPolicyManager{repo: repo, events: &events, applyErrs: []error{
+		policymgr.ErrBackendNotRunning, policymgr.ErrBackendNotRunning, policymgr.ErrBackendNotRunning,
+		policymgr.ErrBackendNotRunning, policymgr.ErrBackendNotRunning, policymgr.ErrBackendNotRunning,
+	}, repeatLastErr: true}
+	be := &restartableBackend{events: &events}
+	stopCtx, stopCancel := context.WithCancel(context.Background())
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{"snmp_discovery": be},
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), repo),
+		config:              config.Config{},
+		reapplyRetryDelay:   time.Millisecond,
+		replayRetryInterval: time.Hour,
+		stopCtx:             stopCtx,
+		stopCancel:          stopCancel,
+	}
+	pm.agent = a
+
+	require.NoError(t, a.RestartBackend(context.Background(), "snmp_discovery", "test"))
+	require.NoError(t, a.RestartBackend(context.Background(), "snmp_discovery", "test"))
+
+	assert.Equal(t, int32(1), a.replayStarts.Load(),
+		"a second give-up while one replay is already scheduled must not start a second goroutine")
+
+	a.stopCancel()
+	waitDone := make(chan struct{})
+	go func() { a.replayers.Wait(); close(waitDone) }()
+	select {
+	case <-waitDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("replayers.Wait did not return within 5s of shutdown")
+	}
+}
+
+// A failure that is not ErrBackendNotRunning is not transient, so it must
+// not be rescheduled either: nothing about it will change on its own.
+func TestRestartBackendDoesNotRescheduleANonRetryableFailure(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	events := []string{}
+	pm := &mockPolicyManager{repo: repo, events: &events, applyErrs: []error{
+		errors.New("repo failure"),
+	}}
+	be := &restartableBackend{events: &events}
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{"snmp_discovery": be},
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), repo),
+		config:              config.Config{},
+		reapplyRetryDelay:   time.Millisecond,
+		replayRetryInterval: time.Millisecond,
+	}
+	pm.agent = a
+
+	require.NoError(t, a.RestartBackend(context.Background(), "snmp_discovery", "test"))
+
+	assert.Equal(t, int32(0), a.replayStarts.Load(), "a non-retryable failure must not be rescheduled")
 }
 
 // A reset that fails leaves the policies marked for the next restart and

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/configmgr"
 	"github.com/netboxlabs/orb-agent/agent/filesmgr"
 	"github.com/netboxlabs/orb-agent/agent/policies"
+	"github.com/netboxlabs/orb-agent/agent/policymgr"
 )
 
 // mockConfigManager implements configmgr.Manager for testing Stop delegation
@@ -144,6 +145,8 @@ func (m *mockPolicyManager) RemoveBackendPolicies(_ string, _ backend.Backend, _
 func (m *mockPolicyManager) RemovePolicy(_ string, _ string, _ string) error {
 	return nil
 }
+
+func (m *mockPolicyManager) SetStarter(_ policymgr.BackendStarter) {}
 
 // mockFilesManager implements filesmgr.Manager for testing (no-op)
 type mockFilesManager struct{}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"testing"
@@ -17,6 +19,7 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/filesmgr"
 	"github.com/netboxlabs/orb-agent/agent/policies"
 	"github.com/netboxlabs/orb-agent/agent/policymgr"
+	"github.com/netboxlabs/orb-agent/agent/secretsmgr"
 )
 
 // mockConfigManager implements configmgr.Manager for testing Stop delegation
@@ -121,7 +124,14 @@ func TestAgentStop_FailNonTerminalRunsBeforeConfigManagerStop(t *testing.T) {
 
 // mockPolicyManager implements policymgr.PolicyManager for testing
 type mockPolicyManager struct {
-	repo policies.PolicyRepo
+	repo   policies.PolicyRepo
+	events *[]string // shared with the backend stub so one slice records the order
+}
+
+func (m *mockPolicyManager) record(event string) {
+	if m.events != nil {
+		*m.events = append(*m.events, event)
+	}
 }
 
 func (m *mockPolicyManager) ManagePolicy(_ config.PolicyPayload)                                 {}
@@ -134,11 +144,13 @@ func (m *mockPolicyManager) GetRepo() policies.PolicyRepo {
 	return m.repo
 }
 
-func (m *mockPolicyManager) ApplyBackendPolicies(_ string, _ backend.Backend) error {
+func (m *mockPolicyManager) ApplyBackendPolicies(name string, _ backend.Backend) error {
+	m.record("apply:" + name)
 	return nil
 }
 
-func (m *mockPolicyManager) RemoveBackendPolicies(_ string, _ backend.Backend, _ bool) error {
+func (m *mockPolicyManager) RemoveBackendPolicies(name string, _ backend.Backend, permanently bool) error {
+	m.record(fmt.Sprintf("remove:%s:permanently=%t", name, permanently))
 	return nil
 }
 
@@ -147,6 +159,268 @@ func (m *mockPolicyManager) RemovePolicy(_ string, _ string, _ string) error {
 }
 
 func (m *mockPolicyManager) SetStarter(_ policymgr.BackendStarter) {}
+
+// restartableBackend records, into the shared slice, the calls a restart makes.
+type restartableBackend struct {
+	backend.Backend
+	events  *[]string
+	applied []policies.PolicyData
+}
+
+func (r *restartableBackend) Configure(*slog.Logger, policies.PolicyRepo, map[string]any, config.BackendCommons, filesmgr.Manager) error {
+	*r.events = append(*r.events, "configure")
+	return nil
+}
+
+func (r *restartableBackend) FullReset(context.Context) error {
+	*r.events = append(*r.events, "reset")
+	return nil
+}
+
+func (r *restartableBackend) GetRunningStatus() (backend.RunningStatus, string, error) {
+	return backend.Running, "", nil
+}
+
+func (r *restartableBackend) ApplyPolicy(pd policies.PolicyData, updatePolicy bool) error {
+	*r.events = append(*r.events, fmt.Sprintf("apply-policy:%s:update=%t", pd.ID, updatePolicy))
+	r.applied = append(r.applied, pd)
+	return nil
+}
+
+func (r *restartableBackend) RemovePolicy(pd policies.PolicyData) error {
+	*r.events = append(*r.events, "remove-policy:"+pd.ID)
+	return nil
+}
+
+type failingResetBackend struct{ restartableBackend }
+
+func (f *failingResetBackend) FullReset(context.Context) error {
+	*f.events = append(*f.events, "reset")
+	return errors.New("reset failed")
+}
+
+type failingConfigureBackend struct{ restartableBackend }
+
+func (f *failingConfigureBackend) Configure(*slog.Logger, policies.PolicyRepo, map[string]any, config.BackendCommons, filesmgr.Manager) error {
+	*f.events = append(*f.events, "configure")
+	return errors.New("configure failed")
+}
+
+// A restart keeps the backend's policies and re-applies them once the
+// backend is back: they are marked unknown for the restart, not deleted,
+// and applied after the reset.
+func TestRestartBackendReappliesItsOwnPolicies(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	events := []string{}
+	pm := &mockPolicyManager{repo: repo, events: &events}
+	be := &restartableBackend{events: &events}
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{"snmp_discovery": be},
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), repo),
+		config:              config.Config{},
+	}
+
+	require.NoError(t, a.RestartBackend(context.Background(), "snmp_discovery", "test"))
+
+	assert.Equal(t, []string{
+		"remove:snmp_discovery:permanently=false",
+		"configure",
+		"reset",
+		"apply:snmp_discovery",
+	}, events, "policies kept, removed before the reset and applied after it")
+}
+
+// A reset that fails leaves the policies marked for the next restart and
+// does not apply them to a backend that is not back.
+func TestRestartBackendDoesNotReapplyWhenTheResetFails(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	events := []string{}
+	pm := &mockPolicyManager{repo: repo, events: &events}
+	be := &failingResetBackend{restartableBackend: restartableBackend{events: &events}}
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{"snmp_discovery": be},
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), repo),
+		config:              config.Config{},
+	}
+
+	require.NoError(t, a.RestartBackend(context.Background(), "snmp_discovery", "test"))
+
+	assert.Equal(t, []string{
+		"remove:snmp_discovery:permanently=false",
+		"configure",
+		"reset",
+	}, events, "the removal still runs and nothing past the failed reset does")
+}
+
+// A Configure failure never stops the backend: it is still running its
+// previous configuration, so the policies removed for the restart are handed
+// back immediately rather than left marked unknown for a restart that may
+// not come again soon.
+func TestRestartBackendReappliesPoliciesWhenConfigureFails(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	events := []string{}
+	pm := &mockPolicyManager{repo: repo, events: &events}
+	be := &failingConfigureBackend{restartableBackend: restartableBackend{events: &events}}
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{"snmp_discovery": be},
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), repo),
+		config:              config.Config{},
+	}
+
+	restartErr := a.RestartBackend(context.Background(), "snmp_discovery", "test")
+
+	require.Error(t, restartErr)
+	assert.Equal(t, []string{
+		"remove:snmp_discovery:permanently=false",
+		"configure",
+		"apply:snmp_discovery",
+	}, events, "the backend never stopped, so the removed policies are reapplied immediately")
+}
+
+// End to end with the real policy manager: a policy the backend ran before
+// the restart is still in the repo afterwards, running, and was handed to
+// the backend once more in the remove-then-apply form.
+func TestRestartBackendReappliesPoliciesEndToEnd(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secrets, err := secretsmgr.New(logger, config.ManagerSecrets{})
+	require.NoError(t, err)
+	pm, err := policymgr.New(logger, secrets, config.Config{})
+	require.NoError(t, err)
+	events := []string{}
+	be := &restartableBackend{events: &events}
+	require.NoError(t, pm.GetRepo().Update(policies.PolicyData{ID: "kept", Name: "Kept", Backend: "snmp_discovery", Version: 3, Data: map[string]any{"k": "v"}, State: policies.Running}))
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{"snmp_discovery": be},
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), pm.GetRepo()),
+		config:              config.Config{},
+	}
+
+	require.NoError(t, a.RestartBackend(context.Background(), "snmp_discovery", "test"))
+
+	stored, err := pm.GetRepo().Get("kept")
+	require.NoError(t, err, "the policy survives the restart")
+	assert.Equal(t, policies.Running, stored.State)
+	assert.Equal(t, int32(3), stored.Version)
+	assert.Equal(t, []string{"remove-policy:kept", "configure", "reset", "apply-policy:kept:update=true"}, events,
+		"the backend is asked to drop the policy before the reset and handed it again after")
+	require.Len(t, be.applied, 1)
+	assert.Equal(t, int32(3), be.applied[0].Version)
+}
+
+// filesmgrRestartBackend records, into the shared slice, the Stop/Start calls
+// a filesmgr-driven restart makes. startFailures controls how many of the
+// first calls to Start return an error before Start starts succeeding; a
+// zero value never fails.
+type filesmgrRestartBackend struct {
+	restartableBackend
+	binaryName    string
+	startFailures int
+	startCalls    int
+}
+
+func (r *filesmgrRestartBackend) ManagedBinaryName() string { return r.binaryName }
+
+func (r *filesmgrRestartBackend) Stop(context.Context) error {
+	*r.events = append(*r.events, "stop")
+	return nil
+}
+
+func (r *filesmgrRestartBackend) Start(context.Context, context.CancelFunc) error {
+	r.startCalls++
+	*r.events = append(*r.events, "start")
+	if r.startCalls <= r.startFailures {
+		return errors.New("start failed")
+	}
+	return nil
+}
+
+// A filesmgr-driven restart brackets its Stop/Start sequence the same way
+// RestartBackend does: policies are marked unknown before Stop and handed
+// back to the backend once Start succeeds.
+func TestRestartBackendWithFilesmgrRollback_ReappliesPoliciesAfterSuccessfulStart(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	events := []string{}
+	pm := &mockPolicyManager{events: &events}
+	be := &filesmgrRestartBackend{restartableBackend: restartableBackend{events: &events}, binaryName: "orb-worker"}
+	a := &orbAgent{
+		logger:        logger,
+		backends:      map[string]backend.Backend{"worker": be},
+		policyManager: pm,
+		filesManager:  &mockFilesManager{},
+	}
+
+	a.restartBackendWithFilesmgrRollback(context.Background(), "worker")
+
+	assert.Equal(t, []string{
+		"remove:worker:permanently=false",
+		"stop",
+		"start",
+		"apply:worker",
+	}, events)
+}
+
+// A Start that fails, then succeeds after a rollback, is re-applied exactly
+// once, after the retry, not after the failed first attempt.
+func TestRestartBackendWithFilesmgrRollback_ReappliesPoliciesAfterRollbackRetry(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	events := []string{}
+	pm := &mockPolicyManager{events: &events}
+	be := &filesmgrRestartBackend{restartableBackend: restartableBackend{events: &events}, binaryName: "orb-worker", startFailures: 1}
+	a := &orbAgent{
+		logger:        logger,
+		backends:      map[string]backend.Backend{"worker": be},
+		policyManager: pm,
+		filesManager:  &mockFilesManager{},
+	}
+
+	a.restartBackendWithFilesmgrRollback(context.Background(), "worker")
+
+	assert.Equal(t, []string{
+		"remove:worker:permanently=false",
+		"stop",
+		"start",
+		"start",
+		"apply:worker",
+	}, events, "apply must run exactly once, after the successful retry")
+}
+
+// A Start that fails on a backend with no managed binary name cannot roll
+// back, so the restart gives up without ever reapplying the policies it
+// removed.
+func TestRestartBackendWithFilesmgrRollback_DoesNotReapplyWithoutAManagedBinary(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	events := []string{}
+	pm := &mockPolicyManager{events: &events}
+	be := &filesmgrRestartBackend{restartableBackend: restartableBackend{events: &events}, startFailures: 1}
+	a := &orbAgent{
+		logger:        logger,
+		backends:      map[string]backend.Backend{"worker": be},
+		policyManager: pm,
+		filesManager:  &mockFilesManager{},
+	}
+
+	a.restartBackendWithFilesmgrRollback(context.Background(), "worker")
+
+	assert.Equal(t, []string{
+		"remove:worker:permanently=false",
+		"stop",
+		"start",
+	}, events)
+}
 
 // mockFilesManager implements filesmgr.Manager for testing (no-op)
 type mockFilesManager struct{}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -133,7 +133,7 @@ func (m *mockPolicyManager) GetRepo() policies.PolicyRepo {
 	return m.repo
 }
 
-func (m *mockPolicyManager) ApplyBackendPolicies(_ backend.Backend) error {
+func (m *mockPolicyManager) ApplyBackendPolicies(_ string, _ backend.Backend) error {
 	return nil
 }
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -351,6 +351,53 @@ func TestRestartBackendReappliesPoliciesEndToEnd(t *testing.T) {
 	assert.Equal(t, int32(3), be.applied[0].Version)
 }
 
+// failOnceApplyBackend fails the first ApplyPolicy call and succeeds on any
+// call after, recording how many times it was called, so a test can prove a
+// replay's second pass does not retry a policy its first pass already
+// answered.
+type failOnceApplyBackend struct {
+	restartableBackend
+	calls int
+}
+
+func (f *failOnceApplyBackend) ApplyPolicy(pd policies.PolicyData, updatePolicy bool) error {
+	f.calls++
+	if f.calls == 1 {
+		return errors.New("apply timed out")
+	}
+	return f.restartableBackend.ApplyPolicy(pd, updatePolicy)
+}
+
+// End to end with the real policy manager: a policy the first replay pass
+// fails to apply is stored failed to apply with the backend's own reason,
+// and the second pass, taken after the restart mutex is released, must not
+// hand it to the backend again.
+func TestRestartBackendSecondPassDoesNotRetryAPolicyTheFirstPassFailed(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secrets, err := secretsmgr.New(logger, config.ManagerSecrets{})
+	require.NoError(t, err)
+	pm, err := policymgr.New(logger, secrets, config.Config{})
+	require.NoError(t, err)
+	events := []string{}
+	be := &failOnceApplyBackend{restartableBackend: restartableBackend{events: &events}}
+	require.NoError(t, pm.GetRepo().Update(policies.PolicyData{ID: "flaky", Name: "Flaky", Backend: "snmp_discovery", Version: 1, Data: map[string]any{"k": "v"}, State: policies.Running}))
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{"snmp_discovery": be},
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), pm.GetRepo()),
+		config:              config.Config{},
+	}
+
+	require.NoError(t, a.RestartBackend(context.Background(), "snmp_discovery", "test"))
+
+	stored, err := pm.GetRepo().Get("flaky")
+	require.NoError(t, err)
+	assert.Equal(t, policies.FailedToApply, stored.State)
+	assert.Equal(t, "apply timed out", stored.BackendErr)
+	assert.Equal(t, 1, be.calls, "the second pass must not retry a policy the first pass already failed")
+}
+
 // A Start (file-driven or otherwise) that is already blocked on the restart
 // mutex when Stop cancels the agent context can still succeed once the
 // mutex is free, but by then the agent is shutting down: the reset succeeds

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -524,6 +526,60 @@ func TestRestartBackendReschedulesAReplayThatGaveUp(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("replayers.Wait did not return promptly once the scheduled replay completed")
 	}
+}
+
+// The scheduled replay clears its per-backend flag while it still holds the
+// restart mutex, so a restart that takes the mutex right after it and gives
+// up is not told a replay is already scheduled by a goroutine about to exit.
+func TestScheduledReplayClearsItsFlagBeforeReleasingTheRestartMutex(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	events := []string{}
+	pm := &mockPolicyManager{repo: repo, events: &events, applyErrs: []error{
+		policymgr.ErrBackendNotRunning, policymgr.ErrBackendNotRunning, policymgr.ErrBackendNotRunning, nil,
+	}}
+	be := &restartableBackend{events: &events}
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{"snmp_discovery": be},
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), repo),
+		config:              config.Config{},
+		reapplyRetryDelay:   time.Millisecond,
+		replayRetryInterval: time.Millisecond,
+	}
+	pm.agent = a
+	var applies atomic.Int32
+	observed := make(chan bool, 1)
+	pm.onApply = func() {
+		if applies.Add(1) != 4 {
+			return
+		}
+		// The fourth apply is the scheduled replay's, made under the restart
+		// mutex. Race for the mutex from here; whoever gets it after the
+		// scheduled replay releases it must see the flag already cleared.
+		go func() {
+			mu := a.backendRestartLock("snmp_discovery")
+			for !mu.TryLock() {
+				runtime.Gosched()
+			}
+			v, _ := a.replayScheduled.Load("snmp_discovery")
+			flag, _ := v.(*atomic.Bool)
+			observed <- flag != nil && flag.Load()
+			mu.Unlock()
+		}()
+	}
+
+	require.NoError(t, a.RestartBackend(context.Background(), "snmp_discovery", "test"))
+
+	select {
+	case stillScheduled := <-observed:
+		assert.False(t, stillScheduled, "the flag must be cleared before the restart mutex is released")
+	case <-time.After(5 * time.Second):
+		t.Fatal("the scheduled replay never made its fourth attempt")
+	}
+	a.replayers.Wait()
 }
 
 // The wait between scheduled replay attempts is cancelled the instant Stop

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -128,11 +128,6 @@ type mockPolicyManager struct {
 	repo   policies.PolicyRepo
 	events *[]string // shared with the backend stub so one slice records the order
 
-	// agent, when set, makes ApplyBackendPolicies record whether a restart of
-	// the backend is in flight at call time (see ApplyBackendPolicies below).
-	// Left nil, and so checked before use, by tests that do not care.
-	agent *orbAgent
-
 	// applyErrs queues the errors ApplyBackendPolicies returns, one per call,
 	// popped in call order; once the queue is empty every further call
 	// returns nil.
@@ -159,20 +154,12 @@ func (m *mockPolicyManager) GetRepo() policies.PolicyRepo {
 	return m.repo
 }
 
-// ApplyBackendPolicies records a plain "apply:<name>" event, unless agent is
-// set: then it records whether a restart of the backend is in flight at call
-// time, as "apply:<name>:restarting=<bool>", so a test can tell the replay
-// (restarting=false, since the marker clears before it runs) from a manage
-// that lands while a restart holds the marker.
+// ApplyBackendPolicies records a plain "apply:<name>" event.
 func (m *mockPolicyManager) ApplyBackendPolicies(_ context.Context, name string, _ backend.Backend) error {
 	if m.onApply != nil {
 		m.onApply()
 	}
-	if m.agent == nil {
-		m.record("apply:" + name)
-	} else {
-		m.record(fmt.Sprintf("apply:%s:restarting=%t", name, m.agent.restartingFlag(name).Load()))
-	}
+	m.record("apply:" + name)
 	var err error
 	if len(m.applyErrs) > 0 {
 		err = m.applyErrs[0]
@@ -240,8 +227,7 @@ func (f *failingConfigureBackend) Configure(*slog.Logger, policies.PolicyRepo, m
 
 // A restart keeps the backend's policies and re-applies them once the
 // backend is back: they are marked unknown for the restart, not deleted,
-// and applied once, after the reset, while the restart mutex is still held
-// and the restarting marker has just cleared.
+// and applied once, after the reset, while the restart mutex is still held.
 func TestRestartBackendReappliesItsOwnPolicies(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	repo, err := policies.NewMemRepo()
@@ -256,7 +242,6 @@ func TestRestartBackendReappliesItsOwnPolicies(t *testing.T) {
 		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), repo),
 		config:              config.Config{},
 	}
-	pm.agent = a
 
 	require.NoError(t, a.RestartBackend(context.Background(), "snmp_discovery", "test"))
 
@@ -264,8 +249,8 @@ func TestRestartBackendReappliesItsOwnPolicies(t *testing.T) {
 		"remove:snmp_discovery:permanently=false",
 		"configure",
 		"reset",
-		"apply:snmp_discovery:restarting=false",
-	}, events, "policies kept, removed before the reset, applied once with the restarting marker already cleared")
+		"apply:snmp_discovery",
+	}, events, "policies kept, removed before the reset, applied once after")
 }
 
 // Right after a reset or start, a backend's status probe can transiently
@@ -666,26 +651,6 @@ func TestRestartBackendStopsReplayingWhenStopBeginsMidLoop(t *testing.T) {
 	assert.Equal(t, 1, unknown, "the policy the replay never reached stays as it was")
 }
 
-// A restart sets the restarting marker for the whole sequence, so the
-// starter reports a backend as starting for as long as the marker is set,
-// and running again the instant it clears.
-func TestRestartStarterReportsStartingWhileTheMarkerIsSet(t *testing.T) {
-	a := &orbAgent{}
-	starter := restartStarter{agent: a}
-
-	a.restartingFlag("snmp_discovery").Store(true)
-
-	state, err := starter.EnsureStarted("snmp_discovery")
-	require.NoError(t, err)
-	assert.Equal(t, policymgr.StartStarting, state, "the marker is set, so the starter must report starting")
-
-	a.restartingFlag("snmp_discovery").Store(false)
-
-	state, err = starter.EnsureStarted("snmp_discovery")
-	require.NoError(t, err)
-	assert.Equal(t, policymgr.StartRunning, state, "the marker is clear, so the starter must report running")
-}
-
 // blockingResetBackend signals entry into FullReset on a channel and waits on
 // a release channel before returning, so a test can deliver a policy while a
 // restart is blocked inside the reset.
@@ -729,9 +694,6 @@ func TestManageDuringARestartIsAppliedExactlyOnce(t *testing.T) {
 		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), pm.GetRepo()),
 		config:              config.Config{},
 	}
-	// Installed the same way agent.New installs it: after the orbAgent is
-	// built, before any goroutine can reach the policy manager.
-	pm.SetStarter(restartStarter{agent: a})
 
 	restartDone := make(chan error, 1)
 	go func() {
@@ -828,7 +790,6 @@ func TestRestartBackendHealsAPolicyStampedBackendStartingDuringTheRestart(t *tes
 		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), pm.GetRepo()),
 		config:              config.Config{},
 	}
-	pm.SetStarter(restartStarter{agent: a})
 
 	require.NoError(t, a.RestartBackend(context.Background(), "snmp_discovery", "test"))
 
@@ -893,7 +854,6 @@ func TestManageArrivingDuringTheReplayAppliesDirectlyOnce(t *testing.T) {
 		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), pm.GetRepo()),
 		config:              config.Config{},
 	}
-	pm.SetStarter(restartStarter{agent: a})
 
 	restartDone := make(chan error, 1)
 	go func() {
@@ -997,7 +957,6 @@ func TestBackToBackRestartsDoNotLoseAPolicy(t *testing.T) {
 		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), pm.GetRepo()),
 		config:              config.Config{},
 	}
-	pm.SetStarter(restartStarter{agent: a})
 
 	var wg sync.WaitGroup
 	errs := make(chan error, 2)
@@ -1038,8 +997,111 @@ func TestBackToBackRestartsDoNotLoseAPolicy(t *testing.T) {
 	assert.Equal(t, 2, applies, "each restart replays the policy once")
 }
 
-// Outside a restart, a manage applies the way it always has: the starter
-// reports the backend running and the policy is applied once.
+// notRunningOnceBackend answers not running the first time GetRunningStatus
+// is called after the reset, then running for every call after, closing
+// notRunningSeen the moment it gives that first not-running answer so a test
+// can deliver a manage while the retry delay that follows it is still
+// running.
+type notRunningOnceBackend struct {
+	restartableBackend
+	mu             sync.Mutex
+	calls          int
+	notRunningSeen chan struct{}
+}
+
+func (b *notRunningOnceBackend) GetRunningStatus() (backend.RunningStatus, string, error) {
+	b.mu.Lock()
+	b.calls++
+	first := b.calls == 1
+	b.mu.Unlock()
+	if first {
+		close(b.notRunningSeen)
+		return backend.BackendError, "not ready yet", nil
+	}
+	return backend.Running, "", nil
+}
+
+// End to end with the real policy manager: a manage delivered while the
+// replay's first attempt has already answered not running, but before its
+// retry delay has elapsed, is stored as starting by the marker the removal
+// set (the failed gate left it set). The retry's next attempt, once the
+// backend answers, applies it exactly like every other record a restart
+// deferred: through the replay's own remove-then-apply form, not a manage
+// applying it directly.
+func TestManageDuringTheReplayRetryDelayIsAppliedByTheRetry(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secrets, err := secretsmgr.New(logger, config.ManagerSecrets{})
+	require.NoError(t, err)
+	pm, err := policymgr.New(logger, secrets, config.Config{})
+	require.NoError(t, err)
+
+	events := []string{}
+	be := &notRunningOnceBackend{restartableBackend: restartableBackend{events: &events}, notRunningSeen: make(chan struct{})}
+	backend.Register("snmp_discovery", be)
+
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{"snmp_discovery": be},
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), pm.GetRepo()),
+		config:              config.Config{},
+		reapplyRetryDelay:   50 * time.Millisecond,
+	}
+
+	restartDone := make(chan error, 1)
+	go func() {
+		restartDone <- a.RestartBackend(context.Background(), "snmp_discovery", "test")
+	}()
+
+	select {
+	case <-be.notRunningSeen:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the replay's first not-running probe")
+	}
+
+	manageDone := make(chan struct{})
+	go func() {
+		defer close(manageDone)
+		pm.ManagePolicy(config.PolicyPayload{
+			Action:    "manage",
+			ID:        "during-retry-delay",
+			Name:      "during-retry-delay-policy",
+			Backend:   "snmp_discovery",
+			DatasetID: "dataset-1",
+			Version:   1,
+			Data:      map[string]any{"k": "v"},
+		})
+	}()
+
+	select {
+	case restartErr := <-restartDone:
+		require.NoError(t, restartErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for RestartBackend to return")
+	}
+	select {
+	case <-manageDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the manage to finish")
+	}
+
+	stored, err := pm.GetRepo().Get("during-retry-delay")
+	require.NoError(t, err)
+	assert.Equal(t, policies.Running, stored.State, "the manage must be healed by the retry, not left failed")
+
+	var applies int
+	for _, applied := range be.applied {
+		if applied.ID == "during-retry-delay" {
+			applies++
+		}
+	}
+	assert.Equal(t, 1, applies, "applied exactly once")
+	assert.Contains(t, events, "apply-policy:during-retry-delay:update=true",
+		"applied by the replay's remove-then-apply form, not a direct manage")
+}
+
+// Outside a restart, a manage applies the way it always has: no restart has
+// set the backend's marker, so the policy is applied once, directly.
 func TestManageOutsideARestartAppliesAsToday(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	secrets, err := secretsmgr.New(logger, config.ManagerSecrets{})
@@ -1050,15 +1112,6 @@ func TestManageOutsideARestartAppliesAsToday(t *testing.T) {
 	events := []string{}
 	be := &restartableBackend{events: &events}
 	backend.Register("snmp_discovery", be)
-
-	a := &orbAgent{
-		logger:              logger,
-		backends:            map[string]backend.Backend{"snmp_discovery": be},
-		policyManager:       pm,
-		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), pm.GetRepo()),
-		config:              config.Config{},
-	}
-	pm.SetStarter(restartStarter{agent: a})
 
 	payload := config.PolicyPayload{
 		Action:    "manage",
@@ -1109,7 +1162,7 @@ func (r *filesmgrRestartBackend) Start(context.Context, context.CancelFunc) erro
 // A filesmgr-driven restart brackets its Stop/Start sequence the same way
 // RestartBackend does: policies are marked unknown before Stop and handed
 // back to the backend once, after Start succeeds, while the restart mutex is
-// still held and the restarting marker has just cleared.
+// still held.
 func TestRestartBackendWithFilesmgrRollback_ReappliesPoliciesAfterSuccessfulStart(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	events := []string{}
@@ -1121,7 +1174,6 @@ func TestRestartBackendWithFilesmgrRollback_ReappliesPoliciesAfterSuccessfulStar
 		policyManager: pm,
 		filesManager:  &mockFilesManager{},
 	}
-	pm.agent = a
 
 	a.restartBackendWithFilesmgrRollback(context.Background(), "worker")
 
@@ -1129,13 +1181,13 @@ func TestRestartBackendWithFilesmgrRollback_ReappliesPoliciesAfterSuccessfulStar
 		"remove:worker:permanently=false",
 		"stop",
 		"start",
-		"apply:worker:restarting=false",
+		"apply:worker",
 	}, events)
 }
 
 // A Start that fails, then succeeds after a rollback, is re-applied exactly
 // once, after the retry rather than the failed first attempt, with the
-// restart mutex still held and the restarting marker already cleared.
+// restart mutex still held.
 func TestRestartBackendWithFilesmgrRollback_ReappliesPoliciesAfterRollbackRetry(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	events := []string{}
@@ -1147,7 +1199,6 @@ func TestRestartBackendWithFilesmgrRollback_ReappliesPoliciesAfterRollbackRetry(
 		policyManager: pm,
 		filesManager:  &mockFilesManager{},
 	}
-	pm.agent = a
 
 	a.restartBackendWithFilesmgrRollback(context.Background(), "worker")
 
@@ -1156,7 +1207,7 @@ func TestRestartBackendWithFilesmgrRollback_ReappliesPoliciesAfterRollbackRetry(
 		"stop",
 		"start",
 		"start",
-		"apply:worker:restarting=false",
+		"apply:worker",
 	}, events, "apply runs exactly once, after the successful retry")
 }
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -127,11 +128,9 @@ type mockPolicyManager struct {
 	repo   policies.PolicyRepo
 	events *[]string // shared with the backend stub so one slice records the order
 
-	// agent, when set, makes ApplyBackendPolicies record whether the
-	// backend's restart mutex is held at call time (see ApplyBackendPolicies
-	// below), for tests asserting a restart's second re-apply pass runs only
-	// after the mutex is released. Left nil, and so checked before use, by
-	// tests that do not care.
+	// agent, when set, makes ApplyBackendPolicies record whether a restart of
+	// the backend is in flight at call time (see ApplyBackendPolicies below).
+	// Left nil, and so checked before use, by tests that do not care.
 	agent *orbAgent
 }
 
@@ -152,25 +151,16 @@ func (m *mockPolicyManager) GetRepo() policies.PolicyRepo {
 }
 
 // ApplyBackendPolicies records a plain "apply:<name>" event, unless agent is
-// set: then it records whether the backend's restart mutex was held at call
-// time, as "apply:<name>:locked" or "apply:<name>:unlocked", so a test can
-// tell a restart's first (locked) re-apply pass from its second (unlocked,
-// taken after the mutex is released) one.
+// set: then it records whether a restart of the backend is in flight at call
+// time, as "apply:<name>:restarting=<bool>", so a test can tell the replay
+// (restarting=false, since the marker clears before it runs) from a manage
+// that lands while a restart holds the marker.
 func (m *mockPolicyManager) ApplyBackendPolicies(_ context.Context, name string, _ backend.Backend) error {
 	if m.agent == nil {
 		m.record("apply:" + name)
 		return nil
 	}
-	mu := m.agent.backendRestartLock(name)
-	held := !mu.TryLock()
-	if !held {
-		mu.Unlock()
-	}
-	state := "unlocked"
-	if held {
-		state = "locked"
-	}
-	m.record(fmt.Sprintf("apply:%s:%s", name, state))
+	m.record(fmt.Sprintf("apply:%s:restarting=%t", name, m.agent.restartingFlag(name).Load()))
 	return nil
 }
 
@@ -233,9 +223,8 @@ func (f *failingConfigureBackend) Configure(*slog.Logger, policies.PolicyRepo, m
 
 // A restart keeps the backend's policies and re-applies them once the
 // backend is back: they are marked unknown for the restart, not deleted,
-// and applied after the reset, once while the restart mutex is still held
-// and once more after it is released, to pick up anything that landed as
-// "starting" in between.
+// and applied once, after the reset, while the restart mutex is still held
+// and the restarting marker has just cleared.
 func TestRestartBackendReappliesItsOwnPolicies(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	repo, err := policies.NewMemRepo()
@@ -258,9 +247,8 @@ func TestRestartBackendReappliesItsOwnPolicies(t *testing.T) {
 		"remove:snmp_discovery:permanently=false",
 		"configure",
 		"reset",
-		"apply:snmp_discovery:locked",
-		"apply:snmp_discovery:unlocked",
-	}, events, "policies kept, removed before the reset, applied once under the restart mutex and once more after it releases")
+		"apply:snmp_discovery:restarting=false",
+	}, events, "policies kept, removed before the reset, applied once with the restarting marker already cleared")
 }
 
 // A reset that fails leaves the policies marked for the next restart and
@@ -315,8 +303,7 @@ func TestRestartBackendReappliesPoliciesWhenConfigureFails(t *testing.T) {
 		"remove:snmp_discovery:permanently=false",
 		"configure",
 		"apply:snmp_discovery",
-		"apply:snmp_discovery",
-	}, events, "the backend never stopped, so the removed policies are reapplied immediately, then once more with the mutex released")
+	}, events, "the backend never stopped, so the removed policies are reapplied immediately")
 }
 
 // End to end with the real policy manager: a policy the backend ran before
@@ -353,8 +340,7 @@ func TestRestartBackendReappliesPoliciesEndToEnd(t *testing.T) {
 
 // failOnceApplyBackend fails the first ApplyPolicy call and succeeds on any
 // call after, recording how many times it was called, so a test can prove a
-// replay's second pass does not retry a policy its first pass already
-// answered.
+// replay does not retry a policy it already failed to apply.
 type failOnceApplyBackend struct {
 	restartableBackend
 	calls int
@@ -368,11 +354,10 @@ func (f *failOnceApplyBackend) ApplyPolicy(pd policies.PolicyData, updatePolicy 
 	return f.restartableBackend.ApplyPolicy(pd, updatePolicy)
 }
 
-// End to end with the real policy manager: a policy the first replay pass
-// fails to apply is stored failed to apply with the backend's own reason,
-// and the second pass, taken after the restart mutex is released, must not
-// hand it to the backend again.
-func TestRestartBackendSecondPassDoesNotRetryAPolicyTheFirstPassFailed(t *testing.T) {
+// End to end with the real policy manager: a policy the replay fails to
+// apply is stored failed to apply with the backend's own reason, and is not
+// retried within the same replay.
+func TestRestartBackendDoesNotRetryAPolicyItFailed(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	secrets, err := secretsmgr.New(logger, config.ManagerSecrets{})
 	require.NoError(t, err)
@@ -395,7 +380,7 @@ func TestRestartBackendSecondPassDoesNotRetryAPolicyTheFirstPassFailed(t *testin
 	require.NoError(t, err)
 	assert.Equal(t, policies.FailedToApply, stored.State)
 	assert.Equal(t, "apply timed out", stored.BackendErr)
-	assert.Equal(t, 1, be.calls, "the second pass must not retry a policy the first pass already failed")
+	assert.Equal(t, 1, be.calls, "the replay must not retry a policy it already failed to apply")
 }
 
 // A Start (file-driven or otherwise) that is already blocked on the restart
@@ -524,28 +509,24 @@ func TestRestartBackendStopsReplayingWhenStopBeginsMidLoop(t *testing.T) {
 	assert.Equal(t, 1, unknown, "the policy the replay never reached stays as it was")
 }
 
-// A restart holds the restart mutex across the whole sequence, so the
-// starter reports a backend as starting for as long as a restart of it is in
-// flight, and running again the instant the mutex is free.
-func TestRestartStarterReportsStartingWhileARestartHoldsTheMutex(t *testing.T) {
+// A restart sets the restarting marker for the whole sequence, so the
+// starter reports a backend as starting for as long as the marker is set,
+// and running again the instant it clears.
+func TestRestartStarterReportsStartingWhileTheMarkerIsSet(t *testing.T) {
 	a := &orbAgent{}
 	starter := restartStarter{agent: a}
 
-	mu := a.backendRestartLock("snmp_discovery")
-	mu.Lock()
+	a.restartingFlag("snmp_discovery").Store(true)
 
 	state, err := starter.EnsureStarted("snmp_discovery")
 	require.NoError(t, err)
-	assert.Equal(t, policymgr.StartStarting, state, "a restart holds the mutex, so the starter must report starting")
+	assert.Equal(t, policymgr.StartStarting, state, "the marker is set, so the starter must report starting")
 
-	mu.Unlock()
+	a.restartingFlag("snmp_discovery").Store(false)
 
 	state, err = starter.EnsureStarted("snmp_discovery")
 	require.NoError(t, err)
-	assert.Equal(t, policymgr.StartRunning, state, "no restart is in flight, so the starter must report running")
-
-	require.True(t, a.backendRestartLock("snmp_discovery").TryLock(), "the mutex must be free after EnsureStarted reports running")
-	a.backendRestartLock("snmp_discovery").Unlock()
+	assert.Equal(t, policymgr.StartRunning, state, "the marker is clear, so the starter must report running")
 }
 
 // blockingResetBackend signals entry into FullReset on a channel and waits on
@@ -642,10 +623,9 @@ func TestManageDuringARestartIsAppliedExactlyOnce(t *testing.T) {
 
 // windowStampingBackend writes a policy record directly to the repo from
 // within FullReset, stamped the way the starter stamps a manage that lands
-// while a restart holds the backend's restart mutex: failed to apply with
-// the "backend starting" reason. This stands in for the window Finding B
-// closes (a manage landing between the restart's first replay and the
-// mutex unlock) without needing to choreograph the real race.
+// while the restarting marker is set: failed to apply with the "backend
+// starting" reason. This stands in for a manage landing during the restart
+// without needing to choreograph the real race.
 type windowStampingBackend struct {
 	restartableBackend
 	repo policies.PolicyRepo
@@ -667,10 +647,9 @@ func (w *windowStampingBackend) FullReset(ctx context.Context) error {
 }
 
 // End to end with the real policy manager: a policy stamped failed to apply
-// with the starter's "backend starting" reason, the way one landing in the
-// window RestartBackend documents (between the first replay and the restart
-// mutex releasing) is stamped, is healed by the restart's own replay and
-// ends Running, applied exactly once even though two replay passes run.
+// with the starter's "backend starting" reason, the way one landing while
+// the restarting marker is set is stamped, is healed by the restart's own
+// single replay and ends Running, applied exactly once.
 // TestManageDuringARestartIsAppliedExactlyOnce proves the same "exactly
 // once" outcome through the real concurrent race; this test isolates the
 // running-skip's role in it.
@@ -706,7 +685,200 @@ func TestRestartBackendHealsAPolicyStampedBackendStartingDuringTheRestart(t *tes
 			appliedCount++
 		}
 	}
-	assert.Equal(t, 1, appliedCount, "applied exactly once, even though two replay passes ran")
+	assert.Equal(t, 1, appliedCount, "applied exactly once by the replay")
+}
+
+// blockingApplyBackend blocks the first call to ApplyPolicy on a channel,
+// signalling entry so a test can deliver a manage while that call is in
+// flight, then waits for release before returning. Any later call (a manage
+// applied directly once the backend is up) proceeds unblocked.
+type blockingApplyBackend struct {
+	restartableBackend
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingApplyBackend) ApplyPolicy(pd policies.PolicyData, updatePolicy bool) error {
+	b.once.Do(func() {
+		close(b.entered)
+		<-b.release
+	})
+	return b.restartableBackend.ApplyPolicy(pd, updatePolicy)
+}
+
+// A manage delivered while the restart's replay is itself inside an apply
+// call (the restarting marker has already cleared, since the replay only
+// starts after the clear) waits on the apply mutex the replay holds and,
+// once it is free, applies directly to the backend, which is up; it is
+// never stored as starting and never replayed.
+func TestManageArrivingDuringTheReplayAppliesDirectlyOnce(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secrets, err := secretsmgr.New(logger, config.ManagerSecrets{})
+	require.NoError(t, err)
+	pm, err := policymgr.New(logger, secrets, config.Config{})
+	require.NoError(t, err)
+
+	events := []string{}
+	be := &blockingApplyBackend{
+		restartableBackend: restartableBackend{events: &events},
+		entered:            make(chan struct{}),
+		release:            make(chan struct{}),
+	}
+	backend.Register("snmp_discovery", be)
+
+	require.NoError(t, pm.GetRepo().Update(policies.PolicyData{ID: "seeded", Name: "seeded", Backend: "snmp_discovery", Version: 1, Data: map[string]any{"k": "v"}, State: policies.Running}))
+
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{"snmp_discovery": be},
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), pm.GetRepo()),
+		config:              config.Config{},
+	}
+	pm.SetStarter(restartStarter{agent: a})
+
+	restartDone := make(chan error, 1)
+	go func() {
+		restartDone <- a.RestartBackend(context.Background(), "snmp_discovery", "test")
+	}()
+
+	select {
+	case <-be.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the replay to enter its apply call")
+	}
+
+	manageDone := make(chan struct{})
+	go func() {
+		defer close(manageDone)
+		pm.ManagePolicy(config.PolicyPayload{
+			Action:    "manage",
+			ID:        "during-replay",
+			Name:      "during-replay-policy",
+			Backend:   "snmp_discovery",
+			DatasetID: "dataset-1",
+			Version:   1,
+			Data:      map[string]any{"k": "v"},
+		})
+	}()
+
+	close(be.release)
+
+	select {
+	case restartErr := <-restartDone:
+		require.NoError(t, restartErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for RestartBackend to return")
+	}
+
+	select {
+	case <-manageDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the manage to finish")
+	}
+
+	stored, err := pm.GetRepo().Get("during-replay")
+	require.NoError(t, err)
+	assert.Equal(t, policies.Running, stored.State, "a manage arriving during the replay must apply directly")
+
+	var directApplies int
+	for _, applied := range be.applied {
+		if applied.ID == "during-replay" {
+			directApplies++
+		}
+	}
+	assert.Equal(t, 1, directApplies, "the manage must be applied exactly once")
+	assert.Contains(t, events, "apply-policy:during-replay:update=false",
+		"a direct manage uses the plain apply form, not the replay's remove-then-apply form")
+
+	seededStored, err := pm.GetRepo().Get("seeded")
+	require.NoError(t, err)
+	assert.Equal(t, policies.Running, seededStored.State)
+	var seededApplies int
+	for _, applied := range be.applied {
+		if applied.ID == "seeded" {
+			seededApplies++
+		}
+	}
+	assert.Equal(t, 1, seededApplies, "the seeded policy was applied exactly once by the replay")
+}
+
+// yieldingResetBackend sleeps briefly inside FullReset, widening the window
+// in which a second, concurrent restart of the same backend can attempt to
+// take the restart mutex while the first is still inside it.
+type yieldingResetBackend struct {
+	restartableBackend
+}
+
+func (y *yieldingResetBackend) FullReset(ctx context.Context) error {
+	time.Sleep(20 * time.Millisecond)
+	return y.restartableBackend.FullReset(ctx)
+}
+
+// Two restarts of the same backend issued at once are serialized by the
+// restart mutex: each removes the policy, resets, and replays it, so it
+// ends Running and was handed to the backend exactly twice, once per
+// restart, never lost to an interleaving between them.
+func TestBackToBackRestartsDoNotLoseAPolicy(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secrets, err := secretsmgr.New(logger, config.ManagerSecrets{})
+	require.NoError(t, err)
+	pm, err := policymgr.New(logger, secrets, config.Config{})
+	require.NoError(t, err)
+
+	events := []string{}
+	be := &yieldingResetBackend{restartableBackend: restartableBackend{events: &events}}
+	backend.Register("snmp_discovery", be)
+
+	require.NoError(t, pm.GetRepo().Update(policies.PolicyData{ID: "seeded", Name: "seeded", Backend: "snmp_discovery", Version: 1, Data: map[string]any{"k": "v"}, State: policies.Running}))
+
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{"snmp_discovery": be},
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), pm.GetRepo()),
+		config:              config.Config{},
+	}
+	pm.SetStarter(restartStarter{agent: a})
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- a.RestartBackend(context.Background(), "snmp_discovery", "test")
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for both restarts to finish")
+	}
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	stored, err := pm.GetRepo().Get("seeded")
+	require.NoError(t, err)
+	assert.Equal(t, policies.Running, stored.State)
+
+	var applies int
+	for _, applied := range be.applied {
+		if applied.ID == "seeded" {
+			applies++
+		}
+	}
+	assert.Equal(t, 2, applies, "each restart replays the policy once")
 }
 
 // Outside a restart, a manage applies the way it always has: the starter
@@ -779,8 +951,8 @@ func (r *filesmgrRestartBackend) Start(context.Context, context.CancelFunc) erro
 
 // A filesmgr-driven restart brackets its Stop/Start sequence the same way
 // RestartBackend does: policies are marked unknown before Stop and handed
-// back to the backend once Start succeeds, once while the restart mutex is
-// still held and once more after it is released.
+// back to the backend once, after Start succeeds, while the restart mutex is
+// still held and the restarting marker has just cleared.
 func TestRestartBackendWithFilesmgrRollback_ReappliesPoliciesAfterSuccessfulStart(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	events := []string{}
@@ -800,14 +972,13 @@ func TestRestartBackendWithFilesmgrRollback_ReappliesPoliciesAfterSuccessfulStar
 		"remove:worker:permanently=false",
 		"stop",
 		"start",
-		"apply:worker:locked",
-		"apply:worker:unlocked",
+		"apply:worker:restarting=false",
 	}, events)
 }
 
 // A Start that fails, then succeeds after a rollback, is re-applied exactly
-// once under the restart mutex, after the retry rather than the failed first
-// attempt, and once more after the mutex is released.
+// once, after the retry rather than the failed first attempt, with the
+// restart mutex still held and the restarting marker already cleared.
 func TestRestartBackendWithFilesmgrRollback_ReappliesPoliciesAfterRollbackRetry(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	events := []string{}
@@ -828,9 +999,8 @@ func TestRestartBackendWithFilesmgrRollback_ReappliesPoliciesAfterRollbackRetry(
 		"stop",
 		"start",
 		"start",
-		"apply:worker:locked",
-		"apply:worker:unlocked",
-	}, events, "apply runs exactly once under the mutex, after the successful retry, and once more after the mutex releases")
+		"apply:worker:restarting=false",
+	}, events, "apply runs exactly once, after the successful retry")
 }
 
 // A Start that fails on a backend with no managed binary name cannot roll

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -321,6 +321,163 @@ func TestRestartBackendReappliesPoliciesEndToEnd(t *testing.T) {
 	assert.Equal(t, int32(3), be.applied[0].Version)
 }
 
+// A restart holds the restart mutex across the whole sequence, so the
+// starter reports a backend as starting for as long as a restart of it is in
+// flight, and running again the instant the mutex is free.
+func TestRestartStarterReportsStartingWhileARestartHoldsTheMutex(t *testing.T) {
+	a := &orbAgent{}
+	starter := restartStarter{agent: a}
+
+	mu := a.backendRestartLock("snmp_discovery")
+	mu.Lock()
+
+	state, err := starter.EnsureStarted("snmp_discovery")
+	require.NoError(t, err)
+	assert.Equal(t, policymgr.StartStarting, state, "a restart holds the mutex, so the starter must report starting")
+
+	mu.Unlock()
+
+	state, err = starter.EnsureStarted("snmp_discovery")
+	require.NoError(t, err)
+	assert.Equal(t, policymgr.StartRunning, state, "no restart is in flight, so the starter must report running")
+
+	require.True(t, a.backendRestartLock("snmp_discovery").TryLock(), "the mutex must be free after EnsureStarted reports running")
+	a.backendRestartLock("snmp_discovery").Unlock()
+}
+
+// blockingResetBackend signals entry into FullReset on a channel and waits on
+// a release channel before returning, so a test can deliver a policy while a
+// restart is blocked inside the reset.
+type blockingResetBackend struct {
+	restartableBackend
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingResetBackend) FullReset(context.Context) error {
+	*b.events = append(*b.events, "reset")
+	close(b.entered)
+	<-b.release
+	return nil
+}
+
+// A policy delivered while a restart is in flight for its backend is stored
+// failed to apply with the reason the starter gives, is never handed to the
+// backend, and is applied exactly once, by the restart's own re-apply, once
+// the restart finishes. This is the window RestartBackend documents between
+// FullReset returning and the re-apply taking the policy manager's mutex.
+func TestManageDuringARestartIsAppliedExactlyOnce(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secrets, err := secretsmgr.New(logger, config.ManagerSecrets{})
+	require.NoError(t, err)
+	pm, err := policymgr.New(logger, secrets, config.Config{})
+	require.NoError(t, err)
+
+	events := []string{}
+	be := &blockingResetBackend{
+		restartableBackend: restartableBackend{events: &events},
+		entered:            make(chan struct{}),
+		release:            make(chan struct{}),
+	}
+	backend.Register("snmp_discovery", be)
+
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{"snmp_discovery": be},
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), pm.GetRepo()),
+		config:              config.Config{},
+	}
+	// Installed the same way agent.New installs it: after the orbAgent is
+	// built, before any goroutine can reach the policy manager.
+	pm.SetStarter(restartStarter{agent: a})
+
+	restartDone := make(chan error, 1)
+	go func() {
+		restartDone <- a.RestartBackend(context.Background(), "snmp_discovery", "test")
+	}()
+
+	select {
+	case <-be.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the restart to enter FullReset")
+	}
+
+	payload := config.PolicyPayload{
+		Action:    "manage",
+		ID:        "during-restart",
+		Name:      "during-restart-policy",
+		Backend:   "snmp_discovery",
+		DatasetID: "dataset-1",
+		Version:   1,
+		Data:      map[string]any{"k": "v"},
+	}
+	pm.ManagePolicy(payload)
+
+	stored, err := pm.GetRepo().Get("during-restart")
+	require.NoError(t, err)
+	assert.Equal(t, policies.FailedToApply, stored.State, "a manage during the restart must not apply")
+	assert.Equal(t, "backend starting", stored.BackendErr)
+	assert.Empty(t, be.applied, "the backend must not receive the policy while the restart is in flight")
+
+	close(be.release)
+
+	select {
+	case restartErr := <-restartDone:
+		require.NoError(t, restartErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for RestartBackend to return")
+	}
+
+	stored, err = pm.GetRepo().Get("during-restart")
+	require.NoError(t, err)
+	assert.Equal(t, policies.Running, stored.State, "the re-apply after the restart must apply the policy stored while it was in flight")
+	require.Len(t, be.applied, 1, "the backend must receive the policy exactly once")
+	assert.Equal(t, "during-restart", be.applied[0].ID)
+	assert.Contains(t, events, "apply-policy:during-restart:update=true")
+}
+
+// Outside a restart, a manage applies the way it always has: the starter
+// reports the backend running and the policy is applied once.
+func TestManageOutsideARestartAppliesAsToday(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secrets, err := secretsmgr.New(logger, config.ManagerSecrets{})
+	require.NoError(t, err)
+	pm, err := policymgr.New(logger, secrets, config.Config{})
+	require.NoError(t, err)
+
+	events := []string{}
+	be := &restartableBackend{events: &events}
+	backend.Register("snmp_discovery", be)
+
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{"snmp_discovery": be},
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), pm.GetRepo()),
+		config:              config.Config{},
+	}
+	pm.SetStarter(restartStarter{agent: a})
+
+	payload := config.PolicyPayload{
+		Action:    "manage",
+		ID:        "outside-restart",
+		Name:      "outside-restart-policy",
+		Backend:   "snmp_discovery",
+		DatasetID: "dataset-1",
+		Version:   1,
+		Data:      map[string]any{"k": "v"},
+	}
+	pm.ManagePolicy(payload)
+
+	stored, err := pm.GetRepo().Get("outside-restart")
+	require.NoError(t, err)
+	assert.Equal(t, policies.Running, stored.State)
+	require.Len(t, be.applied, 1)
+	assert.Equal(t, "outside-restart", be.applied[0].ID)
+	assert.Contains(t, events, "apply-policy:outside-restart:update=false")
+}
+
 // filesmgrRestartBackend records, into the shared slice, the Stop/Start calls
 // a filesmgr-driven restart makes. startFailures controls how many of the
 // first calls to Start return an error before Start starts succeeding; a

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -132,6 +132,15 @@ type mockPolicyManager struct {
 	// the backend is in flight at call time (see ApplyBackendPolicies below).
 	// Left nil, and so checked before use, by tests that do not care.
 	agent *orbAgent
+
+	// applyErrs queues the errors ApplyBackendPolicies returns, one per call,
+	// popped in call order; once the queue is empty every further call
+	// returns nil.
+	applyErrs []error
+
+	// onApply, when set, runs at the start of every ApplyBackendPolicies
+	// call, before the queued error is popped.
+	onApply func()
 }
 
 func (m *mockPolicyManager) record(event string) {
@@ -156,12 +165,20 @@ func (m *mockPolicyManager) GetRepo() policies.PolicyRepo {
 // (restarting=false, since the marker clears before it runs) from a manage
 // that lands while a restart holds the marker.
 func (m *mockPolicyManager) ApplyBackendPolicies(_ context.Context, name string, _ backend.Backend) error {
+	if m.onApply != nil {
+		m.onApply()
+	}
 	if m.agent == nil {
 		m.record("apply:" + name)
-		return nil
+	} else {
+		m.record(fmt.Sprintf("apply:%s:restarting=%t", name, m.agent.restartingFlag(name).Load()))
 	}
-	m.record(fmt.Sprintf("apply:%s:restarting=%t", name, m.agent.restartingFlag(name).Load()))
-	return nil
+	var err error
+	if len(m.applyErrs) > 0 {
+		err = m.applyErrs[0]
+		m.applyErrs = m.applyErrs[1:]
+	}
+	return err
 }
 
 func (m *mockPolicyManager) RemoveBackendPolicies(name string, _ backend.Backend, permanently bool) error {
@@ -249,6 +266,146 @@ func TestRestartBackendReappliesItsOwnPolicies(t *testing.T) {
 		"reset",
 		"apply:snmp_discovery:restarting=false",
 	}, events, "policies kept, removed before the reset, applied once with the restarting marker already cleared")
+}
+
+// Right after a reset or start, a backend's status probe can transiently
+// fail, so the applier answers ErrBackendNotRunning even though the backend
+// is on its way up. The replay must retry rather than leave the policies
+// unknown until some later restart that may not come.
+func TestRestartBackendRetriesTheReplayWhileTheBackendIsNotAnsweringYet(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	events := []string{}
+	pm := &mockPolicyManager{repo: repo, events: &events, applyErrs: []error{
+		policymgr.ErrBackendNotRunning, policymgr.ErrBackendNotRunning, nil,
+	}}
+	be := &restartableBackend{events: &events}
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{"snmp_discovery": be},
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), repo),
+		config:              config.Config{},
+		reapplyRetryDelay:   time.Millisecond,
+	}
+
+	require.NoError(t, a.RestartBackend(context.Background(), "snmp_discovery", "test"))
+
+	assert.Equal(t, []string{
+		"remove:snmp_discovery:permanently=false",
+		"configure",
+		"reset",
+		"apply:snmp_discovery",
+		"apply:snmp_discovery",
+		"apply:snmp_discovery",
+	}, events, "the replay retries while the backend answers not-running, then succeeds on the third attempt")
+}
+
+// The replay is retried a bounded number of times: a backend that keeps
+// answering not-running must not be retried forever, since nothing else
+// would ever install its policies (the health monitor sees it as healthy).
+func TestRestartBackendGivesUpTheReplayAfterThreeAttempts(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	events := []string{}
+	pm := &mockPolicyManager{repo: repo, events: &events, applyErrs: []error{
+		policymgr.ErrBackendNotRunning, policymgr.ErrBackendNotRunning, policymgr.ErrBackendNotRunning,
+	}}
+	be := &restartableBackend{events: &events}
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{"snmp_discovery": be},
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), repo),
+		config:              config.Config{},
+		reapplyRetryDelay:   time.Millisecond,
+	}
+
+	require.NoError(t, a.RestartBackend(context.Background(), "snmp_discovery", "test"))
+
+	assert.Equal(t, []string{
+		"remove:snmp_discovery:permanently=false",
+		"configure",
+		"reset",
+		"apply:snmp_discovery",
+		"apply:snmp_discovery",
+		"apply:snmp_discovery",
+	}, events, "the replay gives up after three attempts and leaves the policies unknown")
+}
+
+// A failure that is not ErrBackendNotRunning is not transient in the same
+// way, so the replay must not retry it.
+func TestRestartBackendDoesNotRetryAReplayThatFailedForAnotherReason(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	events := []string{}
+	pm := &mockPolicyManager{repo: repo, events: &events, applyErrs: []error{
+		errors.New("repo failure"),
+	}}
+	be := &restartableBackend{events: &events}
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{"snmp_discovery": be},
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), repo),
+		config:              config.Config{},
+		reapplyRetryDelay:   time.Millisecond,
+	}
+
+	require.NoError(t, a.RestartBackend(context.Background(), "snmp_discovery", "test"))
+
+	assert.Equal(t, []string{
+		"remove:snmp_discovery:permanently=false",
+		"configure",
+		"reset",
+		"apply:snmp_discovery",
+	}, events, "a non-transient failure must not be retried")
+}
+
+// A retry waits on the apply context, not a plain sleep, so a shutdown that
+// begins mid-wait ends the wait immediately instead of the replay sleeping
+// out a long retry delay.
+func TestRestartBackendStopsRetryingWhenStopBegins(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	events := []string{}
+	pm := &mockPolicyManager{repo: repo, events: &events, applyErrs: []error{
+		policymgr.ErrBackendNotRunning, policymgr.ErrBackendNotRunning, policymgr.ErrBackendNotRunning,
+	}}
+	be := &restartableBackend{events: &events}
+	stopCtx, stopCancel := context.WithCancel(context.Background())
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{"snmp_discovery": be},
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), repo),
+		config:              config.Config{},
+		reapplyRetryDelay:   time.Hour,
+		stopCtx:             stopCtx,
+		stopCancel:          stopCancel,
+	}
+	pm.onApply = func() { a.stopCancel() }
+
+	done := make(chan error, 1)
+	go func() { done <- a.RestartBackend(context.Background(), "snmp_discovery", "test") }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("RestartBackend did not return promptly once Stop began")
+	}
+
+	assert.Equal(t, []string{
+		"remove:snmp_discovery:permanently=false",
+		"configure",
+		"reset",
+		"apply:snmp_discovery",
+	}, events, "the retry wait is cancelled the instant Stop begins, not slept out")
 }
 
 // A reset that fails leaves the policies marked for the next restart and

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -126,6 +126,13 @@ func TestAgentStop_FailNonTerminalRunsBeforeConfigManagerStop(t *testing.T) {
 type mockPolicyManager struct {
 	repo   policies.PolicyRepo
 	events *[]string // shared with the backend stub so one slice records the order
+
+	// agent, when set, makes ApplyBackendPolicies record whether the
+	// backend's restart mutex is held at call time (see ApplyBackendPolicies
+	// below), for tests asserting a restart's second re-apply pass runs only
+	// after the mutex is released. Left nil, and so checked before use, by
+	// tests that do not care.
+	agent *orbAgent
 }
 
 func (m *mockPolicyManager) record(event string) {
@@ -144,8 +151,26 @@ func (m *mockPolicyManager) GetRepo() policies.PolicyRepo {
 	return m.repo
 }
 
-func (m *mockPolicyManager) ApplyBackendPolicies(name string, _ backend.Backend) error {
-	m.record("apply:" + name)
+// ApplyBackendPolicies records a plain "apply:<name>" event, unless agent is
+// set: then it records whether the backend's restart mutex was held at call
+// time, as "apply:<name>:locked" or "apply:<name>:unlocked", so a test can
+// tell a restart's first (locked) re-apply pass from its second (unlocked,
+// taken after the mutex is released) one.
+func (m *mockPolicyManager) ApplyBackendPolicies(_ context.Context, name string, _ backend.Backend) error {
+	if m.agent == nil {
+		m.record("apply:" + name)
+		return nil
+	}
+	mu := m.agent.backendRestartLock(name)
+	held := !mu.TryLock()
+	if !held {
+		mu.Unlock()
+	}
+	state := "unlocked"
+	if held {
+		state = "locked"
+	}
+	m.record(fmt.Sprintf("apply:%s:%s", name, state))
 	return nil
 }
 
@@ -208,7 +233,9 @@ func (f *failingConfigureBackend) Configure(*slog.Logger, policies.PolicyRepo, m
 
 // A restart keeps the backend's policies and re-applies them once the
 // backend is back: they are marked unknown for the restart, not deleted,
-// and applied after the reset.
+// and applied after the reset, once while the restart mutex is still held
+// and once more after it is released, to pick up anything that landed as
+// "starting" in between.
 func TestRestartBackendReappliesItsOwnPolicies(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	repo, err := policies.NewMemRepo()
@@ -223,6 +250,7 @@ func TestRestartBackendReappliesItsOwnPolicies(t *testing.T) {
 		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), repo),
 		config:              config.Config{},
 	}
+	pm.agent = a
 
 	require.NoError(t, a.RestartBackend(context.Background(), "snmp_discovery", "test"))
 
@@ -230,8 +258,9 @@ func TestRestartBackendReappliesItsOwnPolicies(t *testing.T) {
 		"remove:snmp_discovery:permanently=false",
 		"configure",
 		"reset",
-		"apply:snmp_discovery",
-	}, events, "policies kept, removed before the reset and applied after it")
+		"apply:snmp_discovery:locked",
+		"apply:snmp_discovery:unlocked",
+	}, events, "policies kept, removed before the reset, applied once under the restart mutex and once more after it releases")
 }
 
 // A reset that fails leaves the policies marked for the next restart and
@@ -286,7 +315,8 @@ func TestRestartBackendReappliesPoliciesWhenConfigureFails(t *testing.T) {
 		"remove:snmp_discovery:permanently=false",
 		"configure",
 		"apply:snmp_discovery",
-	}, events, "the backend never stopped, so the removed policies are reapplied immediately")
+		"apply:snmp_discovery",
+	}, events, "the backend never stopped, so the removed policies are reapplied immediately, then once more with the mutex released")
 }
 
 // End to end with the real policy manager: a policy the backend ran before
@@ -358,7 +388,7 @@ func TestRestartBackendDoesNotReapplyAfterShutdownBegan(t *testing.T) {
 // context at the end, after every backend is stopped. A health or fleet
 // restart that already holds the restart mutex when Stop begins therefore
 // still sees a live context when it reaches the re-apply: ctx.Err() alone
-// would not catch it, so the stopping flag does.
+// would not catch it, so the stop context does.
 func TestRestartBackendDoesNotReapplyOnceStopBegan(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	repo, err := policies.NewMemRepo()
@@ -373,7 +403,8 @@ func TestRestartBackendDoesNotReapplyOnceStopBegan(t *testing.T) {
 		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), repo),
 		config:              config.Config{},
 	}
-	a.stopping.Store(true)
+	a.stopCtx, a.stopCancel = context.WithCancel(context.Background())
+	a.stopCancel()
 
 	require.NoError(t, a.RestartBackend(context.Background(), "snmp_discovery", "test"))
 
@@ -382,6 +413,68 @@ func TestRestartBackendDoesNotReapplyOnceStopBegan(t *testing.T) {
 		"configure",
 		"reset",
 	}, events, "Stop already began, so the policies must stay unknown rather than be reapplied")
+}
+
+// stopCancellingBackend calls the agent's stopCancel from every ApplyPolicy
+// call, simulating Stop beginning while a restart's replay of more than one
+// policy is mid-loop: once the first policy's apply triggers it, the loop's
+// own per-iteration context check must stop the replay before the second.
+type stopCancellingBackend struct {
+	restartableBackend
+	agent *orbAgent
+}
+
+func (s *stopCancellingBackend) ApplyPolicy(pd policies.PolicyData, updatePolicy bool) error {
+	s.agent.stopCancel()
+	return s.restartableBackend.ApplyPolicy(pd, updatePolicy)
+}
+
+// End to end with the real policy manager: Stop beginning mid-replay (through
+// the stop context, not the ctx argument, which stays live throughout) must
+// be observed between policies, the same way a cancelled ctx argument is.
+// Only one of the two stored policies reaches the backend; the other is left
+// as it was.
+func TestRestartBackendStopsReplayingWhenStopBeginsMidLoop(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secrets, err := secretsmgr.New(logger, config.ManagerSecrets{})
+	require.NoError(t, err)
+	pm, err := policymgr.New(logger, secrets, config.Config{})
+	require.NoError(t, err)
+
+	events := []string{}
+	stopCtx, stopCancel := context.WithCancel(context.Background())
+	a := &orbAgent{
+		logger:              logger,
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), pm.GetRepo()),
+		config:              config.Config{},
+		stopCtx:             stopCtx,
+		stopCancel:          stopCancel,
+	}
+	be := &stopCancellingBackend{restartableBackend: restartableBackend{events: &events}, agent: a}
+	a.backends = map[string]backend.Backend{"snmp_discovery": be}
+	backend.Register("snmp_discovery", be)
+
+	require.NoError(t, pm.GetRepo().Update(policies.PolicyData{ID: "one", Name: "one", Backend: "snmp_discovery", Version: 1, Data: map[string]any{"k": "v"}, State: policies.Unknown}))
+	require.NoError(t, pm.GetRepo().Update(policies.PolicyData{ID: "two", Name: "two", Backend: "snmp_discovery", Version: 1, Data: map[string]any{"k": "v"}, State: policies.Unknown}))
+
+	require.NoError(t, a.RestartBackend(context.Background(), "snmp_discovery", "test"))
+
+	require.Len(t, be.applied, 1, "the second policy must never reach the backend once Stop begins")
+
+	state, err := pm.GetPolicyState()
+	require.NoError(t, err)
+	var running, unknown int
+	for _, pd := range state {
+		switch pd.State {
+		case policies.Running:
+			running++
+		case policies.Unknown:
+			unknown++
+		}
+	}
+	assert.Equal(t, 1, running, "the policy reached before Stop began was applied")
+	assert.Equal(t, 1, unknown, "the policy the replay never reached stays as it was")
 }
 
 // A restart holds the restart mutex across the whole sequence, so the
@@ -500,6 +593,75 @@ func TestManageDuringARestartIsAppliedExactlyOnce(t *testing.T) {
 	assert.Contains(t, events, "apply-policy:during-restart:update=true")
 }
 
+// windowStampingBackend writes a policy record directly to the repo from
+// within FullReset, stamped the way the starter stamps a manage that lands
+// while a restart holds the backend's restart mutex: failed to apply with
+// the "backend starting" reason. This stands in for the window Finding B
+// closes (a manage landing between the restart's first replay and the
+// mutex unlock) without needing to choreograph the real race.
+type windowStampingBackend struct {
+	restartableBackend
+	repo policies.PolicyRepo
+}
+
+func (w *windowStampingBackend) FullReset(ctx context.Context) error {
+	if err := w.restartableBackend.FullReset(ctx); err != nil {
+		return err
+	}
+	return w.repo.Update(policies.PolicyData{
+		ID:         "during-window",
+		Name:       "during-window",
+		Backend:    "snmp_discovery",
+		Version:    1,
+		Data:       map[string]any{"k": "v"},
+		State:      policies.FailedToApply,
+		BackendErr: policymgr.ReasonBackendStarting,
+	})
+}
+
+// End to end with the real policy manager: a policy stamped failed to apply
+// with the starter's "backend starting" reason, the way one landing in the
+// window RestartBackend documents (between the first replay and the restart
+// mutex releasing) is stamped, is healed by the restart's own replay and
+// ends Running, applied exactly once even though two replay passes run.
+// TestManageDuringARestartIsAppliedExactlyOnce proves the same "exactly
+// once" outcome through the real concurrent race; this test isolates the
+// running-skip's role in it.
+func TestRestartBackendHealsAPolicyStampedBackendStartingDuringTheRestart(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secrets, err := secretsmgr.New(logger, config.ManagerSecrets{})
+	require.NoError(t, err)
+	pm, err := policymgr.New(logger, secrets, config.Config{})
+	require.NoError(t, err)
+
+	events := []string{}
+	be := &windowStampingBackend{restartableBackend: restartableBackend{events: &events}, repo: pm.GetRepo()}
+	backend.Register("snmp_discovery", be)
+
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{"snmp_discovery": be},
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), pm.GetRepo()),
+		config:              config.Config{},
+	}
+	pm.SetStarter(restartStarter{agent: a})
+
+	require.NoError(t, a.RestartBackend(context.Background(), "snmp_discovery", "test"))
+
+	stored, err := pm.GetRepo().Get("during-window")
+	require.NoError(t, err)
+	assert.Equal(t, policies.Running, stored.State, "the record stamped starting during the restart is healed by the restart's own replay")
+
+	var appliedCount int
+	for _, applied := range be.applied {
+		if applied.ID == "during-window" {
+			appliedCount++
+		}
+	}
+	assert.Equal(t, 1, appliedCount, "applied exactly once, even though two replay passes ran")
+}
+
 // Outside a restart, a manage applies the way it always has: the starter
 // reports the backend running and the policy is applied once.
 func TestManageOutsideARestartAppliesAsToday(t *testing.T) {
@@ -570,7 +732,8 @@ func (r *filesmgrRestartBackend) Start(context.Context, context.CancelFunc) erro
 
 // A filesmgr-driven restart brackets its Stop/Start sequence the same way
 // RestartBackend does: policies are marked unknown before Stop and handed
-// back to the backend once Start succeeds.
+// back to the backend once Start succeeds, once while the restart mutex is
+// still held and once more after it is released.
 func TestRestartBackendWithFilesmgrRollback_ReappliesPoliciesAfterSuccessfulStart(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	events := []string{}
@@ -582,6 +745,7 @@ func TestRestartBackendWithFilesmgrRollback_ReappliesPoliciesAfterSuccessfulStar
 		policyManager: pm,
 		filesManager:  &mockFilesManager{},
 	}
+	pm.agent = a
 
 	a.restartBackendWithFilesmgrRollback(context.Background(), "worker")
 
@@ -589,12 +753,14 @@ func TestRestartBackendWithFilesmgrRollback_ReappliesPoliciesAfterSuccessfulStar
 		"remove:worker:permanently=false",
 		"stop",
 		"start",
-		"apply:worker",
+		"apply:worker:locked",
+		"apply:worker:unlocked",
 	}, events)
 }
 
 // A Start that fails, then succeeds after a rollback, is re-applied exactly
-// once, after the retry, not after the failed first attempt.
+// once under the restart mutex, after the retry rather than the failed first
+// attempt, and once more after the mutex is released.
 func TestRestartBackendWithFilesmgrRollback_ReappliesPoliciesAfterRollbackRetry(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	events := []string{}
@@ -606,6 +772,7 @@ func TestRestartBackendWithFilesmgrRollback_ReappliesPoliciesAfterRollbackRetry(
 		policyManager: pm,
 		filesManager:  &mockFilesManager{},
 	}
+	pm.agent = a
 
 	a.restartBackendWithFilesmgrRollback(context.Background(), "worker")
 
@@ -614,8 +781,9 @@ func TestRestartBackendWithFilesmgrRollback_ReappliesPoliciesAfterRollbackRetry(
 		"stop",
 		"start",
 		"start",
-		"apply:worker",
-	}, events, "apply must run exactly once, after the successful retry")
+		"apply:worker:locked",
+		"apply:worker:unlocked",
+	}, events, "apply runs exactly once under the mutex, after the successful retry, and once more after the mutex releases")
 }
 
 // A Start that fails on a backend with no managed binary name cannot roll

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -353,6 +353,37 @@ func TestRestartBackendDoesNotReapplyAfterShutdownBegan(t *testing.T) {
 	}, events, "shutdown already began, so the policies must stay unknown rather than be reapplied")
 }
 
+// Stop cancels the dispatcher and the file-driven restart contexts, then
+// takes each backend's restart mutex to stop it, and only cancels the agent
+// context at the end, after every backend is stopped. A health or fleet
+// restart that already holds the restart mutex when Stop begins therefore
+// still sees a live context when it reaches the re-apply: ctx.Err() alone
+// would not catch it, so the stopping flag does.
+func TestRestartBackendDoesNotReapplyOnceStopBegan(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	events := []string{}
+	pm := &mockPolicyManager{repo: repo, events: &events}
+	be := &restartableBackend{events: &events}
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{"snmp_discovery": be},
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), repo),
+		config:              config.Config{},
+	}
+	a.stopping.Store(true)
+
+	require.NoError(t, a.RestartBackend(context.Background(), "snmp_discovery", "test"))
+
+	assert.Equal(t, []string{
+		"remove:snmp_discovery:permanently=false",
+		"configure",
+		"reset",
+	}, events, "Stop already began, so the policies must stay unknown rather than be reapplied")
+}
+
 // A restart holds the restart mutex across the whole sequence, so the
 // starter reports a backend as starting for as long as a restart of it is in
 // flight, and running again the instant the mutex is free.

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -321,6 +321,38 @@ func TestRestartBackendReappliesPoliciesEndToEnd(t *testing.T) {
 	assert.Equal(t, int32(3), be.applied[0].Version)
 }
 
+// A Start (file-driven or otherwise) that is already blocked on the restart
+// mutex when Stop cancels the agent context can still succeed once the
+// mutex is free, but by then the agent is shutting down: the reset succeeds
+// and the policies stay marked unknown rather than being handed back to a
+// backend about to be torn down.
+func TestRestartBackendDoesNotReapplyAfterShutdownBegan(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+	events := []string{}
+	pm := &mockPolicyManager{repo: repo, events: &events}
+	be := &restartableBackend{events: &events}
+	a := &orbAgent{
+		logger:              logger,
+		backends:            map[string]backend.Backend{"snmp_discovery": be},
+		policyManager:       pm,
+		backendStateManager: backend.NewStateManager("local", logger, make(chan string, 1), repo),
+		config:              config.Config{},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.NoError(t, a.RestartBackend(ctx, "snmp_discovery", "test"))
+
+	assert.Equal(t, []string{
+		"remove:snmp_discovery:permanently=false",
+		"configure",
+		"reset",
+	}, events, "shutdown already began, so the policies must stay unknown rather than be reapplied")
+}
+
 // A restart holds the restart mutex across the whole sequence, so the
 // starter reports a backend as starting for as long as a restart of it is in
 // flight, and running again the instant the mutex is free.
@@ -577,6 +609,33 @@ func TestRestartBackendWithFilesmgrRollback_DoesNotReapplyWithoutAManagedBinary(
 		"stop",
 		"start",
 	}, events)
+}
+
+// A Start that succeeds after the agent context was already cancelled before
+// the call (Stop ran while this restart was blocked on the restart mutex)
+// must not hand the policies back: the agent is shutting down.
+func TestRestartBackendWithFilesmgrRollbackDoesNotReapplyAfterShutdownBegan(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	events := []string{}
+	pm := &mockPolicyManager{events: &events}
+	be := &filesmgrRestartBackend{restartableBackend: restartableBackend{events: &events}, binaryName: "orb-worker"}
+	a := &orbAgent{
+		logger:        logger,
+		backends:      map[string]backend.Backend{"worker": be},
+		policyManager: pm,
+		filesManager:  &mockFilesManager{},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	a.restartBackendWithFilesmgrRollback(ctx, "worker")
+
+	assert.Equal(t, []string{
+		"remove:worker:permanently=false",
+		"stop",
+		"start",
+	}, events, "shutdown already began, so the policies must stay unknown rather than be reapplied")
 }
 
 // mockFilesManager implements filesmgr.Manager for testing (no-op)

--- a/agent/configmgr/fleet/connection_hooks_test.go
+++ b/agent/configmgr/fleet/connection_hooks_test.go
@@ -21,7 +21,7 @@ func (noopPM) ManagePolicy(_ config.PolicyPayload)                             {
 func (noopPM) RemovePolicyDataset(_ string, _ string, _ backend.Backend)       {}
 func (noopPM) GetPolicyState() ([]policies.PolicyData, error)                  { return nil, nil }
 func (noopPM) GetRepo() policies.PolicyRepo                                    { return nil }
-func (noopPM) ApplyBackendPolicies(_ backend.Backend) error                    { return nil }
+func (noopPM) ApplyBackendPolicies(_ string, _ backend.Backend) error          { return nil }
 func (noopPM) RemoveBackendPolicies(_ string, _ backend.Backend, _ bool) error { return nil }
 func (noopPM) RemovePolicy(_ string, _ string, _ string) error                 { return nil }
 

--- a/agent/configmgr/fleet/connection_hooks_test.go
+++ b/agent/configmgr/fleet/connection_hooks_test.go
@@ -17,13 +17,13 @@ import (
 // minimal policy manager impl for constructor
 type noopPM struct{}
 
-func (noopPM) ManagePolicy(_ config.PolicyPayload)                             {}
-func (noopPM) RemovePolicyDataset(_ string, _ string, _ backend.Backend)       {}
-func (noopPM) GetPolicyState() ([]policies.PolicyData, error)                  { return nil, nil }
-func (noopPM) GetRepo() policies.PolicyRepo                                    { return nil }
-func (noopPM) ApplyBackendPolicies(_ string, _ backend.Backend) error          { return nil }
-func (noopPM) RemoveBackendPolicies(_ string, _ backend.Backend, _ bool) error { return nil }
-func (noopPM) RemovePolicy(_ string, _ string, _ string) error                 { return nil }
+func (noopPM) ManagePolicy(_ config.PolicyPayload)                                 {}
+func (noopPM) RemovePolicyDataset(_ string, _ string, _ string, _ backend.Backend) {}
+func (noopPM) GetPolicyState() ([]policies.PolicyData, error)                      { return nil, nil }
+func (noopPM) GetRepo() policies.PolicyRepo                                        { return nil }
+func (noopPM) ApplyBackendPolicies(_ string, _ backend.Backend) error              { return nil }
+func (noopPM) RemoveBackendPolicies(_ string, _ backend.Backend, _ bool) error     { return nil }
+func (noopPM) RemovePolicy(_ string, _ string, _ string) error                     { return nil }
 
 type noopBackendState struct{}
 

--- a/agent/configmgr/fleet/connection_hooks_test.go
+++ b/agent/configmgr/fleet/connection_hooks_test.go
@@ -18,14 +18,14 @@ import (
 // minimal policy manager impl for constructor
 type noopPM struct{}
 
-func (noopPM) ManagePolicy(_ config.PolicyPayload)                                 {}
-func (noopPM) RemovePolicyDataset(_ string, _ string, _ string, _ backend.Backend) {}
-func (noopPM) GetPolicyState() ([]policies.PolicyData, error)                      { return nil, nil }
-func (noopPM) GetRepo() policies.PolicyRepo                                        { return nil }
-func (noopPM) ApplyBackendPolicies(_ string, _ backend.Backend) error              { return nil }
-func (noopPM) RemoveBackendPolicies(_ string, _ backend.Backend, _ bool) error     { return nil }
-func (noopPM) RemovePolicy(_ string, _ string, _ string) error                     { return nil }
-func (noopPM) SetStarter(_ policymgr.BackendStarter)                               {}
+func (noopPM) ManagePolicy(_ config.PolicyPayload)                                       {}
+func (noopPM) RemovePolicyDataset(_ string, _ string, _ string, _ backend.Backend)       {}
+func (noopPM) GetPolicyState() ([]policies.PolicyData, error)                            { return nil, nil }
+func (noopPM) GetRepo() policies.PolicyRepo                                              { return nil }
+func (noopPM) ApplyBackendPolicies(_ context.Context, _ string, _ backend.Backend) error { return nil }
+func (noopPM) RemoveBackendPolicies(_ string, _ backend.Backend, _ bool) error           { return nil }
+func (noopPM) RemovePolicy(_ string, _ string, _ string) error                           { return nil }
+func (noopPM) SetStarter(_ policymgr.BackendStarter)                                     {}
 
 type noopBackendState struct{}
 

--- a/agent/configmgr/fleet/connection_hooks_test.go
+++ b/agent/configmgr/fleet/connection_hooks_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/policies"
+	"github.com/netboxlabs/orb-agent/agent/policymgr"
 )
 
 // minimal policy manager impl for constructor
@@ -24,6 +25,7 @@ func (noopPM) GetRepo() policies.PolicyRepo                                     
 func (noopPM) ApplyBackendPolicies(_ string, _ backend.Backend) error              { return nil }
 func (noopPM) RemoveBackendPolicies(_ string, _ backend.Backend, _ bool) error     { return nil }
 func (noopPM) RemovePolicy(_ string, _ string, _ string) error                     { return nil }
+func (noopPM) SetStarter(_ policymgr.BackendStarter)                               {}
 
 type noopBackendState struct{}
 

--- a/agent/configmgr/fleet/connection_test.go
+++ b/agent/configmgr/fleet/connection_test.go
@@ -41,8 +41,8 @@ func (m *mockPolicyManagerForFleet) GetRepo() policies.PolicyRepo {
 	return args.Get(0).(policies.PolicyRepo)
 }
 
-func (m *mockPolicyManagerForFleet) ApplyBackendPolicies(be backend.Backend) error {
-	args := m.Called(be)
+func (m *mockPolicyManagerForFleet) ApplyBackendPolicies(name string, be backend.Backend) error {
+	args := m.Called(name, be)
 	return args.Error(0)
 }
 

--- a/agent/configmgr/fleet/connection_test.go
+++ b/agent/configmgr/fleet/connection_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/policies"
+	"github.com/netboxlabs/orb-agent/agent/policymgr"
 )
 
 // mockPolicyManagerForFleet implements the PolicyManager interface for fleet testing
@@ -55,6 +56,8 @@ func (m *mockPolicyManagerForFleet) RemovePolicy(policyID string, policyName str
 	args := m.Called(policyID, policyName, beName)
 	return args.Error(0)
 }
+
+func (m *mockPolicyManagerForFleet) SetStarter(_ policymgr.BackendStarter) {}
 
 type mockBackendState struct {
 	backendState map[string]*backend.State

--- a/agent/configmgr/fleet/connection_test.go
+++ b/agent/configmgr/fleet/connection_test.go
@@ -42,7 +42,7 @@ func (m *mockPolicyManagerForFleet) GetRepo() policies.PolicyRepo {
 	return args.Get(0).(policies.PolicyRepo)
 }
 
-func (m *mockPolicyManagerForFleet) ApplyBackendPolicies(name string, be backend.Backend) error {
+func (m *mockPolicyManagerForFleet) ApplyBackendPolicies(_ context.Context, name string, be backend.Backend) error {
 	args := m.Called(name, be)
 	return args.Error(0)
 }

--- a/agent/configmgr/fleet/connection_test.go
+++ b/agent/configmgr/fleet/connection_test.go
@@ -27,8 +27,8 @@ func (m *mockPolicyManagerForFleet) ManagePolicy(payload config.PolicyPayload) {
 	m.Called(payload)
 }
 
-func (m *mockPolicyManagerForFleet) RemovePolicyDataset(policyID string, datasetID string, be backend.Backend) {
-	m.Called(policyID, datasetID, be)
+func (m *mockPolicyManagerForFleet) RemovePolicyDataset(policyID string, datasetID string, beName string, be backend.Backend) {
+	m.Called(policyID, datasetID, beName, be)
 }
 
 func (m *mockPolicyManagerForFleet) GetPolicyState() ([]policies.PolicyData, error) {

--- a/agent/configmgr/fleet/from_rpc.go
+++ b/agent/configmgr/fleet/from_rpc.go
@@ -248,7 +248,7 @@ func (messaging *Messaging) handleAgentGroupRemoval(rpc messages.GroupRemovedRPC
 		} else {
 			for _, datasetID := range rpc.Datasets {
 				if backend.HaveBackend(policy.Backend) {
-					messaging.policyManager.RemovePolicyDataset(policy.ID, datasetID, backend.GetBackend(policy.Backend))
+					messaging.policyManager.RemovePolicyDataset(policy.ID, datasetID, policy.Backend, backend.GetBackend(policy.Backend))
 				}
 			}
 		}
@@ -267,7 +267,7 @@ func (messaging *Messaging) handleDatasetRemoval(rpc messages.DatasetRemovedRPCP
 		return
 	}
 	be := backend.GetBackend(policy.Backend)
-	messaging.policyManager.RemovePolicyDataset(rpc.PolicyID, rpc.DatasetID, be)
+	messaging.policyManager.RemovePolicyDataset(rpc.PolicyID, rpc.DatasetID, policy.Backend, be)
 }
 
 func (messaging *Messaging) handleAgentReset(ctx context.Context, payload messages.AgentResetRPCPayload) {

--- a/agent/configmgr/fleet/from_rpc_test.go
+++ b/agent/configmgr/fleet/from_rpc_test.go
@@ -30,8 +30,8 @@ func (m *mockPolicyManager) ManagePolicy(payload config.PolicyPayload) {
 	m.Called(payload)
 }
 
-func (m *mockPolicyManager) RemovePolicyDataset(policyID string, datasetID string, be backend.Backend) {
-	m.Called(policyID, datasetID, be)
+func (m *mockPolicyManager) RemovePolicyDataset(policyID string, datasetID string, beName string, be backend.Backend) {
+	m.Called(policyID, datasetID, beName, be)
 }
 
 func (m *mockPolicyManager) GetPolicyState() ([]policies.PolicyData, error) {
@@ -241,7 +241,7 @@ func TestMessageHandlers_DispatchToHandlers(t *testing.T) {
 					Backend: "test_backend_dispatch",
 				}, nil)
 				m.On("GetRepo").Return(mockRepo)
-				m.On("RemovePolicyDataset", "policy1", "dataset1", mock.Anything).Return()
+				m.On("RemovePolicyDataset", "policy1", "dataset1", "test_backend_dispatch", mock.Anything).Return()
 			},
 			expectedError:         false,
 			expectedPolicyMgrCall: true,
@@ -1020,8 +1020,8 @@ func TestMessageHandlers_handleAgentGroupRemoval_RemovesDatasetsWhenGroupsRemain
 	// Setup mock expectations
 	mockPMgr.On("GetRepo").Return(mockRepo)
 	mockRepo.On("GetAll").Return(existingPolicies, nil)
-	mockPMgr.On("RemovePolicyDataset", "policy1", "dataset1", mock.Anything).Return()
-	mockPMgr.On("RemovePolicyDataset", "policy1", "dataset2", mock.Anything).Return()
+	mockPMgr.On("RemovePolicyDataset", "policy1", "dataset1", "pktvisor", mock.Anything).Return()
+	mockPMgr.On("RemovePolicyDataset", "policy1", "dataset2", "pktvisor", mock.Anything).Return()
 
 	// Create group removal payload
 	groupRemoval := messages.GroupRemovedRPCPayload{
@@ -1269,7 +1269,7 @@ func TestMessageHandlers_handleDatasetRemoval_Success(t *testing.T) {
 		Name:    "Test Policy",
 		Backend: "test_backend",
 	}, nil)
-	mockPMgr.On("RemovePolicyDataset", "policy1", "dataset1", mockBe).Return()
+	mockPMgr.On("RemovePolicyDataset", "policy1", "dataset1", "test_backend", mockBe).Return()
 
 	// Create dataset removal payload
 	datasetRemoval := messages.DatasetRemovedRPCPayload{
@@ -1309,7 +1309,7 @@ func TestMessageHandlers_handleDatasetRemoval_PolicyRetrievalFails(t *testing.T)
 	handlers.handleDatasetRemoval(datasetRemoval)
 
 	// Assert - should return early without calling RemovePolicyDataset
-	mockPMgr.AssertNotCalled(t, "RemovePolicyDataset", mock.Anything, mock.Anything, mock.Anything)
+	mockPMgr.AssertNotCalled(t, "RemovePolicyDataset", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	mockPMgr.AssertExpectations(t)
 	mockRepo.AssertExpectations(t)
 }
@@ -1342,7 +1342,7 @@ func TestMessageHandlers_handleDatasetRemoval_BackendNotFound(t *testing.T) {
 	handlers.handleDatasetRemoval(datasetRemoval)
 
 	// Assert - should return early without calling RemovePolicyDataset
-	mockPMgr.AssertNotCalled(t, "RemovePolicyDataset", mock.Anything, mock.Anything, mock.Anything)
+	mockPMgr.AssertNotCalled(t, "RemovePolicyDataset", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	mockPMgr.AssertExpectations(t)
 	mockRepo.AssertExpectations(t)
 }

--- a/agent/configmgr/fleet/from_rpc_test.go
+++ b/agent/configmgr/fleet/from_rpc_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/configmgr/fleet/messages"
 	"github.com/netboxlabs/orb-agent/agent/policies"
+	"github.com/netboxlabs/orb-agent/agent/policymgr"
 )
 
 // mockPolicyManager implements the PolicyManager interface for testing
@@ -58,6 +59,8 @@ func (m *mockPolicyManager) RemovePolicy(policyID string, policyName string, beN
 	args := m.Called(policyID, policyName, beName)
 	return args.Error(0)
 }
+
+func (m *mockPolicyManager) SetStarter(_ policymgr.BackendStarter) {}
 
 // mockPolicyRepo implements the PolicyRepo interface for testing
 type mockPolicyRepo struct {

--- a/agent/configmgr/fleet/from_rpc_test.go
+++ b/agent/configmgr/fleet/from_rpc_test.go
@@ -44,8 +44,8 @@ func (m *mockPolicyManager) GetRepo() policies.PolicyRepo {
 	return args.Get(0).(policies.PolicyRepo)
 }
 
-func (m *mockPolicyManager) ApplyBackendPolicies(be backend.Backend) error {
-	args := m.Called(be)
+func (m *mockPolicyManager) ApplyBackendPolicies(name string, be backend.Backend) error {
+	args := m.Called(name, be)
 	return args.Error(0)
 }
 

--- a/agent/configmgr/fleet/from_rpc_test.go
+++ b/agent/configmgr/fleet/from_rpc_test.go
@@ -45,7 +45,7 @@ func (m *mockPolicyManager) GetRepo() policies.PolicyRepo {
 	return args.Get(0).(policies.PolicyRepo)
 }
 
-func (m *mockPolicyManager) ApplyBackendPolicies(name string, be backend.Backend) error {
+func (m *mockPolicyManager) ApplyBackendPolicies(_ context.Context, name string, be backend.Backend) error {
 	args := m.Called(name, be)
 	return args.Error(0)
 }

--- a/agent/configmgr/fleet/from_rpc_test.go
+++ b/agent/configmgr/fleet/from_rpc_test.go
@@ -87,6 +87,11 @@ func (m *mockPolicyRepo) Update(data policies.PolicyData) error {
 	return args.Error(0)
 }
 
+func (m *mockPolicyRepo) UpdateKeepingRuns(data policies.PolicyData) error {
+	args := m.Called(data)
+	return args.Error(0)
+}
+
 func (m *mockPolicyRepo) GetAll() ([]policies.PolicyData, error) {
 	args := m.Called()
 	if args.Get(0) == nil {

--- a/agent/configmgr/fleet/heartbeats_test.go
+++ b/agent/configmgr/fleet/heartbeats_test.go
@@ -51,7 +51,9 @@ func (t *testPolicyManagerWithRepo) GetPolicyState() ([]policies.PolicyData, err
 
 func (t *testPolicyManagerWithRepo) GetRepo() policies.PolicyRepo { return t.repo }
 
-func (t *testPolicyManagerWithRepo) ApplyBackendPolicies(_ backend.Backend) error { return nil }
+func (t *testPolicyManagerWithRepo) ApplyBackendPolicies(_ string, _ backend.Backend) error {
+	return nil
+}
 
 func (t *testPolicyManagerWithRepo) RemoveBackendPolicies(_ string, _ backend.Backend, _ bool) error {
 	return nil
@@ -94,8 +96,8 @@ func (m *mockPolicyManagerForHeartbeat) GetRepo() policies.PolicyRepo {
 	return args.Get(0).(policies.PolicyRepo)
 }
 
-func (m *mockPolicyManagerForHeartbeat) ApplyBackendPolicies(be backend.Backend) error {
-	args := m.Called(be)
+func (m *mockPolicyManagerForHeartbeat) ApplyBackendPolicies(name string, be backend.Backend) error {
+	args := m.Called(name, be)
 	return args.Error(0)
 }
 

--- a/agent/configmgr/fleet/heartbeats_test.go
+++ b/agent/configmgr/fleet/heartbeats_test.go
@@ -43,7 +43,8 @@ type testPolicyManagerWithRepo struct {
 
 func (t *testPolicyManagerWithRepo) ManagePolicy(_ config.PolicyPayload) {}
 
-func (t *testPolicyManagerWithRepo) RemovePolicyDataset(_ string, _ string, _ backend.Backend) {}
+func (t *testPolicyManagerWithRepo) RemovePolicyDataset(_ string, _ string, _ string, _ backend.Backend) {
+}
 
 func (t *testPolicyManagerWithRepo) GetPolicyState() ([]policies.PolicyData, error) {
 	return t.repo.GetAll()
@@ -82,8 +83,8 @@ func (m *mockPolicyManagerForHeartbeat) ManagePolicy(payload config.PolicyPayloa
 	m.Called(payload)
 }
 
-func (m *mockPolicyManagerForHeartbeat) RemovePolicyDataset(policyID string, datasetID string, be backend.Backend) {
-	m.Called(policyID, datasetID, be)
+func (m *mockPolicyManagerForHeartbeat) RemovePolicyDataset(policyID string, datasetID string, beName string, be backend.Backend) {
+	m.Called(policyID, datasetID, beName, be)
 }
 
 func (m *mockPolicyManagerForHeartbeat) GetPolicyState() ([]policies.PolicyData, error) {

--- a/agent/configmgr/fleet/heartbeats_test.go
+++ b/agent/configmgr/fleet/heartbeats_test.go
@@ -52,7 +52,7 @@ func (t *testPolicyManagerWithRepo) GetPolicyState() ([]policies.PolicyData, err
 
 func (t *testPolicyManagerWithRepo) GetRepo() policies.PolicyRepo { return t.repo }
 
-func (t *testPolicyManagerWithRepo) ApplyBackendPolicies(_ string, _ backend.Backend) error {
+func (t *testPolicyManagerWithRepo) ApplyBackendPolicies(_ context.Context, _ string, _ backend.Backend) error {
 	return nil
 }
 
@@ -99,7 +99,7 @@ func (m *mockPolicyManagerForHeartbeat) GetRepo() policies.PolicyRepo {
 	return args.Get(0).(policies.PolicyRepo)
 }
 
-func (m *mockPolicyManagerForHeartbeat) ApplyBackendPolicies(name string, be backend.Backend) error {
+func (m *mockPolicyManagerForHeartbeat) ApplyBackendPolicies(_ context.Context, name string, be backend.Backend) error {
 	args := m.Called(name, be)
 	return args.Error(0)
 }

--- a/agent/configmgr/fleet/heartbeats_test.go
+++ b/agent/configmgr/fleet/heartbeats_test.go
@@ -62,6 +62,8 @@ func (t *testPolicyManagerWithRepo) RemoveBackendPolicies(_ string, _ backend.Ba
 
 func (t *testPolicyManagerWithRepo) RemovePolicy(_ string, _ string, _ string) error { return nil }
 
+func (t *testPolicyManagerWithRepo) SetStarter(_ policymgr.BackendStarter) {}
+
 var _ policymgr.PolicyManager = (*testPolicyManagerWithRepo)(nil)
 
 // mockPublishFunc is a testify mock for the publish function
@@ -111,6 +113,8 @@ func (m *mockPolicyManagerForHeartbeat) RemovePolicy(policyID string, policyName
 	args := m.Called(policyID, policyName, beName)
 	return args.Error(0)
 }
+
+func (m *mockPolicyManagerForHeartbeat) SetStarter(_ policymgr.BackendStarter) {}
 
 // Test helper to create a heartbeater instance for testing
 func createTestHeartbeater() *heartbeater {

--- a/agent/configmgr/fleet/to_rpc_test.go
+++ b/agent/configmgr/fleet/to_rpc_test.go
@@ -42,8 +42,8 @@ func (m *mockPolicyManagerForToRPC) GetRepo() policies.PolicyRepo {
 	return args.Get(0).(policies.PolicyRepo)
 }
 
-func (m *mockPolicyManagerForToRPC) ApplyBackendPolicies(be backend.Backend) error {
-	args := m.Called(be)
+func (m *mockPolicyManagerForToRPC) ApplyBackendPolicies(name string, be backend.Backend) error {
+	args := m.Called(name, be)
 	return args.Error(0)
 }
 

--- a/agent/configmgr/fleet/to_rpc_test.go
+++ b/agent/configmgr/fleet/to_rpc_test.go
@@ -28,8 +28,8 @@ func (m *mockPolicyManagerForToRPC) ManagePolicy(payload config.PolicyPayload) {
 	m.Called(payload)
 }
 
-func (m *mockPolicyManagerForToRPC) RemovePolicyDataset(policyID string, datasetID string, be backend.Backend) {
-	m.Called(policyID, datasetID, be)
+func (m *mockPolicyManagerForToRPC) RemovePolicyDataset(policyID string, datasetID string, beName string, be backend.Backend) {
+	m.Called(policyID, datasetID, beName, be)
 }
 
 func (m *mockPolicyManagerForToRPC) GetPolicyState() ([]policies.PolicyData, error) {

--- a/agent/configmgr/fleet/to_rpc_test.go
+++ b/agent/configmgr/fleet/to_rpc_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/config"
 	"github.com/netboxlabs/orb-agent/agent/configmgr/fleet/messages"
 	"github.com/netboxlabs/orb-agent/agent/policies"
+	"github.com/netboxlabs/orb-agent/agent/policymgr"
 )
 
 // mockPolicyManagerForToRPC implements the PolicyManager interface for to_rpc testing
@@ -56,6 +57,8 @@ func (m *mockPolicyManagerForToRPC) RemovePolicy(policyID string, policyName str
 	args := m.Called(policyID, policyName, beName)
 	return args.Error(0)
 }
+
+func (m *mockPolicyManagerForToRPC) SetStarter(_ policymgr.BackendStarter) {}
 
 func TestMessaging_SendCapabilities_Success(t *testing.T) {
 	// Arrange

--- a/agent/configmgr/fleet/to_rpc_test.go
+++ b/agent/configmgr/fleet/to_rpc_test.go
@@ -43,7 +43,7 @@ func (m *mockPolicyManagerForToRPC) GetRepo() policies.PolicyRepo {
 	return args.Get(0).(policies.PolicyRepo)
 }
 
-func (m *mockPolicyManagerForToRPC) ApplyBackendPolicies(name string, be backend.Backend) error {
+func (m *mockPolicyManagerForToRPC) ApplyBackendPolicies(_ context.Context, name string, be backend.Backend) error {
 	args := m.Called(name, be)
 	return args.Error(0)
 }

--- a/agent/configmgr/fleet_test.go
+++ b/agent/configmgr/fleet_test.go
@@ -53,8 +53,8 @@ func (m *mockPolicyManagerForFleet) GetRepo() policies.PolicyRepo {
 	return val.(policies.PolicyRepo)
 }
 
-func (m *mockPolicyManagerForFleet) ApplyBackendPolicies(be backend.Backend) error {
-	args := m.Called(be)
+func (m *mockPolicyManagerForFleet) ApplyBackendPolicies(name string, be backend.Backend) error {
+	args := m.Called(name, be)
 	return args.Error(0)
 }
 

--- a/agent/configmgr/fleet_test.go
+++ b/agent/configmgr/fleet_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/configmgr/fleet"
 	"github.com/netboxlabs/orb-agent/agent/otlpbridge"
 	"github.com/netboxlabs/orb-agent/agent/policies"
+	"github.com/netboxlabs/orb-agent/agent/policymgr"
 )
 
 // mockPolicyManagerForFleet implements the PolicyManager interface for fleet testing
@@ -67,6 +68,8 @@ func (m *mockPolicyManagerForFleet) RemovePolicy(policyID string, policyName str
 	args := m.Called(policyID, policyName, beName)
 	return args.Error(0)
 }
+
+func (m *mockPolicyManagerForFleet) SetStarter(_ policymgr.BackendStarter) {}
 
 type mockBackendState struct {
 	mock.Mock

--- a/agent/configmgr/fleet_test.go
+++ b/agent/configmgr/fleet_test.go
@@ -35,8 +35,8 @@ func (m *mockPolicyManagerForFleet) ManagePolicy(payload config.PolicyPayload) {
 	m.Called(payload)
 }
 
-func (m *mockPolicyManagerForFleet) RemovePolicyDataset(policyID string, datasetID string, be backend.Backend) {
-	m.Called(policyID, datasetID, be)
+func (m *mockPolicyManagerForFleet) RemovePolicyDataset(policyID string, datasetID string, beName string, be backend.Backend) {
+	m.Called(policyID, datasetID, beName, be)
 }
 
 func (m *mockPolicyManagerForFleet) GetPolicyState() ([]policies.PolicyData, error) {

--- a/agent/configmgr/fleet_test.go
+++ b/agent/configmgr/fleet_test.go
@@ -54,7 +54,7 @@ func (m *mockPolicyManagerForFleet) GetRepo() policies.PolicyRepo {
 	return val.(policies.PolicyRepo)
 }
 
-func (m *mockPolicyManagerForFleet) ApplyBackendPolicies(name string, be backend.Backend) error {
+func (m *mockPolicyManagerForFleet) ApplyBackendPolicies(_ context.Context, name string, be backend.Backend) error {
 	args := m.Called(name, be)
 	return args.Error(0)
 }

--- a/agent/configmgr/manager_test.go
+++ b/agent/configmgr/manager_test.go
@@ -27,8 +27,8 @@ func (m *mockPolicyManager) ManagePolicy(payload config.PolicyPayload) {
 	m.Called(payload)
 }
 
-func (m *mockPolicyManager) RemovePolicyDataset(policyID string, datasetID string, be backend.Backend) {
-	m.Called(policyID, datasetID, be)
+func (m *mockPolicyManager) RemovePolicyDataset(policyID string, datasetID string, beName string, be backend.Backend) {
+	m.Called(policyID, datasetID, beName, be)
 }
 
 func (m *mockPolicyManager) GetPolicyState() ([]policies.PolicyData, error) {

--- a/agent/configmgr/manager_test.go
+++ b/agent/configmgr/manager_test.go
@@ -42,7 +42,7 @@ func (m *mockPolicyManager) GetRepo() policies.PolicyRepo {
 	return args.Get(0).(policies.PolicyRepo)
 }
 
-func (m *mockPolicyManager) ApplyBackendPolicies(name string, be backend.Backend) error {
+func (m *mockPolicyManager) ApplyBackendPolicies(_ context.Context, name string, be backend.Backend) error {
 	args := m.Called(name, be)
 	return args.Error(0)
 }

--- a/agent/configmgr/manager_test.go
+++ b/agent/configmgr/manager_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/netboxlabs/orb-agent/agent/configmgr"
 	"github.com/netboxlabs/orb-agent/agent/filesmgr"
 	"github.com/netboxlabs/orb-agent/agent/policies"
+	"github.com/netboxlabs/orb-agent/agent/policymgr"
 )
 
 // Mock implementations for testing
@@ -55,6 +56,8 @@ func (m *mockPolicyManager) RemovePolicy(policyID string, policyName string, beN
 	args := m.Called(policyID, policyName, beName)
 	return args.Error(0)
 }
+
+func (m *mockPolicyManager) SetStarter(_ policymgr.BackendStarter) {}
 
 type mockBackend struct {
 	mock.Mock

--- a/agent/configmgr/manager_test.go
+++ b/agent/configmgr/manager_test.go
@@ -41,8 +41,8 @@ func (m *mockPolicyManager) GetRepo() policies.PolicyRepo {
 	return args.Get(0).(policies.PolicyRepo)
 }
 
-func (m *mockPolicyManager) ApplyBackendPolicies(be backend.Backend) error {
-	args := m.Called(be)
+func (m *mockPolicyManager) ApplyBackendPolicies(name string, be backend.Backend) error {
+	args := m.Called(name, be)
 	return args.Error(0)
 }
 

--- a/agent/policies/repo.go
+++ b/agent/policies/repo.go
@@ -16,6 +16,11 @@ type PolicyRepo interface {
 	Get(policyID string) (PolicyData, error)
 	Remove(policyID string) error
 	Update(data PolicyData) error
+	// UpdateKeepingRuns replaces the stored record with data but keeps the
+	// runs the store already holds, in one locked operation, so a run update
+	// written while the caller held its snapshot is not discarded. A record
+	// that does not exist yet is stored as given.
+	UpdateKeepingRuns(data PolicyData) error
 	GetAll() ([]PolicyData, error)
 	GetByName(policyName string) (PolicyData, error)
 	EnsureDataset(policyID string, datasetID string) error
@@ -115,6 +120,26 @@ func (p *policyMemRepo) Remove(policyID string) error {
 func (p *policyMemRepo) Update(data PolicyData) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	p.storeLocked(data)
+	return nil
+}
+
+// UpdateKeepingRuns replaces the stored record with data but keeps the runs
+// already held for that ID, merging under the same lock used to store it so
+// a concurrent run update is never discarded between a read and this write.
+func (p *policyMemRepo) UpdateKeepingRuns(data PolicyData) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if existing, ok := p.db[data.ID]; ok {
+		data.Runs = existing.Runs
+	}
+	p.storeLocked(data)
+	return nil
+}
+
+// storeLocked writes data into the db and name map, clearing any prior name
+// mapping for data.ID. The caller must hold p.mu.
+func (p *policyMemRepo) storeLocked(data PolicyData) {
 	policy, ok := p.db[data.ID]
 	if ok {
 		// existed, clear old map
@@ -122,7 +147,6 @@ func (p *policyMemRepo) Update(data PolicyData) error {
 	}
 	p.db[data.ID] = data
 	p.nameMap[data.Name] = data.ID
-	return nil
 }
 
 func (p *policyMemRepo) GetAll() (ret []PolicyData, err error) {

--- a/agent/policies/repo_test.go
+++ b/agent/policies/repo_test.go
@@ -396,6 +396,97 @@ func TestUpdateRenamingPolicy(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestUpdateKeepingRunsKeepsTheStoredRuns(t *testing.T) {
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	pd := policies.PolicyData{
+		ID:       "test-id",
+		Name:     "test-policy",
+		Backend:  "test-backend",
+		Version:  1,
+		Datasets: map[string]bool{"dataset1": true},
+		GroupIDs: map[string]bool{"group1": true},
+		Data:     map[string]any{"key": "value"},
+		State:    policies.Unknown,
+	}
+	require.NoError(t, repo.Update(pd))
+
+	require.NoError(t, repo.UpdateRuns("test-policy", []policies.RunData{
+		{ID: "run-1", Status: "running"},
+	}))
+
+	// Snapshot taken before the run update above landed: new State, no Runs.
+	snapshot := pd
+	snapshot.State = policies.Running
+
+	require.NoError(t, repo.UpdateKeepingRuns(snapshot))
+
+	got, err := repo.Get("test-id")
+	require.NoError(t, err)
+	assert.Equal(t, policies.Running, got.State)
+	require.Len(t, got.Runs, 1)
+	assert.Equal(t, "run-1", got.Runs[0].ID)
+
+	// A second, unrelated write-back must not have kept these stale Runs
+	// as the snapshot's own value: nothing else changes.
+	assert.Equal(t, "test-policy", got.Name)
+}
+
+func TestUpdateKeepingRunsCreatesUnknownID(t *testing.T) {
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	pd := policies.PolicyData{
+		ID:       "new-id",
+		Name:     "new-policy",
+		Backend:  "test-backend",
+		Version:  1,
+		Datasets: map[string]bool{"dataset1": true},
+		GroupIDs: map[string]bool{"group1": true},
+		Data:     map[string]any{"key": "value"},
+		State:    policies.Unknown,
+	}
+
+	require.NoError(t, repo.UpdateKeepingRuns(pd))
+
+	got, err := repo.Get("new-id")
+	require.NoError(t, err)
+	assert.Equal(t, "new-policy", got.Name)
+
+	byName, err := repo.GetByName("new-policy")
+	require.NoError(t, err)
+	assert.Equal(t, "new-id", byName.ID)
+}
+
+func TestUpdateKeepingRunsRenamesThePolicy(t *testing.T) {
+	repo, err := policies.NewMemRepo()
+	require.NoError(t, err)
+
+	pd := policies.PolicyData{
+		ID:       "test-id",
+		Name:     "old-name",
+		Backend:  "test-backend",
+		Version:  1,
+		Datasets: map[string]bool{"dataset1": true},
+		GroupIDs: map[string]bool{"group1": true},
+		Data:     map[string]any{"key": "value"},
+		State:    policies.Unknown,
+	}
+	require.NoError(t, repo.Update(pd))
+
+	renamed := pd
+	renamed.Name = "new-name"
+	require.NoError(t, repo.UpdateKeepingRuns(renamed))
+
+	_, err = repo.GetByName("old-name")
+	assert.Error(t, err)
+
+	got, err := repo.GetByName("new-name")
+	require.NoError(t, err)
+	assert.Equal(t, "test-id", got.ID)
+}
+
 func TestUpdateRuns(t *testing.T) {
 	repo, err := policies.NewMemRepo()
 	require.NoError(t, err)

--- a/agent/policymgr/manager.go
+++ b/agent/policymgr/manager.go
@@ -1,6 +1,7 @@
 package policymgr
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -19,7 +20,7 @@ type PolicyManager interface {
 	RemovePolicyDataset(policyID string, datasetID string, beName string, be backend.Backend)
 	GetPolicyState() ([]policies.PolicyData, error)
 	GetRepo() policies.PolicyRepo
-	ApplyBackendPolicies(name string, be backend.Backend) error
+	ApplyBackendPolicies(ctx context.Context, name string, be backend.Backend) error
 	RemoveBackendPolicies(name string, be backend.Backend, permanently bool) error
 	RemovePolicy(policyID string, policyName string, beName string) error
 	SetStarter(starter BackendStarter)
@@ -106,6 +107,10 @@ func (a *policyManager) SetStarter(starter BackendStarter) {
 	a.starter = starter
 }
 
+// ReasonBackendStarting is the operator-facing reason stored on a policy
+// whose apply was deferred because the starter reported the backend starting.
+const ReasonBackendStarting = "backend starting"
+
 // backendReady consults the starter for the policy's backend. It returns
 // true when the apply may proceed; otherwise it has set the policy's state
 // and reason and the caller persists the record.
@@ -121,7 +126,7 @@ func (a *policyManager) backendReady(name string, pd *policies.PolicyData) bool 
 		return false
 	case state == StartStarting:
 		pd.State = policies.FailedToApply
-		pd.BackendErr = "backend starting"
+		pd.BackendErr = ReasonBackendStarting
 		return false
 	}
 	return true
@@ -541,14 +546,30 @@ var ErrBackendNotRunning = errors.New("backend is not running; its policies are 
 // policy failed; that per-policy check is a second GetRunningStatus call,
 // an HTTP round trip for every policy in the loop, and is not redundant
 // with the gate above, so do not remove either thinking the other covers it.
-func (a *policyManager) ApplyBackendPolicies(name string, be backend.Backend) error {
+//
+// The context is checked before every policy, not only once on entry: a
+// caller whose shutdown begins mid-loop must stop launching further HTTP
+// calls, including one-shot policies, rather than run the whole backlog
+// because the loop was already past the first check. A cancellation ends
+// the loop and is returned, leaving whatever policies were not yet reached
+// as they were (most often unknown) for a later replay to pick up.
+//
+// A record already Running is skipped: every restart marks a backend's
+// policies unknown before stopping it, and a manage that lands while a
+// restart is in flight is stored failed to apply rather than running, so a
+// running record can only reflect this same process's own prior apply.
+// Skipping it is what lets a restart's second pass, taken after its mutex is
+// released to pick up anything that arrived in the window between the first
+// pass and the unlock, run safely alongside (or after) the first without
+// applying a policy twice.
+func (a *policyManager) ApplyBackendPolicies(ctx context.Context, name string, be backend.Backend) error {
 	mu := a.applyLock(name)
 	mu.Lock()
 	defer mu.Unlock()
-	return a.applyBackendPoliciesLocked(name, be)
+	return a.applyBackendPoliciesLocked(ctx, name, be)
 }
 
-func (a *policyManager) applyBackendPoliciesLocked(name string, be backend.Backend) error {
+func (a *policyManager) applyBackendPoliciesLocked(ctx context.Context, name string, be backend.Backend) error {
 	if state, detail, err := be.GetRunningStatus(); state != backend.Running || err != nil {
 		a.logger.Warn("backend is not running; its policies are left for its next start",
 			"backend", name, "backend_state", state.String(), "detail", detail, "error", err)
@@ -561,6 +582,13 @@ func (a *policyManager) applyBackendPoliciesLocked(name string, be backend.Backe
 	}
 	for _, policy := range plcies {
 		if policy.Backend != name {
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			a.logger.Info("shutting down; remaining backend policies left unknown", "backend", name, "error", err)
+			return err
+		}
+		if policy.State == policies.Running {
 			continue
 		}
 		a.applyStoredPolicy(&policy, be)

--- a/agent/policymgr/manager.go
+++ b/agent/policymgr/manager.go
@@ -703,6 +703,12 @@ func (a *policyManager) ApplyBackendPolicies(ctx context.Context, name string, b
 }
 
 func (a *policyManager) applyBackendPoliciesLocked(ctx context.Context, name string, be backend.Backend) error {
+	// Checked again here, after the wait for the apply mutex: a shutdown that
+	// landed meanwhile must not cost one more status round trip.
+	if err := ctx.Err(); err != nil {
+		a.logger.Info("shutting down; backend policies left unknown", "backend", name, "error", err)
+		return err
+	}
 	if state, detail, err := be.GetRunningStatus(); state != backend.Running || err != nil {
 		a.logger.Warn("backend is not running; its policies are left for its next start",
 			"backend", name, "backend_state", state.String(), "detail", detail, "error", err)

--- a/agent/policymgr/manager.go
+++ b/agent/policymgr/manager.go
@@ -40,6 +40,11 @@ const (
 // BackendStarter starts a backend on demand for a policy that needs it. The
 // supervisor implements it; until one is set, every backend is assumed to be
 // started at agent start, as before.
+//
+// EnsureStarted is called while the policy manager holds that backend's apply
+// mutex, so it must not block: it launches the start and reports StartStarting,
+// it never waits for one to finish. It must also never call back into the
+// policy manager, which would deadlock on that mutex.
 type BackendStarter interface {
 	EnsureStarted(name string) (StartState, error)
 }
@@ -522,7 +527,8 @@ func (a *policyManager) removeBackendPoliciesLocked(name string, be backend.Back
 
 // ErrBackendNotRunning is returned by ApplyBackendPolicies when the backend
 // cannot take an apply at that moment; its policies are left as they are,
-// for the next start or restart, rather than stamped failed.
+// for the next start or restart, rather than stamped failed. Its intended
+// consumer is the supervisor's retry loop; today's only consumer logs it.
 var ErrBackendNotRunning = errors.New("backend is not running; its policies are left for its next start")
 
 // ApplyBackendPolicies applies every policy the repo holds for the named
@@ -533,7 +539,9 @@ var ErrBackendNotRunning = errors.New("backend is not running; its policies are 
 // before it touches anything: a backend that does not answer at that moment
 // keeps its policies untouched and the caller learns why. A backend that
 // stops mid-loop is caught by applyPolicy's own check, which does stamp the
-// policy failed.
+// policy failed; that per-policy check is a second GetRunningStatus call,
+// an HTTP round trip for every policy in the loop, and is not redundant
+// with the gate above, so do not remove either thinking the other covers it.
 func (a *policyManager) ApplyBackendPolicies(name string, be backend.Backend) error {
 	mu := a.applyLock(name)
 	mu.Lock()

--- a/agent/policymgr/manager.go
+++ b/agent/policymgr/manager.go
@@ -565,11 +565,22 @@ func (a *policyManager) applyBackendPoliciesLocked(name string, be backend.Backe
 			continue
 		}
 		a.applyStoredPolicy(&policy, be)
-		if err := a.repo.Update(policy); err != nil {
+		if err := a.persistApplyOutcome(policy); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// persistApplyOutcome writes a policy back after an apply without discarding
+// the run updates the state monitor may have written while the backend was
+// being called: only the apply outcome (state, reason, data, rename) comes
+// from the snapshot; the runs are re-read from the store.
+func (a *policyManager) persistApplyOutcome(policy policies.PolicyData) error {
+	if latest, err := a.repo.Get(policy.ID); err == nil {
+		policy.Runs = latest.Runs
+	}
+	return a.repo.Update(policy)
 }
 
 // applyStoredPolicy applies a policy the repo already holds to its backend:
@@ -646,7 +657,7 @@ func (a *policyManager) refreshPolicyLocked(backendName, id string, valid bool) 
 	} else if a.backendReady(policy.Backend, &policy) {
 		a.applyStoredPolicy(&policy, backend.GetBackend(policy.Backend))
 	}
-	if err := a.repo.Update(policy); err != nil {
+	if err := a.persistApplyOutcome(policy); err != nil {
 		a.logger.Error("got error in update last status", "error", err)
 	}
 }

--- a/agent/policymgr/manager.go
+++ b/agent/policymgr/manager.go
@@ -18,7 +18,7 @@ type PolicyManager interface {
 	RemovePolicyDataset(policyID string, datasetID string, be backend.Backend)
 	GetPolicyState() ([]policies.PolicyData, error)
 	GetRepo() policies.PolicyRepo
-	ApplyBackendPolicies(be backend.Backend) error
+	ApplyBackendPolicies(name string, be backend.Backend) error
 	RemoveBackendPolicies(name string, be backend.Backend, permanently bool) error
 	RemovePolicy(policyID string, policyName string, beName string) error
 }
@@ -354,33 +354,64 @@ func (a *policyManager) RemoveBackendPolicies(name string, be backend.Backend, p
 	return nil
 }
 
-func (a *policyManager) ApplyBackendPolicies(be backend.Backend) error {
+// ErrBackendNotRunning is returned by ApplyBackendPolicies when the backend
+// cannot take an apply at that moment; its policies are left as they are,
+// for the next start or restart, rather than stamped failed.
+var ErrBackendNotRunning = errors.New("backend is not running; its policies are left for its next start")
+
+// ApplyBackendPolicies applies every policy the repo holds for the named
+// backend, the way a manage does: secrets solved for the call and the
+// unsolved references persisted, the name checked, and updatePolicy true,
+// the remove-then-apply form every backend implements, which is safe
+// against a name the backend already runs. It gates on the backend running
+// before it touches anything: a backend that does not answer at that moment
+// keeps its policies untouched and the caller learns why. A backend that
+// stops mid-loop is caught by applyPolicy's own check, which does stamp the
+// policy failed.
+func (a *policyManager) ApplyBackendPolicies(name string, be backend.Backend) error {
+	if state, detail, err := be.GetRunningStatus(); state != backend.Running || err != nil {
+		a.logger.Warn("backend is not running; its policies are left for its next start",
+			"backend", name, "backend_state", state.String(), "detail", detail, "error", err)
+		return fmt.Errorf("%w: %s", ErrBackendNotRunning, name)
+	}
 	plcies, err := a.repo.GetAll()
 	if err != nil {
 		a.logger.Error("failed to retrieve list of policies", "error", err)
 		return err
 	}
-
 	for _, policy := range plcies {
-		err := be.ApplyPolicy(policy, false)
-		if err != nil {
-			a.logger.Warn("policy failed to apply", "policy_id", policy.ID, "policy_name", policy.Name, "error", err)
-			policy.State = policies.FailedToApply
-			policy.BackendErr = err.Error()
-		} else {
-			a.logger.Info("policy applied successfully", "policy_id", policy.ID, "policy_name", policy.Name)
-			policy.State = policies.Running
-			policy.BackendErr = ""
-			// see ManagePolicy: clearing on Running assumes the rename delete
-			// succeeded, which backends do not confirm (swallowed remove error)
-			policy.PreviousPolicyData = nil
+		if policy.Backend != name {
+			continue
 		}
-		err = a.repo.Update(policy)
-		if err != nil {
+		a.applyStoredPolicy(&policy, be)
+		if err := a.repo.Update(policy); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// applyStoredPolicy applies a policy the repo already holds to its backend:
+// secrets are solved for the call, the policy is applied with updatePolicy
+// true, the unsolved data is put back for the caller to persist, and a
+// successful apply clears a pending rename. The caller persists the record.
+func (a *policyManager) applyStoredPolicy(policy *policies.PolicyData, be backend.Backend) {
+	payload := config.PolicyPayload{ID: policy.ID, Name: policy.Name, Backend: policy.Backend, Version: policy.Version, Data: policy.Data}
+	solved, err := a.secrets.SolvePolicySecrets(payload)
+	if err != nil {
+		a.logger.Error("failed to solve secrets", "policy_id", policy.ID, "policy_name", policy.Name, "error", err)
+		policy.State = policies.FailedToApply
+		policy.BackendErr = secretsFailureReason(err)
+	} else {
+		policy.Data = solved.Data
+		a.applyPolicy(payload, be, policy, true)
+		policy.Data = payload.Data
+	}
+	if policy.State == policies.Running {
+		// see ManagePolicy: clearing on Running assumes the rename delete
+		// succeeded, which backends do not confirm (swallowed remove error)
+		policy.PreviousPolicyData = nil
+	}
 }
 
 func (a *policyManager) policiesChanged(policiesIDs map[string]bool) {

--- a/agent/policymgr/manager.go
+++ b/agent/policymgr/manager.go
@@ -275,7 +275,9 @@ func (a *policyManager) managePolicyLocked(payload config.PolicyPayload) {
 				pd.BackendErr = secretsFailureReason(err)
 			} else {
 				pd.Data = newPayload.Data
-				a.applyPolicy(payload, be, &pd, updatePolicy)
+				// A manage answers its caller through the stored state below,
+				// not a return value; the record is stamped either way.
+				_ = a.applyPolicy(payload, be, &pd, updatePolicy)
 				pd.Data = payload.Data
 			}
 		}
@@ -415,7 +417,16 @@ func (a *policyManager) removePolicyDatasetLocked(policyID string, datasetID str
 	}
 }
 
-func (a *policyManager) applyPolicy(payload config.PolicyPayload, be backend.Backend, pd *policies.PolicyData, updatePolicy bool) {
+// applyPolicy returns ErrBackendNotRunning when its own running-gate probe
+// refuses the apply, after stamping the record FailedToApply the same as
+// today; every other path (name refused, backend rejected the apply,
+// success) stamps the record itself and returns nil. managePolicyLocked and
+// refreshPolicyLocked ignore the return: a manage or a refresh answers its
+// caller through the stored state, not a return value, and the record is
+// already stamped either way. applyBackendPoliciesLocked is the one caller
+// that acts on it, to stop a replay instead of persisting the probe's
+// failure and losing the record from the next one.
+func (a *policyManager) applyPolicy(payload config.PolicyPayload, be backend.Backend, pd *policies.PolicyData, updatePolicy bool) error {
 	// A name the agent cannot address over a backend's API is refused before
 	// the policy is created rather than when it is removed. Removal is the
 	// wrong place to find out: RemovePolicy discards the local record even
@@ -428,7 +439,7 @@ func (a *policyManager) applyPolicy(payload config.PolicyPayload, be backend.Bac
 			"policy_id", payload.ID, "policy_name", payload.Name, "backend", pd.Backend, "error", err)
 		pd.State = policies.FailedToApply
 		pd.BackendErr = err.Error()
-		return
+		return nil
 	}
 
 	state, detail, err := be.GetRunningStatus()
@@ -452,7 +463,7 @@ func (a *policyManager) applyPolicy(payload config.PolicyPayload, be backend.Bac
 			"detail", detail,
 			"error", err,
 		)
-		return
+		return fmt.Errorf("%w: %s", ErrBackendNotRunning, pd.Backend)
 	}
 
 	err = be.ApplyPolicy(*pd, updatePolicy)
@@ -467,6 +478,7 @@ func (a *policyManager) applyPolicy(payload config.PolicyPayload, be backend.Bac
 		pd.State = policies.Running
 		pd.BackendErr = ""
 	}
+	return nil
 }
 
 // errBackendNeverStarted stands in for a call to a backend the agent never
@@ -542,10 +554,14 @@ var ErrBackendNotRunning = errors.New("backend is not running; its policies are 
 // against a name the backend already runs. It gates on the backend running
 // before it touches anything: a backend that does not answer at that moment
 // keeps its policies untouched and the caller learns why. A backend that
-// stops mid-loop is caught by applyPolicy's own check, which does stamp the
-// policy failed; that per-policy check is a second GetRunningStatus call,
-// an HTTP round trip for every policy in the loop, and is not redundant
-// with the gate above, so do not remove either thinking the other covers it.
+// stops mid-loop is caught by applyPolicy's own check, a second
+// GetRunningStatus call, an HTTP round trip for every policy in the loop,
+// and not redundant with the gate above, so do not remove either thinking
+// the other covers it. Both the entry gate and this per-policy probe map to
+// ErrBackendNotRunning; unlike the entry gate, the per-policy probe leaves
+// its record unpersisted rather than stamped failed, so the record it was
+// checking, and every record not yet reached, stay deferred for the
+// caller's retry instead of being excluded from the next replay.
 //
 // The context is checked before every policy, not only once on entry: a
 // caller whose shutdown begins mid-loop must stop launching further HTTP
@@ -593,7 +609,15 @@ func (a *policyManager) applyBackendPoliciesLocked(ctx context.Context, name str
 		if !deferredByRestart(policy) {
 			continue
 		}
-		a.applyStoredPolicy(&policy, be)
+		if err := a.applyStoredPolicy(&policy, be); errors.Is(err, ErrBackendNotRunning) {
+			// The backend stopped answering mid-replay. This record is left
+			// exactly as it was read (still deferred), the rest of the loop
+			// is not attempted, and the caller's retry picks them all up;
+			// the records already applied are running and are skipped then.
+			a.logger.Warn("backend stopped answering mid-replay; leaving the remaining policies for a retry",
+				"backend", name, "policy_id", policy.ID, "policy_name", policy.Name)
+			return fmt.Errorf("%w: %s", ErrBackendNotRunning, name)
+		}
 		if err := a.persistApplyOutcome(policy); err != nil {
 			return err
 		}
@@ -632,8 +656,11 @@ func (a *policyManager) persistApplyOutcome(policy policies.PolicyData) error {
 // applyStoredPolicy applies a policy the repo already holds to its backend:
 // secrets are solved for the call, the policy is applied with updatePolicy
 // true, the unsolved data is put back for the caller to persist, and a
-// successful apply clears a pending rename. The caller persists the record.
-func (a *policyManager) applyStoredPolicy(policy *policies.PolicyData, be backend.Backend) {
+// successful apply clears a pending rename. The caller persists the record,
+// except when the returned error matches ErrBackendNotRunning: that record is
+// left exactly as it was stamped by applyPolicy's own running-gate probe, for
+// the caller to leave unpersisted (still deferred) rather than write back.
+func (a *policyManager) applyStoredPolicy(policy *policies.PolicyData, be backend.Backend) error {
 	payload := config.PolicyPayload{ID: policy.ID, Name: policy.Name, Backend: policy.Backend, Version: policy.Version, Data: policy.Data}
 	solved, err := a.secrets.SolvePolicySecrets(payload)
 	if err != nil {
@@ -642,7 +669,7 @@ func (a *policyManager) applyStoredPolicy(policy *policies.PolicyData, be backen
 		policy.BackendErr = secretsFailureReason(err)
 	} else {
 		policy.Data = solved.Data
-		a.applyPolicy(payload, be, policy, true)
+		err = a.applyPolicy(payload, be, policy, true)
 		policy.Data = payload.Data
 	}
 	if policy.State == policies.Running {
@@ -650,6 +677,7 @@ func (a *policyManager) applyStoredPolicy(policy *policies.PolicyData, be backen
 		// succeeded, which backends do not confirm (swallowed remove error)
 		policy.PreviousPolicyData = nil
 	}
+	return err
 }
 
 func (a *policyManager) policiesChanged(policiesIDs map[string]bool) {
@@ -701,7 +729,9 @@ func (a *policyManager) refreshPolicyLocked(backendName, id string, valid bool) 
 		policy.State = policies.FailedToApply
 		policy.BackendErr = "backend not available"
 	} else if a.backendReady(policy.Backend, &policy) {
-		a.applyStoredPolicy(&policy, backend.GetBackend(policy.Backend))
+		// A refresh answers its caller through the stored state below, not a
+		// return value; the record is stamped either way.
+		_ = a.applyStoredPolicy(&policy, backend.GetBackend(policy.Backend))
 	}
 	if err := a.persistApplyOutcome(policy); err != nil {
 		a.logger.Error("got error in update last status", "error", err)

--- a/agent/policymgr/manager.go
+++ b/agent/policymgr/manager.go
@@ -560,10 +560,10 @@ var ErrBackendNotRunning = errors.New("backend is not running; its policies are 
 // Running reflects this process's own prior apply, and a record failed for
 // any other reason failed in this same replay or in a manage this process
 // already answered; applying either again could run a one-shot policy
-// twice. Excluding both is what lets a restart's second pass, taken after
-// its mutex is released to pick up anything that arrived in the window
-// between the first pass and the unlock, run safely alongside (or after)
-// the first without applying a policy twice.
+// twice. Excluding both is what lets a manage that lands directly on the
+// backend, once the restart's marker has cleared, coexist safely with the
+// replay racing for the same apply mutex: whichever gets in first is not
+// re-applied by the other.
 func (a *policyManager) ApplyBackendPolicies(ctx context.Context, name string, be backend.Backend) error {
 	mu := a.applyLock(name)
 	mu.Lock()

--- a/agent/policymgr/manager.go
+++ b/agent/policymgr/manager.go
@@ -208,16 +208,19 @@ func (a *policyManager) manageUnderLock(key string, payload config.PolicyPayload
 
 // policyLockKey returns the backend whose mutex an operation on this payload
 // must hold: the stored record's backend when there is one, else the
-// payload's. A manage that would move the policy to another backend is
-// refused here (ok false) and logged.
+// payload's. A payload naming a backend other than the stored one is
+// refused here (ok false) and logged, for a manage and a remove alike: a
+// manage would move the policy to another backend, and a remove would go to
+// the wrong backend while deleting the only record left to remove the policy
+// from its real one.
 func (a *policyManager) policyLockKey(payload config.PolicyPayload) (string, bool) {
 	stored, err := a.repo.Get(payload.ID)
 	if err != nil || stored.Backend == "" {
 		return payload.Backend, true
 	}
-	if payload.Action == "manage" && stored.Backend != payload.Backend {
+	if stored.Backend != payload.Backend {
 		a.logger.Warn("policy names a different backend than the one it runs on; ignoring",
-			"policy_id", payload.ID, "policy_name", payload.Name, "stored_backend", stored.Backend, "backend", payload.Backend)
+			"action", payload.Action, "policy_id", payload.ID, "policy_name", payload.Name, "stored_backend", stored.Backend, "backend", payload.Backend)
 		return "", false
 	}
 	return stored.Backend, true

--- a/agent/policymgr/manager.go
+++ b/agent/policymgr/manager.go
@@ -22,6 +22,26 @@ type PolicyManager interface {
 	ApplyBackendPolicies(name string, be backend.Backend) error
 	RemoveBackendPolicies(name string, be backend.Backend, permanently bool) error
 	RemovePolicy(policyID string, policyName string, beName string) error
+	SetStarter(starter BackendStarter)
+}
+
+// StartState is what a BackendStarter reports for a backend.
+type StartState int
+
+const (
+	// StartRunning means the backend is running and can take a policy now.
+	StartRunning StartState = iota
+	// StartStarting means a start is in flight or was just launched; the
+	// policy is stored and applied by the starter's applier once the
+	// backend is running.
+	StartStarting
+)
+
+// BackendStarter starts a backend on demand for a policy that needs it. The
+// supervisor implements it; until one is set, every backend is assumed to be
+// started at agent start, as before.
+type BackendStarter interface {
+	EnsureStarted(name string) (StartState, error)
 }
 
 var _ PolicyManager = (*policyManager)(nil)
@@ -42,6 +62,7 @@ type policyManager struct {
 
 	repo    policies.PolicyRepo
 	secrets secretsmgr.Manager
+	starter BackendStarter
 
 	applyMu sync.Map // backend name -> *sync.Mutex
 }
@@ -72,6 +93,33 @@ func (a *policyManager) GetRepo() policies.PolicyRepo {
 
 func (a *policyManager) GetPolicyState() ([]policies.PolicyData, error) {
 	return a.repo.GetAll()
+}
+
+// SetStarter installs the starter consulted before a policy is applied. It
+// is called once, after construction, before any policy can arrive.
+func (a *policyManager) SetStarter(starter BackendStarter) {
+	a.starter = starter
+}
+
+// backendReady consults the starter for the policy's backend. It returns
+// true when the apply may proceed; otherwise it has set the policy's state
+// and reason and the caller persists the record.
+func (a *policyManager) backendReady(name string, pd *policies.PolicyData) bool {
+	if a.starter == nil {
+		return true
+	}
+	state, err := a.starter.EnsureStarted(name)
+	switch {
+	case err != nil:
+		pd.State = policies.FailedToApply
+		pd.BackendErr = err.Error()
+		return false
+	case state == StartStarting:
+		pd.State = policies.FailedToApply
+		pd.BackendErr = "backend starting"
+		return false
+	}
+	return true
 }
 
 // ManagePolicy serialises the manage or remove under the mutex of the
@@ -207,7 +255,7 @@ func (a *policyManager) managePolicyLocked(payload config.PolicyPayload) {
 			a.logger.Warn("policy failed to apply because backend is not available", "policy_id", payload.ID, "policy_name", payload.Name)
 			pd.State = policies.FailedToApply
 			pd.BackendErr = "backend not available"
-		} else {
+		} else if a.backendReady(payload.Backend, &pd) {
 			// attempt to apply the policy to the backend. status of policy application (running/failed) is maintained there.
 			be := backend.GetBackend(payload.Backend)
 			newPayload, err := a.secrets.SolvePolicySecrets(payload)
@@ -587,7 +635,7 @@ func (a *policyManager) refreshPolicyLocked(backendName, id string, valid bool) 
 		a.logger.Warn("policy failed to apply because backend is not available", "policy_id", policy.ID, "policy_name", policy.Name)
 		policy.State = policies.FailedToApply
 		policy.BackendErr = "backend not available"
-	} else {
+	} else if a.backendReady(policy.Backend, &policy) {
 		a.applyStoredPolicy(&policy, backend.GetBackend(policy.Backend))
 	}
 	if err := a.repo.Update(policy); err != nil {

--- a/agent/policymgr/manager.go
+++ b/agent/policymgr/manager.go
@@ -516,8 +516,7 @@ func (a *policyManager) removeBackendPoliciesLocked(name string, be backend.Back
 			}
 		} else {
 			plcy.State = policies.Unknown
-			err = a.repo.Update(plcy)
-			if err != nil {
+			if err := a.persistApplyOutcome(plcy); err != nil {
 				return err
 			}
 		}
@@ -572,10 +571,11 @@ func (a *policyManager) applyBackendPoliciesLocked(name string, be backend.Backe
 	return nil
 }
 
-// persistApplyOutcome writes a policy back after an apply without discarding
-// the run updates the state monitor may have written while the backend was
-// being called: only the apply outcome (state, reason, data, rename) comes
-// from the snapshot; the runs are re-read from the store.
+// persistApplyOutcome writes a policy back after an apply or a removal that
+// keeps the record, without discarding the run updates the state monitor may
+// have written while the backend was being called: only the apply outcome
+// (state, reason, data, rename) comes from the snapshot; the runs are
+// re-read from the store.
 func (a *policyManager) persistApplyOutcome(policy policies.PolicyData) error {
 	if latest, err := a.repo.Get(policy.ID); err == nil {
 		policy.Runs = latest.Runs

--- a/agent/policymgr/manager.go
+++ b/agent/policymgr/manager.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sync"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/config"
@@ -15,7 +16,7 @@ import (
 // PolicyManager is the interface for managing policies
 type PolicyManager interface {
 	ManagePolicy(payload config.PolicyPayload)
-	RemovePolicyDataset(policyID string, datasetID string, be backend.Backend)
+	RemovePolicyDataset(policyID string, datasetID string, beName string, be backend.Backend)
 	GetPolicyState() ([]policies.PolicyData, error)
 	GetRepo() policies.PolicyRepo
 	ApplyBackendPolicies(name string, be backend.Backend) error
@@ -25,12 +26,33 @@ type PolicyManager interface {
 
 var _ PolicyManager = (*policyManager)(nil)
 
+// policyManager keeps the agent's policies and applies them to backends.
+//
+// One mutex per backend name serialises every operation on that backend's
+// policies: a manage, a remove, a dataset removal, a whole-backend removal
+// and the applier. Each exported operation is a locking wrapper over an
+// unexported body, and the bodies call each other, so nothing re-enters a
+// mutex. Lock order: the agent's per-backend restart mutex is taken before
+// this one; this mutex is taken before any supervisor entry mutex when both
+// are needed, never the reverse; the repo's own lock is innermost and never
+// held across a call out.
 type policyManager struct {
 	logger *slog.Logger
 	config config.Config
 
 	repo    policies.PolicyRepo
 	secrets secretsmgr.Manager
+
+	applyMu sync.Map // backend name -> *sync.Mutex
+}
+
+// applyLock returns the mutex serialising every policy operation on one
+// backend. Entries are never deleted, same race rationale as the agent's
+// backendRestartLock.
+func (a *policyManager) applyLock(backendName string) *sync.Mutex {
+	v, _ := a.applyMu.LoadOrStore(backendName, &sync.Mutex{})
+	mu, _ := v.(*sync.Mutex) // LoadOrStore stored a *sync.Mutex; assertion cannot fail.
+	return mu
 }
 
 // New creates a new instance of PolicyManager
@@ -52,7 +74,60 @@ func (a *policyManager) GetPolicyState() ([]policies.PolicyData, error) {
 	return a.repo.GetAll()
 }
 
+// ManagePolicy serialises the manage or remove under the mutex of the
+// backend the stored record names. The key is read before the lock and
+// checked again under it: a record created, removed or re-created meanwhile
+// changes the key, and the wrapper starts over on the right mutex. A manage
+// that names a backend other than the stored one is refused with the record
+// untouched, since the two backends' mutexes could otherwise leave the
+// policy running on both with nothing left to remove the old copy.
 func (a *policyManager) ManagePolicy(payload config.PolicyPayload) {
+	for {
+		key, ok := a.policyLockKey(payload)
+		if !ok {
+			return
+		}
+		if a.manageUnderLock(key, payload) {
+			return
+		}
+	}
+}
+
+// manageUnderLock runs the manage under key's mutex, reporting whether the
+// operation is finished; false means the key changed and the caller retries.
+func (a *policyManager) manageUnderLock(key string, payload config.PolicyPayload) bool {
+	mu := a.applyLock(key)
+	mu.Lock()
+	defer mu.Unlock()
+	current, ok := a.policyLockKey(payload)
+	if !ok {
+		return true
+	}
+	if current != key {
+		return false
+	}
+	a.managePolicyLocked(payload)
+	return true
+}
+
+// policyLockKey returns the backend whose mutex an operation on this payload
+// must hold: the stored record's backend when there is one, else the
+// payload's. A manage that would move the policy to another backend is
+// refused here (ok false) and logged.
+func (a *policyManager) policyLockKey(payload config.PolicyPayload) (string, bool) {
+	stored, err := a.repo.Get(payload.ID)
+	if err != nil || stored.Backend == "" {
+		return payload.Backend, true
+	}
+	if payload.Action == "manage" && stored.Backend != payload.Backend {
+		a.logger.Warn("policy names a different backend than the one it runs on; ignoring",
+			"policy_id", payload.ID, "policy_name", payload.Name, "stored_backend", stored.Backend, "backend", payload.Backend)
+		return "", false
+	}
+	return stored.Backend, true
+}
+
+func (a *policyManager) managePolicyLocked(payload config.PolicyPayload) {
 	a.logger.Info("managing agent policy from core",
 		"action", payload.Action,
 		"name", payload.Name,
@@ -168,7 +243,7 @@ func (a *policyManager) ManagePolicy(payload config.PolicyPayload) {
 		}
 		return
 	case "remove":
-		err := a.RemovePolicy(payload.ID, payload.Name, payload.Backend)
+		err := a.removePolicyLocked(payload.ID, payload.Name, payload.Backend)
 		if err != nil {
 			a.logger.Error("policy failed to be removed", "policy_id", payload.ID, "policy_name", payload.Name, "error", err)
 		}
@@ -178,7 +253,26 @@ func (a *policyManager) ManagePolicy(payload config.PolicyPayload) {
 	}
 }
 
+// RemovePolicy removes a policy under the mutex of the backend the stored
+// record names (the argument when there is no record), so a remove naming
+// the wrong backend cannot run beside a manage on the right one. The key is
+// a best-effort read; the body re-reads the record under the lock, and a
+// remove is idempotent, so no re-validation loop is needed. Every caller is
+// expected to pass the backend the repo already names for this policy; a
+// caller passing a different name breaks the mutex invariant this wrapper
+// exists to enforce.
 func (a *policyManager) RemovePolicy(policyID string, policyName string, beName string) error {
+	key := beName
+	if stored, err := a.repo.Get(policyID); err == nil && stored.Backend != "" {
+		key = stored.Backend
+	}
+	mu := a.applyLock(key)
+	mu.Lock()
+	defer mu.Unlock()
+	return a.removePolicyLocked(policyID, policyName, beName)
+}
+
+func (a *policyManager) removePolicyLocked(policyID string, policyName string, beName string) error {
 	pd := policies.PolicyData{
 		ID:   policyID,
 		Name: policyName,
@@ -221,7 +315,24 @@ func (a *policyManager) RemovePolicy(policyID string, policyName string, beName 
 	return nil
 }
 
-func (a *policyManager) RemovePolicyDataset(policyID string, datasetID string, be backend.Backend) {
+// RemovePolicyDataset removes a dataset under the mutex of the backend the
+// stored record names, with the caller's name as the fallback; both callers
+// read the name from the repo right before calling. Every caller is expected
+// to pass the backend the repo already names for this policy; a caller
+// passing a different name breaks the mutex invariant this wrapper exists to
+// enforce.
+func (a *policyManager) RemovePolicyDataset(policyID string, datasetID string, beName string, be backend.Backend) {
+	key := beName
+	if stored, err := a.repo.Get(policyID); err == nil && stored.Backend != "" {
+		key = stored.Backend
+	}
+	mu := a.applyLock(key)
+	mu.Lock()
+	defer mu.Unlock()
+	a.removePolicyDatasetLocked(policyID, datasetID, be)
+}
+
+func (a *policyManager) removePolicyDatasetLocked(policyID string, datasetID string, be backend.Backend) {
 	policyData, err := a.repo.Get(policyID)
 	if err != nil {
 		a.logger.Warn("failed to retrieve policy data", "policy_id", policyID, "policy_name", policyData.Name, "error", err)
@@ -323,6 +434,13 @@ func removeFromBackend(be backend.Backend, pd policies.PolicyData) error {
 // own: the repo holds every backend's policies, and a restart of one backend
 // must not take the others' with it.
 func (a *policyManager) RemoveBackendPolicies(name string, be backend.Backend, permanently bool) error {
+	mu := a.applyLock(name)
+	mu.Lock()
+	defer mu.Unlock()
+	return a.removeBackendPoliciesLocked(name, be, permanently)
+}
+
+func (a *policyManager) removeBackendPoliciesLocked(name string, be backend.Backend, permanently bool) error {
 	plcies, err := a.repo.GetAll()
 	if err != nil {
 		a.logger.Error("failed to retrieve list of policies", "error", err)
@@ -369,6 +487,13 @@ var ErrBackendNotRunning = errors.New("backend is not running; its policies are 
 // stops mid-loop is caught by applyPolicy's own check, which does stamp the
 // policy failed.
 func (a *policyManager) ApplyBackendPolicies(name string, be backend.Backend) error {
+	mu := a.applyLock(name)
+	mu.Lock()
+	defer mu.Unlock()
+	return a.applyBackendPoliciesLocked(name, be)
+}
+
+func (a *policyManager) applyBackendPoliciesLocked(name string, be backend.Backend) error {
 	if state, detail, err := be.GetRunningStatus(); state != backend.Running || err != nil {
 		a.logger.Warn("backend is not running; its policies are left for its next start",
 			"backend", name, "backend_state", state.String(), "detail", detail, "error", err)
@@ -421,44 +546,52 @@ func (a *policyManager) policiesChanged(policiesIDs map[string]bool) {
 			a.logger.Error("failed to get policy", "error", err)
 			continue
 		}
-		if !valid {
-			if err := a.RemovePolicy(policy.ID, policy.Name, policy.Backend); err != nil {
-				a.logger.Error("failed to remove policy", "error", err)
-			}
-			continue
-		}
-		if !backend.HaveBackend(policy.Backend) {
-			a.logger.Warn("policy failed to apply because backend is not available", "policy_id", policy.ID, "policy_name", policy.Name)
-			policy.State = policies.FailedToApply
-			policy.BackendErr = "backend not available"
-		} else {
-			payload := config.PolicyPayload{
-				ID:   policy.ID,
-				Name: policy.Name,
-				Data: policy.Data,
-			}
-			newPayload, err := a.secrets.SolvePolicySecrets(payload)
-			if err != nil {
-				a.logger.Error("failed to solve secrets", "policy_id", policy.ID, "policy_name", policy.Name, "error", err)
-				policy.State = policies.FailedToApply
-				policy.BackendErr = secretsFailureReason(err)
-			} else {
-				policy.Data = newPayload.Data
-				be := backend.GetBackend(policy.Backend)
-				a.applyPolicy(payload, be, &policy, true)
-				policy.Data = payload.Data
-			}
-		}
+		a.refreshPolicy(policy.Backend, id, valid)
+	}
+}
 
-		if policy.State == policies.Running {
-			// see ManagePolicy: persisted PreviousPolicyData means "rename pending"
-			// (and the same swallowed-remove caveat about the old-name delete)
-			policy.PreviousPolicyData = nil
-		}
+// refreshPolicy re-applies or removes one policy after a secrets change,
+// under its backend's mutex. The record is re-read under the lock: the
+// pre-lock read only chose the mutex, and a remove that landed meanwhile
+// must not be undone by a stale copy.
+func (a *policyManager) refreshPolicy(backendName, id string, valid bool) {
+	mu := a.applyLock(backendName)
+	mu.Lock()
+	defer mu.Unlock()
+	a.refreshPolicyLocked(backendName, id, valid)
+}
 
-		if err = a.repo.Update(policy); err != nil {
-			a.logger.Error("got error in update last status", "error", err)
+// refreshPolicyLocked re-reads the record under backendName's mutex and bails
+// if it no longer names backendName: a remove followed by a re-create on
+// another backend between the pre-lock read that chose the mutex and this
+// re-read would otherwise apply the policy to a different backend than the
+// one whose mutex is held.
+func (a *policyManager) refreshPolicyLocked(backendName, id string, valid bool) {
+	policy, err := a.repo.Get(id)
+	if err != nil {
+		a.logger.Info("policy changed by the secrets provider is no longer stored, skipping", "policy_id", id)
+		return
+	}
+	if policy.Backend != backendName {
+		a.logger.Info("policy moved backends since the secrets change, skipping",
+			"policy_id", id, "locked_backend", backendName, "backend", policy.Backend)
+		return
+	}
+	if !valid {
+		if err := a.removePolicyLocked(policy.ID, policy.Name, policy.Backend); err != nil {
+			a.logger.Error("failed to remove policy", "error", err)
 		}
+		return
+	}
+	if !backend.HaveBackend(policy.Backend) {
+		a.logger.Warn("policy failed to apply because backend is not available", "policy_id", policy.ID, "policy_name", policy.Name)
+		policy.State = policies.FailedToApply
+		policy.BackendErr = "backend not available"
+	} else {
+		a.applyStoredPolicy(&policy, backend.GetBackend(policy.Backend))
+	}
+	if err := a.repo.Update(policy); err != nil {
+		a.logger.Error("got error in update last status", "error", err)
 	}
 }
 

--- a/agent/policymgr/manager.go
+++ b/agent/policymgr/manager.go
@@ -554,14 +554,16 @@ var ErrBackendNotRunning = errors.New("backend is not running; its policies are 
 // the loop and is returned, leaving whatever policies were not yet reached
 // as they were (most often unknown) for a later replay to pick up.
 //
-// A record already Running is skipped: every restart marks a backend's
-// policies unknown before stopping it, and a manage that lands while a
-// restart is in flight is stored failed to apply rather than running, so a
-// running record can only reflect this same process's own prior apply.
-// Skipping it is what lets a restart's second pass, taken after its mutex is
-// released to pick up anything that arrived in the window between the first
-// pass and the unlock, run safely alongside (or after) the first without
-// applying a policy twice.
+// Only a record deferredByRestart is applied: one marked unknown, one
+// marked offline while the process was down, or one stored failed to apply
+// because the starter reported the backend starting. A record already
+// Running reflects this process's own prior apply, and a record failed for
+// any other reason failed in this same replay or in a manage this process
+// already answered; applying either again could run a one-shot policy
+// twice. Excluding both is what lets a restart's second pass, taken after
+// its mutex is released to pick up anything that arrived in the window
+// between the first pass and the unlock, run safely alongside (or after)
+// the first without applying a policy twice.
 func (a *policyManager) ApplyBackendPolicies(ctx context.Context, name string, be backend.Backend) error {
 	mu := a.applyLock(name)
 	mu.Lock()
@@ -588,7 +590,7 @@ func (a *policyManager) applyBackendPoliciesLocked(ctx context.Context, name str
 			a.logger.Info("shutting down; remaining backend policies left unknown", "backend", name, "error", err)
 			return err
 		}
-		if policy.State == policies.Running {
+		if !deferredByRestart(policy) {
 			continue
 		}
 		a.applyStoredPolicy(&policy, be)
@@ -597,6 +599,24 @@ func (a *policyManager) applyBackendPoliciesLocked(ctx context.Context, name str
 		}
 	}
 	return nil
+}
+
+// deferredByRestart reports whether a replay must hand this record to the
+// backend: a record the restart marked unknown, one the state monitor marked
+// offline while the previous process was down, or one stored as starting
+// because a manage arrived while the restart was in flight. A running record
+// reflects this process's own apply, and a record that failed for any other
+// reason failed in this same replay or in a manage this process already
+// answered; applying either again could run a one-shot policy twice.
+func deferredByRestart(policy policies.PolicyData) bool {
+	switch policy.State {
+	case policies.Unknown, policies.Offline:
+		return true
+	case policies.FailedToApply:
+		return policy.BackendErr == ReasonBackendStarting
+	default:
+		return false
+	}
 }
 
 // persistApplyOutcome writes a policy back after an apply or a removal that

--- a/agent/policymgr/manager.go
+++ b/agent/policymgr/manager.go
@@ -574,13 +574,11 @@ func (a *policyManager) applyBackendPoliciesLocked(name string, be backend.Backe
 // persistApplyOutcome writes a policy back after an apply or a removal that
 // keeps the record, without discarding the run updates the state monitor may
 // have written while the backend was being called: only the apply outcome
-// (state, reason, data, rename) comes from the snapshot; the runs are
-// re-read from the store.
+// (state, reason, data, rename) comes from the snapshot; the store merges in
+// the runs it already holds under its own lock, so a run update written
+// while the caller held its snapshot is not lost between a read and a write.
 func (a *policyManager) persistApplyOutcome(policy policies.PolicyData) error {
-	if latest, err := a.repo.Get(policy.ID); err == nil {
-		policy.Runs = latest.Runs
-	}
-	return a.repo.Update(policy)
+	return a.repo.UpdateKeepingRuns(policy)
 }
 
 // applyStoredPolicy applies a policy the repo already holds to its backend:

--- a/agent/policymgr/manager.go
+++ b/agent/policymgr/manager.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"sync"
+	"sync/atomic"
 
 	"github.com/netboxlabs/orb-agent/agent/backend"
 	"github.com/netboxlabs/orb-agent/agent/config"
@@ -62,6 +63,18 @@ var _ PolicyManager = (*policyManager)(nil)
 // this one; this mutex is taken before any supervisor entry mutex when both
 // are needed, never the reverse; the repo's own lock is innermost and never
 // held across a call out.
+//
+// A per-backend marker tracks a restart in flight: a non-permanent
+// RemoveBackendPolicies sets it, the first thing it does under this mutex, so
+// a manage arriving while it is set is stored as starting instead of reaching
+// the backend, and is applied once by the replay that follows. A successful
+// ApplyBackendPolicies clears it once its entry gate has confirmed the
+// backend answers, also under this mutex, so a manage arriving after the
+// clear applies directly to a backend already confirmed up, and coexists
+// safely with the replay racing for the same mutex: whichever gets in first
+// is not re-applied by the other. A replay whose gate never passes leaves the
+// marker set, so manages for that backend stay deferred until the next
+// successful restart.
 type policyManager struct {
 	logger *slog.Logger
 	config config.Config
@@ -71,6 +84,9 @@ type policyManager struct {
 	starter BackendStarter
 
 	applyMu sync.Map // backend name -> *sync.Mutex
+
+	// restarting is the marker described in the type comment above.
+	restarting sync.Map // backend name -> *atomic.Bool
 }
 
 // applyLock returns the mutex serialising every policy operation on one
@@ -80,6 +96,16 @@ func (a *policyManager) applyLock(backendName string) *sync.Mutex {
 	v, _ := a.applyMu.LoadOrStore(backendName, &sync.Mutex{})
 	mu, _ := v.(*sync.Mutex) // LoadOrStore stored a *sync.Mutex; assertion cannot fail.
 	return mu
+}
+
+// restartingFlag returns the per-backend restart marker described on
+// policyManager: set by a non-permanent removal, cleared by a replay once its
+// entry gate confirms the backend answers. Entries are never deleted, same
+// race rationale as applyLock.
+func (a *policyManager) restartingFlag(name string) *atomic.Bool {
+	v, _ := a.restarting.LoadOrStore(name, &atomic.Bool{})
+	flag, _ := v.(*atomic.Bool) // LoadOrStore stored a *atomic.Bool; assertion cannot fail.
+	return flag
 }
 
 // New creates a new instance of PolicyManager
@@ -111,10 +137,20 @@ func (a *policyManager) SetStarter(starter BackendStarter) {
 // whose apply was deferred because the starter reported the backend starting.
 const ReasonBackendStarting = "backend starting"
 
-// backendReady consults the starter for the policy's backend. It returns
-// true when the apply may proceed; otherwise it has set the policy's state
-// and reason and the caller persists the record.
+// backendReady reports whether a manage or refresh may proceed for name's
+// backend. A restart in flight defers the manage the same way a starting
+// backend does: the replay applies it once the backend answers. The marker
+// is checked before the starter because it is this package's own state,
+// cheaper than a call out, and independent of whether a starter is even
+// installed. Past that check it consults the starter; either way, when the
+// apply may not proceed it has set the policy's state and reason and the
+// caller persists the record.
 func (a *policyManager) backendReady(name string, pd *policies.PolicyData) bool {
+	if a.restartingFlag(name).Load() {
+		pd.State = policies.FailedToApply
+		pd.BackendErr = ReasonBackendStarting
+		return false
+	}
 	if a.starter == nil {
 		return true
 	}
@@ -502,7 +538,12 @@ func removeFromBackend(be backend.Backend, pd policies.PolicyData) error {
 
 // RemoveBackendPolicies removes the named backend's policies, and only its
 // own: the repo holds every backend's policies, and a restart of one backend
-// must not take the others' with it.
+// must not take the others' with it. A non-permanent removal also sets the
+// backend's restarting marker, the first statement of the locked body run
+// under this backend's apply mutex, so a manage racing in for the same mutex
+// sees a restart in flight rather than a backend it can apply to.
+// ApplyBackendPolicies clears the marker once its replay's entry gate
+// confirms the backend is back.
 func (a *policyManager) RemoveBackendPolicies(name string, be backend.Backend, permanently bool) error {
 	mu := a.applyLock(name)
 	mu.Lock()
@@ -511,6 +552,13 @@ func (a *policyManager) RemoveBackendPolicies(name string, be backend.Backend, p
 }
 
 func (a *policyManager) removeBackendPoliciesLocked(name string, be backend.Backend, permanently bool) error {
+	if !permanently {
+		// A non-permanent removal is the start of a restart: setting the
+		// marker here, under this backend's apply mutex, means no manage can
+		// be mid-apply when it flips. ApplyBackendPolicies clears it once its
+		// replay confirms the backend is answering again.
+		a.restartingFlag(name).Store(true)
+	}
 	plcies, err := a.repo.GetAll()
 	if err != nil {
 		a.logger.Error("failed to retrieve list of policies", "error", err)
@@ -570,6 +618,16 @@ var ErrBackendNotRunning = errors.New("backend is not running; its policies are 
 // the loop and is returned, leaving whatever policies were not yet reached
 // as they were (most often unknown) for a later replay to pick up.
 //
+// Once the entry gate above passes, the restart marker for this backend
+// (see the policyManager type comment) is cleared under this same mutex: the
+// backend has answered once, so a manage arriving from here on applies
+// directly instead of waiting for this call. A gate failure leaves the
+// marker set, so a manage arriving during the caller's retry delay keeps
+// being deferred, and a caller that gives up after every retry leaves it set
+// too, so manages for the backend stay deferred until the next successful
+// restart, because the backend was not answering the same probe the health
+// monitor uses.
+//
 // Only a record deferredByRestart is applied: one marked unknown, one
 // marked offline while the process was down, or one stored failed to apply
 // because the starter reported the backend starting. A record already
@@ -593,6 +651,10 @@ func (a *policyManager) applyBackendPoliciesLocked(ctx context.Context, name str
 			"backend", name, "backend_state", state.String(), "detail", detail, "error", err)
 		return fmt.Errorf("%w: %s", ErrBackendNotRunning, name)
 	}
+	// The gate passed: the backend has answered once, so clear the restart
+	// marker now, before the loop below, so a manage arriving from here on
+	// applies directly rather than waiting for this replay.
+	a.restartingFlag(name).Store(false)
 	plcies, err := a.repo.GetAll()
 	if err != nil {
 		a.logger.Error("failed to retrieve list of policies", "error", err)

--- a/agent/policymgr/manager.go
+++ b/agent/policymgr/manager.go
@@ -68,13 +68,15 @@ var _ PolicyManager = (*policyManager)(nil)
 // RemoveBackendPolicies sets it, the first thing it does under this mutex, so
 // a manage arriving while it is set is stored as starting instead of reaching
 // the backend, and is applied once by the replay that follows. A successful
-// ApplyBackendPolicies clears it once its entry gate has confirmed the
-// backend answers, also under this mutex, so a manage arriving after the
-// clear applies directly to a backend already confirmed up, and coexists
-// safely with the replay racing for the same mutex: whichever gets in first
-// is not re-applied by the other. A replay whose gate never passes leaves the
-// marker set, so manages for that backend stay deferred until the next
-// successful restart.
+// ApplyBackendPolicies clears it only once its replay has handed every
+// deferred policy to a backend that answered, at the end of the call and
+// still under this mutex, so a manage arriving after the clear applies
+// directly to a backend already confirmed up, and coexists safely with the
+// replay racing for the same mutex: whichever gets in first is not re-applied
+// by the other. Any retryable exit, the entry gate refusing, a per-policy
+// probe refusing mid-loop, a cancelled context, or a persist error, leaves
+// the marker set, so manages for that backend stay deferred until a replay
+// completes.
 type policyManager struct {
 	logger *slog.Logger
 	config config.Config
@@ -99,9 +101,9 @@ func (a *policyManager) applyLock(backendName string) *sync.Mutex {
 }
 
 // restartingFlag returns the per-backend restart marker described on
-// policyManager: set by a non-permanent removal, cleared by a replay once its
-// entry gate confirms the backend answers. Entries are never deleted, same
-// race rationale as applyLock.
+// policyManager: set by a non-permanent removal, cleared by a replay once it
+// completes, having handed every deferred policy to a backend that answered.
+// Entries are never deleted, same race rationale as applyLock.
 func (a *policyManager) restartingFlag(name string) *atomic.Bool {
 	v, _ := a.restarting.LoadOrStore(name, &atomic.Bool{})
 	flag, _ := v.(*atomic.Bool) // LoadOrStore stored a *atomic.Bool; assertion cannot fail.
@@ -349,23 +351,53 @@ func (a *policyManager) managePolicyLocked(payload config.PolicyPayload) {
 	}
 }
 
+// removeLockKey is the backend whose mutex a remove of this policy must hold:
+// the stored record's when there is one, else the caller's.
+func (a *policyManager) removeLockKey(policyID, beName string) string {
+	if stored, err := a.repo.Get(policyID); err == nil && stored.Backend != "" {
+		return stored.Backend
+	}
+	return beName
+}
+
 // RemovePolicy removes a policy under the mutex of the backend the stored
 // record names (the argument when there is no record), so a remove naming
 // the wrong backend cannot run beside a manage on the right one. The key is
-// a best-effort read; the body re-reads the record under the lock, and a
-// remove is idempotent, so no re-validation loop is needed. Every caller is
-// expected to pass the backend the repo already names for this policy; a
-// caller passing a different name breaks the mutex invariant this wrapper
-// exists to enforce.
+// re-validated under the lock the same way manageUnderLock re-validates a
+// manage's: a record deleted and re-created under another backend between
+// the pre-lock read and the lock changes the key, and the wrapper starts
+// over on the right mutex. A remove naming a backend other than the one the
+// stored record names is refused, with the record untouched: acting on it
+// would remove from the caller's backend and delete the record, stranding
+// the backend the record actually names with the policy still running and no
+// state left to remove it from. Every caller is expected to pass the backend
+// the repo already names for this policy; this wrapper enforces that even
+// when it isn't.
 func (a *policyManager) RemovePolicy(policyID string, policyName string, beName string) error {
-	key := beName
-	if stored, err := a.repo.Get(policyID); err == nil && stored.Backend != "" {
-		key = stored.Backend
+	for {
+		key := a.removeLockKey(policyID, beName)
+		done, err := a.removeUnderLock(key, policyID, policyName, beName)
+		if done {
+			return err
+		}
 	}
+}
+
+// removeUnderLock runs the remove under key's mutex, reporting whether the
+// operation is finished; false means the key changed and the caller retries.
+func (a *policyManager) removeUnderLock(key, policyID, policyName, beName string) (bool, error) {
 	mu := a.applyLock(key)
 	mu.Lock()
 	defer mu.Unlock()
-	return a.removePolicyLocked(policyID, policyName, beName)
+	if current := a.removeLockKey(policyID, beName); current != key {
+		return false, nil
+	}
+	if stored, err := a.repo.Get(policyID); err == nil && stored.Backend != "" && stored.Backend != beName {
+		a.logger.Warn("policy remove names a backend other than the one it runs on; ignoring",
+			"policy_id", policyID, "policy_name", policyName, "stored_backend", stored.Backend, "backend", beName)
+		return true, fmt.Errorf("policy %s runs on backend %s, not %s; remove ignored", policyID, stored.Backend, beName)
+	}
+	return true, a.removePolicyLocked(policyID, policyName, beName)
 }
 
 func (a *policyManager) removePolicyLocked(policyID string, policyName string, beName string) error {
@@ -413,19 +445,39 @@ func (a *policyManager) removePolicyLocked(policyID string, policyName string, b
 
 // RemovePolicyDataset removes a dataset under the mutex of the backend the
 // stored record names, with the caller's name as the fallback; both callers
-// read the name from the repo right before calling. Every caller is expected
-// to pass the backend the repo already names for this policy; a caller
-// passing a different name breaks the mutex invariant this wrapper exists to
-// enforce.
+// read the name from the repo right before calling. The key is re-validated
+// under the lock the same way RemovePolicy's is, and a caller naming a
+// backend other than the stored one is refused rather than acted on, for the
+// same reason: acting on it would strand the other backend's copy with
+// nothing left to remove it. Every caller is expected to pass the backend the
+// repo already names for this policy; this wrapper enforces that even when it
+// isn't.
 func (a *policyManager) RemovePolicyDataset(policyID string, datasetID string, beName string, be backend.Backend) {
-	key := beName
-	if stored, err := a.repo.Get(policyID); err == nil && stored.Backend != "" {
-		key = stored.Backend
+	for {
+		key := a.removeLockKey(policyID, beName)
+		if a.removeDatasetUnderLock(key, policyID, datasetID, beName, be) {
+			return
+		}
 	}
+}
+
+// removeDatasetUnderLock runs the dataset removal under key's mutex,
+// reporting whether the operation is finished; false means the key changed
+// and the caller retries.
+func (a *policyManager) removeDatasetUnderLock(key, policyID, datasetID, beName string, be backend.Backend) bool {
 	mu := a.applyLock(key)
 	mu.Lock()
 	defer mu.Unlock()
+	if current := a.removeLockKey(policyID, beName); current != key {
+		return false
+	}
+	if stored, err := a.repo.Get(policyID); err == nil && stored.Backend != "" && stored.Backend != beName {
+		a.logger.Warn("policy dataset remove names a backend other than the one it runs on; ignoring",
+			"policy_id", policyID, "dataset_id", datasetID, "stored_backend", stored.Backend, "backend", beName)
+		return true
+	}
 	a.removePolicyDatasetLocked(policyID, datasetID, be)
+	return true
 }
 
 func (a *policyManager) removePolicyDatasetLocked(policyID string, datasetID string, be backend.Backend) {
@@ -542,8 +594,8 @@ func removeFromBackend(be backend.Backend, pd policies.PolicyData) error {
 // backend's restarting marker, the first statement of the locked body run
 // under this backend's apply mutex, so a manage racing in for the same mutex
 // sees a restart in flight rather than a backend it can apply to.
-// ApplyBackendPolicies clears the marker once its replay's entry gate
-// confirms the backend is back.
+// ApplyBackendPolicies clears the marker once its replay completes, having
+// handed every deferred policy to a backend that answered.
 func (a *policyManager) RemoveBackendPolicies(name string, be backend.Backend, permanently bool) error {
 	mu := a.applyLock(name)
 	mu.Lock()
@@ -556,7 +608,7 @@ func (a *policyManager) removeBackendPoliciesLocked(name string, be backend.Back
 		// A non-permanent removal is the start of a restart: setting the
 		// marker here, under this backend's apply mutex, means no manage can
 		// be mid-apply when it flips. ApplyBackendPolicies clears it once its
-		// replay confirms the backend is answering again.
+		// replay completes.
 		a.restartingFlag(name).Store(true)
 	}
 	plcies, err := a.repo.GetAll()
@@ -618,15 +670,17 @@ var ErrBackendNotRunning = errors.New("backend is not running; its policies are 
 // the loop and is returned, leaving whatever policies were not yet reached
 // as they were (most often unknown) for a later replay to pick up.
 //
-// Once the entry gate above passes, the restart marker for this backend
-// (see the policyManager type comment) is cleared under this same mutex: the
-// backend has answered once, so a manage arriving from here on applies
-// directly instead of waiting for this call. A gate failure leaves the
-// marker set, so a manage arriving during the caller's retry delay keeps
-// being deferred, and a caller that gives up after every retry leaves it set
-// too, so manages for the backend stay deferred until the next successful
-// restart, because the backend was not answering the same probe the health
-// monitor uses.
+// The restart marker for this backend (see the policyManager type comment) is
+// cleared only once this replay has handed every deferred policy to a
+// backend that answered: at the end of this call, still under this same
+// mutex, immediately before it returns nil. From then on a manage applies
+// directly instead of waiting for another replay. Any exit before that
+// point, the entry gate refusing, a per-policy probe refusing mid-loop, a
+// cancelled context, or a persist error, leaves the marker set, so a manage
+// arriving during the caller's retry delay keeps being deferred, and a
+// caller that gives up after every retry leaves it set too, so manages for
+// the backend stay deferred until a replay completes, because the backend
+// was not answering the same probe the health monitor uses.
 //
 // Only a record deferredByRestart is applied: one marked unknown, one
 // marked offline while the process was down, or one stored failed to apply
@@ -651,10 +705,6 @@ func (a *policyManager) applyBackendPoliciesLocked(ctx context.Context, name str
 			"backend", name, "backend_state", state.String(), "detail", detail, "error", err)
 		return fmt.Errorf("%w: %s", ErrBackendNotRunning, name)
 	}
-	// The gate passed: the backend has answered once, so clear the restart
-	// marker now, before the loop below, so a manage arriving from here on
-	// applies directly rather than waiting for this replay.
-	a.restartingFlag(name).Store(false)
 	plcies, err := a.repo.GetAll()
 	if err != nil {
 		a.logger.Error("failed to retrieve list of policies", "error", err)
@@ -684,6 +734,11 @@ func (a *policyManager) applyBackendPoliciesLocked(ctx context.Context, name str
 			return err
 		}
 	}
+	// The loop has handed every deferred policy to a backend that answered:
+	// clear the restart marker now, still under this mutex, so a manage
+	// arriving from here on applies directly instead of waiting for another
+	// replay.
+	a.restartingFlag(name).Store(false)
 	return nil
 }
 

--- a/agent/policymgr/manager_test.go
+++ b/agent/policymgr/manager_test.go
@@ -665,35 +665,48 @@ func TestApplyBackendPoliciesStopsWhenTheContextIsCancelledMidLoop(t *testing.T)
 	assert.Equal(t, 1, unknown, "the policy never reached stays as it was")
 }
 
-// A record already Running reflects the current process: every restart marks
-// a backend's policies unknown before stopping it, and a manage during a
-// restart is stored failed to apply rather than running, so a running record
-// can only have been applied by this same process already. Skipping it is
-// what lets the replay run more than once (the restart's second pass, after
-// the mutex is released) without applying a policy twice.
-func TestApplyBackendPoliciesSkipsPoliciesAlreadyRunning(t *testing.T) {
+// A replay must hand the backend only the records a restart deferred: one
+// marked unknown, one marked offline while the process was down, and one
+// stored failed to apply because the starter reported the backend starting.
+// A record already Running reflects this process's own prior apply, and a
+// record failed for any other reason failed in this same replay or in a
+// manage this process already answered; applying either again could run a
+// one-shot policy twice.
+func TestApplyBackendPoliciesAppliesOnlyWhatTheRestartDeferred(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	secretsMgr := &mockSecretsManager{passthrough: true}
-	be := &mockBackend{name: "skip_running_backend"}
+	be := &mockBackend{name: "deferred_backend"}
 	be.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 
 	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
 	require.NoError(t, err)
 	repo := mgr.GetRepo()
-	require.NoError(t, repo.Update(policies.PolicyData{ID: "already-running", Name: "already-running", Backend: "skip_running_backend", Version: 1, Data: map[string]any{}, State: policies.Running}))
-	require.NoError(t, repo.Update(policies.PolicyData{ID: "not-yet", Name: "not-yet", Backend: "skip_running_backend", Version: 1, Data: map[string]any{}, State: policies.Unknown}))
+	require.NoError(t, repo.Update(policies.PolicyData{ID: "unknown", Name: "unknown", Backend: "deferred_backend", Version: 1, Data: map[string]any{}, State: policies.Unknown}))
+	require.NoError(t, repo.Update(policies.PolicyData{ID: "offline", Name: "offline", Backend: "deferred_backend", Version: 1, Data: map[string]any{}, State: policies.Offline}))
+	require.NoError(t, repo.Update(policies.PolicyData{ID: "starting", Name: "starting", Backend: "deferred_backend", Version: 1, Data: map[string]any{}, State: policies.FailedToApply, BackendErr: policymgr.ReasonBackendStarting}))
+	require.NoError(t, repo.Update(policies.PolicyData{ID: "failed", Name: "failed", Backend: "deferred_backend", Version: 1, Data: map[string]any{}, State: policies.FailedToApply, BackendErr: "failed to apply"}))
+	require.NoError(t, repo.Update(policies.PolicyData{ID: "already-running", Name: "already-running", Backend: "deferred_backend", Version: 1, Data: map[string]any{}, State: policies.Running}))
 
-	be.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool { return pd.ID == "not-yet" }), true).Return(nil).Once()
+	applied := []string{"unknown", "offline", "starting"}
+	for _, id := range applied {
+		be.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool { return pd.ID == id }), true).Return(nil).Once()
+	}
 
-	require.NoError(t, mgr.ApplyBackendPolicies(context.Background(), "skip_running_backend", be))
+	require.NoError(t, mgr.ApplyBackendPolicies(context.Background(), "deferred_backend", be))
 
-	be.AssertExpectations(t) // the running record calling ApplyPolicy again would panic on the exhausted expectation
+	be.AssertExpectations(t) // the failed and already-running records calling ApplyPolicy again would panic on the exhausted expectations
+	for _, id := range applied {
+		stored, err := repo.Get(id)
+		require.NoError(t, err)
+		assert.Equal(t, policies.Running, stored.State, "id %s must be applied by the replay", id)
+	}
+	failed, err := repo.Get("failed")
+	require.NoError(t, err)
+	assert.Equal(t, policies.FailedToApply, failed.State, "a failure this process already answered is not replayed")
+	assert.Equal(t, "failed to apply", failed.BackendErr)
 	alreadyRunning, err := repo.Get("already-running")
 	require.NoError(t, err)
 	assert.Equal(t, policies.Running, alreadyRunning.State)
-	notYet, err := repo.Get("not-yet")
-	require.NoError(t, err)
-	assert.Equal(t, policies.Running, notYet.State)
 }
 
 // The state monitor calls repo.UpdateRuns for a policy at any time and does

--- a/agent/policymgr/manager_test.go
+++ b/agent/policymgr/manager_test.go
@@ -1146,6 +1146,142 @@ func TestRemoveBackendPoliciesLeavesOtherBackendsAlone(t *testing.T) {
 	assert.Equal(t, "policy-other_backend", state[0].ID)
 }
 
+// A non-permanent removal marks the backend as restarting: a manage that
+// arrives before any replay confirms the backend again is stored as starting
+// instead of reaching the backend, the same way a manage during a starter's
+// reported start is.
+func TestManageIsDeferredAfterANonPermanentRemoval(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := &mockSecretsManager{passthrough: true}
+	be := &mockBackend{name: "marker_removal_backend"}
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	be.On("RemovePolicy", mock.Anything).Return(nil).Maybe()
+	backend.Register("marker_removal_backend", be)
+
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	require.NoError(t, mgr.GetRepo().Update(policies.PolicyData{ID: "seed", Name: "seed", Backend: "marker_removal_backend", Version: 1, Data: map[string]any{}, State: policies.Running}))
+
+	require.NoError(t, mgr.RemoveBackendPolicies("marker_removal_backend", be, false))
+
+	mgr.ManagePolicy(config.PolicyPayload{
+		Action: "manage", ID: "new-during-removal", Name: "new-during-removal",
+		Backend: "marker_removal_backend", DatasetID: "d1", Version: 1, Data: map[string]any{},
+	})
+
+	stored, err := mgr.GetRepo().Get("new-during-removal")
+	require.NoError(t, err)
+	assert.Equal(t, policies.FailedToApply, stored.State, "a manage while the marker is set must not reach the backend")
+	assert.Equal(t, policymgr.ReasonBackendStarting, stored.BackendErr)
+	be.AssertNotCalled(t, "ApplyPolicy", mock.Anything, mock.Anything)
+}
+
+// Once a replay's entry gate has confirmed the backend answers, the marker is
+// clear, so a manage arriving afterwards applies directly rather than waiting
+// for another replay.
+func TestManageAppliesDirectlyOnceTheReplayConfirmedTheBackend(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := &mockSecretsManager{passthrough: true}
+	be := &mockBackend{name: "marker_confirmed_backend"}
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	be.On("RemovePolicy", mock.Anything).Return(nil).Maybe()
+	backend.Register("marker_confirmed_backend", be)
+
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	require.NoError(t, mgr.GetRepo().Update(policies.PolicyData{ID: "seed", Name: "seed", Backend: "marker_confirmed_backend", Version: 1, Data: map[string]any{}, State: policies.Running}))
+
+	require.NoError(t, mgr.RemoveBackendPolicies("marker_confirmed_backend", be, false))
+
+	be.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool { return pd.ID == "seed" }), true).Return(nil).Once()
+	require.NoError(t, mgr.ApplyBackendPolicies(context.Background(), "marker_confirmed_backend", be))
+
+	be.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool { return pd.ID == "after-replay" }), false).Return(nil).Once()
+	mgr.ManagePolicy(config.PolicyPayload{
+		Action: "manage", ID: "after-replay", Name: "after-replay",
+		Backend: "marker_confirmed_backend", DatasetID: "d1", Version: 1, Data: map[string]any{},
+	})
+
+	stored, err := mgr.GetRepo().Get("after-replay")
+	require.NoError(t, err)
+	assert.Equal(t, policies.Running, stored.State)
+	be.AssertExpectations(t)
+}
+
+// A replay whose entry gate keeps failing must not clear the marker: a
+// manage arriving in that window stays deferred, and the next replay whose
+// gate passes applies both the record the removal marked unknown and the one
+// the manage stored as starting, each exactly once.
+func TestManageStaysDeferredWhileTheReplayGateFails(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := &mockSecretsManager{passthrough: true}
+	be := &mockBackend{name: "marker_gate_fail_backend"}
+	be.On("RemovePolicy", mock.Anything).Return(nil).Maybe()
+	backend.Register("marker_gate_fail_backend", be)
+
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	require.NoError(t, mgr.GetRepo().Update(policies.PolicyData{ID: "seed", Name: "seed", Backend: "marker_gate_fail_backend", Version: 1, Data: map[string]any{}, State: policies.Running}))
+
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Once() // the removal's own probe
+	require.NoError(t, mgr.RemoveBackendPolicies("marker_gate_fail_backend", be, false))
+
+	be.On("GetRunningStatus").Return(backend.BackendError, "process running, REST API unavailable", nil).Once() // the failing replay's entry gate
+	err = mgr.ApplyBackendPolicies(context.Background(), "marker_gate_fail_backend", be)
+	require.ErrorIs(t, err, policymgr.ErrBackendNotRunning)
+
+	mgr.ManagePolicy(config.PolicyPayload{
+		Action: "manage", ID: "deferred-manage", Name: "deferred-manage",
+		Backend: "marker_gate_fail_backend", DatasetID: "d1", Version: 1, Data: map[string]any{},
+	})
+	deferredAfterFailedGate, err := mgr.GetRepo().Get("deferred-manage")
+	require.NoError(t, err)
+	assert.Equal(t, policies.FailedToApply, deferredAfterFailedGate.State, "the manage must stay deferred while the gate keeps failing")
+	assert.Equal(t, policymgr.ReasonBackendStarting, deferredAfterFailedGate.BackendErr)
+
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe() // the successful replay: entry gate, then one per-policy probe each
+	be.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool { return pd.ID == "seed" }), true).Return(nil).Once()
+	be.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool { return pd.ID == "deferred-manage" }), true).Return(nil).Once()
+
+	require.NoError(t, mgr.ApplyBackendPolicies(context.Background(), "marker_gate_fail_backend", be))
+
+	be.AssertExpectations(t) // a second ApplyPolicy call for either id would panic on the exhausted expectation
+	seedStored, err := mgr.GetRepo().Get("seed")
+	require.NoError(t, err)
+	assert.Equal(t, policies.Running, seedStored.State)
+	deferredStored, err := mgr.GetRepo().Get("deferred-manage")
+	require.NoError(t, err)
+	assert.Equal(t, policies.Running, deferredStored.State)
+}
+
+// A permanent removal is not the start of a restart, so it must not defer
+// manages: one arriving afterwards applies directly.
+func TestPermanentRemovalDoesNotDeferManages(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := &mockSecretsManager{passthrough: true}
+	be := &mockBackend{name: "marker_permanent_backend"}
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	be.On("RemovePolicy", mock.Anything).Return(nil).Maybe()
+	backend.Register("marker_permanent_backend", be)
+
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	require.NoError(t, mgr.GetRepo().Update(policies.PolicyData{ID: "seed", Name: "seed", Backend: "marker_permanent_backend", Version: 1, Data: map[string]any{}, State: policies.Running}))
+
+	require.NoError(t, mgr.RemoveBackendPolicies("marker_permanent_backend", be, true))
+
+	be.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool { return pd.ID == "after-permanent-removal" }), false).Return(nil).Once()
+	mgr.ManagePolicy(config.PolicyPayload{
+		Action: "manage", ID: "after-permanent-removal", Name: "after-permanent-removal",
+		Backend: "marker_permanent_backend", DatasetID: "d1", Version: 1, Data: map[string]any{},
+	})
+
+	stored, err := mgr.GetRepo().Get("after-permanent-removal")
+	require.NoError(t, err)
+	assert.Equal(t, policies.Running, stored.State)
+	be.AssertExpectations(t)
+}
+
 func policyIDs(state []policies.PolicyData) []string {
 	ids := make([]string, 0, len(state))
 	for _, p := range state {

--- a/agent/policymgr/manager_test.go
+++ b/agent/policymgr/manager_test.go
@@ -686,6 +686,39 @@ func TestSecretsRefreshKeepsRunUpdatesWrittenDuringTheApply(t *testing.T) {
 	assert.Equal(t, "run-2", stored.Runs[0].ID)
 }
 
+// Same as TestApplyBackendPoliciesKeepsRunUpdatesWrittenDuringTheApply, for
+// the non-permanent removal path: the write-back after RemovePolicy must
+// carry forward any run the state monitor wrote while the backend call was
+// in flight, not overwrite it with the pre-removal snapshot.
+func TestRemoveBackendPoliciesKeepsRunUpdatesWrittenDuringTheRemoval(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	secretsMgr.On("RegisterUpdatePoliciesCallback", mock.Anything).Return()
+	be := &mockBackend{name: "remover_runs"}
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	backend.Register("remover_runs", be)
+
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	repo := mgr.GetRepo()
+	require.NoError(t, repo.Update(policies.PolicyData{ID: "runs-3", Name: "Runs Three", Backend: "remover_runs", Version: 1, Data: map[string]any{}, State: policies.Running}))
+
+	be.On("RemovePolicy", mock.MatchedBy(func(pd policies.PolicyData) bool { return pd.ID == "runs-3" })).
+		Run(func(_ mock.Arguments) {
+			require.NoError(t, repo.UpdateRuns("Runs Three", []policies.RunData{{ID: "run-3", Status: "running"}}))
+		}).
+		Return(nil).Once()
+
+	require.NoError(t, mgr.RemoveBackendPolicies("remover_runs", be, false))
+
+	be.AssertExpectations(t)
+	stored, err := repo.Get("runs-3")
+	require.NoError(t, err)
+	assert.Equal(t, policies.Unknown, stored.State)
+	require.Len(t, stored.Runs, 1, "the run written during the removal must not be discarded by the write-back")
+	assert.Equal(t, "run-3", stored.Runs[0].ID)
+}
+
 func TestPoliciesChanged(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	secretsMgr := new(mockSecretsManager)

--- a/agent/policymgr/manager_test.go
+++ b/agent/policymgr/manager_test.go
@@ -481,94 +481,140 @@ func TestRemoveBackendPolicies(t *testing.T) {
 	assert.Empty(t, state)
 }
 
-func TestApplyBackendPolicies(t *testing.T) {
+// A backend's policies are re-applied with their secrets solved the way a
+// manage solves them, with updatePolicy true (the remove-then-apply form
+// every backend implements, safe against a name already present), and the
+// repo keeps the unsolved data. Another backend's policies are not touched.
+func TestApplyBackendPoliciesAppliesOnlyThatBackendsPoliciesWithSolvedSecrets(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	secretsMgr := new(mockSecretsManager)
-	cfg := config.Config{}
+	mine := &mockBackend{name: "applier_mine"}
+	mine.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	other := &mockBackend{name: "applier_other"}
+	other.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
 
-	mockBe := &mockBackend{name: "testbackend"}
-	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
-	backend.Register("testbackend", mockBe)
-
-	mgr, err := policymgr.New(logger, secretsMgr, cfg)
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
 	require.NoError(t, err)
-
-	// First add policies but mark them as unknown (simulating a backend restart)
 	repo := mgr.GetRepo()
-	for i := 1; i <= 3; i++ {
-		policy := policies.PolicyData{
-			ID:       fmt.Sprintf("policy%d", i),
-			Name:     fmt.Sprintf("Test Policy %d", i),
-			Backend:  "testbackend",
-			Version:  int32(i),
-			Data:     map[string]any{},
-			State:    policies.Unknown,
-			Datasets: map[string]bool{fmt.Sprintf("dataset%d", i): true},
-		}
-		err := repo.Update(policy)
-		require.NoError(t, err)
-	}
+	unsolved := map[string]any{"community": "${vault://snmp/community}"}
+	require.NoError(t, repo.Update(policies.PolicyData{ID: "mine-1", Name: "Mine One", Backend: "applier_mine", Version: 1, Data: unsolved, State: policies.Unknown, PreviousPolicyData: &policies.PolicyData{Name: "Old Name"}}))
+	require.NoError(t, repo.Update(policies.PolicyData{ID: "other-1", Name: "Other One", Backend: "applier_other", Version: 1, Data: map[string]any{}, State: policies.Unknown}))
 
-	// Set up expectations for applying policies
-	mockBe.On("ApplyPolicy", mock.Anything, false).Return(nil).Times(3)
+	secretsMgr.On("SolvePolicySecrets", mock.MatchedBy(func(p config.PolicyPayload) bool { return p.ID == "mine-1" && p.Backend == "applier_mine" })).
+		Return(config.PolicyPayload{ID: "mine-1", Name: "Mine One", Backend: "applier_mine", Version: 1, Data: map[string]any{"community": "s3cr3t"}}, nil).Once()
+	secretsMgr.On("SolvePolicySecrets", mock.MatchedBy(func(p config.PolicyPayload) bool { return p.ID == "other-1" })).
+		Return(config.PolicyPayload{ID: "other-1", Name: "Other One", Backend: "applier_other", Version: 1, Data: map[string]any{}}, nil).Maybe()
+	mine.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool {
+		data, _ := pd.Data.(map[string]any)
+		return pd.ID == "mine-1" && data["community"] == "s3cr3t"
+	}), true).Return(nil).Once()
+	// registered after the specific expectation, so testify's first-match
+	// rule still routes mine-1 to it; a wrong implementation then fails on
+	// the assertions below instead of panicking inside testify
+	mine.On("ApplyPolicy", mock.Anything, mock.Anything).Return(nil).Maybe()
 
-	// Execute
-	err = mgr.ApplyBackendPolicies(mockBe)
+	require.NoError(t, mgr.ApplyBackendPolicies("applier_mine", mine))
+
+	mine.AssertExpectations(t)
+	secretsMgr.AssertExpectations(t)
+	other.AssertNotCalled(t, "ApplyPolicy", mock.Anything, mock.Anything)
+	stored, err := repo.Get("mine-1")
 	require.NoError(t, err)
-
-	// Verify policies are now running
-	state, err := mgr.GetPolicyState()
+	assert.Equal(t, policies.Running, stored.State)
+	assert.Empty(t, stored.BackendErr)
+	assert.Equal(t, unsolved, stored.Data, "the repo keeps the unsolved references")
+	assert.Nil(t, stored.PreviousPolicyData, "a successful apply clears a pending rename")
+	otherStored, err := repo.Get("other-1")
 	require.NoError(t, err)
-	assert.Len(t, state, 3)
-	for _, policy := range state {
-		assert.Equal(t, policies.Running, policy.State)
-		assert.Empty(t, policy.BackendErr)
-	}
+	assert.Equal(t, policies.Unknown, otherStored.State)
+}
 
-	// Test error case - one policy fails to apply
-	repo = mgr.GetRepo() // Get fresh repo
-	for i := 1; i <= 3; i++ {
-		policy := policies.PolicyData{
-			ID:       fmt.Sprintf("policy%d", i),
-			Name:     fmt.Sprintf("Test Policy %d", i),
-			Backend:  "testbackend",
-			Version:  int32(i),
-			Data:     map[string]any{},
-			State:    policies.Unknown,
-			Datasets: map[string]bool{fmt.Sprintf("dataset%d", i): true},
-		}
-		err := repo.Update(policy)
-		require.NoError(t, err)
-	}
+// A backend that is not running at that moment cannot take an apply; the
+// policies are left as they are for its next start rather than stamped
+// failed, and the caller learns why.
+func TestApplyBackendPoliciesLeavesPoliciesWhenTheBackendIsNotRunning(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	flaky := &mockBackend{name: "applier_flaky"}
+	flaky.On("GetRunningStatus").Return(backend.BackendError, "process running, REST API unavailable", nil)
+	flaky.On("ApplyPolicy", mock.Anything, mock.Anything).Return(nil).Maybe()
+	secretsMgr.On("SolvePolicySecrets", mock.Anything).Return(config.PolicyPayload{}, nil).Maybe()
 
-	// Make policy2 fail
-	mockBe.ExpectedCalls = nil
-	mockBe.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
-	mockBe.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool {
-		return pd.ID == "policy1" || pd.ID == "policy3"
-	}), false).Return(nil).Times(2)
-	mockBe.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool {
-		return pd.ID == "policy2"
-	}), false).Return(errors.New("failed to apply")).Once()
-
-	// Execute
-	err = mgr.ApplyBackendPolicies(mockBe)
-	require.NoError(t, err) // Function should not return error even if some policies fail
-
-	// Verify status
-	state, err = mgr.GetPolicyState()
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
 	require.NoError(t, err)
-	assert.Len(t, state, 3)
+	require.NoError(t, mgr.GetRepo().Update(policies.PolicyData{ID: "flaky-1", Name: "Flaky One", Backend: "applier_flaky", Version: 1, Data: map[string]any{}, State: policies.Unknown}))
 
-	for _, policy := range state {
-		if policy.ID == "policy2" {
-			assert.Equal(t, policies.FailedToApply, policy.State)
-			assert.Equal(t, "failed to apply", policy.BackendErr)
-		} else {
-			assert.Equal(t, policies.Running, policy.State)
-			assert.Empty(t, policy.BackendErr)
-		}
+	err = mgr.ApplyBackendPolicies("applier_flaky", flaky)
+
+	require.ErrorIs(t, err, policymgr.ErrBackendNotRunning)
+	flaky.AssertNotCalled(t, "ApplyPolicy", mock.Anything, mock.Anything)
+	stored, err := mgr.GetRepo().Get("flaky-1")
+	require.NoError(t, err)
+	assert.Equal(t, policies.Unknown, stored.State, "untouched for the next start")
+}
+
+// A secret that cannot be solved fails that policy alone, with the operator
+// facing reason, and the others still apply.
+func TestApplyBackendPoliciesFailsOnlyThePolicyWhoseSecretsCannotBeSolved(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	be := &mockBackend{name: "applier_secrets"}
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	repo := mgr.GetRepo()
+	for _, id := range []string{"sec-good", "sec-bad"} {
+		require.NoError(t, repo.Update(policies.PolicyData{ID: id, Name: id, Backend: "applier_secrets", Version: 1, Data: map[string]any{}, State: policies.Unknown}))
 	}
+	secretsMgr.On("SolvePolicySecrets", mock.MatchedBy(func(p config.PolicyPayload) bool { return p.ID == "sec-good" })).
+		Return(config.PolicyPayload{ID: "sec-good", Name: "sec-good", Backend: "applier_secrets", Version: 1, Data: map[string]any{}}, nil).Once()
+	secretsMgr.On("SolvePolicySecrets", mock.MatchedBy(func(p config.PolicyPayload) bool { return p.ID == "sec-bad" })).
+		Return(config.PolicyPayload{}, errors.New("vault: permission denied")).Once()
+	be.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool { return pd.ID == "sec-good" }), true).Return(nil).Once()
+	be.On("ApplyPolicy", mock.Anything, mock.Anything).Return(nil).Maybe() // after the specific one, see the first test
+
+	require.NoError(t, mgr.ApplyBackendPolicies("applier_secrets", be))
+
+	be.AssertExpectations(t)
+	secretsMgr.AssertExpectations(t)
+	good, _ := repo.Get("sec-good")
+	bad, _ := repo.Get("sec-bad")
+	assert.Equal(t, policies.Running, good.State)
+	assert.Equal(t, policies.FailedToApply, bad.State)
+	assert.Contains(t, bad.BackendErr, "failed to resolve policy secrets: vault: permission denied")
+}
+
+// A backend that rejects one policy's apply fails that policy alone, with
+// the backend's own error as the reason, and the others still apply.
+func TestApplyBackendPoliciesFailsOnlyThePolicyTheBackendRejects(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	be := &mockBackend{name: "applier_backend_fail"}
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	repo := mgr.GetRepo()
+	for _, id := range []string{"be-good", "be-bad"} {
+		require.NoError(t, repo.Update(policies.PolicyData{ID: id, Name: id, Backend: "applier_backend_fail", Version: 1, Data: map[string]any{}, State: policies.Unknown}))
+	}
+	secretsMgr.On("SolvePolicySecrets", mock.MatchedBy(func(p config.PolicyPayload) bool { return p.ID == "be-good" })).
+		Return(config.PolicyPayload{ID: "be-good", Name: "be-good", Backend: "applier_backend_fail", Version: 1, Data: map[string]any{}}, nil).Once()
+	secretsMgr.On("SolvePolicySecrets", mock.MatchedBy(func(p config.PolicyPayload) bool { return p.ID == "be-bad" })).
+		Return(config.PolicyPayload{ID: "be-bad", Name: "be-bad", Backend: "applier_backend_fail", Version: 1, Data: map[string]any{}}, nil).Once()
+	be.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool { return pd.ID == "be-good" }), true).Return(nil).Once()
+	be.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool { return pd.ID == "be-bad" }), true).Return(errors.New("failed to apply")).Once()
+
+	require.NoError(t, mgr.ApplyBackendPolicies("applier_backend_fail", be))
+
+	be.AssertExpectations(t)
+	secretsMgr.AssertExpectations(t)
+	good, _ := repo.Get("be-good")
+	bad, _ := repo.Get("be-bad")
+	assert.Equal(t, policies.Running, good.State)
+	assert.Equal(t, policies.FailedToApply, bad.State)
+	assert.Equal(t, "failed to apply", bad.BackendErr)
 }
 
 func TestPoliciesChanged(t *testing.T) {

--- a/agent/policymgr/manager_test.go
+++ b/agent/policymgr/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -89,10 +90,14 @@ func (m *mockBackend) RemovePolicy(policy policies.PolicyData) error {
 // Mock for the secretsmgr.Manager interface
 type mockSecretsManager struct {
 	mock.Mock
-	callbacks []func(map[string]bool)
+	callbacks   []func(map[string]bool)
+	passthrough bool
 }
 
 func (m *mockSecretsManager) SolvePolicySecrets(payload config.PolicyPayload) (config.PolicyPayload, error) {
+	if m.passthrough {
+		return payload, nil
+	}
 	args := m.Called(payload)
 	return args.Get(0).(config.PolicyPayload), args.Error(1)
 }
@@ -751,7 +756,7 @@ func TestRemovePolicyDataset(t *testing.T) {
 	assert.True(t, state[0].Datasets["dataset2"])
 
 	// Test removing one dataset
-	mgr.RemovePolicyDataset("policy1", "dataset1", mockBe)
+	mgr.RemovePolicyDataset("policy1", "dataset1", "testbackend", mockBe)
 
 	// Verify policy still exists but with only one dataset
 	state, err = mgr.GetPolicyState()
@@ -763,7 +768,7 @@ func TestRemovePolicyDataset(t *testing.T) {
 
 	// Test removing the last dataset - should remove the policy
 	mockBe.On("RemovePolicy", mock.Anything).Return(nil)
-	mgr.RemovePolicyDataset("policy1", "dataset2", mockBe)
+	mgr.RemovePolicyDataset("policy1", "dataset2", "testbackend", mockBe)
 
 	// Verify policy is gone
 	state, err = mgr.GetPolicyState()
@@ -826,7 +831,7 @@ func TestRemovePolicyDataset_GetError(t *testing.T) {
 	require.NoError(t, err)
 
 	// Call RemovePolicyDataset on a policy that doesn't exist — should not panic
-	mgr.RemovePolicyDataset("nonexistent_policy", "dataset1", mockBe)
+	mgr.RemovePolicyDataset("nonexistent_policy", "dataset1", "be_dataset_get_err", mockBe)
 	mockBe.AssertNotCalled(t, "RemovePolicy")
 }
 
@@ -860,7 +865,7 @@ func TestRemovePolicyDataset_RemovePolicyError(t *testing.T) {
 
 	// RemovePolicy on backend errors — should still complete
 	mockBe.On("RemovePolicy", mock.Anything).Return(errors.New("backend remove error"))
-	mgr.RemovePolicyDataset("p_ds_rm", "ds1", mockBe)
+	mgr.RemovePolicyDataset("p_ds_rm", "ds1", "be_dataset_rm_err", mockBe)
 
 	// Policy should be gone from repo
 	state, err := mgr.GetPolicyState()
@@ -941,7 +946,7 @@ func TestRemovePolicyDoesNotCallABackendThatIsNotRunning(t *testing.T) {
 
 	// The dataset path removes through the same gate.
 	mgr.ManagePolicy(payload)
-	mgr.RemovePolicyDataset("policy-cold", "ds-cold", cold)
+	mgr.RemovePolicyDataset("policy-cold", "ds-cold", "cold_backend", cold)
 	cold.AssertNotCalled(t, "RemovePolicy", mock.Anything)
 	state, err = mgr.GetPolicyState()
 	require.NoError(t, err)
@@ -1358,10 +1363,11 @@ func TestPoliciesChanged_SecretsFailureAndRecovery(t *testing.T) {
 	}), mock.Anything).Return(nil)
 	mgr.ManagePolicy(payload)
 
-	// The secrets-changed callback rebuilds a minimal payload from the repo.
-	// IMPORTANT: verify the matcher against the ACTUAL payload construction in
-	// the re-apply loop (config.PolicyPayload{ID, Name, Data}) before finalizing.
-	reapplyPayload := config.PolicyPayload{ID: "policy-rc1", Name: "Recheck Policy", Data: policyData}
+	// The secrets-changed callback rebuilds the payload from the repo via
+	// applyStoredPolicy. IMPORTANT: verify the matcher against the ACTUAL
+	// payload construction in the re-apply loop (config.PolicyPayload{ID,
+	// Name, Backend, Version, Data}) before finalizing.
+	reapplyPayload := config.PolicyPayload{ID: "policy-rc1", Name: "Recheck Policy", Backend: "secretsreapplybackend", Version: 1, Data: policyData}
 	secretsMgr.On("SolvePolicySecrets", reapplyPayload).Return(config.PolicyPayload{}, errors.New("vault sealed")).Once()
 	secretsMgr.TriggerCallbacks(map[string]bool{"policy-rc1": true})
 
@@ -1686,4 +1692,272 @@ func TestManagePolicy_RefusesUnaddressableName(t *testing.T) {
 		"the recorded error must say why, since the operator has to rename the policy")
 
 	secretsMgr.AssertExpectations(t)
+}
+
+// blockingBackend is a backend whose ApplyPolicy blocks, for one policy
+// version only, until released, so a test can hold the backend's apply
+// mutex from an applier while another operation for the same backend is
+// attempted. Every other apply goes straight through.
+type blockingBackend struct {
+	mockBackend
+	blockID      string
+	blockVersion int32
+	entered      chan struct{}
+	release      chan struct{}
+
+	mu      sync.Mutex
+	applied []policies.PolicyData
+}
+
+func newBlockingBackend(name, blockID string, blockVersion int32) *blockingBackend {
+	b := &blockingBackend{
+		mockBackend:  mockBackend{name: name},
+		blockID:      blockID,
+		blockVersion: blockVersion,
+		entered:      make(chan struct{}, 4),
+		release:      make(chan struct{}),
+	}
+	b.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	return b
+}
+
+func (b *blockingBackend) ApplyPolicy(pd policies.PolicyData, _ bool) error {
+	if pd.ID == b.blockID && pd.Version == b.blockVersion {
+		b.entered <- struct{}{}
+		<-b.release
+	}
+	b.mu.Lock()
+	b.applied = append(b.applied, pd)
+	b.mu.Unlock()
+	return nil
+}
+
+func (b *blockingBackend) RemovePolicy(_ policies.PolicyData) error { return nil }
+
+func (b *blockingBackend) appliedVersions(id string) []int32 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	var versions []int32
+	for _, pd := range b.applied {
+		if pd.ID == id {
+			versions = append(versions, pd.Version)
+		}
+	}
+	return versions
+}
+
+// waitFor fails the test instead of hanging when a goroutine that should
+// have reached a point never does (the re-entrancy deadlock this mutex must
+// never introduce).
+func waitFor(t *testing.T, ch <-chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("%s did not happen within 5s; a goroutine is probably deadlocked on the apply mutex", what)
+	}
+}
+
+// Every policy operation for one backend waits for any other in flight for
+// that backend: a manage that arrives while the applier holds the backend's
+// mutex is applied after it, not interleaved with it.
+func TestManagePolicyWaitsForAnApplierHoldingTheBackendsMutex(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	be := newBlockingBackend("mutex_backend", "held", 1)
+	backend.Register("mutex_backend", be)
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	require.NoError(t, mgr.GetRepo().Update(policies.PolicyData{ID: "held", Name: "Held", Backend: "mutex_backend", Version: 1, Data: map[string]any{}, State: policies.Unknown}))
+	secretsMgr.On("SolvePolicySecrets", mock.MatchedBy(func(p config.PolicyPayload) bool { return p.ID == "held" })).
+		Return(config.PolicyPayload{ID: "held", Name: "Held", Backend: "mutex_backend", Version: 1, Data: map[string]any{}}, nil).Maybe()
+	incoming := config.PolicyPayload{Action: "manage", ID: "new", Name: "New", Backend: "mutex_backend", Version: 1, Data: map[string]any{}, DatasetID: "ds-new"}
+	secretsMgr.On("SolvePolicySecrets", incoming).Return(incoming, nil).Maybe()
+
+	applierDone := make(chan struct{})
+	go func() { _ = mgr.ApplyBackendPolicies("mutex_backend", be); close(applierDone) }()
+	waitFor(t, be.entered, "the applier reaching the backend") // it now holds the mutex inside ApplyPolicy
+
+	manageDone := make(chan struct{})
+	go func() { mgr.ManagePolicy(incoming); close(manageDone) }()
+	select {
+	case <-manageDone:
+		t.Fatal("the manage completed while the applier held the backend's mutex")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(be.release)
+	waitFor(t, applierDone, "the applier finishing after release")
+	waitFor(t, manageDone, "the manage finishing after the applier released the mutex")
+	assert.Equal(t, []int32{1}, be.appliedVersions("held"))
+	assert.Equal(t, []int32{1}, be.appliedVersions("new"))
+}
+
+// Two operations on the same policy cannot interleave: a manage with a newer
+// version that arrives while the applier is re-applying the older one runs
+// after it, so the repo ends with the newer version and the applier's stale
+// copy is never written back over it.
+func TestManageOfTheSamePolicyIsNotLostUnderAConcurrentApplier(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := &mockSecretsManager{passthrough: true}
+	be := newBlockingBackend("same_policy_backend", "same", 1)
+	backend.Register("same_policy_backend", be)
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	require.NoError(t, mgr.GetRepo().Update(policies.PolicyData{ID: "same", Name: "Same", Backend: "same_policy_backend", Version: 1, Data: map[string]any{}, State: policies.Unknown, Datasets: map[string]bool{"ds": true}}))
+	newer := config.PolicyPayload{Action: "manage", ID: "same", Name: "Same", Backend: "same_policy_backend", Version: 2, Data: map[string]any{}}
+
+	applierDone := make(chan struct{})
+	go func() { _ = mgr.ApplyBackendPolicies("same_policy_backend", be); close(applierDone) }()
+	waitFor(t, be.entered, "the applier reaching the backend")
+
+	manageDone := make(chan struct{})
+	go func() { mgr.ManagePolicy(newer); close(manageDone) }()
+	select {
+	case <-manageDone:
+		t.Fatal("the manage completed while the applier held the backend's mutex")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(be.release)
+	waitFor(t, applierDone, "the applier finishing after release")
+	waitFor(t, manageDone, "the manage finishing after the applier released the mutex")
+	assert.Equal(t, []int32{1, 2}, be.appliedVersions("same"), "each version applied exactly once, in order")
+	stored, err := mgr.GetRepo().Get("same")
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), stored.Version, "the applier's stale copy was not written back over the manage")
+	assert.Equal(t, policies.Running, stored.State)
+}
+
+// A manage whose payload names a different backend than the stored record
+// is refused with the record untouched: the two backends have different
+// mutexes, so a move would let the policy run on both with nothing left to
+// remove the old copy.
+func TestManagePolicyRefusesMovingAPolicyToAnotherBackend(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := &mockSecretsManager{passthrough: true}
+	first := &mockBackend{name: "move_first"}
+	first.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	first.On("RemovePolicy", mock.Anything).Return(nil).Maybe()
+	second := &mockBackend{name: "move_second"}
+	second.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	second.On("ApplyPolicy", mock.Anything, mock.Anything).Return(nil).Maybe()
+	backend.Register("move_first", first)
+	backend.Register("move_second", second)
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	stored := policies.PolicyData{ID: "mover", Name: "Mover", Backend: "move_first", Version: 1, Data: map[string]any{}, State: policies.Running, Datasets: map[string]bool{"ds": true}}
+	require.NoError(t, mgr.GetRepo().Update(stored))
+
+	mgr.ManagePolicy(config.PolicyPayload{Action: "manage", ID: "mover", Name: "Mover", Backend: "move_second", Version: 2, Data: map[string]any{}})
+
+	second.AssertNotCalled(t, "ApplyPolicy", mock.Anything, mock.Anything)
+	first.AssertNotCalled(t, "RemovePolicy", mock.Anything)
+	after, err := mgr.GetRepo().Get("mover")
+	require.NoError(t, err)
+	assert.Equal(t, stored.Backend, after.Backend)
+	assert.Equal(t, stored.Version, after.Version)
+	assert.Equal(t, policies.Running, after.State)
+}
+
+// The secrets refresh removes a policy the provider no longer allows through
+// the same removal the remove action uses; both run inside the backend's
+// critical section without taking the mutex twice.
+func TestRemovalsInsideTheCriticalSectionDoNotDeadlock(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	be := &mockBackend{name: "reentrant_backend"}
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	be.On("RemovePolicy", mock.Anything).Return(nil).Maybe()
+	backend.Register("reentrant_backend", be)
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	for _, id := range []string{"gone-1", "gone-2"} {
+		require.NoError(t, mgr.GetRepo().Update(policies.PolicyData{ID: id, Name: id, Backend: "reentrant_backend", Version: 1, Data: map[string]any{}, State: policies.Running}))
+	}
+
+	done := make(chan struct{})
+	go func() {
+		secretsMgr.TriggerCallbacks(map[string]bool{"gone-1": false})
+		mgr.ManagePolicy(config.PolicyPayload{Action: "remove", ID: "gone-2", Name: "gone-2", Backend: "reentrant_backend"})
+		close(done)
+	}()
+	waitFor(t, done, "the two removals")
+	state, err := mgr.GetPolicyState()
+	require.NoError(t, err)
+	assert.Empty(t, policyIDs(state))
+}
+
+// A policy removed while the secrets refresh was about to re-apply it is not
+// resurrected: the refresh re-reads the record under the backend's mutex and
+// finds it gone.
+func TestPoliciesChangedDoesNotResurrectARemovedPolicy(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := &mockSecretsManager{passthrough: true}
+	be := newBlockingBackend("resurrect_backend", "victim", 1) // its RemovePolicy override returns nil
+	backend.Register("resurrect_backend", be)
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	require.NoError(t, mgr.GetRepo().Update(policies.PolicyData{ID: "victim", Name: "Victim", Backend: "resurrect_backend", Version: 1, Data: map[string]any{}, State: policies.Running}))
+
+	// the applier holds the mutex; the refresh queues behind it having read
+	// nothing yet, and a remove that also queues behind it lands first
+	applierDone := make(chan struct{})
+	go func() { _ = mgr.ApplyBackendPolicies("resurrect_backend", be); close(applierDone) }()
+	waitFor(t, be.entered, "the applier reaching the backend")
+	removeDone := make(chan struct{})
+	go func() { _ = mgr.RemovePolicy("victim", "Victim", "resurrect_backend"); close(removeDone) }()
+	time.Sleep(50 * time.Millisecond) // let the remove queue on the mutex first
+	refreshDone := make(chan struct{})
+	go func() { secretsMgr.TriggerCallbacks(map[string]bool{"victim": true}); close(refreshDone) }()
+	time.Sleep(50 * time.Millisecond)
+
+	close(be.release)
+	waitFor(t, applierDone, "the applier finishing")
+	waitFor(t, removeDone, "the remove finishing")
+	waitFor(t, refreshDone, "the refresh finishing")
+	assert.False(t, mgr.GetRepo().Exists("victim"), "the refresh must not write a removed policy back")
+	assert.Equal(t, []int32{1}, be.appliedVersions("victim"), "only the applier applied it")
+}
+
+// A policy moved to another backend while the secrets refresh was queued on
+// the old backend's mutex is left untouched: refreshPolicyLocked re-reads the
+// record under the lock it holds and, finding the record now names a
+// different backend, skips rather than acting on it under the wrong mutex.
+func TestRefreshPolicySkipsAPolicyMovedToAnotherBackendWhileQueued(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := &mockSecretsManager{passthrough: true}
+	from := newBlockingBackend("moved_from_backend", "blocker", 1)
+	backend.Register("moved_from_backend", from)
+	to := &mockBackend{name: "moved_to_backend"}
+	to.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	backend.Register("moved_to_backend", to)
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	require.NoError(t, mgr.GetRepo().Update(policies.PolicyData{ID: "held", Name: "Held", Backend: "moved_from_backend", Version: 1, Data: map[string]any{}, State: policies.Running}))
+
+	// a manage on an unrelated policy on the same backend holds the mutex,
+	// without touching "held"'s record, so it can block without racing the
+	// repo mutation below
+	blockerDone := make(chan struct{})
+	go func() {
+		mgr.ManagePolicy(config.PolicyPayload{Action: "manage", ID: "blocker", Name: "Blocker", Backend: "moved_from_backend", Version: 1, Data: map[string]any{}, DatasetID: "ds-blocker"})
+		close(blockerDone)
+	}()
+	waitFor(t, from.entered, "the blocking manage reaching the backend")
+
+	refreshDone := make(chan struct{})
+	go func() { secretsMgr.TriggerCallbacks(map[string]bool{"held": true}); close(refreshDone) }()
+	time.Sleep(50 * time.Millisecond) // let the refresh read "held"'s current backend and queue on its mutex
+
+	require.NoError(t, mgr.GetRepo().Update(policies.PolicyData{ID: "held", Name: "Held", Backend: "moved_to_backend", Version: 1, Data: map[string]any{}, State: policies.Running}))
+
+	close(from.release)
+	waitFor(t, blockerDone, "the blocking manage finishing")
+	waitFor(t, refreshDone, "the refresh finishing")
+
+	to.AssertNotCalled(t, "ApplyPolicy", mock.Anything, mock.Anything)
+	stored, err := mgr.GetRepo().Get("held")
+	require.NoError(t, err)
+	assert.Equal(t, "moved_to_backend", stored.Backend, "the refresh must not act on a policy that moved to another backend while queued")
 }

--- a/agent/policymgr/manager_test.go
+++ b/agent/policymgr/manager_test.go
@@ -518,7 +518,7 @@ func TestApplyBackendPoliciesAppliesOnlyThatBackendsPoliciesWithSolvedSecrets(t 
 	// the assertions below instead of panicking inside testify
 	mine.On("ApplyPolicy", mock.Anything, mock.Anything).Return(nil).Maybe()
 
-	require.NoError(t, mgr.ApplyBackendPolicies("applier_mine", mine))
+	require.NoError(t, mgr.ApplyBackendPolicies(context.Background(), "applier_mine", mine))
 
 	mine.AssertExpectations(t)
 	secretsMgr.AssertExpectations(t)
@@ -549,7 +549,7 @@ func TestApplyBackendPoliciesLeavesPoliciesWhenTheBackendIsNotRunning(t *testing
 	require.NoError(t, err)
 	require.NoError(t, mgr.GetRepo().Update(policies.PolicyData{ID: "flaky-1", Name: "Flaky One", Backend: "applier_flaky", Version: 1, Data: map[string]any{}, State: policies.Unknown}))
 
-	err = mgr.ApplyBackendPolicies("applier_flaky", flaky)
+	err = mgr.ApplyBackendPolicies(context.Background(), "applier_flaky", flaky)
 
 	require.ErrorIs(t, err, policymgr.ErrBackendNotRunning)
 	flaky.AssertNotCalled(t, "ApplyPolicy", mock.Anything, mock.Anything)
@@ -579,7 +579,7 @@ func TestApplyBackendPoliciesFailsOnlyThePolicyWhoseSecretsCannotBeSolved(t *tes
 	be.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool { return pd.ID == "sec-good" }), true).Return(nil).Once()
 	be.On("ApplyPolicy", mock.Anything, mock.Anything).Return(nil).Maybe() // after the specific one, see the first test
 
-	require.NoError(t, mgr.ApplyBackendPolicies("applier_secrets", be))
+	require.NoError(t, mgr.ApplyBackendPolicies(context.Background(), "applier_secrets", be))
 
 	be.AssertExpectations(t)
 	secretsMgr.AssertExpectations(t)
@@ -611,7 +611,7 @@ func TestApplyBackendPoliciesFailsOnlyThePolicyTheBackendRejects(t *testing.T) {
 	be.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool { return pd.ID == "be-good" }), true).Return(nil).Once()
 	be.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool { return pd.ID == "be-bad" }), true).Return(errors.New("failed to apply")).Once()
 
-	require.NoError(t, mgr.ApplyBackendPolicies("applier_backend_fail", be))
+	require.NoError(t, mgr.ApplyBackendPolicies(context.Background(), "applier_backend_fail", be))
 
 	be.AssertExpectations(t)
 	secretsMgr.AssertExpectations(t)
@@ -620,6 +620,80 @@ func TestApplyBackendPoliciesFailsOnlyThePolicyTheBackendRejects(t *testing.T) {
 	assert.Equal(t, policies.Running, good.State)
 	assert.Equal(t, policies.FailedToApply, bad.State)
 	assert.Equal(t, "failed to apply", bad.BackendErr)
+}
+
+// A context cancelled partway through the loop stops the replay before the
+// next policy: the one already applied keeps its outcome, the one never
+// reached stays unknown, and the call reports the cancellation so the caller
+// knows the remaining policies were left untouched rather than applied.
+func TestApplyBackendPoliciesStopsWhenTheContextIsCancelledMidLoop(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := &mockSecretsManager{passthrough: true}
+	be := &mockBackend{name: "midloop_backend"}
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	repo := mgr.GetRepo()
+	require.NoError(t, repo.Update(policies.PolicyData{ID: "first", Name: "first", Backend: "midloop_backend", Version: 1, Data: map[string]any{}, State: policies.Unknown}))
+	require.NoError(t, repo.Update(policies.PolicyData{ID: "second", Name: "second", Backend: "midloop_backend", Version: 1, Data: map[string]any{}, State: policies.Unknown}))
+
+	// GetAll iterates a map, so which record is applied first is not fixed;
+	// whichever one is, its own ApplyPolicy call cancels the context, and the
+	// assertions below check the outcome by state rather than by ID.
+	ctx, cancel := context.WithCancel(context.Background())
+	be.On("ApplyPolicy", mock.Anything, true).
+		Run(func(_ mock.Arguments) { cancel() }).
+		Return(nil).Once()
+
+	err = mgr.ApplyBackendPolicies(ctx, "midloop_backend", be)
+
+	require.ErrorIs(t, err, context.Canceled)
+	be.AssertExpectations(t) // exactly one ApplyPolicy call: a second would panic on the exhausted expectation
+	state, err := mgr.GetPolicyState()
+	require.NoError(t, err)
+	var running, unknown int
+	for _, pd := range state {
+		switch pd.State {
+		case policies.Running:
+			running++
+		case policies.Unknown:
+			unknown++
+		}
+	}
+	assert.Equal(t, 1, running, "the policy reached before the cancellation was applied")
+	assert.Equal(t, 1, unknown, "the policy never reached stays as it was")
+}
+
+// A record already Running reflects the current process: every restart marks
+// a backend's policies unknown before stopping it, and a manage during a
+// restart is stored failed to apply rather than running, so a running record
+// can only have been applied by this same process already. Skipping it is
+// what lets the replay run more than once (the restart's second pass, after
+// the mutex is released) without applying a policy twice.
+func TestApplyBackendPoliciesSkipsPoliciesAlreadyRunning(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := &mockSecretsManager{passthrough: true}
+	be := &mockBackend{name: "skip_running_backend"}
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	repo := mgr.GetRepo()
+	require.NoError(t, repo.Update(policies.PolicyData{ID: "already-running", Name: "already-running", Backend: "skip_running_backend", Version: 1, Data: map[string]any{}, State: policies.Running}))
+	require.NoError(t, repo.Update(policies.PolicyData{ID: "not-yet", Name: "not-yet", Backend: "skip_running_backend", Version: 1, Data: map[string]any{}, State: policies.Unknown}))
+
+	be.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool { return pd.ID == "not-yet" }), true).Return(nil).Once()
+
+	require.NoError(t, mgr.ApplyBackendPolicies(context.Background(), "skip_running_backend", be))
+
+	be.AssertExpectations(t) // the running record calling ApplyPolicy again would panic on the exhausted expectation
+	alreadyRunning, err := repo.Get("already-running")
+	require.NoError(t, err)
+	assert.Equal(t, policies.Running, alreadyRunning.State)
+	notYet, err := repo.Get("not-yet")
+	require.NoError(t, err)
+	assert.Equal(t, policies.Running, notYet.State)
 }
 
 // The state monitor calls repo.UpdateRuns for a policy at any time and does
@@ -643,7 +717,7 @@ func TestApplyBackendPoliciesKeepsRunUpdatesWrittenDuringTheApply(t *testing.T) 
 		}).
 		Return(nil).Once()
 
-	require.NoError(t, mgr.ApplyBackendPolicies("applier_runs", be))
+	require.NoError(t, mgr.ApplyBackendPolicies(context.Background(), "applier_runs", be))
 
 	be.AssertExpectations(t)
 	stored, err := repo.Get("runs-1")
@@ -1872,7 +1946,7 @@ func TestManagePolicyWaitsForAnApplierHoldingTheBackendsMutex(t *testing.T) {
 	secretsMgr.On("SolvePolicySecrets", incoming).Return(incoming, nil).Maybe()
 
 	applierDone := make(chan struct{})
-	go func() { _ = mgr.ApplyBackendPolicies("mutex_backend", be); close(applierDone) }()
+	go func() { _ = mgr.ApplyBackendPolicies(context.Background(), "mutex_backend", be); close(applierDone) }()
 	waitFor(t, be.entered, "the applier reaching the backend") // it now holds the mutex inside ApplyPolicy
 
 	manageDone := make(chan struct{})
@@ -1908,7 +1982,10 @@ func TestManageOfTheSamePolicyIsNotLostUnderAConcurrentApplier(t *testing.T) {
 	newer := config.PolicyPayload{Action: "manage", ID: "same", Name: "Same", Backend: "same_policy_backend", Version: 2, Data: map[string]any{}}
 
 	applierDone := make(chan struct{})
-	go func() { _ = mgr.ApplyBackendPolicies("same_policy_backend", be); close(applierDone) }()
+	go func() {
+		_ = mgr.ApplyBackendPolicies(context.Background(), "same_policy_backend", be)
+		close(applierDone)
+	}()
 	waitFor(t, be.entered, "the applier reaching the backend")
 
 	manageDone := make(chan struct{})
@@ -1998,7 +2075,7 @@ func TestPoliciesChangedDoesNotResurrectARemovedPolicy(t *testing.T) {
 	backend.Register("resurrect_backend", be)
 	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
 	require.NoError(t, err)
-	require.NoError(t, mgr.GetRepo().Update(policies.PolicyData{ID: "victim", Name: "Victim", Backend: "resurrect_backend", Version: 1, Data: map[string]any{}, State: policies.Running}))
+	require.NoError(t, mgr.GetRepo().Update(policies.PolicyData{ID: "victim", Name: "Victim", Backend: "resurrect_backend", Version: 1, Data: map[string]any{}, State: policies.Unknown}))
 
 	// the applier holds the mutex; the refresh queues behind it having read
 	// nothing yet, and a remove that also queues behind it lands first.
@@ -2006,7 +2083,10 @@ func TestPoliciesChangedDoesNotResurrectARemovedPolicy(t *testing.T) {
 	// a lost sleep race here fails the appliedVersions assertion below
 	// cleanly rather than panicking on an unregistered call.
 	applierDone := make(chan struct{})
-	go func() { _ = mgr.ApplyBackendPolicies("resurrect_backend", be); close(applierDone) }()
+	go func() {
+		_ = mgr.ApplyBackendPolicies(context.Background(), "resurrect_backend", be)
+		close(applierDone)
+	}()
 	waitFor(t, be.entered, "the applier reaching the backend")
 	removeDone := make(chan struct{})
 	go func() { _ = mgr.RemovePolicy("victim", "Victim", "resurrect_backend"); close(removeDone) }()

--- a/agent/policymgr/manager_test.go
+++ b/agent/policymgr/manager_test.go
@@ -1961,3 +1961,108 @@ func TestRefreshPolicySkipsAPolicyMovedToAnotherBackendWhileQueued(t *testing.T)
 	require.NoError(t, err)
 	assert.Equal(t, "moved_to_backend", stored.Backend, "the refresh must not act on a policy that moved to another backend while queued")
 }
+
+// fakeStarter answers EnsureStarted with a fixed state or error and counts
+// the calls.
+type fakeStarter struct {
+	state policymgr.StartState
+	err   error
+	calls []string
+}
+
+func (f *fakeStarter) EnsureStarted(name string) (policymgr.StartState, error) {
+	f.calls = append(f.calls, name)
+	return f.state, f.err
+}
+
+// A backend the starter reports as starting does not receive the policy
+// yet: it is stored as failed to apply with "backend starting", the reason
+// the supervisor's applier will replace once the backend is running.
+func TestManagePolicyStoresAPolicyForABackendThatIsStarting(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := &mockSecretsManager{passthrough: true}
+	be := &mockBackend{name: "starter_backend"}
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	be.On("ApplyPolicy", mock.Anything, mock.Anything).Return(nil).Maybe()
+	backend.Register("starter_backend", be)
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	starter := &fakeStarter{state: policymgr.StartStarting}
+	mgr.SetStarter(starter)
+	payload := config.PolicyPayload{Action: "manage", ID: "starting-1", Name: "Starting", Backend: "starter_backend", Version: 1, Data: map[string]any{}, DatasetID: "ds"}
+
+	mgr.ManagePolicy(payload)
+
+	assert.Equal(t, []string{"starter_backend"}, starter.calls)
+	be.AssertNotCalled(t, "ApplyPolicy", mock.Anything, mock.Anything)
+	stored, err := mgr.GetRepo().Get("starting-1")
+	require.NoError(t, err)
+	assert.Equal(t, policies.FailedToApply, stored.State)
+	assert.Equal(t, "backend starting", stored.BackendErr)
+	assert.Equal(t, map[string]bool{"ds": true}, stored.Datasets, "the dataset bookkeeping is persisted with the record")
+}
+
+// A starter that reports the backend running changes nothing: the policy is
+// applied as it is today.
+func TestManagePolicyAppliesWhenTheStarterReportsRunning(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	be := &mockBackend{name: "starter_running"}
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	backend.Register("starter_running", be)
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	mgr.SetStarter(&fakeStarter{state: policymgr.StartRunning})
+	payload := config.PolicyPayload{Action: "manage", ID: "running-1", Name: "Running", Backend: "starter_running", Version: 1, Data: map[string]any{}, DatasetID: "ds"}
+	secretsMgr.On("SolvePolicySecrets", payload).Return(payload, nil).Once()
+	be.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool { return pd.ID == "running-1" }), false).Return(nil).Once()
+
+	mgr.ManagePolicy(payload)
+
+	be.AssertExpectations(t)
+	stored, _ := mgr.GetRepo().Get("running-1")
+	assert.Equal(t, policies.Running, stored.State)
+}
+
+// A starter that cannot start the backend fails the policy with its reason.
+func TestManagePolicyStoresTheStartersError(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := &mockSecretsManager{passthrough: true}
+	be := &mockBackend{name: "starter_failing"}
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	be.On("ApplyPolicy", mock.Anything, mock.Anything).Return(nil).Maybe()
+	backend.Register("starter_failing", be)
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	mgr.SetStarter(&fakeStarter{err: errors.New("binary not found")})
+
+	mgr.ManagePolicy(config.PolicyPayload{Action: "manage", ID: "failing-1", Name: "Failing", Backend: "starter_failing", Version: 1, Data: map[string]any{}, DatasetID: "ds"})
+
+	be.AssertNotCalled(t, "ApplyPolicy", mock.Anything, mock.Anything)
+	stored, _ := mgr.GetRepo().Get("failing-1")
+	assert.Equal(t, policies.FailedToApply, stored.State)
+	assert.Equal(t, "binary not found", stored.BackendErr)
+}
+
+// The secrets refresh consults the starter the same way.
+func TestPoliciesChangedConsultsTheStarter(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := &mockSecretsManager{passthrough: true}
+	be := &mockBackend{name: "starter_refresh"}
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	be.On("ApplyPolicy", mock.Anything, mock.Anything).Return(nil).Maybe()
+	backend.Register("starter_refresh", be)
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	require.NoError(t, mgr.GetRepo().Update(policies.PolicyData{ID: "refresh-1", Name: "Refresh", Backend: "starter_refresh", Version: 1, Data: map[string]any{}, State: policies.Running}))
+	starter := &fakeStarter{state: policymgr.StartStarting}
+	mgr.SetStarter(starter)
+
+	secretsMgr.TriggerCallbacks(map[string]bool{"refresh-1": true})
+
+	assert.Equal(t, []string{"starter_refresh"}, starter.calls)
+	be.AssertNotCalled(t, "ApplyPolicy", mock.Anything, mock.Anything)
+	stored, _ := mgr.GetRepo().Get("refresh-1")
+	assert.Equal(t, policies.FailedToApply, stored.State)
+	assert.Equal(t, "backend starting", stored.BackendErr)
+}

--- a/agent/policymgr/manager_test.go
+++ b/agent/policymgr/manager_test.go
@@ -626,6 +626,31 @@ func TestApplyBackendPoliciesFailsOnlyThePolicyTheBackendRejects(t *testing.T) {
 // next policy: the one already applied keeps its outcome, the one never
 // reached stays unknown, and the call reports the cancellation so the caller
 // knows the remaining policies were left untouched rather than applied.
+// A replay whose context is already done when it gets the apply mutex does
+// not probe the backend at all: a shutdown that landed while it was queued
+// must not cost one more status round trip while Stop waits.
+func TestApplyBackendPoliciesDoesNotProbeTheBackendWhenTheContextIsAlreadyDone(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := &mockSecretsManager{passthrough: true}
+	be := &mockBackend{name: "applier_cancelled"}
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	be.On("ApplyPolicy", mock.Anything, mock.Anything).Return(nil).Maybe()
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	require.NoError(t, mgr.GetRepo().Update(policies.PolicyData{ID: "cancelled-1", Name: "Cancelled", Backend: "applier_cancelled", Version: 1, Data: map[string]any{}, State: policies.Unknown}))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = mgr.ApplyBackendPolicies(ctx, "applier_cancelled", be)
+
+	require.ErrorIs(t, err, context.Canceled)
+	be.AssertNotCalled(t, "GetRunningStatus")
+	be.AssertNotCalled(t, "ApplyPolicy", mock.Anything, mock.Anything)
+	stored, err := mgr.GetRepo().Get("cancelled-1")
+	require.NoError(t, err)
+	assert.Equal(t, policies.Unknown, stored.State)
+}
+
 func TestApplyBackendPoliciesStopsWhenTheContextIsCancelledMidLoop(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	secretsMgr := &mockSecretsManager{passthrough: true}

--- a/agent/policymgr/manager_test.go
+++ b/agent/policymgr/manager_test.go
@@ -2283,6 +2283,32 @@ func TestManageOfTheSamePolicyIsNotLostUnderAConcurrentApplier(t *testing.T) {
 // is refused with the record untouched: the two backends have different
 // mutexes, so a move would let the policy run on both with nothing left to
 // remove the old copy.
+// A remove action whose payload names a backend other than the one the
+// stored record runs on is refused with the record untouched: the removal
+// would otherwise go to the wrong backend while the record, the only state
+// left to remove the policy from its real backend, is deleted.
+func TestManagePolicyRefusesARemoveNamingAnotherBackend(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := &mockSecretsManager{passthrough: true}
+	actual := &mockBackend{name: "remove_actual"}
+	actual.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	actual.On("RemovePolicy", mock.Anything).Return(nil).Maybe()
+	stale := &mockBackend{name: "remove_stale"}
+	stale.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	stale.On("RemovePolicy", mock.Anything).Return(nil).Maybe()
+	backend.Register("remove_actual", actual)
+	backend.Register("remove_stale", stale)
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	require.NoError(t, mgr.GetRepo().Update(policies.PolicyData{ID: "kept", Name: "Kept", Backend: "remove_actual", Version: 1, Data: map[string]any{}, State: policies.Running}))
+
+	mgr.ManagePolicy(config.PolicyPayload{Action: "remove", ID: "kept", Name: "Kept", Backend: "remove_stale"})
+
+	stale.AssertNotCalled(t, "RemovePolicy", mock.Anything)
+	actual.AssertNotCalled(t, "RemovePolicy", mock.Anything)
+	assert.True(t, mgr.GetRepo().Exists("kept"), "the record stays, it is the only state left to remove the policy from its backend")
+}
+
 func TestManagePolicyRefusesMovingAPolicyToAnotherBackend(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	secretsMgr := &mockSecretsManager{passthrough: true}

--- a/agent/policymgr/manager_test.go
+++ b/agent/policymgr/manager_test.go
@@ -709,6 +709,61 @@ func TestApplyBackendPoliciesAppliesOnlyWhatTheRestartDeferred(t *testing.T) {
 	assert.Equal(t, policies.Running, alreadyRunning.State)
 }
 
+// A replay's per-policy probe (applyPolicy's own GetRunningStatus call, not
+// the loop's entry gate) can fail transiently while the backend is still
+// settling. That must stop the loop and leave the record it was checking, and
+// everything after it, exactly as read, rather than stamping the record
+// failed and letting the loop press on: a record stamped failed is excluded
+// from the next replay by deferredByRestart, so the policy would stay absent
+// until another delivery or restart.
+//
+// GetAll iterates a map, so which of the three records the loop reaches
+// first is not fixed. The mock is scripted by call order instead of by
+// policy identity: entry gate succeeds, the probe for whichever record is
+// reached first succeeds, and the probe for whichever is reached second
+// fails. The assertions below check outcomes by count rather than by ID, the
+// same way TestApplyBackendPoliciesStopsWhenTheContextIsCancelledMidLoop
+// does for the same reason.
+func TestApplyBackendPoliciesLeavesAPolicyDeferredWhenTheBackendStopsAnsweringMidReplay(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := &mockSecretsManager{passthrough: true}
+	be := &mockBackend{name: "midreplay_backend"}
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Once()                                           // entry gate
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Once()                                           // first record reached
+	be.On("GetRunningStatus").Return(backend.BackendError, "process running, REST API unavailable", nil).Once() // second record reached
+
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	repo := mgr.GetRepo()
+	require.NoError(t, repo.Update(policies.PolicyData{ID: "p1", Name: "p1", Backend: "midreplay_backend", Version: 1, Data: map[string]any{}, State: policies.Unknown}))
+	require.NoError(t, repo.Update(policies.PolicyData{ID: "p2", Name: "p2", Backend: "midreplay_backend", Version: 1, Data: map[string]any{}, State: policies.Unknown}))
+	require.NoError(t, repo.Update(policies.PolicyData{ID: "p3", Name: "p3", Backend: "midreplay_backend", Version: 1, Data: map[string]any{}, State: policies.Unknown}))
+
+	be.On("ApplyPolicy", mock.Anything, true).Return(nil).Once()
+
+	err = mgr.ApplyBackendPolicies(context.Background(), "midreplay_backend", be)
+
+	require.ErrorIs(t, err, policymgr.ErrBackendNotRunning)
+	be.AssertExpectations(t) // a second ApplyPolicy call, or a fourth GetRunningStatus call, would panic on the exhausted expectations
+
+	state, err := mgr.GetPolicyState()
+	require.NoError(t, err)
+	var running, unknown int
+	for _, pd := range state {
+		switch pd.State {
+		case policies.Running:
+			running++
+		case policies.Unknown:
+			unknown++
+			assert.Empty(t, pd.BackendErr, "a record the loop never reached, or left as read after the probe refused, must not carry a failure reason")
+		default:
+			t.Fatalf("unexpected state %v for policy %s", pd.State, pd.ID)
+		}
+	}
+	assert.Equal(t, 1, running, "the record reached before the probe refused was applied")
+	assert.Equal(t, 2, unknown, "the record the probe refused, and the one never reached, are left for the caller's retry")
+}
+
 // The state monitor calls repo.UpdateRuns for a policy at any time and does
 // not take the backend's apply mutex, so a run it writes while an apply's
 // HTTP call to the backend is in flight must survive the write-back that

--- a/agent/policymgr/manager_test.go
+++ b/agent/policymgr/manager_test.go
@@ -1254,6 +1254,75 @@ func TestManageStaysDeferredWhileTheReplayGateFails(t *testing.T) {
 	assert.Equal(t, policies.Running, deferredStored.State)
 }
 
+// A replay that exits on a per-policy probe failure (not the entry gate)
+// must leave the restart marker set too: clearing it right after the entry
+// gate let a manage arriving during the caller's retry delay reach the
+// backend directly, get stamped with the probe's own transient reason, and
+// be excluded from the next replay by deferredByRestart.
+func TestManageStaysDeferredWhileAReplayExitsOnAPerPolicyProbeFailure(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := &mockSecretsManager{passthrough: true}
+	be := &mockBackend{name: "midreplay_marker_backend"}
+	backend.Register("midreplay_marker_backend", be)
+
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	repo := mgr.GetRepo()
+
+	// Set the restart marker with an empty repo, so this sets the flag
+	// without exercising any backend call, then seed the two policies the
+	// replay below will reach.
+	require.NoError(t, mgr.RemoveBackendPolicies("midreplay_marker_backend", be, false))
+	require.NoError(t, repo.Update(policies.PolicyData{ID: "p1", Name: "p1", Backend: "midreplay_marker_backend", Version: 1, Data: map[string]any{}, State: policies.Unknown}))
+	require.NoError(t, repo.Update(policies.PolicyData{ID: "p2", Name: "p2", Backend: "midreplay_marker_backend", Version: 1, Data: map[string]any{}, State: policies.Unknown}))
+
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Once()                                           // entry gate
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Once()                                           // first policy reached
+	be.On("GetRunningStatus").Return(backend.BackendError, "process running, REST API unavailable", nil).Once() // second policy reached
+	be.On("ApplyPolicy", mock.Anything, true).Return(nil).Once()                                                // the one record the loop reaches before the probe fails
+
+	err = mgr.ApplyBackendPolicies(context.Background(), "midreplay_marker_backend", be)
+	require.ErrorIs(t, err, policymgr.ErrBackendNotRunning)
+
+	// A manage during the retry delay must stay deferred, not reach the
+	// backend: the marker is still set because this replay exited on the
+	// per-policy probe rather than completing.
+	mgr.ManagePolicy(config.PolicyPayload{
+		Action: "manage", ID: "new-during-retry", Name: "new-during-retry",
+		Backend: "midreplay_marker_backend", DatasetID: "d1", Version: 1, Data: map[string]any{},
+	})
+	deferredManage, err := repo.Get("new-during-retry")
+	require.NoError(t, err)
+	assert.Equal(t, policies.FailedToApply, deferredManage.State, "a manage during the retry delay must stay deferred")
+	assert.Equal(t, policymgr.ReasonBackendStarting, deferredManage.BackendErr)
+
+	// A second, successful replay applies the seeded record the first replay
+	// never reached, plus the manage stored as starting, each exactly once.
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	be.On("ApplyPolicy", mock.Anything, true).Return(nil).Times(2)
+
+	require.NoError(t, mgr.ApplyBackendPolicies(context.Background(), "midreplay_marker_backend", be))
+	be.AssertExpectations(t) // a third ApplyPolicy call here would panic on the exhausted expectation
+
+	for _, id := range []string{"p1", "p2", "new-during-retry"} {
+		stored, err := repo.Get(id)
+		require.NoError(t, err)
+		assert.Equal(t, policies.Running, stored.State, "id %s must be running once the replay completed", id)
+	}
+
+	// Once that replay has completed, a manage arriving afterwards applies
+	// directly rather than waiting for another replay.
+	be.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool { return pd.ID == "after-replay" }), false).Return(nil).Once()
+	mgr.ManagePolicy(config.PolicyPayload{
+		Action: "manage", ID: "after-replay", Name: "after-replay",
+		Backend: "midreplay_marker_backend", DatasetID: "d2", Version: 1, Data: map[string]any{},
+	})
+	afterReplay, err := repo.Get("after-replay")
+	require.NoError(t, err)
+	assert.Equal(t, policies.Running, afterReplay.State)
+	be.AssertExpectations(t)
+}
+
 // A permanent removal is not the start of a restart, so it must not defer
 // manages: one arriving afterwards applies directly.
 func TestPermanentRemovalDoesNotDeferManages(t *testing.T) {
@@ -2239,6 +2308,59 @@ func TestManagePolicyRefusesMovingAPolicyToAnotherBackend(t *testing.T) {
 	assert.Equal(t, stored.Backend, after.Backend)
 	assert.Equal(t, stored.Version, after.Version)
 	assert.Equal(t, policies.Running, after.State)
+}
+
+// A remove naming a backend other than the one the stored record runs on is
+// refused: acting on it would remove from the caller's backend and delete the
+// record, stranding the backend the record actually names with the policy
+// still running and no state left to remove it from.
+func TestRemovePolicyRefusesABackendOtherThanTheStoredOne(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	beA := &mockBackend{name: "remove_refuse_a"}
+	beB := &mockBackend{name: "remove_refuse_b"}
+	backend.Register("remove_refuse_a", beA)
+	backend.Register("remove_refuse_b", beB)
+
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	require.NoError(t, mgr.GetRepo().Update(policies.PolicyData{ID: "moved", Name: "moved", Backend: "remove_refuse_b", Version: 1, Data: map[string]any{}, State: policies.Running}))
+
+	err = mgr.RemovePolicy("moved", "moved", "remove_refuse_a")
+	require.Error(t, err)
+
+	beA.AssertNotCalled(t, "RemovePolicy", mock.Anything)
+	beB.AssertNotCalled(t, "RemovePolicy", mock.Anything)
+	stored, err := mgr.GetRepo().Get("moved")
+	require.NoError(t, err)
+	assert.Equal(t, "remove_refuse_b", stored.Backend, "the record must be untouched")
+}
+
+// Same shape as TestRemovePolicyRefusesABackendOtherThanTheStoredOne, for the
+// dataset removal: a caller naming a backend other than the stored one is
+// refused, and the dataset stays.
+func TestRemovePolicyDatasetRefusesABackendOtherThanTheStoredOne(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	beA := &mockBackend{name: "remove_ds_refuse_a"}
+	beB := &mockBackend{name: "remove_ds_refuse_b"}
+	backend.Register("remove_ds_refuse_a", beA)
+	backend.Register("remove_ds_refuse_b", beB)
+
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	require.NoError(t, mgr.GetRepo().Update(policies.PolicyData{
+		ID: "moved-ds", Name: "moved-ds", Backend: "remove_ds_refuse_b", Version: 1,
+		Data: map[string]any{}, State: policies.Running, Datasets: map[string]bool{"ds1": true},
+	}))
+
+	mgr.RemovePolicyDataset("moved-ds", "ds1", "remove_ds_refuse_a", beA)
+
+	beA.AssertNotCalled(t, "RemovePolicy", mock.Anything)
+	beB.AssertNotCalled(t, "RemovePolicy", mock.Anything)
+	stored, err := mgr.GetRepo().Get("moved-ds")
+	require.NoError(t, err)
+	assert.Contains(t, stored.Datasets, "ds1", "the dataset must stay")
 }
 
 // The secrets refresh removes a policy the provider no longer allows through

--- a/agent/policymgr/manager_test.go
+++ b/agent/policymgr/manager_test.go
@@ -1796,7 +1796,10 @@ func TestManagePolicyWaitsForAnApplierHoldingTheBackendsMutex(t *testing.T) {
 // Two operations on the same policy cannot interleave: a manage with a newer
 // version that arrives while the applier is re-applying the older one runs
 // after it, so the repo ends with the newer version and the applier's stale
-// copy is never written back over it.
+// copy is never written back over it. This is the spec's "a policy
+// persisted between the starter's decision and the applier's read is
+// applied by exactly one of them", exercised here through the applier alone,
+// since no starter exists yet.
 func TestManageOfTheSamePolicyIsNotLostUnderAConcurrentApplier(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	secretsMgr := &mockSecretsManager{passthrough: true}
@@ -1901,7 +1904,10 @@ func TestPoliciesChangedDoesNotResurrectARemovedPolicy(t *testing.T) {
 	require.NoError(t, mgr.GetRepo().Update(policies.PolicyData{ID: "victim", Name: "Victim", Backend: "resurrect_backend", Version: 1, Data: map[string]any{}, State: policies.Running}))
 
 	// the applier holds the mutex; the refresh queues behind it having read
-	// nothing yet, and a remove that also queues behind it lands first
+	// nothing yet, and a remove that also queues behind it lands first.
+	// be is the hand-written blockingBackend, not a testify expectation, so
+	// a lost sleep race here fails the appliedVersions assertion below
+	// cleanly rather than panicking on an unregistered call.
 	applierDone := make(chan struct{})
 	go func() { _ = mgr.ApplyBackendPolicies("resurrect_backend", be); close(applierDone) }()
 	waitFor(t, be.entered, "the applier reaching the backend")
@@ -1931,6 +1937,10 @@ func TestRefreshPolicySkipsAPolicyMovedToAnotherBackendWhileQueued(t *testing.T)
 	backend.Register("moved_from_backend", from)
 	to := &mockBackend{name: "moved_to_backend"}
 	to.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	// Permissive stub so a lost sleep race (the refresh reading the record
+	// after the move instead of before) fails the AssertNotCalled assertion
+	// below cleanly instead of panicking on an unregistered expectation.
+	to.On("ApplyPolicy", mock.Anything, mock.Anything).Return(nil).Maybe()
 	backend.Register("moved_to_backend", to)
 	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
 	require.NoError(t, err)
@@ -1963,16 +1973,31 @@ func TestRefreshPolicySkipsAPolicyMovedToAnotherBackendWhileQueued(t *testing.T)
 }
 
 // fakeStarter answers EnsureStarted with a fixed state or error and counts
-// the calls.
+// the calls under a mutex: EnsureStarted is called under a per-backend
+// mutex, so two backends sharing one starter can reach it concurrently.
 type fakeStarter struct {
 	state policymgr.StartState
 	err   error
+
+	mu    sync.Mutex
 	calls []string
 }
 
 func (f *fakeStarter) EnsureStarted(name string) (policymgr.StartState, error) {
+	f.mu.Lock()
 	f.calls = append(f.calls, name)
+	f.mu.Unlock()
 	return f.state, f.err
+}
+
+// callsSeen returns a snapshot of the backend names EnsureStarted was
+// called with, safe to read while other goroutines may still be calling it.
+func (f *fakeStarter) callsSeen() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.calls))
+	copy(out, f.calls)
+	return out
 }
 
 // A backend the starter reports as starting does not receive the policy
@@ -1993,7 +2018,7 @@ func TestManagePolicyStoresAPolicyForABackendThatIsStarting(t *testing.T) {
 
 	mgr.ManagePolicy(payload)
 
-	assert.Equal(t, []string{"starter_backend"}, starter.calls)
+	assert.Equal(t, []string{"starter_backend"}, starter.callsSeen())
 	be.AssertNotCalled(t, "ApplyPolicy", mock.Anything, mock.Anything)
 	stored, err := mgr.GetRepo().Get("starting-1")
 	require.NoError(t, err)
@@ -2060,7 +2085,7 @@ func TestPoliciesChangedConsultsTheStarter(t *testing.T) {
 
 	secretsMgr.TriggerCallbacks(map[string]bool{"refresh-1": true})
 
-	assert.Equal(t, []string{"starter_refresh"}, starter.calls)
+	assert.Equal(t, []string{"starter_refresh"}, starter.callsSeen())
 	be.AssertNotCalled(t, "ApplyPolicy", mock.Anything, mock.Anything)
 	stored, _ := mgr.GetRepo().Get("refresh-1")
 	assert.Equal(t, policies.FailedToApply, stored.State)

--- a/agent/policymgr/manager_test.go
+++ b/agent/policymgr/manager_test.go
@@ -622,6 +622,70 @@ func TestApplyBackendPoliciesFailsOnlyThePolicyTheBackendRejects(t *testing.T) {
 	assert.Equal(t, "failed to apply", bad.BackendErr)
 }
 
+// The state monitor calls repo.UpdateRuns for a policy at any time and does
+// not take the backend's apply mutex, so a run it writes while an apply's
+// HTTP call to the backend is in flight must survive the write-back that
+// follows the apply.
+func TestApplyBackendPoliciesKeepsRunUpdatesWrittenDuringTheApply(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := &mockSecretsManager{passthrough: true}
+	be := &mockBackend{name: "applier_runs"}
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	repo := mgr.GetRepo()
+	require.NoError(t, repo.Update(policies.PolicyData{ID: "runs-1", Name: "Runs One", Backend: "applier_runs", Version: 1, Data: map[string]any{}, State: policies.Unknown}))
+
+	be.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool { return pd.ID == "runs-1" }), true).
+		Run(func(_ mock.Arguments) {
+			require.NoError(t, repo.UpdateRuns("Runs One", []policies.RunData{{ID: "run-1", Status: "running"}}))
+		}).
+		Return(nil).Once()
+
+	require.NoError(t, mgr.ApplyBackendPolicies("applier_runs", be))
+
+	be.AssertExpectations(t)
+	stored, err := repo.Get("runs-1")
+	require.NoError(t, err)
+	assert.Equal(t, policies.Running, stored.State)
+	require.Len(t, stored.Runs, 1, "the run written during the apply must not be discarded by the write-back")
+	assert.Equal(t, "run-1", stored.Runs[0].ID)
+}
+
+// Same as above, through the secrets-refresh path (refreshPolicyLocked)
+// instead of the applier: a run written mid-apply must survive that
+// write-back too.
+func TestSecretsRefreshKeepsRunUpdatesWrittenDuringTheApply(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	secretsMgr := new(mockSecretsManager)
+	be := &mockBackend{name: "refresher_runs"}
+	be.On("GetRunningStatus").Return(backend.Running, "", nil).Maybe()
+	backend.Register("refresher_runs", be)
+
+	mgr, err := policymgr.New(logger, secretsMgr, config.Config{})
+	require.NoError(t, err)
+	repo := mgr.GetRepo()
+	require.NoError(t, repo.Update(policies.PolicyData{ID: "runs-2", Name: "Runs Two", Backend: "refresher_runs", Version: 1, Data: map[string]any{}, State: policies.Unknown}))
+
+	solved := config.PolicyPayload{ID: "runs-2", Name: "Runs Two", Backend: "refresher_runs", Version: 1, Data: map[string]any{}}
+	secretsMgr.On("SolvePolicySecrets", mock.MatchedBy(func(p config.PolicyPayload) bool { return p.ID == "runs-2" })).Return(solved, nil)
+	be.On("ApplyPolicy", mock.MatchedBy(func(pd policies.PolicyData) bool { return pd.ID == "runs-2" }), true).
+		Run(func(_ mock.Arguments) {
+			require.NoError(t, repo.UpdateRuns("Runs Two", []policies.RunData{{ID: "run-2", Status: "running"}}))
+		}).
+		Return(nil).Once()
+
+	secretsMgr.TriggerCallbacks(map[string]bool{"runs-2": true})
+
+	be.AssertExpectations(t)
+	stored, err := repo.Get("runs-2")
+	require.NoError(t, err)
+	assert.Equal(t, policies.Running, stored.State)
+	require.Len(t, stored.Runs, 1, "the run written during the apply must not be discarded by the write-back")
+	assert.Equal(t, "run-2", stored.Runs[0].ID)
+}
+
 func TestPoliciesChanged(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	secretsMgr := new(mockSecretsManager)


### PR DESCRIPTION
Second PR of the backend supervisor series (after #604). It makes the policy manager safe to drive from more than one goroutine and gives it the seam the supervisor will use, and it fixes a live loss: a backend restart deleted the backend's policies from the repo and never applied them again.

## What changes

**A restart re-applies the backend's own policies.** `RestartBackend` (health monitor and fleet reset) and the binary-upgrade restart (`restartBackendWithFilesmgrRollback`) both marked or dropped policies and never handed them back to the restarted process. Under the local manager the policies were gone for the life of the process; under git until the next commit; under fleet until the control plane resent a newer version, because the repo still claimed `Running` at the old version and the version gate skipped the resend. Both paths now mark the policies `Unknown` for the restart and apply them again after a successful reset or start. A failed reset or start leaves them `Unknown`, logs an error naming that consequence, and schedules the replay so a process that survived a failed stop still gets them back.

**`ApplyBackendPolicies(name, be)` rewritten.** It had no caller and could not be used as it stood: it applied every policy in the repo to whichever backend it was handed, with no running gate and with the secret references the repo keeps unsolved. It now applies only the named backend's policies a restart deferred: records marked unknown by the removal, records the state monitor marked offline while the process was down, and records stored as "backend starting" because a manage arrived during the restart. A running record reflects the current process and a record that failed for any other reason failed in this same replay, so neither is applied again and a replay can run more than once without applying a one-shot policy twice. The applier solves secrets for the call the way a manage does and persists the unsolved data, uses `updatePolicy` true (the remove-then-apply form every backend implements, safe against a name already present), checks its context before every policy, and returns `ErrBackendNotRunning` with the policies untouched when the backend does not answer. The shared helper `applyStoredPolicy` is also what the secrets refresh now uses.

**One mutex per backend serialises every policy operation on it.** Manage, remove, dataset removal, whole-backend removal and the applier each read the repo, called the backend and wrote the repo back with nothing between them, from the fleet dispatch worker, the secrets refresh goroutine and (from the next PR) the supervisor's applier. Every exported operation is now a locking wrapper over an unexported body keyed by the backend the stored record names; the internal calls use the bodies so nothing re-enters; the secrets refresh re-reads the record under the lock so a removal that landed meanwhile is not undone. Lock order, written into the type comment: the agent's per-backend restart mutex outside, then this mutex, then any supervisor entry mutex, and the repo's own lock innermost, never held across a call out.

**`BackendStarter` seam.** `SetStarter(BackendStarter)` on the policy manager; `EnsureStarted(name) (StartState, error)` is consulted before secrets are solved. `StartStarting` stores the policy `FailedToApply` with reason `backend starting` for the replay to apply once the backend runs; a starter error is stored as the reason; `StartRunning` proceeds as today. No implementer in this PR; with no starter set, nothing changes.

**A restart defers manages until the backend answers.** The policy manager keeps a per-backend restart marker: the non-permanent removal sets it and the replay clears it only once it has completed, both under the apply mutex; a retryable exit (the backend not answering a probe) leaves it set through the retry delay. A manage that lands while it is set is stored as "backend starting" and applied exactly once by the replay, never to a process about to be reset and never replayed after it ran; a manage after the clear applies directly to a backend that is up, and the replay skips it as running. Every restart path holds the restart mutex across removal, reset or start, and replay, so back to back restarts cannot interleave. A replay that gives up is rescheduled: a per-backend goroutine waits a minute off the restart mutex, takes the mutex for each attempt, and keeps trying until a replay completes or the agent stops, so deferred manages are never stuck; `Stop` joins these goroutines.

**Replay retry.** A backend that has just come back may not answer its first status probe; the replay retries a not-running answer up to three times, ten seconds apart, under the restart mutex and cancelled by shutdown, because nothing else would install the policies (the health monitor sees a healthy backend). A per-policy probe that refuses mid-replay leaves that record deferred, stops the loop and triggers the same retry; any other failure is logged and not retried.

**Shutdown and run bookkeeping.** No policies are replayed once `Stop` began: the applier checks its context before every policy, and the agent derives that context from the caller's context and a stop context cancelled as the first statement of `Stop`, since the agent context is cancelled only at the end of `Stop`. The replay, the secrets refresh and the non-permanent removal persist through one helper that re-reads the stored record and carries its `Runs` forward, so run statuses the state monitor writes while a backend call is in flight are not discarded by the write-back.

## Observable behaviour changes

Five, for every config manager:

1. A restart keeps the backend's policies and re-applies them (they pass through `Unknown`, then `Running`). A heartbeat landing mid-restart reports them `unknown` instead of omitting them. Every stored policy for the backend is handed back, including a one-shot policy whose run already finished, so it runs again after a restart; under local this is new for the binary-upgrade restart, which previously re-applied nothing. A restart that fails after the removal but before the reset (a bad config or a failed `Configure`) re-applies immediately, since the backend never stopped.
2. A manage or remove whose payload names a different backend than the stored record is refused and logged, with the record untouched. Reachable only from fleet (git and local derive the policy id from the backend name, so a move is a new id there).
3. Every policy operation for a backend waits for any other in flight for that backend.
4. A manage that arrives while that backend is restarting, up to the point where the replay has confirmed the backend answers, is stored `failed_to_apply` with reason `backend starting` and applied by the replay; a heartbeat in that window shows the reason.
5. A manage carrying an older version than the stored record is refused whatever the record's state (before, only a running record was protected); the same version is still accepted for a record that is not running, so a failed apply can be retried.

The remove action still passes the payload's backend name; the version gate, dataset and group bookkeeping and rename handling are unchanged.

## Interface changes (root module only)

`policymgr.PolicyManager`: `ApplyBackendPolicies(ctx context.Context, name string, be backend.Backend) error`, `RemovePolicyDataset(policyID, datasetID, beName string, be backend.Backend)` (both fleet callers already hold the name), `SetStarter(BackendStarter)`. New: `ErrBackendNotRunning`, `ReasonBackendStarting`, `StartState` (`StartRunning`, `StartStarting`), `BackendStarter`; `policies.PolicyRepo` gains `UpdateKeepingRuns`. `RemovePolicy` and `RemovePolicyDataset` re-validate their lock key under the mutex and refuse a call naming a backend other than the one the stored record names (every caller passes the name read from the repo, so this is a guard, not a reachable path today). The nine test mocks are updated; no other module in the repo implements or calls the interface.

## Verification

- `GOWORK=off go test -count=1 -race ./...` green; the concurrency tests also at `-count=20 -race`; `make lint` 0 issues.
- Mutation testing per task: applier 7 mutants killed; mutex 5 killed and 1 recorded survivor (dropping the second key check under the lock needs a remove and a re-create of the same policy id in the window, which no test drives; covered by review); starter 5 killed; restart 11 killed (both restart paths, including the reconfigure-failure return); shutdown guard, run preservation, deferred-only rule, restart marker, replay retry and rescheduling 31 killed (two ordering mutants are not reproducible under the Go scheduler and are recorded as such).
- Known, pre-existing, not touched here: `PolicyData.Datasets` and `GroupIDs` maps are handed out by the repo's shallow copies and mutated in place by `EnsureDataset`/`EnsureGroupID`; the per-backend mutex reduces that exposure. `backend.RestartAll` (fleet `agent reset` with `full_reset`) still bypasses the policy manager; the supervisor PR deletes it and routes resets through the supervisor.

## Container validation

Two images built from the same Dockerfile, `develop` at 8cb95560 and this branch merged onto it, run in the orb-test-lab (gNMI simulator, SNMP simulators, OTLP collector). Scripts and full logs kept locally.

| Scenario | develop | this branch |
|---|---|---|
| Local manager, nine backends, two policies (gNMI telemetry against the simulator, SNMP discovery against a simulated router) | 9/9 ready in 13 s, both policies applied, 1 dry-run entity file, stop 642 ms, exit 0 | 9/9 ready in 12 s, both applied, 1 dry-run file of the same size, stop 600 ms, exit 0 |
| Stop 2 s into startup | 29.9 s, exit 0, no panic | 29.6 s, exit 0, no panic |
| Git manager polling a repository every minute: add a gNMI policy, update the SNMP policy (second target), remove the gNMI policy, each verified through the backends' own APIs after the next tick | 6 manages, 6 applies; gNMI policy present after the add tick, gone after the removal tick; SNMP run against the second target after the update; 0 errors beyond OTLP export | identical counts and API states; 0 errors beyond OTLP export |

Stop sequences (which backends stop gracefully, in what order) are identical between the two images, and the warning and error classes match line for line. None of the new log lines (restart marker, replay retry, version refusal, shutdown guards) appears in normal local or git operation; they only engage on a restart, which is a fleet-only path.

**Not covered here:** the restart paths themselves (`RestartBackend` is driven by the fleet health monitor or the fleet reset RPC; the binary-upgrade restart needs the fleet files manager), so the restart re-apply, the deferred manages and the replay retry are covered by the unit and end to end tests in `agent/agent_test.go` and `agent/policymgr/manager_test.go` rather than by a container run.

Next in the series: PR 3 supervisor (eager start only), PR 4 on-demand start, PR 5 `default_config` telemetry entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
