### PR TITLE
fix(device-discovery): classify Junos switchports when the reply carries no port-mode element

### DIFF
--- a/orb-discovery/device-discovery/custom_napalm/junos.py
+++ b/orb-discovery/device-discovery/custom_napalm/junos.py
@@ -200,7 +200,109 @@ def _els_details_to_switchports(root) -> dict[str, dict]:
     return result
 
 
-def _interface_to_switchport_info(intf_elem) -> SwitchportInfo:
+def _vlan_name_resolver(driver):
+    """
+    Return a callable mapping a VLAN name to its id, built on first use.
+
+    Junos reports a member either by tag id or by name alone. A name can only be
+    turned into an id by asking the device's own VLAN table, which costs an RPC,
+    so the table is fetched the first time a nameless member is actually seen and
+    not at all on the devices that never report one.
+
+    **Matched exactly, never case-folded.** On a measured EX4550 the VLAN table
+    holds ``MGMT`` at tag 20, while ``me0.0`` reports a member named ``mgmt``:
+    Junos puts the out-of-band management port in a pseudo-VLAN of that name that
+    is not in the switching space at all. Case-folding would bind the management
+    port to VLAN 20, which is wrong, and wrong silently. A name that differs in
+    case is a different name.
+
+    A name the table gives more than one id for is refused for the same reason
+    nothing else here guesses: the device is the only thing that could say which
+    was meant, and it has not.
+    """
+    cache: dict[str, int] = {}
+    loaded = False
+
+    def resolve(name: str) -> int | None:
+        nonlocal loaded
+        if not name:
+            return None
+        if not loaded:
+            loaded = True
+            cache.update(_vlan_ids_by_name(driver))
+        return cache.get(name)
+
+    return resolve
+
+
+def _vlan_ids_by_name(driver) -> dict[str, int]:
+    """Build name -> id from ``get_vlans()``, dropping names that are not unique."""
+    try:
+        vlans = driver.get_vlans() or {}
+    except Exception:
+        logger.debug("Junos get_vlans failed while resolving a VLAN name", exc_info=True)
+        return {}
+
+    ids_by_name: dict[str, set[int]] = {}
+    for vid, data in vlans.items():
+        name = (data or {}).get("name") or ""
+        parsed = _maybe_int(vid)
+        if not name or parsed is None:
+            continue
+        ids_by_name.setdefault(name, set()).add(parsed)
+
+    resolved: dict[str, int] = {}
+    for name, ids in ids_by_name.items():
+        if len(ids) > 1:
+            logger.warning(
+                "Junos VLAN name %r maps to %d ids (%s); not resolving members by that name",
+                name,
+                len(ids),
+                ", ".join(str(i) for i in sorted(ids)),
+            )
+            continue
+        resolved[name] = next(iter(ids))
+    return resolved
+
+
+def _members_to_vids(member_list, resolve_vlan_name) -> tuple[int | None, list[int], bool]:
+    """
+    Read one ``<interface-vlan-member-list>`` into (untagged, tagged, has-all).
+
+    A member carries its id in ``<interface-vlan-member-tagid>`` and its side of
+    the trunk in ``<interface-vlan-member-tagness>``. Where the id is absent the
+    name is put to the device's VLAN table; see _vlan_name_resolver.
+    """
+    members = _find_children(member_list, "interface-vlan-member") if member_list is not None else []
+
+    untagged_vid: int | None = None
+    tagged_vids: list[int] = []
+    has_all_member = False
+    for m in members:
+        name = _text(_find_child(m, "interface-vlan-name"))
+        if name.lower() == "all":
+            has_all_member = True
+            continue
+        vid = _maybe_int(_text(_find_child(m, "interface-vlan-member-tagid")))
+        if vid is None and resolve_vlan_name is not None:
+            vid = resolve_vlan_name(name)
+        if vid is None:
+            # Nothing names this member: either the table has no VLAN called
+            # that, or it has several. Warn so operators see the association go
+            # missing at default log levels rather than wondering.
+            logger.warning(
+                "Junos interface-vlan-member %r has no tagid and no VLAN of that exact name; skipping",
+                name,
+            )
+            continue
+        if "untagged" in _text(_find_child(m, "interface-vlan-member-tagness")).lower():
+            untagged_vid = vid
+        else:
+            tagged_vids.append(vid)
+    return untagged_vid, tagged_vids, has_all_member
+
+
+def _interface_to_switchport_info(intf_elem, resolve_vlan_name=None) -> SwitchportInfo:
     """
     Build a SwitchportInfo from one ``<interface>`` element.
 
@@ -230,32 +332,25 @@ def _interface_to_switchport_info(intf_elem) -> SwitchportInfo:
 
     native_vid = _maybe_int(_text(_find_child(intf_elem, "interface-native-vlan-id")))
 
-    member_list = _find_child(intf_elem, "interface-vlan-member-list")
-    members = _find_children(member_list, "interface-vlan-member") if member_list is not None else []
+    untagged_vid, tagged_vids, has_all_member = _members_to_vids(
+        _find_child(intf_elem, "interface-vlan-member-list"), resolve_vlan_name
+    )
 
-    untagged_vid: int | None = None
-    tagged_vids: list[int] = []
-    has_all_member = False
-    for m in members:
-        name = _text(_find_child(m, "interface-vlan-name"))
-        if name.lower() == "all":
-            has_all_member = True
-            continue
-        vid = _maybe_int(_text(_find_child(m, "interface-vlan-member-tagid")))
-        tagness = _text(_find_child(m, "interface-vlan-member-tagness")).lower()
-        if vid is None:
-            # Member emitted with only a name (no tagid). v1 doesn't resolve
-            # names → IDs via self.get_vlans(); warn so operators see the
-            # missing association at default log levels.
-            logger.warning(
-                "Junos interface-vlan-member %r has no tagid; skipping (name resolution out-of-scope for v1)",
-                name,
-            )
-            continue
-        if "untagged" in tagness:
-            untagged_vid = vid
-        else:
-            tagged_vids.append(vid)
+    # No mode element, but the device did report memberships. Read the mode off
+    # them: a member the port carries tagged makes it a trunk, and a port with
+    # only an untagged member is an access port. This is the same conclusion the
+    # SNMP path draws from Q-BRIDGE, and it is what the plain form of this RPC
+    # leaves us — a measured EX4550 returns 56 memberships with no mode element
+    # anywhere, and without this every one of its ports read as routed and the
+    # whole switch reached NetBox with no VLAN associations at all.
+    #
+    # Checked against that device's own detailed reply, which does carry the
+    # mode: 11 of its 11 classifiable interfaces agree, none disagree. Inference
+    # is still the fallback rather than the rule, because a trunk that happens
+    # to carry only an untagged member reads as access, and the mode element
+    # says so outright.
+    if admin is None and (tagged_vids or untagged_vid is not None):
+        admin = "trunk" if tagged_vids else "access"
 
     if admin == "trunk":
         allowed: list[int] | str | None = "all" if has_all_member else tagged_vids
@@ -1166,14 +1261,7 @@ class JunOSDriver(NapalmJunOSDriver):
         emit subtly-different XML and we'd rather skip VLAN ingest than fail
         the whole device.
         """
-        reply = None
-        try:
-            reply = self.device.rpc.get_ethernet_switching_interface_information()
-        except Exception:
-            # An ELS switch refuses this RPC outright, as a syntax error: it
-            # is the normal state of such a switch, not a fault, and the
-            # fallback below is its path.
-            logger.debug("Junos get-ethernet-switching-interface-information failed", exc_info=True)
+        reply = self._switching_interface_reply()
 
         # Wrapper element is <ethernet-switching-interface-information> (non-ELS)
         # or <l2ng-l2ald-iff-information> (ELS). Each <interface> child has the
@@ -1182,17 +1270,50 @@ class JunOSDriver(NapalmJunOSDriver):
         if not interfaces:
             return self._interfaces_vlans_from_details()
         try:
+            resolve_name = _vlan_name_resolver(self)
             result: dict[str, dict] = {}
             for intf in interfaces:
                 ifname = _text(_find_child(intf, "interface-name"))
                 if not ifname:
                     continue
-                info = _interface_to_switchport_info(intf)
+                info = _interface_to_switchport_info(intf, resolve_name)
                 result[ifname] = classify_switchport(info)
             return result
         except Exception:
             logger.debug("Junos VLAN XML parse failed", exc_info=True)
             return {}
+
+    def _switching_interface_reply(self):
+        """
+        Fetch ``<get-ethernet-switching-interface-information>``, detail first.
+
+        The two CLI forms map to one RPC, the detailed one adding ``<detail/>``.
+        They do not answer alike: on a measured EX4550 running 15.1 the plain
+        form returns the VLAN memberships with NO ``<interface-port-mode>`` at
+        all, while the detailed form carries it on every interface. The mode is
+        the authoritative statement of access versus trunk, so ask for the reply
+        that has it.
+
+        The plain form is still tried when the detailed one yields nothing, so a
+        platform that rejects the argument keeps the behaviour it has today, and
+        an ELS switch that refuses the RPC in both forms falls through to its own.
+        """
+        for kwargs in ({"detail": True}, {}):
+            try:
+                reply = self.device.rpc.get_ethernet_switching_interface_information(**kwargs)
+            except Exception:
+                # An ELS switch refuses this RPC outright, as a syntax error: it
+                # is the normal state of such a switch, not a fault, and the
+                # details RPC is its path.
+                logger.debug(
+                    "Junos get-ethernet-switching-interface-information%s failed",
+                    " (detail)" if kwargs else "",
+                    exc_info=True,
+                )
+                continue
+            if _find_children(reply, "interface"):
+                return reply
+        return None
 
     def _interfaces_vlans_from_details(self) -> dict[str, dict]:
         """

--- a/orb-discovery/device-discovery/custom_napalm/junos.py
+++ b/orb-discovery/device-discovery/custom_napalm/junos.py
@@ -61,7 +61,7 @@ from custom_napalm._modules import (
 from custom_napalm._modules import (
     to_payload as _modules_to_payload,
 )
-from custom_napalm._vlan import SwitchportInfo, classify_switchport
+from custom_napalm._vlan import SwitchportInfo, classify_switchport, coerce_vid
 
 logger = logging.getLogger(__name__)
 
@@ -207,7 +207,10 @@ def _vlan_name_resolver(driver):
     Junos reports a member either by tag id or by name alone. A name can only be
     turned into an id by asking the device's own VLAN table, which costs an RPC,
     so the table is fetched the first time a nameless member is actually seen and
-    not at all on the devices that never report one.
+    not at all on the devices that never report one. Once per call, that is: the
+    runner asks get_vlans for its own reasons just before this, and napalm does
+    not memoize it, so a device reporting any nameless member does pay for a
+    second round trip.
 
     **Matched exactly, never case-folded.** On a measured EX4550 the VLAN table
     holds ``MGMT`` at tag 20, while ``me0.0`` reports a member named ``mgmt``:
@@ -283,9 +286,14 @@ def _members_to_vids(member_list, resolve_vlan_name) -> tuple[int | None, list[i
         if name.lower() == "all":
             has_all_member = True
             continue
-        vid = _maybe_int(_text(_find_child(m, "interface-vlan-member-tagid")))
+        # coerce_vid, not _maybe_int, so a value outside 1-4094 is refused here
+        # rather than counted as membership and dropped later. The difference is
+        # not cosmetic: a member with tagid 0 would otherwise make the port look
+        # like it has an untagged VLAN, infer access from that, and write
+        # mode=access to NetBox with no VLAN to go with it.
+        vid = coerce_vid(_text(_find_child(m, "interface-vlan-member-tagid")))
         if vid is None and resolve_vlan_name is not None:
-            vid = resolve_vlan_name(name)
+            vid = coerce_vid(resolve_vlan_name(name))
         if vid is None:
             # Nothing names this member: either the table has no VLAN called
             # that, or it has several. Warn so operators see the association go
@@ -313,9 +321,12 @@ def _interface_to_switchport_info(intf_elem, resolve_vlan_name=None) -> Switchpo
     VLAN membership is in ``<interface-vlan-member-list>`` containing
     ``<interface-vlan-member>`` entries with
     ``<interface-vlan-member-tagid>`` and
-    ``<interface-vlan-member-tagness>`` ("tagged"|"untagged"). Members
-    with only a name (no tagid) are dropped with a warning log — VLAN-name
-    resolution against ``self.get_vlans()`` is out-of-scope for v1.
+    ``<interface-vlan-member-tagness>`` ("tagged"|"untagged"). A member with
+    only a name is put to ``resolve_vlan_name`` when the caller supplies one,
+    and dropped with a warning when nothing names it.
+
+    Where the reply carries no mode element at all, the mode is read off the
+    membership; see the comment on that branch for which signals decide it.
     """
     # Mode — read whichever element is present
     mode_text = (
@@ -346,11 +357,21 @@ def _interface_to_switchport_info(intf_elem, resolve_vlan_name=None) -> Switchpo
     #
     # Checked against that device's own detailed reply, which does carry the
     # mode: 11 of its 11 classifiable interfaces agree, none disagree. Inference
-    # is still the fallback rather than the rule, because a trunk that happens
-    # to carry only an untagged member reads as access, and the mode element
-    # says so outright.
-    if admin is None and (tagged_vids or untagged_vid is not None):
-        admin = "trunk" if tagged_vids else "access"
+    # is still the fallback rather than the rule, because a trunk carrying only
+    # an untagged member and no other trunk signal reads as access, and the mode
+    # element says so outright.
+    #
+    # Three things make a trunk here, not one. A member the port carries tagged
+    # is the obvious one. A member named "all" is a trunk-only construct, since
+    # "vlan members all" is only configurable under "port-mode trunk". And a
+    # native VLAN id is only meaningful on a trunk, which is what makes it the
+    # deciding signal for a port whose single member is untagged: without it
+    # that port is access, with it the untagged member is the native VLAN.
+    if admin is None:
+        if tagged_vids or has_all_member or native_vid is not None:
+            admin = "trunk"
+        elif untagged_vid is not None:
+            admin = "access"
 
     if admin == "trunk":
         allowed: list[int] | str | None = "all" if has_all_member else tagged_vids

--- a/orb-discovery/device-discovery/custom_napalm/junos.py
+++ b/orb-discovery/device-discovery/custom_napalm/junos.py
@@ -341,7 +341,12 @@ def _interface_to_switchport_info(intf_elem, resolve_vlan_name=None) -> Switchpo
     else:
         admin = None
 
-    native_vid = _maybe_int(_text(_find_child(intf_elem, "interface-native-vlan-id")))
+    # coerce_vid, for the same reason the member ids below use it, and with a
+    # sharper consequence: a native id is now a trunk signal, so an
+    # out-of-range or placeholder value would make a port a trunk AND be
+    # substituted for its real untagged member, which classify_switchport then
+    # rejects — leaving a port that has a VLAN reported as a trunk with none.
+    native_vid = coerce_vid(_text(_find_child(intf_elem, "interface-native-vlan-id")))
 
     untagged_vid, tagged_vids, has_all_member = _members_to_vids(
         _find_child(intf_elem, "interface-vlan-member-list"), resolve_vlan_name

--- a/orb-discovery/device-discovery/custom_napalm/junos.py
+++ b/orb-discovery/device-discovery/custom_napalm/junos.py
@@ -1303,7 +1303,14 @@ class JunOSDriver(NapalmJunOSDriver):
                 if not ifname:
                     continue
                 info = _interface_to_switchport_info(intf, resolve_name)
-                result[ifname] = classify_switchport(info)
+                # Junos reports switching per logical unit — the measured EX4550
+                # answers with ge-0/0/23.0 — while NetBox carries switchport mode
+                # and VLANs on the port. The ELS path has normalised this since it
+                # was written; this one did not, and no fixture caught it because
+                # every synthetic non-ELS reply was written without unit suffixes.
+                # Left literal, the recovered VLANs land on the subinterface and
+                # the port they belong to stays blank.
+                result[_physical_name(ifname)] = classify_switchport(info)
             return result
         except Exception:
             logger.debug("Junos VLAN XML parse failed", exc_info=True)

--- a/orb-discovery/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/brief_reply_without_mode/expected_result.json
+++ b/orb-discovery/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/brief_reply_without_mode/expected_result.json
@@ -1,5 +1,20 @@
 {
-  "ge-0/0/23.0": {"mode": "access", "tagged": [], "untagged": 888},
-  "xe-0/0/17.0": {"mode": "trunk", "tagged": [156, 178], "untagged": null},
-  "ae4.0": {"mode": "routed", "tagged": [], "untagged": null}
+  "ae4": {
+    "mode": "routed",
+    "tagged": [],
+    "untagged": null
+  },
+  "ge-0/0/23": {
+    "mode": "access",
+    "tagged": [],
+    "untagged": 888
+  },
+  "xe-0/0/17": {
+    "mode": "trunk",
+    "tagged": [
+      156,
+      178
+    ],
+    "untagged": null
+  }
 }

--- a/orb-discovery/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/brief_reply_without_mode/expected_result.json
+++ b/orb-discovery/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/brief_reply_without_mode/expected_result.json
@@ -1,0 +1,5 @@
+{
+  "ge-0/0/23.0": {"mode": "access", "tagged": [], "untagged": 888},
+  "xe-0/0/17.0": {"mode": "trunk", "tagged": [156, 178], "untagged": null},
+  "ae4.0": {"mode": "routed", "tagged": [], "untagged": null}
+}

--- a/orb-discovery/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/brief_reply_without_mode/get-ethernet-switching-interface-information.xml
+++ b/orb-discovery/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/brief_reply_without_mode/get-ethernet-switching-interface-information.xml
@@ -1,0 +1,43 @@
+<switching-interface-information junos:style="brief" xmlns:junos="http://xml.juniper.net/junos/15.1R7/junos">
+        <interface>
+            <interface-name>ae4.0</interface-name>
+            <interface-state>down</interface-state>
+            <interface-vlan-member-list>
+                <interface-vlan-member>
+                    <interface-vlan-name>default</interface-vlan-name>
+                    <interface-vlan-member-tagness>untagged</interface-vlan-member-tagness>
+                    <blocking-status junos:emit="emit">unblocked</blocking-status>
+                </interface-vlan-member>
+            </interface-vlan-member-list>
+        </interface>
+        <interface>
+            <interface-name>ge-0/0/23.0</interface-name>
+            <interface-state>up</interface-state>
+            <interface-vlan-member-list>
+                <interface-vlan-member>
+                    <interface-vlan-name>VL888</interface-vlan-name>
+                    <interface-vlan-member-tagid>888</interface-vlan-member-tagid>
+                    <interface-vlan-member-tagness>untagged</interface-vlan-member-tagness>
+                    <blocking-status junos:emit="emit">unblocked</blocking-status>
+                </interface-vlan-member>
+            </interface-vlan-member-list>
+        </interface>
+        <interface>
+            <interface-name>xe-0/0/17.0</interface-name>
+            <interface-state>up</interface-state>
+            <interface-vlan-member-list>
+                <interface-vlan-member>
+                    <interface-vlan-name>VL156</interface-vlan-name>
+                    <interface-vlan-member-tagid>156</interface-vlan-member-tagid>
+                    <interface-vlan-member-tagness>tagged</interface-vlan-member-tagness>
+                    <blocking-status junos:emit="emit">unblocked</blocking-status>
+                </interface-vlan-member>
+                <interface-vlan-member>
+                    <interface-vlan-name>VL178</interface-vlan-name>
+                    <interface-vlan-member-tagid>178</interface-vlan-member-tagid>
+                    <interface-vlan-member-tagness>tagged</interface-vlan-member-tagness>
+                    <blocking-status junos:emit="emit">unblocked</blocking-status>
+                </interface-vlan-member>
+            </interface-vlan-member-list>
+        </interface>
+    </switching-interface-information>

--- a/orb-discovery/device-discovery/tests/custom_drivers/juniper_junos/test_driver.py
+++ b/orb-discovery/device-discovery/tests/custom_drivers/juniper_junos/test_driver.py
@@ -306,8 +306,8 @@ class TestJunosSwitchportModeFallback:
         d = self._driver(self.ACCESS_MEMBER + self.TRUNK_MEMBER)
         result = d.get_interfaces_vlans()
 
-        assert result["ge-0/0/23.0"] == {"mode": "access", "tagged": [], "untagged": 888}
-        assert result["xe-0/0/17.0"] == {"mode": "trunk", "tagged": [156], "untagged": None}
+        assert result["ge-0/0/23"] == {"mode": "access", "tagged": [], "untagged": 888}
+        assert result["xe-0/0/17"] == {"mode": "trunk", "tagged": [156], "untagged": None}
 
     def test_the_detail_form_is_asked_for_first(self):
         """
@@ -334,7 +334,7 @@ class TestJunosSwitchportModeFallback:
         assert d.device.asked[0] == {"detail": True}, "the detailed form must be asked for first"
         # The device says trunk. Membership alone would have inferred access,
         # which is the case inference cannot get right and the element can.
-        assert result["ge-0/0/23.0"]["mode"] == "trunk"
+        assert result["ge-0/0/23"]["mode"] == "trunk"
 
     def test_the_plain_form_still_answers_when_detail_is_refused(self):
         """A platform that rejects the argument keeps the behaviour it has."""
@@ -342,7 +342,7 @@ class TestJunosSwitchportModeFallback:
         result = d.get_interfaces_vlans()
 
         assert [kw.get("detail", False) for kw in d.device.asked] == [True, False]
-        assert result["ge-0/0/23.0"]["mode"] == "access"
+        assert result["ge-0/0/23"]["mode"] == "access"
 
     def test_a_member_named_but_not_tagged_is_resolved_from_the_vlan_table(self):
         """Junos reports some members by name alone; the device's own table names them."""
@@ -358,7 +358,7 @@ class TestJunosSwitchportModeFallback:
         </interface>"""
         d = self._driver(xml, vlans={30: {"name": "VOICE"}, 40: {"name": "DATA"}})
 
-        assert d.get_interfaces_vlans()["ge-0/0/9.0"] == {
+        assert d.get_interfaces_vlans()["ge-0/0/9"] == {
             "mode": "access",
             "tagged": [],
             "untagged": 30,
@@ -385,7 +385,7 @@ class TestJunosSwitchportModeFallback:
         </interface>"""
         d = self._driver(xml, vlans={20: {"name": "MGMT"}})
 
-        assert d.get_interfaces_vlans()["me0.0"]["untagged"] is None
+        assert d.get_interfaces_vlans()["me0"]["untagged"] is None
 
     def test_a_name_the_table_gives_two_ids_is_refused(self):
         """Nothing but the device could say which was meant, and it has not."""
@@ -401,7 +401,7 @@ class TestJunosSwitchportModeFallback:
         </interface>"""
         d = self._driver(xml, vlans={10: {"name": "SHARED"}, 11: {"name": "SHARED"}})
 
-        assert d.get_interfaces_vlans()["ge-0/0/9.0"]["untagged"] is None
+        assert d.get_interfaces_vlans()["ge-0/0/9"]["untagged"] is None
 
     def test_the_vlan_table_is_fetched_once_at_most(self):
         """
@@ -440,7 +440,7 @@ class TestJunosSwitchportModeFallback:
         d.get_vlans = lambda: (calls.append(1), {30: {"name": "VOICE"}, 40: {"name": "DATA"}})[1]
         result = d.get_interfaces_vlans()
         assert len(calls) == 1, f"three named members must cost one get_vlans, got {len(calls)}"
-        assert result["ge-0/0/10.0"] == {"mode": "trunk", "tagged": [30], "untagged": 40}
+        assert result["ge-0/0/10"] == {"mode": "trunk", "tagged": [30], "untagged": 40}
 
         calls.clear()
         d = self._driver(self.ACCESS_MEMBER + self.TRUNK_MEMBER)
@@ -468,7 +468,7 @@ class TestJunosSwitchportModeFallback:
         </interface>"""
         d = self._driver(xml)
 
-        assert d.get_interfaces_vlans()["xe-0/0/40.0"]["mode"] == "trunk-all"
+        assert d.get_interfaces_vlans()["xe-0/0/40"]["mode"] == "trunk-all"
 
     def test_a_native_vlan_id_makes_a_single_untagged_member_a_trunk(self):
         """
@@ -493,7 +493,7 @@ class TestJunosSwitchportModeFallback:
         </interface>"""
         d = self._driver(xml)
 
-        assert d.get_interfaces_vlans()["xe-0/0/41.0"] == {
+        assert d.get_interfaces_vlans()["xe-0/0/41"] == {
             "mode": "trunk",
             "tagged": [],
             "untagged": 99,
@@ -521,7 +521,7 @@ class TestJunosSwitchportModeFallback:
         </interface>"""
         d = self._driver(xml)
 
-        assert d.get_interfaces_vlans()["ge-0/0/44.0"]["mode"] == "routed"
+        assert d.get_interfaces_vlans()["ge-0/0/44"]["mode"] == "routed"
 
     def test_the_vlan_table_may_key_on_strings(self):
         """
@@ -542,7 +542,7 @@ class TestJunosSwitchportModeFallback:
         </interface>"""
         d = self._driver(xml, vlans={"30": {"name": "VOICE"}, "40": {"name": "DATA"}})
 
-        assert d.get_interfaces_vlans()["ge-0/0/9.0"]["untagged"] == 30
+        assert d.get_interfaces_vlans()["ge-0/0/9"]["untagged"] == 30
 
     def test_a_name_resolving_outside_the_dot1q_range_is_refused(self):
         """A table entry out of range names no VLAN that NetBox could hold."""
@@ -558,7 +558,7 @@ class TestJunosSwitchportModeFallback:
         </interface>"""
         d = self._driver(xml, vlans={9999: {"name": "ODD"}})
 
-        assert d.get_interfaces_vlans()["ge-0/0/9.0"]["mode"] == "routed"
+        assert d.get_interfaces_vlans()["ge-0/0/9"]["mode"] == "routed"
 
     def test_an_unusable_native_vlan_id_does_not_make_a_trunk(self):
         """
@@ -583,7 +583,7 @@ class TestJunosSwitchportModeFallback:
         </interface>"""
         d = self._driver(xml)
 
-        assert d.get_interfaces_vlans()["ge-0/0/45.0"] == {
+        assert d.get_interfaces_vlans()["ge-0/0/45"] == {
             "mode": "access",
             "tagged": [],
             "untagged": 888,

--- a/orb-discovery/device-discovery/tests/custom_drivers/juniper_junos/test_driver.py
+++ b/orb-discovery/device-discovery/tests/custom_drivers/juniper_junos/test_driver.py
@@ -228,3 +228,222 @@ def test_details_walk_survives_an_xml_comment_in_the_reply():
     assert "<!--" in text
     result = _els_details_to_switchports(etree.fromstring(text.encode("utf-8")))
     assert result["xe-0/0/19"] == {"mode": "trunk", "tagged": [665], "untagged": None}
+
+
+class TestJunosSwitchportModeFallback:
+    """
+    Classify a switchport when the reply carries no mode element.
+
+    The plain form of ``<get-ethernet-switching-interface-information>`` can
+    answer with VLAN memberships and no ``<interface-port-mode>`` anywhere. A
+    measured EX4550 on 15.1 does exactly that, and every one of its ports read
+    as routed, so the switch reached NetBox with no VLAN associations at all.
+    """
+
+    @staticmethod
+    def _wrapper(xml: str):
+        from lxml import etree
+
+        return etree.fromstring(
+            b'<switching-interface-information xmlns:junos="http://xml.juniper.net/junos/x/junos">'
+            + xml.encode()
+            + b"</switching-interface-information>"
+        )
+
+    @staticmethod
+    def _driver(brief: str, detail: str | None = None, vlans: dict | None = None):
+        from custom_napalm.junos import JunOSDriver
+
+        wrapper = TestJunosSwitchportModeFallback._wrapper
+
+        class Dev:
+            def __init__(self):
+                self.rpc = self
+                self.asked = []
+
+            def get_ethernet_switching_interface_information(self, **kw):
+                self.asked.append(kw)
+                if kw.get("detail"):
+                    if detail is None:
+                        raise RuntimeError("this platform rejects the argument")
+                    return wrapper(detail)
+                return wrapper(brief)
+
+            def get_ethernet_switching_interface_details(self, **kw):
+                raise RuntimeError("not an ELS switch")
+
+        d = object.__new__(JunOSDriver)
+        d.device = Dev()
+        d.get_vlans = lambda: (vlans if vlans is not None else {})
+        return d
+
+    ACCESS_MEMBER = """
+        <interface>
+          <interface-name>ge-0/0/23.0</interface-name>
+          <interface-vlan-member-list>
+            <interface-vlan-member>
+              <interface-vlan-name>VL888</interface-vlan-name>
+              <interface-vlan-member-tagid>888</interface-vlan-member-tagid>
+              <interface-vlan-member-tagness>untagged</interface-vlan-member-tagness>
+            </interface-vlan-member>
+          </interface-vlan-member-list>
+        </interface>"""
+
+    TRUNK_MEMBER = """
+        <interface>
+          <interface-name>xe-0/0/17.0</interface-name>
+          <interface-vlan-member-list>
+            <interface-vlan-member>
+              <interface-vlan-name>VL156</interface-vlan-name>
+              <interface-vlan-member-tagid>156</interface-vlan-member-tagid>
+              <interface-vlan-member-tagness>tagged</interface-vlan-member-tagness>
+            </interface-vlan-member>
+          </interface-vlan-member-list>
+        </interface>"""
+
+    def test_mode_is_read_from_membership_when_the_element_is_absent(self):
+        """A tagged member makes a trunk; an untagged-only member makes access."""
+        d = self._driver(self.ACCESS_MEMBER + self.TRUNK_MEMBER)
+        result = d.get_interfaces_vlans()
+
+        assert result["ge-0/0/23.0"] == {"mode": "access", "tagged": [], "untagged": 888}
+        assert result["xe-0/0/17.0"] == {"mode": "trunk", "tagged": [156], "untagged": None}
+
+    def test_the_detail_form_is_asked_for_first(self):
+        """
+        Ask for the reply that carries the mode element.
+
+        It is the authoritative statement of access versus trunk, and only the
+        detailed reply has it.
+        """
+        detail = """
+        <interface>
+          <interface-name>ge-0/0/23.0</interface-name>
+          <interface-port-mode>Trunk</interface-port-mode>
+          <interface-vlan-member-list>
+            <interface-vlan-member>
+              <interface-vlan-name>VL888</interface-vlan-name>
+              <interface-vlan-member-tagid>888</interface-vlan-member-tagid>
+              <interface-vlan-member-tagness>untagged</interface-vlan-member-tagness>
+            </interface-vlan-member>
+          </interface-vlan-member-list>
+        </interface>"""
+        d = self._driver(self.ACCESS_MEMBER, detail=detail)
+        result = d.get_interfaces_vlans()
+
+        assert d.device.asked[0] == {"detail": True}, "the detailed form must be asked for first"
+        # The device says trunk. Membership alone would have inferred access,
+        # which is the case inference cannot get right and the element can.
+        assert result["ge-0/0/23.0"]["mode"] == "trunk"
+
+    def test_the_plain_form_still_answers_when_detail_is_refused(self):
+        """A platform that rejects the argument keeps the behaviour it has."""
+        d = self._driver(self.ACCESS_MEMBER, detail=None)
+        result = d.get_interfaces_vlans()
+
+        assert [kw.get("detail", False) for kw in d.device.asked] == [True, False]
+        assert result["ge-0/0/23.0"]["mode"] == "access"
+
+    def test_a_member_named_but_not_tagged_is_resolved_from_the_vlan_table(self):
+        """Junos reports some members by name alone; the device's own table names them."""
+        xml = """
+        <interface>
+          <interface-name>ge-0/0/9.0</interface-name>
+          <interface-vlan-member-list>
+            <interface-vlan-member>
+              <interface-vlan-name>VOICE</interface-vlan-name>
+              <interface-vlan-member-tagness>untagged</interface-vlan-member-tagness>
+            </interface-vlan-member>
+          </interface-vlan-member-list>
+        </interface>"""
+        d = self._driver(xml, vlans={30: {"name": "VOICE"}, 40: {"name": "DATA"}})
+
+        assert d.get_interfaces_vlans()["ge-0/0/9.0"] == {
+            "mode": "access",
+            "tagged": [],
+            "untagged": 30,
+        }
+
+    def test_a_name_differing_only_in_case_is_a_different_name(self):
+        """
+        A name differing only in case names a different VLAN.
+
+        Junos puts the out-of-band management port in a pseudo-VLAN named
+        ``mgmt`` that is not in the switching space, while a real VLAN on the
+        same measured switch is named ``MGMT`` at tag 20. Case-folding would
+        bind the management port to that VLAN, wrongly and silently.
+        """
+        xml = """
+        <interface>
+          <interface-name>me0.0</interface-name>
+          <interface-vlan-member-list>
+            <interface-vlan-member>
+              <interface-vlan-name>mgmt</interface-vlan-name>
+              <interface-vlan-member-tagness>untagged</interface-vlan-member-tagness>
+            </interface-vlan-member>
+          </interface-vlan-member-list>
+        </interface>"""
+        d = self._driver(xml, vlans={20: {"name": "MGMT"}})
+
+        assert d.get_interfaces_vlans()["me0.0"]["untagged"] is None
+
+    def test_a_name_the_table_gives_two_ids_is_refused(self):
+        """Nothing but the device could say which was meant, and it has not."""
+        xml = """
+        <interface>
+          <interface-name>ge-0/0/9.0</interface-name>
+          <interface-vlan-member-list>
+            <interface-vlan-member>
+              <interface-vlan-name>SHARED</interface-vlan-name>
+              <interface-vlan-member-tagness>untagged</interface-vlan-member-tagness>
+            </interface-vlan-member>
+          </interface-vlan-member-list>
+        </interface>"""
+        d = self._driver(xml, vlans={10: {"name": "SHARED"}, 11: {"name": "SHARED"}})
+
+        assert d.get_interfaces_vlans()["ge-0/0/9.0"]["untagged"] is None
+
+    def test_the_vlan_table_is_fetched_once_at_most(self):
+        """
+        Fetch the VLAN table once at most, and only when a name needs it.
+
+        The table costs an RPC. It is not fetched at all when every member
+        carries a tagid, and fetched once however many members are reported by
+        name, rather than once per member.
+        """
+        xml = """
+        <interface>
+          <interface-name>ge-0/0/9.0</interface-name>
+          <interface-vlan-member-list>
+            <interface-vlan-member>
+              <interface-vlan-name>VOICE</interface-vlan-name>
+              <interface-vlan-member-tagness>untagged</interface-vlan-member-tagness>
+            </interface-vlan-member>
+          </interface-vlan-member-list>
+        </interface>
+        <interface>
+          <interface-name>ge-0/0/10.0</interface-name>
+          <interface-vlan-member-list>
+            <interface-vlan-member>
+              <interface-vlan-name>DATA</interface-vlan-name>
+              <interface-vlan-member-tagness>untagged</interface-vlan-member-tagness>
+            </interface-vlan-member>
+            <interface-vlan-member>
+              <interface-vlan-name>VOICE</interface-vlan-name>
+              <interface-vlan-member-tagness>tagged</interface-vlan-member-tagness>
+            </interface-vlan-member>
+          </interface-vlan-member-list>
+        </interface>"""
+
+        calls = []
+        d = self._driver(xml)
+        d.get_vlans = lambda: (calls.append(1), {30: {"name": "VOICE"}, 40: {"name": "DATA"}})[1]
+        result = d.get_interfaces_vlans()
+        assert len(calls) == 1, f"three named members must cost one get_vlans, got {len(calls)}"
+        assert result["ge-0/0/10.0"] == {"mode": "trunk", "tagged": [30], "untagged": 40}
+
+        calls.clear()
+        d = self._driver(self.ACCESS_MEMBER + self.TRUNK_MEMBER)
+        d.get_vlans = lambda: (calls.append(1), {})[1]
+        d.get_interfaces_vlans()
+        assert calls == [], "a walk with no named member must not fetch the table at all"

--- a/orb-discovery/device-discovery/tests/custom_drivers/juniper_junos/test_driver.py
+++ b/orb-discovery/device-discovery/tests/custom_drivers/juniper_junos/test_driver.py
@@ -559,3 +559,32 @@ class TestJunosSwitchportModeFallback:
         d = self._driver(xml, vlans={9999: {"name": "ODD"}})
 
         assert d.get_interfaces_vlans()["ge-0/0/9.0"]["mode"] == "routed"
+
+    def test_an_unusable_native_vlan_id_does_not_make_a_trunk(self):
+        """
+        A native id outside 1-4094 is not a trunk signal.
+
+        It is a sharper version of the member-id case: a native id is both a
+        trunk signal and the value substituted for the untagged member, so a
+        placeholder like 0 would report a port that has VLAN 888 as a trunk
+        with no VLAN at all, silently discarding the one it does have.
+        """
+        xml = """
+        <interface>
+          <interface-name>ge-0/0/45.0</interface-name>
+          <interface-native-vlan-id>0</interface-native-vlan-id>
+          <interface-vlan-member-list>
+            <interface-vlan-member>
+              <interface-vlan-name>VL888</interface-vlan-name>
+              <interface-vlan-member-tagid>888</interface-vlan-member-tagid>
+              <interface-vlan-member-tagness>untagged</interface-vlan-member-tagness>
+            </interface-vlan-member>
+          </interface-vlan-member-list>
+        </interface>"""
+        d = self._driver(xml)
+
+        assert d.get_interfaces_vlans()["ge-0/0/45.0"] == {
+            "mode": "access",
+            "tagged": [],
+            "untagged": 888,
+        }

--- a/orb-discovery/device-discovery/tests/custom_drivers/juniper_junos/test_driver.py
+++ b/orb-discovery/device-discovery/tests/custom_drivers/juniper_junos/test_driver.py
@@ -447,3 +447,115 @@ class TestJunosSwitchportModeFallback:
         d.get_vlans = lambda: (calls.append(1), {})[1]
         d.get_interfaces_vlans()
         assert calls == [], "a walk with no named member must not fetch the table at all"
+
+    def test_an_all_member_is_a_trunk_even_with_no_mode_element(self):
+        """
+        A member named ``all`` makes a trunk.
+
+        ``vlan members all`` is only configurable under ``port-mode trunk``, so
+        the member named ``all`` is a trunk-only construct. Reading the mode off
+        membership has to count it, or the one shape that says trunk loudest is
+        the one that still reports routed.
+        """
+        xml = """
+        <interface>
+          <interface-name>xe-0/0/40.0</interface-name>
+          <interface-vlan-member-list>
+            <interface-vlan-member>
+              <interface-vlan-name>all</interface-vlan-name>
+            </interface-vlan-member>
+          </interface-vlan-member-list>
+        </interface>"""
+        d = self._driver(xml)
+
+        assert d.get_interfaces_vlans()["xe-0/0/40.0"]["mode"] == "trunk-all"
+
+    def test_a_native_vlan_id_makes_a_single_untagged_member_a_trunk(self):
+        """
+        A native VLAN id makes a single untagged member a trunk.
+
+        A native VLAN is only meaningful on a trunk, so it decides the one case
+        inference otherwise gets wrong: a trunk whose only member is untagged.
+        Without this the port is reported as access, which is not a missing
+        association but an affirmatively wrong one.
+        """
+        xml = """
+        <interface>
+          <interface-name>xe-0/0/41.0</interface-name>
+          <interface-native-vlan-id>99</interface-native-vlan-id>
+          <interface-vlan-member-list>
+            <interface-vlan-member>
+              <interface-vlan-name>VL99</interface-vlan-name>
+              <interface-vlan-member-tagid>99</interface-vlan-member-tagid>
+              <interface-vlan-member-tagness>untagged</interface-vlan-member-tagness>
+            </interface-vlan-member>
+          </interface-vlan-member-list>
+        </interface>"""
+        d = self._driver(xml)
+
+        assert d.get_interfaces_vlans()["xe-0/0/41.0"] == {
+            "mode": "trunk",
+            "tagged": [],
+            "untagged": 99,
+        }
+
+    def test_a_vid_outside_the_dot1q_range_is_not_membership(self):
+        """
+        A VID outside 1-4094 is not membership.
+
+        A member carrying tagid 0 must not make the port look like it has an
+        untagged VLAN. Counting it would infer access and then drop the VID,
+        writing mode=access to NetBox with no VLAN to go with it, where the
+        honest answer is that the port has no usable membership at all.
+        """
+        xml = """
+        <interface>
+          <interface-name>ge-0/0/44.0</interface-name>
+          <interface-vlan-member-list>
+            <interface-vlan-member>
+              <interface-vlan-name>bogus</interface-vlan-name>
+              <interface-vlan-member-tagid>0</interface-vlan-member-tagid>
+              <interface-vlan-member-tagness>untagged</interface-vlan-member-tagness>
+            </interface-vlan-member>
+          </interface-vlan-member-list>
+        </interface>"""
+        d = self._driver(xml)
+
+        assert d.get_interfaces_vlans()["ge-0/0/44.0"]["mode"] == "routed"
+
+    def test_the_vlan_table_may_key_on_strings(self):
+        """
+        The VLAN table may key on strings.
+
+        PyEZ tables key on the reply's ``vlan-tag`` text, so ``get_vlans()``
+        hands back string keys on the switch_style tables this driver meets.
+        """
+        xml = """
+        <interface>
+          <interface-name>ge-0/0/9.0</interface-name>
+          <interface-vlan-member-list>
+            <interface-vlan-member>
+              <interface-vlan-name>VOICE</interface-vlan-name>
+              <interface-vlan-member-tagness>untagged</interface-vlan-member-tagness>
+            </interface-vlan-member>
+          </interface-vlan-member-list>
+        </interface>"""
+        d = self._driver(xml, vlans={"30": {"name": "VOICE"}, "40": {"name": "DATA"}})
+
+        assert d.get_interfaces_vlans()["ge-0/0/9.0"]["untagged"] == 30
+
+    def test_a_name_resolving_outside_the_dot1q_range_is_refused(self):
+        """A table entry out of range names no VLAN that NetBox could hold."""
+        xml = """
+        <interface>
+          <interface-name>ge-0/0/9.0</interface-name>
+          <interface-vlan-member-list>
+            <interface-vlan-member>
+              <interface-vlan-name>ODD</interface-vlan-name>
+              <interface-vlan-member-tagness>untagged</interface-vlan-member-tagness>
+            </interface-vlan-member>
+          </interface-vlan-member-list>
+        </interface>"""
+        d = self._driver(xml, vlans={9999: {"name": "ODD"}})
+
+        assert d.get_interfaces_vlans()["ge-0/0/9.0"]["mode"] == "routed"

--- a/orb-discovery/device-discovery/tests/custom_drivers/mock_device.py
+++ b/orb-discovery/device-discovery/tests/custom_drivers/mock_device.py
@@ -434,7 +434,17 @@ class _FakePyEZRpc:
         candidates = [f"{kebab}.xml", f"{name}.xml"]
 
         def _call(*_args, **_kwargs):
-            for fname in candidates:
+            # A boolean RPC argument becomes a bare child element on the wire
+            # (detail=True -> <detail/>), and Junos often answers a different
+            # shape for it. Serve "<rpc-name>-<arg>.xml" when the scenario
+            # provides one, so a fixture can distinguish the two replies; fall
+            # back to the plain file, which is what every existing scenario has.
+            flagged = [
+                f"{kebab}-{key.replace('_', '-')}.xml"
+                for key, value in sorted(_kwargs.items())
+                if value is True
+            ]
+            for fname in [*flagged, *candidates]:
                 path = self._mock_dir / fname
                 if path.exists():
                     return etree.fromstring(path.read_text(encoding="utf-8").encode("utf-8"))

--- a/orb-discovery/device-discovery/tests/test_translate.py
+++ b/orb-discovery/device-discovery/tests/test_translate.py
@@ -2405,3 +2405,69 @@ def test_translate_data_withholds_prefix_vlan_when_the_option_is_off(sample_devi
     for e in entities:
         if e.WhichOneof("entity") == "prefix":
             assert not e.prefix.HasField("vlan")
+
+
+def test_junos_switching_unit_lands_on_the_physical_port():
+    """
+    Junos reports switching on unit .0; NetBox wants it on the port.
+
+    This is the seam between the two halves and neither side's own tests
+    cross it. The Junos driver reads switching information from the RPC per
+    logical unit (``ge-0/0/23.0`` on a measured EX4550) and keys its result by
+    the physical port, because ``apply_interface_vlans`` pairs on an exact
+    name and orb emits the port and the unit as separate Interfaces. Key it by
+    the unit and the recovered VLANs attach to the subinterface while the port
+    they belong to stays blank, which is the shape of a fix that looks like it
+    worked.
+    """
+    from lxml import etree
+
+    from custom_napalm.junos import JunOSDriver, _localname
+
+    reply = etree.fromstring(
+        b"""<switching-interface-information>
+              <interface>
+                <interface-name>ge-0/0/23.0</interface-name>
+                <interface-port-mode>Access</interface-port-mode>
+                <interface-vlan-member-list>
+                  <interface-vlan-member>
+                    <interface-vlan-name>VL888</interface-vlan-name>
+                    <interface-vlan-member-tagid>888</interface-vlan-member-tagid>
+                    <interface-vlan-member-tagness>untagged</interface-vlan-member-tagness>
+                  </interface-vlan-member>
+                </interface-vlan-member-list>
+              </interface>
+            </switching-interface-information>"""
+    )
+    assert [_localname(c) for c in reply] == ["interface"], "fixture shape changed"
+
+    class Dev:
+        def __init__(self):
+            self.rpc = self
+
+        def get_ethernet_switching_interface_information(self, **_kw):
+            return reply
+
+    driver = object.__new__(JunOSDriver)
+    driver.device = Dev()
+    driver.get_vlans = dict
+    switchports = driver.get_interfaces_vlans()
+
+    assert set(switchports) == {"ge-0/0/23"}, (
+        f"the driver must key on the physical port, got {sorted(switchports)}"
+    )
+
+    # Both interfaces exist in NetBox, as orb emits them.
+    entities = [_make_iface_entity("ge-0/0/23"), _make_iface_entity("ge-0/0/23.0")]
+    defaults = Defaults()
+    options = Options()
+    cache = _build_vlan_cache({"888": {"name": "VL888"}}, defaults)
+    new_stubs: list = []
+
+    apply_interface_vlans(entities, switchports, cache, defaults, options, new_stubs)
+
+    port, unit = entities[0].interface, entities[1].interface
+    assert port.mode == "access"
+    assert port.untagged_vlan.vid == 888
+    assert unit.mode == "", "the subinterface must not carry the switchport config"
+    assert not unit.HasField("untagged_vlan")


### PR DESCRIPTION
address #606.

### The bug

A Juniper EX4550 on Junos 15.1 answers `<get-ethernet-switching-interface-information>` with all of its VLAN memberships and **no `<interface-port-mode>` element anywhere**. The parser derived access-versus-trunk from that element alone, so every port fell through to its "no VLAN config at all → routed" branch, discarding the memberships it had just read. The switch reached NetBox with 14 interfaces and not one `mode`, `tagged_vlans` or `untagged_vlan`.

Replaying the reporter's capture through the unmodified driver reproduces it exactly: **14 interfaces, 0 classified, 14 routed.**

This survived because every existing non-ELS fixture carries `interface-port-mode`, and none carries a unit suffix. The tests were built on synthetic XML that has neither property of the real reply, so the shape a real device produces was never exercised in either respect.

### The fix

**Ask for the reply that carries the mode.** The two CLI forms map to one RPC, the detailed one adding `<detail/>`. They do not answer alike: on this device the plain form has no mode element and the detailed form carries it on every interface. The detailed form is asked for first; the plain form still answers when it yields nothing, so a platform that rejects the argument keeps the behaviour it has, and an ELS switch that refuses both falls through to its own RPC as before.

**Read the mode off the membership where no element arrives.** A member the port carries tagged makes it a trunk; a member named `all` is a trunk-only construct (`vlan members all` is only configurable under `port-mode trunk`); a native VLAN id is only meaningful on a trunk, and decides the case a port with a single untagged member would otherwise get wrong. Otherwise an untagged member makes it access. This is the conclusion the SNMP path already draws from Q-BRIDGE.

Checked against the same device's detailed reply, which does carry the mode: **11 of its 11 classifiable interfaces agree, none disagree.** Inference stays the fallback rather than the rule, because the element states outright what membership can only imply.

**Resolve a member reported by name.** Junos reports some members by name with no tag id. The name is now put to the device's own VLAN table.

The match is **exact and never case-folded**, which matters more than it looks: on this switch the table holds `MGMT` at tag 20 while `me0.0` reports a member named `mgmt`, Junos having put the out-of-band port in a pseudo-VLAN of that name outside the switching space. Case-folding would bind the management port to VLAN 20, wrongly and silently. A name the table gives more than one id is refused for the same reason nothing else here guesses.

**Key the result by the physical port.** Junos reports switching per logical unit (`ge-0/0/23.0`), while NetBox carries switchport mode and VLANs on the port. `_physical_name` exists for exactly this and the ELS path has always normalised through it; this path did not. Since `apply_interface_vlans` pairs on an exact name and orb emits the port and the unit as separate Interfaces, every VLAN recovered here would have attached to the subinterface while the port stayed blank.

Member ids and the native VLAN id go through `coerce_vid`, so a value outside 1-4094 is refused as membership rather than counted and dropped later — a member with tagid 0 would otherwise make a port look like it had an untagged VLAN and write `mode=access` with no VLAN to go with it.

### Result on the reported device

| | interfaces | classified | routed |
|---|---|---|---|
| before | 14 | 0 | 14 |
| after, detailed reply | 14 | 14 | 0 |
| after, plain reply only | 14 | 11 | 3 |

The three that differ are the ones whose only member is nameless. With the detailed reply they arrive with the device's own `mode` and no VLAN; on the plain reply they stay routed. Worth stating plainly: that means `me0.0`, the out-of-band management port, is reported with `mode=access` and no untagged VLAN. That is the device's own statement rather than an inference, and the alternative is to contradict it.

Those three also still log a warning per discovery cycle. They are unresolvable by design, so the message is about data deliberately not emitted rather than a fault.

### Testing

The reporter's real reply shape is now a scenario, with VLAN names synthesized. Plus: the mode read off membership in each direction; `all`-only and native-VLAN-id membership; a VID outside the dot1q range from both a tag id and a resolved name; the detailed form being asked for first and the plain form still answering when it is refused; a name resolved from the table, one differing only in case, one the table gives two ids, and a table keyed by strings as PyEZ actually returns; and the table being fetched once at most and not at all when no member needs it.

A translation-level test crosses the seam neither side's own tests did: an RPC naming the unit, through the driver, to an assertion that the port carries the mode and VLAN and the subinterface beside it carries neither.

Ten mutations, each reverting one rule and failing only the tests that pin it.

The PyEZ test fake can now serve a distinct fixture for a boolean RPC argument, which is what lets one scenario hold both replies. Every existing scenario is unaffected: none has a flagged file, so the plain one still answers.

`uv run pytest tests/` and `uv run --with ruff==0.15.10 ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
